### PR TITLE
KAB-1002 refactor API clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,26 @@
-# Python-generated files
+# Python (build) related files
 __pycache__/
 *.py[oc]
 build/
 dist/
 wheels/
 *.egg-info
+
+# IDE related files
+.cursor/
 .idea/
 .vscode/
+
 # Virtual environments
 .venv
+
+# Environment variables
 .env
-# Coverage files
+
+# Test related files
 .coverage
 .coverage.*
 coverage.xml
 htmlcov/
+.pytest_cache/
 test-results.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.13.1"
+version = "0.14.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -37,12 +37,13 @@ keboola-mcp = "keboola_mcp_server.cli:main"
 [tool.black]
 line-length = 100
 target-version = ["py310"]
-skip_string_normalization = true
+skip-string-normalization = true
 
 [tool.isort]
 profile = "black"
 line_length = 100
 multi_line_output = 3
+use_parentheses = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/keboola_mcp_server"]

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -55,10 +55,12 @@ class KeboolaClient:
         self.storage_client_sync = SyncStorageClient(storage_api_url, self.token)
         self.storage_client = AsyncStorageClient.create(root_url=storage_api_url, token=self.token)
         self.jobs_queue = JobsQueueClient.create(queue_api_url, self.token)
-        self.ai_service_client = AIServiceClient.create(root_url=ai_service_api_url, token=self.token)
+        self.ai_service_client = AIServiceClient.create(
+            root_url=ai_service_api_url, token=self.token
+        )
 
 
-class RawKeboolaClient():
+class RawKeboolaClient:
     """
     Raw async client for Keboola services.
 
@@ -66,7 +68,9 @@ class RawKeboolaClient():
     and can be used to implement high-level functions in clients for individual services.
     """
 
-    def __init__(self, base_api_url: str, api_token: str, headers: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self, base_api_url: str, api_token: str, headers: dict[str, Any] | None = None
+    ) -> None:
         self.base_api_url = base_api_url
         self.headers = {
             'X-StorageApi-Token': api_token,
@@ -201,7 +205,11 @@ class KeboolaServiceClient:
         """
         return cls(raw_client=RawKeboolaClient(base_api_url=root_url, api_token=token))
 
-    async def get(self, endpoint: str, params: Optional[dict[str, Any]] = None,) -> dict[str, Any]:
+    async def get(
+        self,
+        endpoint: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         """
         Makes a GET request to the service API.
 
@@ -211,7 +219,11 @@ class KeboolaServiceClient:
         """
         return await self.raw_client.get(endpoint=endpoint, params=params)
 
-    async def post(self, endpoint: str, data: Optional[dict[str, Any]] = None,) -> dict[str, Any]:
+    async def post(
+        self,
+        endpoint: str,
+        data: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         """
         Makes a POST request to the service API.
 
@@ -221,7 +233,11 @@ class KeboolaServiceClient:
         """
         return await self.raw_client.post(endpoint=endpoint, data=data)
 
-    async def put(self, endpoint: str, data: Optional[dict[str, Any]] = None,) -> dict[str, Any]:
+    async def put(
+        self,
+        endpoint: str,
+        data: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         """
         Makes a PUT request to the service API.
 
@@ -231,7 +247,10 @@ class KeboolaServiceClient:
         """
         return await self.raw_client.put(endpoint=endpoint, data=data)
 
-    async def delete(self, endpoint: str,) -> dict[str, Any]:
+    async def delete(
+        self,
+        endpoint: str,
+    ) -> dict[str, Any]:
         """
         Makes a DELETE request to the service API.
 
@@ -252,7 +271,9 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param token: The Keboola Storage API token
         :return: A new instance of AsyncStorageClient
         """
-        return cls(raw_client=RawKeboolaClient(base_api_url=f'{root_url}/v2/storage', api_token=token))
+        return cls(
+            raw_client=RawKeboolaClient(base_api_url=f'{root_url}/v2/storage', api_token=token)
+        )
 
 
 class JobsQueueClient(KeboolaServiceClient):
@@ -270,7 +291,6 @@ class JobsQueueClient(KeboolaServiceClient):
         :return: A new instance of JobsQueueClient
         """
         return cls(raw_client=RawKeboolaClient(base_api_url=root_url, api_token=token))
-
 
     async def detail(self, job_id: str) -> dict[str, Any]:
         """

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -336,6 +336,7 @@ class JobsQueueClient(KeboolaServiceClient):
             'sortBy': sort_by,
             'sortOrder': sort_order,
         }
+        params = {k: v for k, v in params.items() if v is not None}
         return await self._search(params=params)
 
     async def create_job(

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -295,7 +295,7 @@ class JobsQueueClient(KeboolaServiceClient):
         """
         return cls(raw_client=RawKeboolaClient(base_api_url=root_url, api_token=token))
 
-    async def detail(self, job_id: str) -> dict[str, Any]:
+    async def get_job_detail(self, job_id: str) -> dict[str, Any]:
         """
         Retrieves information about a given job.
 

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -54,7 +54,7 @@ class KeboolaClient:
         # Initialize clients for individual services
         self.storage_client_sync = SyncStorageClient(storage_api_url, self.token)
         self.storage_client = AsyncStorageClient.create(root_url=storage_api_url, token=self.token)
-        self.jobs_queue = JobsQueueClient.create(queue_api_url, self.token)
+        self.jobs_queue_client = JobsQueueClient.create(queue_api_url, self.token)
         self.ai_service_client = AIServiceClient.create(
             root_url=ai_service_api_url, token=self.token
         )

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -263,16 +263,19 @@ class KeboolaServiceClient:
 class AsyncStorageClient(KeboolaServiceClient):
 
     @classmethod
-    def create(cls, root_url: str, token: str) -> 'AsyncStorageClient':
+    def create(cls, root_url: str, token: str, version: str = 'v2') -> 'AsyncStorageClient':
         """
         Creates an AsyncStorageClient from a Keboola Storage API token.
 
         :param root_url: The root URL of the service API
         :param token: The Keboola Storage API token
+        :param version: The version of the API to use (default: 'v2')
         :return: A new instance of AsyncStorageClient
         """
         return cls(
-            raw_client=RawKeboolaClient(base_api_url=f'{root_url}/v2/storage', api_token=token)
+            raw_client=RawKeboolaClient(
+                base_api_url=f'{root_url}/{version}/storage', api_token=token
+            )
         )
 
 
@@ -432,7 +435,7 @@ class AIServiceClient(KeboolaServiceClient):
         :param component_id: The id of the component
         :return: Component details as dictionary
         """
-        return await self.raw_client.get(endpoint=f'docs/components/{component_id}')
+        return await self.get(endpoint=f'docs/components/{component_id}')
 
     async def docs_question(self, query: str) -> DocsQuestionResponse:
         """

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -16,7 +16,7 @@ from keboola_mcp_server.mcp import (
 from keboola_mcp_server.tools.components import add_component_tools
 from keboola_mcp_server.tools.doc import add_doc_tools
 from keboola_mcp_server.tools.jobs import add_job_tools
-from keboola_mcp_server.tools.sql import WorkspaceManager, add_sql_tools, query_table
+from keboola_mcp_server.tools.sql import WorkspaceManager, add_sql_tools
 from keboola_mcp_server.tools.storage import add_storage_tools
 
 LOG = logging.getLogger(__name__)

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 from pydantic import AliasChoices, BaseModel, Field
 

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated, List, Sequence
+from typing import Annotated, Sequence
 
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field
@@ -188,14 +188,14 @@ async def get_component_configuration_details(
     # Get Component Details
     component = await _get_component_details(client=client, component_id=component_id)
     # Get Configuration Details
-    raw_configuration = client.storage_client.configurations.detail(component_id, configuration_id)
+    raw_configuration = client.storage_client_sync.configurations.detail(component_id, configuration_id)
     LOG.info(
         f'Retrieved configuration details for {component_id} component with configuration {configuration_id}.'
     )
 
     # Get Configuration Metadata if exists
-    endpoint = f'branch/{client.storage_client._branch_id}/components/{component_id}/configs/{configuration_id}/metadata'
-    r_metadata = await client.get(endpoint)
+    endpoint = f'branch/{client.storage_client_sync._branch_id}/components/{component_id}/configs/{configuration_id}/metadata'
+    r_metadata = await client.storage_client.get(endpoint)
     if r_metadata:
         LOG.info(
             f'Retrieved configuration metadata for {component_id} component with configuration {configuration_id}.'
@@ -293,7 +293,7 @@ async def create_sql_transformation(
     )
 
     client = KeboolaClient.from_state(ctx.session.state)
-    endpoint = f'branch/{client.storage_client._branch_id}/components/{transformation_id}/configs'
+    endpoint = f'branch/{client.storage_client_sync._branch_id}/components/{transformation_id}/configs'
 
     LOG.info(
         f'Creating new transformation configuration: {name} for component: {transformation_id}.'
@@ -301,7 +301,7 @@ async def create_sql_transformation(
     # Try to create the new transformation configuration and return the new object if successful
     # or log an error and raise an exception if not
     try:
-        new_raw_transformation_configuration = await client.post(
+        new_raw_transformation_configuration = await client.storage_client.post(
             endpoint,
             data={
                 'name': name,

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -188,7 +188,9 @@ async def get_component_configuration_details(
     # Get Component Details
     component = await _get_component_details(client=client, component_id=component_id)
     # Get Configuration Details
-    raw_configuration = client.storage_client_sync.configurations.detail(component_id, configuration_id)
+    raw_configuration = client.storage_client_sync.configurations.detail(
+        component_id, configuration_id
+    )
     LOG.info(
         f'Retrieved configuration details for {component_id} component with configuration {configuration_id}.'
     )
@@ -293,7 +295,9 @@ async def create_sql_transformation(
     )
 
     client = KeboolaClient.from_state(ctx.session.state)
-    endpoint = f'branch/{client.storage_client_sync._branch_id}/components/{transformation_id}/configs'
+    endpoint = (
+        f'branch/{client.storage_client_sync._branch_id}/components/{transformation_id}/configs'
+    )
 
     LOG.info(
         f'Creating new transformation configuration: {name} for component: {transformation_id}.'

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Union, cast, get_args
+from typing import Any, Optional, Sequence, Union, cast, get_args
 
 import requests
 from pydantic import BaseModel, Field
@@ -45,7 +45,7 @@ async def _retrieve_components_configurations_by_types(
     :return: a list of items, each containing a component and its associated configurations
     """
 
-    endpoint = f'branch/{client.storage_client._branch_id}/components'
+    endpoint = f'branch/{client.storage_client_sync._branch_id}/components'
     # retrieve components by types - unable to use list of types as parameter, we need to iterate over types
 
     raw_components_with_configurations = []
@@ -56,7 +56,7 @@ async def _retrieve_components_configurations_by_types(
             'componentType': type,
         }
         raw_components_with_configurations_by_type = cast(
-            list[dict[str, Any]], await client.get(endpoint, params=params)
+            list[dict[str, Any]], await client.storage_client.get(endpoint, params=params)
         )
         # extend the list with the raw components with configurations
         raw_components_with_configurations.extend(raw_components_with_configurations_by_type)
@@ -100,10 +100,10 @@ async def _retrieve_components_configurations_by_ids(
     components_with_configurations = []
     for component_id in component_ids:
         # retrieve configurations for component ids
-        raw_configurations = client.storage_client.configurations.list(component_id)
+        raw_configurations = client.storage_client_sync.configurations.list(component_id)
         # retrieve component details
-        endpoint = f'branch/{client.storage_client._branch_id}/components/{component_id}'
-        raw_component = await client.get(endpoint)
+        endpoint = f'branch/{client.storage_client_sync._branch_id}/components/{component_id}'
+        raw_component = await client.storage_client.get(endpoint)
         # build component configurations list grouped by components
         components_with_configurations.append(
             ComponentWithConfigurations(
@@ -157,8 +157,8 @@ async def _get_component_details(
                 f'Falling back to Storage API.'
             )
 
-            endpoint = f'branch/{client.storage_client._branch_id}/components/{component_id}'
-            raw_component = await client.get(endpoint)
+            endpoint = f'branch/{client.storage_client_sync._branch_id}/components/{component_id}'
+            raw_component = await client.storage_client.get(endpoint)
             LOG.info(f'Retrieved component details for component {component_id} from Storage API.')
             return Component.model_validate(raw_component)
         else:

--- a/src/keboola_mcp_server/tools/doc.py
+++ b/src/keboola_mcp_server/tools/doc.py
@@ -38,6 +38,6 @@ async def docs_query(
     Answers a question using the Keboola documentation as a source.
     """
     client = KeboolaClient.from_state(ctx.session.state)
-    answer = client.ai_service_client.docs_question(query)
+    answer = await client.ai_service_client.docs_question(query)
 
     return DocsAnswer(text=answer.text, source_urls=answer.source_urls)

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -224,7 +224,7 @@ async def retrieve_jobs(
     client = KeboolaClient.from_state(ctx.session.state)
     _status = [status] if status else None
 
-    raw_jobs = client.jobs_queue.search_jobs_by(
+    raw_jobs = client.jobs_queue_client.search_jobs_by(
         component_id=component_id,
         config_id=config_id,
         limit=limit,
@@ -252,7 +252,7 @@ async def get_job_detail(
     """
     client = KeboolaClient.from_state(ctx.session.state)
 
-    raw_job = client.jobs_queue.detail(job_id)
+    raw_job = client.jobs_queue_client.detail(job_id)
     LOG.info(f'Found job details for {job_id}.' if raw_job else f'Job {job_id} not found.')
     return JobDetail.model_validate(raw_job)
 
@@ -273,7 +273,7 @@ async def start_job(
     client = KeboolaClient.from_state(ctx.session.state)
 
     try:
-        raw_job = client.jobs_queue.create_job(
+        raw_job = client.jobs_queue_client.create_job(
             component_id=component_id, configuration_id=configuration_id
         )
         job = JobDetail.model_validate(raw_job)

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -252,7 +252,7 @@ async def get_job_detail(
     """
     client = KeboolaClient.from_state(ctx.session.state)
 
-    raw_job = client.jobs_queue_client.detail(job_id)
+    raw_job = client.jobs_queue_client.get_job_detail(job_id)
     LOG.info(f'Found job details for {job_id}.' if raw_job else f'Job {job_id} not found.')
     return JobDetail.model_validate(raw_job)
 

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -133,7 +133,7 @@ class JobDetail(JobListItem):
         cls, current_value: Union[list[Any], dict[str, Any], None]
     ) -> dict[str, Any]:
         # Ensures that if the result field is passed as an empty list [] or None, it gets converted to an empty dict {}.
-        # Why? Because result is expected to be an Object, but create job endpoint sends [], perhaps it means
+        # Why? Because the result is expected to be an Object, but create job endpoint sends [], perhaps it means
         # "empty". This avoids type errors.
         if not isinstance(current_value, dict):
             if not current_value:
@@ -203,7 +203,7 @@ async def retrieve_jobs(
     list[JobListItem],
     Field(
         list[JobListItem],
-        description=('The retrieved list of jobs list items. If empty then no jobs were found.'),
+        description='The retrieved list of jobs list items. If empty then no jobs were found.',
     ),
 ]:
     """
@@ -245,7 +245,7 @@ async def get_job_detail(
     ctx: Context,
 ) -> Annotated[JobDetail, Field(JobDetail, description='The detailed information about the job.')]:
     """
-    Retrieve a detailed information about a specific job, identified by the job_id, including its status, parameters,
+    Retrieve detailed information about a specific job, identified by the job_id, including its status, parameters,
     results, and any relevant metadata.
     EXAMPLES:
         - if job_id = "123", then the details of the job with id "123" will be retrieved.

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -156,21 +156,21 @@ SORT_ORDER_VALUES = Literal['asc', 'desc']
 async def retrieve_jobs(
     ctx: Context,
     status: Annotated[
-        JOB_STATUS,
+        JOB_STATUS | None,
         Field(
             Optional[JOB_STATUS],
             description='The optional status of the jobs to filter by, if None then default all.',
         ),
     ] = None,
     component_id: Annotated[
-        str,
+        str | None,
         Field(
             Optional[str],
             description='The optional ID of the component whose jobs you want to list, default = None.',
         ),
     ] = None,
     config_id: Annotated[
-        str,
+        str | None,
         Field(
             Optional[str],
             description='The optional ID of the component configuration whose jobs you want to list, default = None.',
@@ -224,7 +224,7 @@ async def retrieve_jobs(
     client = KeboolaClient.from_state(ctx.session.state)
     _status = [status] if status else None
 
-    raw_jobs = client.jobs_queue_client.search_jobs_by(
+    raw_jobs = await client.jobs_queue_client.search_jobs_by(
         component_id=component_id,
         config_id=config_id,
         limit=limit,
@@ -252,7 +252,7 @@ async def get_job_detail(
     """
     client = KeboolaClient.from_state(ctx.session.state)
 
-    raw_job = client.jobs_queue_client.get_job_detail(job_id)
+    raw_job = await client.jobs_queue_client.get_job_detail(job_id)
     LOG.info(f'Found job details for {job_id}.' if raw_job else f'Job {job_id} not found.')
     return JobDetail.model_validate(raw_job)
 
@@ -273,7 +273,7 @@ async def start_job(
     client = KeboolaClient.from_state(ctx.session.state)
 
     try:
-        raw_job = client.jobs_queue_client.create_job(
+        raw_job = await client.jobs_queue_client.create_job(
             component_id=component_id, configuration_id=configuration_id
         )
         job = JobDetail.model_validate(raw_job)

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -164,7 +164,7 @@ class _SnowflakeWorkspace(_Workspace):
             return None
 
     async def execute_query(self, sql_query: str) -> QueryResult:
-        resp = await self._client.post(
+        resp = await self._client.storage_client.post(
             f'branch/default/workspaces/{self.id}/query', {'query': sql_query}
         )
         return TypeAdapter(QueryResult).validate_python(resp)
@@ -259,7 +259,7 @@ class WorkspaceManager:
         if self._workspace:
             return self._workspace
 
-        for wsp_info in await self._client.get('workspaces'):
+        for wsp_info in await self._client.storage_client.get('workspaces'):
             assert isinstance(wsp_info, dict)
             _id = wsp_info.get('id')
             backend = wsp_info.get('connection', {}).get('backend')

--- a/src/keboola_mcp_server/tools/storage.py
+++ b/src/keboola_mcp_server/tools/storage.py
@@ -181,7 +181,7 @@ async def get_bucket_detail(
     """Gets detailed information about a specific bucket."""
     client = KeboolaClient.from_state(ctx.session.state)
     assert isinstance(client, KeboolaClient)
-    raw_bucket = cast(dict[str, Any], client.storage_client.buckets.detail(bucket_id))
+    raw_bucket = cast(dict[str, Any], client.storage_client_sync.buckets.detail(bucket_id))
 
     return BucketDetail(**raw_bucket)
 
@@ -190,7 +190,7 @@ async def retrieve_buckets(ctx: Context) -> list[BucketDetail]:
     """Retrieves information about all buckets in the project."""
     client = KeboolaClient.from_state(ctx.session.state)
     assert isinstance(client, KeboolaClient)
-    raw_bucket_data = client.storage_client.buckets.list()
+    raw_bucket_data = client.storage_client_sync.buckets.list()
 
     return [BucketDetail(**raw_bucket) for raw_bucket in raw_bucket_data]
 
@@ -202,7 +202,7 @@ async def get_table_detail(
     client = KeboolaClient.from_state(ctx.session.state)
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
 
-    raw_table = cast(Mapping[str, Any], client.storage_client.tables.detail(table_id))
+    raw_table = cast(Mapping[str, Any], client.storage_client_sync.tables.detail(table_id))
     column_info = [
         TableColumnInfo(name=col, quoted_name=await workspace_manager.get_quoted_name(col))
         for col in raw_table.get('columns', [])
@@ -229,7 +229,7 @@ async def retrieve_bucket_tables(
     #  This could take time for larger buckets, but could save calls to get_table_metadata() later.
     raw_tables = cast(
         list[Mapping[str, Any]],
-        client.storage_client.buckets.list_tables(bucket_id, include=['metadata']),
+        client.storage_client_sync.buckets.list_tables(bucket_id, include=['metadata']),
     )
     return [TableDetail(**raw_table) for raw_table in raw_tables]
 
@@ -250,7 +250,7 @@ async def update_bucket_description(
         'provider': 'user',
         'metadata': [{'key': MetadataField.DESCRIPTION.value, 'value': description}],
     }
-    response = await client.post(endpoint=metadata_endpoint, data=data)
+    response = await client.storage_client.post(endpoint=metadata_endpoint, data=data)
 
     return UpdateBucketDescriptionResponse.model_validate(response)
 
@@ -271,6 +271,6 @@ async def update_table_description(
         'provider': 'user',
         'metadata': [{'key': MetadataField.DESCRIPTION.value, 'value': description}],
     }
-    response = await client.post(endpoint=metadata_endpoint, data=data)
+    response = await client.storage_client.post(endpoint=metadata_endpoint, data=data)
 
     return UpdateTableDescriptionResponse.model_validate(response)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,10 @@ from mcp.server.fastmcp import Context
 
 from keboola_mcp_server.client import (
     AIServiceClient,
-    AsyncKeboolaClient,
+    RawKeboolaClient,
     JobsQueueClient,
     KeboolaClient,
-    StorageAsyncClient,
+    AsyncStorageClient,
 )
 from keboola_mcp_server.mcp import StatefullServerSession
 from keboola_mcp_server.tools.sql import WorkspaceManager
@@ -22,13 +22,13 @@ def keboola_client(mocker) -> KeboolaClient:
     # Mock synchronous client
     client.storage_client_sync = mocker.MagicMock(KBCClient)
     # Mock asynchronous clients
-    client.storage_client = mocker.MagicMock(StorageAsyncClient)
+    client.storage_client = mocker.MagicMock(AsyncStorageClient)
     client.jobs_queue = mocker.MagicMock(JobsQueueClient)
     client.ai_service_client = mocker.MagicMock(AIServiceClient)
     # Mock the underlying api_client for async clients if needed for deeper testing
-    client.storage_client.api_client = mocker.MagicMock(AsyncKeboolaClient)
-    client.jobs_queue.api_client = mocker.MagicMock(AsyncKeboolaClient)
-    client.ai_service_client.api_client = mocker.MagicMock(AsyncKeboolaClient)
+    client.storage_client.api_client = mocker.MagicMock(RawKeboolaClient)
+    client.jobs_queue.api_client = mocker.MagicMock(RawKeboolaClient)
+    client.ai_service_client.api_client = mocker.MagicMock(RawKeboolaClient)
 
     return client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,35 @@
+from unittest.mock import MagicMock
+
 import pytest
-from kbcstorage.client import Client
+from kbcstorage.client import Client as KBCClient
 from mcp.server.fastmcp import Context
 
-from keboola_mcp_server.client import AIServiceClient, JobsQueue, KeboolaClient
+from keboola_mcp_server.client import (
+    AIServiceClient,
+    AsyncKeboolaClient,
+    JobsQueueClient,
+    KeboolaClient,
+    StorageAsyncClient,
+)
 from keboola_mcp_server.mcp import StatefullServerSession
 from keboola_mcp_server.tools.sql import WorkspaceManager
 
 
 @pytest.fixture
 def keboola_client(mocker) -> KeboolaClient:
-    """Creates mocked `KeboolaClient` instance."""
+    """Creates mocked `KeboolaClient` instance with mocked sub-clients."""
     client = mocker.MagicMock(KeboolaClient)
-    client.storage_client = mocker.MagicMock(Client)
-    client.jobs_queue = mocker.MagicMock(JobsQueue)
+    # Mock synchronous client
+    client.storage_client_sync = mocker.MagicMock(KBCClient)
+    # Mock asynchronous clients
+    client.storage_client = mocker.MagicMock(StorageAsyncClient)
+    client.jobs_queue = mocker.MagicMock(JobsQueueClient)
     client.ai_service_client = mocker.MagicMock(AIServiceClient)
+    # Mock the underlying api_client for async clients if needed for deeper testing
+    client.storage_client.api_client = mocker.MagicMock(AsyncKeboolaClient)
+    client.jobs_queue.api_client = mocker.MagicMock(AsyncKeboolaClient)
+    client.ai_service_client.api_client = mocker.MagicMock(AsyncKeboolaClient)
+
     return client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,13 @@
-from unittest.mock import MagicMock
-
 import pytest
 from kbcstorage.client import Client as KBCClient
 from mcp.server.fastmcp import Context
 
 from keboola_mcp_server.client import (
     AIServiceClient,
-    RawKeboolaClient,
+    AsyncStorageClient,
     JobsQueueClient,
     KeboolaClient,
-    AsyncStorageClient,
+    RawKeboolaClient,
 )
 from keboola_mcp_server.mcp import StatefullServerSession
 from keboola_mcp_server.tools.sql import WorkspaceManager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from kbcstorage.client import Client as KBCClient
+from kbcstorage.client import Client as SyncStorageClient
 from mcp.server.fastmcp import Context
 
 from keboola_mcp_server.client import (
@@ -18,14 +18,14 @@ def keboola_client(mocker) -> KeboolaClient:
     """Creates mocked `KeboolaClient` instance with mocked sub-clients."""
     client = mocker.MagicMock(KeboolaClient)
     # Mock synchronous client
-    client.storage_client_sync = mocker.MagicMock(KBCClient)
+    client.storage_client_sync = mocker.MagicMock(SyncStorageClient)
     # Mock asynchronous clients
     client.storage_client = mocker.MagicMock(AsyncStorageClient)
-    client.jobs_queue = mocker.MagicMock(JobsQueueClient)
+    client.jobs_queue_client = mocker.MagicMock(JobsQueueClient)
     client.ai_service_client = mocker.MagicMock(AIServiceClient)
     # Mock the underlying api_client for async clients if needed for deeper testing
     client.storage_client.api_client = mocker.MagicMock(RawKeboolaClient)
-    client.jobs_queue.api_client = mocker.MagicMock(RawKeboolaClient)
+    client.jobs_queue_client.api_client = mocker.MagicMock(RawKeboolaClient)
     client.ai_service_client.api_client = mocker.MagicMock(RawKeboolaClient)
 
     return client

--- a/tests/tools/components/conftest.py
+++ b/tests/tools/components/conftest.py
@@ -1,8 +1,8 @@
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 from mcp.server.fastmcp import Context
+from pytest_mock import MockerFixture
 
 from keboola_mcp_server.client import KeboolaClient
 
@@ -118,11 +118,13 @@ def mock_branch_id() -> str:
 
 
 @pytest.fixture
-def mcp_context_components_configs(mcp_context_client, mock_branch_id) -> Context:
+def mcp_context_components_configs(
+    mocker: MockerFixture, mcp_context_client, mock_branch_id
+) -> Context:
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client_sync = MagicMock()
-    keboola_client.storage_client_sync.components = MagicMock()
-    keboola_client.storage_client_sync.configurations = MagicMock()
+    keboola_client.storage_client_sync = mocker.MagicMock()
+    keboola_client.storage_client_sync.components = mocker.MagicMock()
+    keboola_client.storage_client_sync.configurations = mocker.MagicMock()
     keboola_client.storage_client_sync._branch_id = mock_branch_id
 
     return mcp_context_client

--- a/tests/tools/components/conftest.py
+++ b/tests/tools/components/conftest.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock
 import pytest
 from mcp.server.fastmcp import Context
 
+from keboola_mcp_server.client import KeboolaClient
+
 
 @pytest.fixture
 def mock_components() -> list[dict[str, Any]]:
@@ -117,8 +119,10 @@ def mock_branch_id() -> str:
 
 @pytest.fixture
 def mcp_context_components_configs(mcp_context_client, mock_branch_id) -> Context:
-    keboola_client = mcp_context_client.session.state['sapi_client']
-    keboola_client.storage_client.components = MagicMock()
-    keboola_client.storage_client.configurations = MagicMock()
-    keboola_client.storage_client._branch_id = mock_branch_id
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.storage_client_sync = MagicMock()
+    keboola_client.storage_client_sync.components = MagicMock()
+    keboola_client.storage_client_sync.configurations = MagicMock()
+    keboola_client.storage_client_sync._branch_id = mock_branch_id
+
     return mcp_context_client

--- a/tests/tools/components/conftest.py
+++ b/tests/tools/components/conftest.py
@@ -119,10 +119,9 @@ def mock_branch_id() -> str:
 
 @pytest.fixture
 def mcp_context_components_configs(
-    mocker: MockerFixture, mcp_context_client, mock_branch_id
+    mocker: MockerFixture, mcp_context_client: Context, mock_branch_id: str
 ) -> Context:
-    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client_sync = mocker.MagicMock()
+    keboola_client = mcp_context_client.session.state[KeboolaClient.STATE_KEY]
     keboola_client.storage_client_sync.components = mocker.MagicMock()
     keboola_client.storage_client_sync.configurations = mocker.MagicMock()
     keboola_client.storage_client_sync._branch_id = mock_branch_id

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -2,6 +2,7 @@ from typing import Any, Callable
 
 import pytest
 from mcp.server.fastmcp import Context
+from pytest_mock import MockerFixture
 
 from keboola_mcp_server.client import KeboolaClient
 from keboola_mcp_server.tools.components import (
@@ -86,7 +87,7 @@ def assert_retrieve_components() -> (
 
 @pytest.mark.asyncio
 async def test_retrieve_components_configurations_by_types(
-    mocker,
+    mocker: MockerFixture,
     mcp_context_components_configs: Context,
     mock_components: list[dict[str, Any]],
     mock_configurations: list[dict[str, Any]],
@@ -99,7 +100,7 @@ async def test_retrieve_components_configurations_by_types(
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
     # mock the get method to return the mock_component with the mock_configurations
-    # simulate the response from the APIAsyncMock
+    # simulate the response from the API
     keboola_client.storage_client.get = mocker.AsyncMock(
         side_effect=[
             [{**component, 'configurations': mock_configurations}] for component in mock_components
@@ -130,7 +131,7 @@ async def test_retrieve_components_configurations_by_types(
 
 @pytest.mark.asyncio
 async def test_retrieve_transformations_configurations(
-    mocker,
+    mocker: MockerFixture,
     mcp_context_components_configs: Context,
     mock_component: dict[str, Any],
     mock_configurations: list[dict[str, Any]],
@@ -164,7 +165,7 @@ async def test_retrieve_transformations_configurations(
 
 @pytest.mark.asyncio
 async def test_retrieve_components_configurations_from_ids(
-    mocker,
+    mocker: MockerFixture,
     mcp_context_components_configs: Context,
     mock_configurations: list[dict[str, Any]],
     mock_component: dict[str, Any],
@@ -196,7 +197,7 @@ async def test_retrieve_components_configurations_from_ids(
 
 @pytest.mark.asyncio
 async def test_retrieve_transformations_configurations_from_ids(
-    mocker,
+    mocker: MockerFixture,
     mcp_context_components_configs: Context,
     mock_configurations: list[dict[str, Any]],
     mock_component: dict[str, Any],
@@ -230,7 +231,7 @@ async def test_retrieve_transformations_configurations_from_ids(
 
 @pytest.mark.asyncio
 async def test_get_component_configuration_details(
-    mocker,
+    mocker: MockerFixture,
     mcp_context_components_configs: Context,
     mock_configuration: dict[str, Any],
     mock_component: dict[str, Any],
@@ -291,7 +292,7 @@ async def test_get_component_configuration_details(
 )
 @pytest.mark.asyncio
 async def test_create_transformation_configuration(
-    mocker,
+    mocker: MockerFixture,
     mcp_context_components_configs: Context,
     mock_component: dict[str, Any],
     mock_configuration: dict[str, Any],
@@ -377,7 +378,7 @@ async def test_create_transformation_configuration(
 @pytest.mark.parametrize('sql_dialect', ['Unknown'])
 @pytest.mark.asyncio
 async def test_create_transformation_configuration_fail(
-    mocker,
+    mocker: MockerFixture,
     sql_dialect: str,
     mcp_context_components_configs: Context,
 ):

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -177,14 +177,18 @@ async def test_retrieve_components_configurations_from_ids(
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
 
-    keboola_client.storage_client_sync.configurations.list = mocker.MagicMock(return_value=mock_configurations)
+    keboola_client.storage_client_sync.configurations.list = mocker.MagicMock(
+        return_value=mock_configurations
+    )
     keboola_client.storage_client.get = mocker.AsyncMock(return_value=mock_component)
 
     result = await retrieve_components_configurations(context, component_ids=[mock_component['id']])
 
     assert_retrieve_components(result, [mock_component], mock_configurations)
 
-    keboola_client.storage_client_sync.configurations.list.assert_called_once_with(mock_component['id'])
+    keboola_client.storage_client_sync.configurations.list.assert_called_once_with(
+        mock_component['id']
+    )
     keboola_client.storage_client.get.assert_called_once_with(
         f'branch/{mock_branch_id}/components/{mock_component["id"]}'
     )
@@ -205,7 +209,9 @@ async def test_retrieve_transformations_configurations_from_ids(
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
 
-    keboola_client.storage_client_sync.configurations.list = mocker.MagicMock(return_value=mock_configurations)
+    keboola_client.storage_client_sync.configurations.list = mocker.MagicMock(
+        return_value=mock_configurations
+    )
     keboola_client.storage_client.get = mocker.AsyncMock(return_value=mock_component)
 
     result = await retrieve_transformations_configurations(
@@ -214,7 +220,9 @@ async def test_retrieve_transformations_configurations_from_ids(
 
     assert_retrieve_components(result, [mock_component], mock_configurations)
 
-    keboola_client.storage_client_sync.configurations.list.assert_called_once_with(mock_component['id'])
+    keboola_client.storage_client_sync.configurations.list.assert_called_once_with(
+        mock_component['id']
+    )
     keboola_client.storage_client.get.assert_called_once_with(
         f'branch/{mock_branch_id}/components/{mock_component["id"]}'
     )
@@ -236,10 +244,16 @@ async def test_get_component_configuration_details(
     keboola_client.storage_client_sync.components = mocker.MagicMock()
 
     # Setup mock to return test data
-    keboola_client.storage_client_sync.configurations.detail = mocker.MagicMock(return_value=mock_configuration)
+    keboola_client.storage_client_sync.configurations.detail = mocker.MagicMock(
+        return_value=mock_configuration
+    )
     keboola_client.ai_service_client = mocker.MagicMock()
-    keboola_client.ai_service_client.get_component_detail = mocker.MagicMock(return_value=mock_component)
-    keboola_client.storage_client_sync.components.detail = mocker.MagicMock(return_value=mock_component)
+    keboola_client.ai_service_client.get_component_detail = mocker.MagicMock(
+        return_value=mock_component
+    )
+    keboola_client.storage_client_sync.components.detail = mocker.MagicMock(
+        return_value=mock_component
+    )
     keboola_client.storage_client_sync._branch_id = mock_branch_id
     keboola_client.storage_client.get = mocker.AsyncMock(return_value=mock_metadata)
 

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -1,5 +1,4 @@
-from typing import Any, Callable, Sequence, Union
-from unittest.mock import AsyncMock, MagicMock, call
+from typing import Any, Callable
 
 import pytest
 from mcp.server.fastmcp import Context
@@ -87,6 +86,7 @@ def assert_retrieve_components() -> (
 
 @pytest.mark.asyncio
 async def test_retrieve_components_configurations_by_types(
+    mocker,
     mcp_context_components_configs: Context,
     mock_components: list[dict[str, Any]],
     mock_configurations: list[dict[str, Any]],
@@ -99,8 +99,8 @@ async def test_retrieve_components_configurations_by_types(
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
     # mock the get method to return the mock_component with the mock_configurations
-    # simulate the response from the API
-    keboola_client.storage_client.get = AsyncMock(
+    # simulate the response from the APIAsyncMock
+    keboola_client.storage_client.get = mocker.AsyncMock(
         side_effect=[
             [{**component, 'configurations': mock_configurations}] for component in mock_components
         ]
@@ -112,15 +112,15 @@ async def test_retrieve_components_configurations_by_types(
 
     keboola_client.storage_client.get.assert_has_calls(
         [
-            call(
+            mocker.call(
                 f'branch/{mock_branch_id}/components',
                 params={'componentType': 'application', 'include': 'configuration'},
             ),
-            call(
+            mocker.call(
                 f'branch/{mock_branch_id}/components',
                 params={'componentType': 'extractor', 'include': 'configuration'},
             ),
-            call(
+            mocker.call(
                 f'branch/{mock_branch_id}/components',
                 params={'componentType': 'writer', 'include': 'configuration'},
             ),
@@ -130,6 +130,7 @@ async def test_retrieve_components_configurations_by_types(
 
 @pytest.mark.asyncio
 async def test_retrieve_transformations_configurations(
+    mocker,
     mcp_context_components_configs: Context,
     mock_component: dict[str, Any],
     mock_configurations: list[dict[str, Any]],
@@ -143,7 +144,7 @@ async def test_retrieve_transformations_configurations(
     keboola_client = KeboolaClient.from_state(context.session.state)
     # mock the get method to return the mock_component with the mock_configurations
     # simulate the response from the API
-    keboola_client.storage_client.get = AsyncMock(
+    keboola_client.storage_client.get = mocker.AsyncMock(
         return_value=[{**mock_component, 'configurations': mock_configurations}]
     )
 
@@ -153,7 +154,7 @@ async def test_retrieve_transformations_configurations(
 
     keboola_client.storage_client.get.assert_has_calls(
         [
-            call(
+            mocker.call(
                 f'branch/{mock_branch_id}/components',
                 params={'componentType': 'transformation', 'include': 'configuration'},
             ),
@@ -163,6 +164,7 @@ async def test_retrieve_transformations_configurations(
 
 @pytest.mark.asyncio
 async def test_retrieve_components_configurations_from_ids(
+    mocker,
     mcp_context_components_configs: Context,
     mock_configurations: list[dict[str, Any]],
     mock_component: dict[str, Any],
@@ -175,8 +177,8 @@ async def test_retrieve_components_configurations_from_ids(
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
 
-    keboola_client.storage_client_sync.configurations.list = MagicMock(return_value=mock_configurations)
-    keboola_client.storage_client.get = AsyncMock(return_value=mock_component)
+    keboola_client.storage_client_sync.configurations.list = mocker.MagicMock(return_value=mock_configurations)
+    keboola_client.storage_client.get = mocker.AsyncMock(return_value=mock_component)
 
     result = await retrieve_components_configurations(context, component_ids=[mock_component['id']])
 
@@ -190,6 +192,7 @@ async def test_retrieve_components_configurations_from_ids(
 
 @pytest.mark.asyncio
 async def test_retrieve_transformations_configurations_from_ids(
+    mocker,
     mcp_context_components_configs: Context,
     mock_configurations: list[dict[str, Any]],
     mock_component: dict[str, Any],
@@ -202,8 +205,8 @@ async def test_retrieve_transformations_configurations_from_ids(
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
 
-    keboola_client.storage_client_sync.configurations.list = MagicMock(return_value=mock_configurations)
-    keboola_client.storage_client.get = AsyncMock(return_value=mock_component)
+    keboola_client.storage_client_sync.configurations.list = mocker.MagicMock(return_value=mock_configurations)
+    keboola_client.storage_client.get = mocker.AsyncMock(return_value=mock_component)
 
     result = await retrieve_transformations_configurations(
         context, transformation_ids=[mock_component['id']]
@@ -219,6 +222,7 @@ async def test_retrieve_transformations_configurations_from_ids(
 
 @pytest.mark.asyncio
 async def test_get_component_configuration_details(
+    mocker,
     mcp_context_components_configs: Context,
     mock_configuration: dict[str, Any],
     mock_component: dict[str, Any],
@@ -228,16 +232,16 @@ async def test_get_component_configuration_details(
     """Test get_component_configuration_details tool."""
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.storage_client_sync.configurations = MagicMock()
-    keboola_client.storage_client_sync.components = MagicMock()
+    keboola_client.storage_client_sync.configurations = mocker.MagicMock()
+    keboola_client.storage_client_sync.components = mocker.MagicMock()
 
     # Setup mock to return test data
-    keboola_client.storage_client_sync.configurations.detail = MagicMock(return_value=mock_configuration)
-    keboola_client.ai_service_client = MagicMock()
-    keboola_client.ai_service_client.get_component_detail = MagicMock(return_value=mock_component)
-    keboola_client.storage_client_sync.components.detail = MagicMock(return_value=mock_component)
+    keboola_client.storage_client_sync.configurations.detail = mocker.MagicMock(return_value=mock_configuration)
+    keboola_client.ai_service_client = mocker.MagicMock()
+    keboola_client.ai_service_client.get_component_detail = mocker.MagicMock(return_value=mock_component)
+    keboola_client.storage_client_sync.components.detail = mocker.MagicMock(return_value=mock_component)
     keboola_client.storage_client_sync._branch_id = mock_branch_id
-    keboola_client.storage_client.get = AsyncMock(return_value=mock_metadata)
+    keboola_client.storage_client.get = mocker.AsyncMock(return_value=mock_metadata)
 
     result = await get_component_configuration_details('keboola.ex-aws-s3', '123', context)
     expected = ComponentConfiguration.model_validate(
@@ -273,6 +277,7 @@ async def test_get_component_configuration_details(
 )
 @pytest.mark.asyncio
 async def test_create_transformation_configuration(
+    mocker,
     mcp_context_components_configs: Context,
     mock_component: dict[str, Any],
     mock_configuration: dict[str, Any],
@@ -286,7 +291,7 @@ async def test_create_transformation_configuration(
 
     # Mock the WorkspaceManager
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = AsyncMock(return_value=sql_dialect)
+    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
     # Mock the KeboolaClient
     keboola_client = KeboolaClient.from_state(context.session.state)
     component = mock_component
@@ -295,9 +300,9 @@ async def test_create_transformation_configuration(
     configuration['id'] = expected_configuration_id
 
     # Set up the mock for ai_service_client
-    keboola_client.ai_service_client = MagicMock()
-    keboola_client.ai_service_client.get_component_detail = MagicMock(return_value=component)
-    keboola_client.storage_client.post = AsyncMock(return_value=configuration)
+    keboola_client.ai_service_client = mocker.MagicMock()
+    keboola_client.ai_service_client.get_component_detail = mocker.MagicMock(return_value=component)
+    keboola_client.storage_client.post = mocker.AsyncMock(return_value=configuration)
 
     transformation_name = mock_configuration['name']
     bucket_name = '-'.join(transformation_name.lower().split())
@@ -358,13 +363,14 @@ async def test_create_transformation_configuration(
 @pytest.mark.parametrize('sql_dialect', ['Unknown'])
 @pytest.mark.asyncio
 async def test_create_transformation_configuration_fail(
+    mocker,
     sql_dialect: str,
     mcp_context_components_configs: Context,
 ):
     """Test create_sql_transformation tool which should raise an error if the sql dialect is unknown."""
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = AsyncMock(return_value=sql_dialect)
+    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
 
     with pytest.raises(ValueError):
         _ = await create_sql_transformation(

--- a/tests/tools/components/test_utils.py
+++ b/tests/tools/components/test_utils.py
@@ -1,5 +1,4 @@
-from typing import Any, Callable, Sequence, Union
-from unittest.mock import AsyncMock, MagicMock, call
+from typing import Sequence, Union
 
 import pytest
 

--- a/tests/tools/test_doc.py
+++ b/tests/tools/test_doc.py
@@ -23,7 +23,9 @@ async def test_docs_query(
     """Tests docs_query tool with a mocked AI service client response."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.ai_service_client.docs_question = mocker.AsyncMock(return_value=mock_docs_response)
+    keboola_client.ai_service_client.docs_question = mocker.AsyncMock(
+        return_value=mock_docs_response
+    )
 
     query = 'How do I create a transformation?'
     result = await docs_query(context, query)

--- a/tests/tools/test_doc.py
+++ b/tests/tools/test_doc.py
@@ -1,5 +1,6 @@
 import pytest
 from mcp.server.fastmcp import Context
+from pytest_mock import MockerFixture
 
 from keboola_mcp_server.client import DocsQuestionResponse, KeboolaClient
 from keboola_mcp_server.tools.doc import DocsAnswer, docs_query
@@ -16,7 +17,7 @@ def mock_docs_response() -> DocsQuestionResponse:
 
 @pytest.mark.asyncio
 async def test_docs_query(
-    mocker,
+    mocker: MockerFixture,
     mcp_context_client: Context,
     mock_docs_response: DocsQuestionResponse,
 ):

--- a/tests/tools/test_doc.py
+++ b/tests/tools/test_doc.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 from mcp.server.fastmcp import Context
 
@@ -17,11 +15,15 @@ def mock_docs_response() -> DocsQuestionResponse:
 
 
 @pytest.mark.asyncio
-async def test_docs_query(mcp_context_client: Context, mock_docs_response: DocsQuestionResponse):
+async def test_docs_query(
+    mocker,
+    mcp_context_client: Context,
+    mock_docs_response: DocsQuestionResponse,
+):
     """Tests docs_query tool with a mocked AI service client response."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.ai_service_client.docs_question = MagicMock(return_value=mock_docs_response)
+    keboola_client.ai_service_client.docs_question = mocker.AsyncMock(return_value=mock_docs_response)
 
     query = 'How do I create a transformation?'
     result = await docs_query(context, query)

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -83,7 +83,7 @@ async def test_retrieve_jobs(
     """Tests retrieve_jobs tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue_client.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(context)
 
@@ -124,7 +124,7 @@ async def test_retrieve_jobs(
     )
     assert all(hasattr(returned, 'not_a_desired_field') is False for returned in result)
 
-    keboola_client.jobs_queue.search_jobs_by.assert_called_once_with(
+    keboola_client.jobs_queue_client.search_jobs_by.assert_called_once_with(
         status=None,
         component_id=None,
         config_id=None,
@@ -142,7 +142,7 @@ async def test_get_job_detail(
     """Tests get_job_detail tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.detail = mocker.MagicMock(return_value=mock_job)
+    keboola_client.jobs_queue_client.detail = mocker.MagicMock(return_value=mock_job)
 
     result = await get_job_detail('123', context)
 
@@ -171,7 +171,7 @@ async def test_get_job_detail(
     # table_id is not present in the mock_job, should be None
     assert result.table_id is None
 
-    keboola_client.jobs_queue.detail.assert_called_once_with('123')
+    keboola_client.jobs_queue_client.detail.assert_called_once_with('123')
 
 
 @pytest.mark.asyncio
@@ -184,7 +184,7 @@ async def retrieve_jobs_with_component_and_config_id(
     """
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue_client.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(
         ctx=context, component_id='keboola.ex-aws-s3', config_id='config-123'
@@ -197,7 +197,7 @@ async def retrieve_jobs_with_component_and_config_id(
         returned.status == expected['status'] for returned, expected in zip(result, mock_jobs)
     )
 
-    keboola_client.jobs_queue.search_jobs_by.assert_called_once_with(
+    keboola_client.jobs_queue_client.search_jobs_by.assert_called_once_with(
         status=None,
         component_id='keboola.ex-aws-s3',
         config_id='config-123',
@@ -216,7 +216,7 @@ async def retrieve_jobs_with_component_id_without_config_id(
     It will return all jobs for the given component_id."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue_client.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(ctx=context, component_id='keboola.ex-aws-s3')
 
@@ -227,7 +227,7 @@ async def retrieve_jobs_with_component_id_without_config_id(
         returned.status == expected['status'] for returned, expected in zip(result, mock_jobs)
     )
 
-    keboola_client.jobs_queue.search_jobs_by.assert_called_once_with(
+    keboola_client.jobs_queue_client.search_jobs_by.assert_called_once_with(
         status=None,
         component_id='keboola.ex-aws-s3',
         config_id=None,
@@ -252,7 +252,7 @@ async def test_start_job(
     keboola_client = KeboolaClient.from_state(context.session.state)
     mock_job['result'] = []  # simulate empty list as returned by create job endpoint
     mock_job['status'] = 'created'  # simulate created status as returned by create job endpoint
-    keboola_client.jobs_queue.create_job = mocker.MagicMock(return_value=mock_job)
+    keboola_client.jobs_queue_client.create_job = mocker.MagicMock(return_value=mock_job)
 
     component_id = mock_job['component']
     configuration_id = mock_job['config']
@@ -268,7 +268,7 @@ async def test_start_job(
     assert job_detail.config_id == configuration_id
     assert job_detail.result == {}
 
-    keboola_client.jobs_queue.create_job.assert_called_once_with(
+    keboola_client.jobs_queue_client.create_job.assert_called_once_with(
         component_id=component_id,
         configuration_id=configuration_id,
     )
@@ -281,7 +281,7 @@ async def test_start_job_fail(
     """Tests start_job tool when job creation fails."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.create_job = mocker.MagicMock(
+    keboola_client.jobs_queue_client.create_job = mocker.MagicMock(
         side_effect=HTTPError('Job creation failed')
     )
 
@@ -291,7 +291,7 @@ async def test_start_job_fail(
     with pytest.raises(HTTPError):
         await start_job(ctx=context, component_id=component_id, configuration_id=configuration_id)
 
-    keboola_client.jobs_queue.create_job.assert_called_once_with(
+    keboola_client.jobs_queue_client.create_job.assert_called_once_with(
         component_id=component_id,
         configuration_id=configuration_id,
     )

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from typing import Any, Type, Union
-from unittest.mock import MagicMock
 
 import pytest
 from httpx import HTTPError
 from mcp.server.fastmcp import Context
+from pytest_mock import MockerFixture
 
 from keboola_mcp_server.client import KeboolaClient
 from keboola_mcp_server.tools.jobs import (
@@ -75,12 +75,15 @@ def iso_format() -> str:
 
 @pytest.mark.asyncio
 async def test_retrieve_jobs(
-    mcp_context_client: Context, mock_jobs: list[dict[str, Any]], iso_format: str
+    mocker: MockerFixture,
+    mcp_context_client: Context,
+    mock_jobs: list[dict[str, Any]],
+    iso_format: str,
 ):
     """Tests retrieve_jobs tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.search_jobs_by = MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(context)
 
@@ -134,12 +137,12 @@ async def test_retrieve_jobs(
 
 @pytest.mark.asyncio
 async def test_get_job_detail(
-    mcp_context_client: Context, mock_job: dict[str, Any], iso_format: str
+    mocker: MockerFixture, mcp_context_client: Context, mock_job: dict[str, Any], iso_format: str
 ):
     """Tests get_job_detail tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.detail = MagicMock(return_value=mock_job)
+    keboola_client.jobs_queue.detail = mocker.MagicMock(return_value=mock_job)
 
     result = await get_job_detail('123', context)
 
@@ -173,7 +176,7 @@ async def test_get_job_detail(
 
 @pytest.mark.asyncio
 async def retrieve_jobs_with_component_and_config_id(
-    mcp_context_client: Context, mock_jobs: list[dict[str, Any]]
+    mocker: MockerFixture, mcp_context_client: Context, mock_jobs: list[dict[str, Any]]
 ):
     """
     Tests retrieve_jobs tool with config_id and component_id. With config_id, the tool will return
@@ -181,7 +184,7 @@ async def retrieve_jobs_with_component_and_config_id(
     """
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.search_jobs_by = MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(
         ctx=context, component_id='keboola.ex-aws-s3', config_id='config-123'
@@ -207,13 +210,13 @@ async def retrieve_jobs_with_component_and_config_id(
 
 @pytest.mark.asyncio
 async def retrieve_jobs_with_component_id_without_config_id(
-    mcp_context_client: Context, mock_jobs: list[dict[str, Any]]
+    mocker: MockerFixture, mcp_context_client: Context, mock_jobs: list[dict[str, Any]]
 ):
     """Tests retrieve_jobs tool with component_id and without config_id.
     It will return all jobs for the given component_id."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.search_jobs_by = MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(ctx=context, component_id='keboola.ex-aws-s3')
 
@@ -237,6 +240,7 @@ async def retrieve_jobs_with_component_id_without_config_id(
 
 @pytest.mark.asyncio
 async def test_start_job(
+    mocker: MockerFixture,
     mcp_context_client: Context,
     mock_job: dict[str, Any],
 ):
@@ -248,7 +252,7 @@ async def test_start_job(
     keboola_client = KeboolaClient.from_state(context.session.state)
     mock_job['result'] = []  # simulate empty list as returned by create job endpoint
     mock_job['status'] = 'created'  # simulate created status as returned by create job endpoint
-    keboola_client.jobs_queue.create_job = MagicMock(return_value=mock_job)
+    keboola_client.jobs_queue.create_job = mocker.MagicMock(return_value=mock_job)
 
     component_id = mock_job['component']
     configuration_id = mock_job['config']
@@ -271,11 +275,15 @@ async def test_start_job(
 
 
 @pytest.mark.asyncio
-async def test_start_job_fail(mcp_context_client: Context, mock_job: dict[str, Any]):
+async def test_start_job_fail(
+    mocker: MockerFixture, mcp_context_client: Context, mock_job: dict[str, Any]
+):
     """Tests start_job tool when job creation fails."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue.create_job = MagicMock(side_effect=HTTPError('Job creation failed'))
+    keboola_client.jobs_queue.create_job = mocker.MagicMock(
+        side_effect=HTTPError('Job creation failed')
+    )
 
     component_id = mock_job['component']
     configuration_id = mock_job['config']

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -83,7 +83,7 @@ async def test_retrieve_jobs(
     """Tests retrieve_jobs tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue_client.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue_client.search_jobs_by = mocker.AsyncMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(context)
 
@@ -142,7 +142,7 @@ async def test_get_job_detail(
     """Tests get_job_detail tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue_client.get_job_detail = mocker.MagicMock(return_value=mock_job)
+    keboola_client.jobs_queue_client.get_job_detail = mocker.AsyncMock(return_value=mock_job)
 
     result = await get_job_detail('123', context)
 
@@ -184,7 +184,7 @@ async def retrieve_jobs_with_component_and_config_id(
     """
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue_client.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue_client.search_jobs_by = mocker.AsyncMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(
         ctx=context, component_id='keboola.ex-aws-s3', config_id='config-123'
@@ -216,7 +216,7 @@ async def retrieve_jobs_with_component_id_without_config_id(
     It will return all jobs for the given component_id."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue_client.search_jobs_by = mocker.MagicMock(return_value=mock_jobs)
+    keboola_client.jobs_queue_client.search_jobs_by = mocker.AsyncMock(return_value=mock_jobs)
 
     result = await retrieve_jobs(ctx=context, component_id='keboola.ex-aws-s3')
 
@@ -252,7 +252,7 @@ async def test_start_job(
     keboola_client = KeboolaClient.from_state(context.session.state)
     mock_job['result'] = []  # simulate empty list as returned by create job endpoint
     mock_job['status'] = 'created'  # simulate created status as returned by create job endpoint
-    keboola_client.jobs_queue_client.create_job = mocker.MagicMock(return_value=mock_job)
+    keboola_client.jobs_queue_client.create_job = mocker.AsyncMock(return_value=mock_job)
 
     component_id = mock_job['component']
     configuration_id = mock_job['config']
@@ -281,7 +281,7 @@ async def test_start_job_fail(
     """Tests start_job tool when job creation fails."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue_client.create_job = mocker.MagicMock(
+    keboola_client.jobs_queue_client.create_job = mocker.AsyncMock(
         side_effect=HTTPError('Job creation failed')
     )
 

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -142,7 +142,7 @@ async def test_get_job_detail(
     """Tests get_job_detail tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
-    keboola_client.jobs_queue_client.detail = mocker.MagicMock(return_value=mock_job)
+    keboola_client.jobs_queue_client.get_job_detail = mocker.MagicMock(return_value=mock_job)
 
     result = await get_job_detail('123', context)
 
@@ -171,7 +171,7 @@ async def test_get_job_detail(
     # table_id is not present in the mock_job, should be None
     assert result.table_id is None
 
-    keboola_client.jobs_queue_client.detail.assert_called_once_with('123')
+    keboola_client.jobs_queue_client.get_job_detail.assert_called_once_with('123')
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -7,6 +7,7 @@ from google.cloud.bigquery import QueryJob
 from google.cloud.bigquery.table import Row, RowIterator
 from mcp.server.fastmcp import Context
 from pydantic import TypeAdapter
+from pytest_mock import MockerFixture
 
 from keboola_mcp_server.client import KeboolaClient
 from keboola_mcp_server.tools.sql import (
@@ -277,7 +278,9 @@ class TestWorkspaceManagerBigQuery:
             ),
         ],
     )
-    async def test_execute_query(self, query: str, expected: QueryResult, context: Context, mocker):
+    async def test_execute_query(
+        self, query: str, expected: QueryResult, context: Context, mocker: MockerFixture
+    ):
         # disable BigQuery's Client's constructor to avoid Google authentication
         bq_client = mocker.patch('keboola_mcp_server.tools.sql.Client.__init__')
         bq_client.return_value = None

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -74,7 +74,7 @@ async def test_get_sql_dialect(dialect: str, empty_context: Context, mocker):
 class TestWorkspaceManagerSnowflake:
     @pytest.fixture()
     def context(self, keboola_client: KeboolaClient, empty_context: Context, mocker) -> Context:
-        keboola_client.get.return_value = [
+        keboola_client.storage_client.get.return_value = [
             {
                 'id': 'workspace_1234',
                 'connection': {
@@ -145,7 +145,7 @@ class TestWorkspaceManagerSnowflake:
         keboola_client: KeboolaClient,
         context: Context,
     ):
-        keboola_client.post.return_value = QueryResult(
+        keboola_client.storage_client.post.return_value = QueryResult(
             status='ok',
             data=SqlSelectData(columns=list(sapi_result.keys()), rows=[sapi_result]),
         )
@@ -183,7 +183,7 @@ class TestWorkspaceManagerSnowflake:
     async def test_execute_query(
         self, query: str, expected: QueryResult, keboola_client: KeboolaClient, context: Context
     ):
-        keboola_client.post.return_value = TypeAdapter(QueryResult).dump_python(expected)
+        keboola_client.storage_client.post.return_value = TypeAdapter(QueryResult).dump_python(expected)
         m = WorkspaceManager.from_state(context.session.state)
         result = await m.execute_query(query)
         assert result == expected
@@ -192,7 +192,7 @@ class TestWorkspaceManagerSnowflake:
 class TestWorkspaceManagerBigQuery:
     @pytest.fixture()
     def context(self, keboola_client: KeboolaClient, empty_context: Context, mocker) -> Context:
-        keboola_client.get.return_value = [
+        keboola_client.storage_client.get.return_value = [
             {
                 'id': 'workspace_1234',
                 'connection': {

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -183,7 +183,9 @@ class TestWorkspaceManagerSnowflake:
     async def test_execute_query(
         self, query: str, expected: QueryResult, keboola_client: KeboolaClient, context: Context
     ):
-        keboola_client.storage_client.post.return_value = TypeAdapter(QueryResult).dump_python(expected)
+        keboola_client.storage_client.post.return_value = TypeAdapter(QueryResult).dump_python(
+            expected
+        )
         m = WorkspaceManager.from_state(context.session.state)
         result = await m.execute_query(query)
         assert result == expected

--- a/tests/tools/test_storage.py
+++ b/tests/tools/test_storage.py
@@ -94,10 +94,10 @@ async def test_get_bucket_detail(
     """Test get_bucket_detail tool."""
 
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client.buckets = MagicMock()
+    keboola_client.storage_client_sync.buckets = MagicMock()
 
     expected_bucket = next(b for b in mock_buckets if b['id'] == bucket_id)
-    keboola_client.storage_client.buckets.detail = MagicMock(return_value=expected_bucket)
+    keboola_client.storage_client_sync.buckets.detail = MagicMock(return_value=expected_bucket)
 
     result = await get_bucket_detail(bucket_id, mcp_context_client)
 
@@ -125,10 +125,10 @@ async def test_retrieve_buckets_in_project(
     """Test the retrieve_buckets_in_project tool."""
 
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client.buckets = MagicMock()
+    keboola_client.storage_client_sync.buckets = MagicMock()
 
     # Mock the list method to return the mock_buckets data
-    keboola_client.storage_client.buckets.list = MagicMock(return_value=mock_buckets)
+    keboola_client.storage_client_sync.buckets.list = MagicMock(return_value=mock_buckets)
 
     result = await retrieve_buckets(mcp_context_client)
 
@@ -151,7 +151,7 @@ async def test_retrieve_buckets_in_project(
         if 'data_size_bytes' in expected_bucket:
             assert result_bucket.data_size_bytes == expected_bucket['data_size_bytes']
 
-    keboola_client.storage_client.buckets.list.assert_called_once()
+    keboola_client.storage_client_sync.buckets.list.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -161,8 +161,8 @@ async def test_get_table_detail(
     """Test get_table_detail tool."""
 
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client.tables = MagicMock()
-    keboola_client.storage_client.tables.detail = MagicMock(
+    keboola_client.storage_client_sync.tables = MagicMock()
+    keboola_client.storage_client_sync.tables.detail = MagicMock(
         return_value=mock_table_data['raw_table_data']
     )
 
@@ -208,11 +208,11 @@ async def test_lretrieve_bucket_tables_in_project(
 ) -> None:
     """Test retrieve_bucket_tables_in_project tool."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client.buckets = MagicMock()
-    keboola_client.storage_client.buckets.list_tables.return_value = sapi_response
+    keboola_client.storage_client_sync.buckets = MagicMock()
+    keboola_client.storage_client_sync.buckets.list_tables.return_value = sapi_response
     result = await retrieve_bucket_tables('bucket-id', mcp_context_client)
     assert result == expected
-    keboola_client.storage_client.buckets.list_tables.assert_called_once_with(
+    keboola_client.storage_client_sync.buckets.list_tables.assert_called_once_with(
         'bucket-id', include=['metadata']
     )
 
@@ -254,7 +254,7 @@ async def test_update_bucket_description_success(
     """Test successful update of bucket description."""
 
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.post = AsyncMock(return_value=mock_update_bucket_description_response)
+    keboola_client.storage_client.post = AsyncMock(return_value=mock_update_bucket_description_response)
 
     result = await update_bucket_description(
         bucket_id='in.c-test.bucket-id',
@@ -266,7 +266,7 @@ async def test_update_bucket_description_success(
     assert result.success is True
     assert result.description == 'Updated bucket description'
     assert result.timestamp == '2025-04-07T17:47:18+0200'
-    keboola_client.post.assert_called_once_with(
+    keboola_client.storage_client.post.assert_called_once_with(
         endpoint='buckets/in.c-test.bucket-id/metadata',
         data={
             'provider': 'user',
@@ -284,8 +284,8 @@ async def test_update_table_description_success(
     """Test successful update of table description."""
 
     # Mock the Keboola client post method
-    keboola_client = mcp_context_client.session.state['sapi_client']
-    keboola_client.post = AsyncMock(return_value=mock_update_table_description_response)
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.storage_client.post = AsyncMock(return_value=mock_update_table_description_response)
 
     result = await update_table_description(
         table_id='in.c-test.test-table',
@@ -297,7 +297,7 @@ async def test_update_table_description_success(
     assert result.success is True
     assert result.description == 'Updated test description'
     assert result.timestamp == '2025-04-07T16:47:18+0200'
-    keboola_client.post.assert_called_once_with(
+    keboola_client.storage_client.post.assert_called_once_with(
         endpoint='tables/in.c-test.test-table/metadata',
         data={
             'provider': 'user',


### PR DESCRIPTION
- Make JobsQueue and AI service clients async
- Refactor the basic async client for storage API (so far it only has raw get/post... methods)
- Use pytest mocker fixture in tests