### PR TITLE
fix: Release CI/CD executed on tagged versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,10 @@
 name: Build and Push Docker Image
 
 on:
-  workflow_dispatch:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
+      - 'v*-dev.*'
 
 env:
   SERVICE_IMAGE_NAME: "keboola/mcp-server"
@@ -37,8 +34,8 @@ jobs:
             type=ref,event=pr
             type=sha,format=long
             type=raw,value=dev-${{ github.sha }},enable=${{ github.event_name == 'pull_request' }}
-            type=raw,value=production-${{ github.sha }},enable={{is_default_branch}}
-            type=raw,value=canary-orion-${{ github.sha }},enable={{is_default_branch}}
+            type=raw,value=production-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
+            type=raw,value=canary-orion-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.') }}
 
       - name: Docker login
         uses: docker/login-action@v3
@@ -59,7 +56,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Trigger image tag update
-        if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/trigger-image-tag-update
         with:
           helm-chart: "mcp-server"


### PR DESCRIPTION
* Change release management for development tags to be deployed on canary stack.
* Release production image only on `vX.Y.Z` versions