### PR TITLE
fix image tag update workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Trigger image tag update
         if: github.ref == 'refs/heads/main'
-        uses: ./.github/actions/trigger-image-tag-update@main
+        uses: ./.github/actions/trigger-image-tag-update
         with:
           helm-chart: "mcp-server"
           image-tag: canary-orion-${{ github.sha }}


### PR DESCRIPTION
Tato uprava fixuje https://github.com/keboola/mcp-server/pull/70 kde [deploy](https://github.com/keboola/mcp-server/actions/runs/14857686075) spadol na chybe:
> Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/mcp-server/mcp-server/.github/actions/trigger-image-tag-update@main'. Did you forget to run actions/checkout before running your local action?

Ja som tam predtym pridal `@main` pretoze mi to poradil copilot, povodne kde nam to funguje to mame bez toho
https://github.com/keboola/keboola-as-code/blob/2cf95201da2127c8d9ff2aa9a9ecb980222e6d0c/.github/workflows/release-service-stream.yml#L122-L127

Tak to tu davam podobne. 