### PR TITLE
Update/uvx execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ source .venv/bin/activate
 pip3 install keboola_mcp_server
 ```
 
+
 ### Installing via Smithery
 
 To install Keboola MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/keboola-mcp-server):
@@ -49,9 +50,8 @@ To use this server with Claude Desktop, follow these steps:
 {
   "mcpServers": {
     "keboola": {
-      "command": "/path/to/keboola-mcp-server/.venv/bin/python",
+      "command": "uvx",
       "args": [
-        "-m",
         "keboola_mcp_server",
         "--api-url",
         "https://connection.YOUR_REGION.keboola.com"
@@ -117,9 +117,8 @@ To use this server with Cursor AI, you have two options for configuring the tran
 {
   "mcpServers": {
     "keboola": {
-      "command": "/path/to/keboola-mcp-server/.venv/bin/python",
+      "command": "uvx",
       "args": [
-        "-m",
         "keboola_mcp_server",
         "--transport",
         "stdio",
@@ -190,11 +189,31 @@ This will give your MCP server instance permissions to access your BigQuery work
 
 The server provides the following tools for interacting with Keboola Connection:
 
-- List buckets and tables
-- Get bucket and table information
-- Preview table data
-- Export table data to CSV
-- List components and configurations
+### Storage Tools
+- `retrieve_buckets` - List all buckets in your Keboola project
+- `get_bucket_detail` - Get detailed information about a specific bucket
+- `retrieve_bucket_tables` - List all tables in a specific bucket
+- `get_table_detail` - Get detailed information about a specific table
+- `update_bucket_description` - Update the description of a bucket
+- `update_table_description` - Update the description of a table
+
+### SQL Tools
+- `query_table` - Execute SQL queries on tables in your workspace
+- `get_sql_dialect` - Get the SQL dialect used in your workspace (Snowflake or BigQuery)
+
+### Component Tools
+- `retrieve_components` - List available components and their configurations
+- `retrieve_transformations` - List transformation configurations
+- `get_component_details` - Get detailed information about a specific component
+- `create_sql_transformation` - Create a new SQL transformation configuration
+
+### Job Tools
+- `retrieve_jobs` - List jobs in your project
+- `get_job_detail` - Get detailed information about a specific job
+- `start_job` - Start a new job for a component configuration
+
+### Documentation Tools
+- `docs_query` - Query documentation and help information
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.13.1"
+version = "0.13.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 ]
 
 [project.scripts]
-keboola-mcp = "keboola_mcp_server.cli:main"
+keboola_mcp_server = "keboola_mcp_server.cli:main"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Update to docs and packaging so it's executable via single `uvx keboola_mcp_server` command
### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L193-R216): Added detailed sections for Storage, SQL, Component, Job, and Documentation tools, listing specific commands and their purposes for interacting with Keboola Connection. This replaces the previous high-level descriptions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-L54): Updated the server command in the configuration examples from `"/path/to/keboola-mcp-server/.venv/bin/python"` to `"uvx"` and removed the `"-m"` argument for simplicity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-L54) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-L122)

### Configuration Changes:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Incremented the package version from `0.13.1` to `0.13.2` to reflect the new updates.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L35-R35): Renamed the script entry point from `keboola-mcp` to `keboola_mcp_server` for consistency with the package name. So it's executable via single `uvx keboola_mcp_server`
