### PR TITLE
fix: freeze mcp version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.17.3"
+version = "0.17.4"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Keboola", email = "devel@keboola.com" }]
 dependencies = [
-    "mcp[cli] ~= 1.6",
+    "mcp[cli] == 1.6.0",
     "kbcstorage ~= 0.9",
     "httpx ~= 0.28",
     "google-cloud-bigquery ~= 3.31",


### PR DESCRIPTION
Fixing the error caused by new features in `1.8.` by freezing the mcp version to `1.6.`.