### PR TITLE
Add Data App Creation

### DIFF
--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -4,7 +4,8 @@ from pydantic import AliasChoices, BaseModel, Field
 
 ComponentType = Literal['application', 'extractor', 'writer']
 TransformationType = Literal['transformation']
-AllComponentTypes = Union[ComponentType, TransformationType]
+DataAppType = Literal['dataapp']
+AllComponentTypes = Union[ComponentType, TransformationType, DataAppType]
 
 
 class ReducedComponent(BaseModel):
@@ -161,4 +162,36 @@ class ComponentConfiguration(ReducedComponentConfiguration):
         validation_alias=AliasChoices('component'),
         serialization_alias='component',
         default=None,
+    )
+
+#! Data App
+class DataApp(BaseModel):
+    """Model for Keboola Data App configuration."""
+    
+    slug: str = Field(description='The unique identifier for the data app')
+    streamlit: Optional[dict[str, str]] = Field(
+        description='Streamlit configuration including config.toml and other settings',
+        default=None
+    )
+    script: List[str] = Field(
+        description='List of Python script lines that make up the data app',
+        default_factory=list
+    )
+    size: str = Field(
+        description='The size of the data app instance (tiny, small, medium, large)',
+        default='tiny'
+    )
+    autoSuspendAfterSeconds: int = Field(
+        description='Number of seconds after which the data app will auto-suspend',
+        default=900
+    )
+
+
+class DataAppConfiguration(ComponentConfiguration):
+    """Extended component configuration specifically for data apps."""
+    
+    data_app: DataApp = Field(description='The data app configuration')
+    authorization: Optional[dict[str, Any]] = Field(
+        description='Authorization configuration for the data app',
+        default=None
     )


### PR DESCRIPTION
This still has to go through testing before implemented, but just a proof of concept for creating and generating Data Apps

**Create Data App**
- Added `create_data_app` function that enables creation of new data apps with customizable configurations
- Implemented script generation using the model data app creation
- Connected to `_get_data_context` to get context for the data/what type of data app may make sense
- Added support for custom streamlit configurations and other params
- Only built out for 'None' auth
- TODO add compatibility for added packages

**Data Context Management**
- Implemented `_get_data_context` to gather comprehensive information about available data
- The goal of this is to be able to pass detail to the model to make sure the streamlit generation makes sense for the data in the related buckets

**Models and Configuration**
- Added new data models:
  - `DataApp`: Core model for data app configuration
  - `DataAppConfiguration`: Extended component configuration for data apps

**Notes**
- The `_start_data_app` function is currently a placeholder and will be implemented in a future PR
- Also need to add some `_get_data_app` functionality
- Some TODO items remain for library management in the script generation process