### PR TITLE
Kab 984 fetch config examples

### DIFF
--- a/src/keboola_mcp_server/json-schemas/output/sample_data_ex-generic-v2.jsonl
+++ b/src/keboola_mcp_server/json-schemas/output/sample_data_ex-generic-v2.jsonl
@@ -1,1 +1,0 @@
-{"component_id": "ex-generic-v2", "config_example": {"parameters": {"api": {"baseUrl": "https://catfact.ninja/"}, "config": {"outputBucket": "test", "incrementalOutput": false, "jobs": [{"__NAME": "fact", "endpoint": "fact", "method": "GET", "dataType": "fact", "dataField": {"path": ".", "delimiter": "."}}]}}}, "config_row_example": null} 

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field
 
 from keboola_mcp_server.client import JsonDict, KeboolaClient, SuggestedComponent
+from keboola_mcp_server.errors import tool_errors
 from keboola_mcp_server.tools.components.model import (
     Component,
     ComponentConfigurationOutput,
@@ -87,6 +88,7 @@ def add_component_tools(mcp: FastMCP) -> None:
 # tools #########################################
 
 
+@tool_errors()
 async def retrieve_components_configurations(
     ctx: Context,
     component_types: Annotated[
@@ -141,6 +143,7 @@ async def retrieve_components_configurations(
         return await _retrieve_components_configurations_by_ids(client, component_ids)
 
 
+@tool_errors()
 async def retrieve_transformations_configurations(
     ctx: Context,
     transformation_ids: Annotated[
@@ -183,6 +186,7 @@ async def retrieve_transformations_configurations(
         return await _retrieve_components_configurations_by_ids(client, transformation_ids)
 
 
+@tool_errors()
 async def get_component_detail(
     ctx: Context,
     component_id: Annotated[str, Field(description='Unique identifier of the Keboola component/transformation')],
@@ -208,6 +212,7 @@ async def get_component_detail(
     return await _get_component_details(component_id=component_id, client=client)
 
 
+@tool_errors()
 async def get_component_configuration_details(
     component_id: Annotated[str, Field(description='Unique identifier of the Keboola component/transformation')],
     configuration_id: Annotated[
@@ -271,6 +276,7 @@ async def get_component_configuration_details(
     return ComponentConfigurationOutput.from_component_configuration_response(configuration_response, component)
 
 
+@tool_errors()
 async def create_sql_transformation(
     ctx: Context,
     name: Annotated[
@@ -389,6 +395,7 @@ async def create_sql_transformation(
         raise e
 
 
+@tool_errors()
 async def update_sql_transformation_configuration(
     ctx: Context,
     configuration_id: Annotated[
@@ -480,6 +487,7 @@ async def update_sql_transformation_configuration(
         raise e
 
 
+@tool_errors()
 async def create_component_root_configuration(
     ctx: Context,
     name: Annotated[
@@ -572,6 +580,7 @@ async def create_component_root_configuration(
         raise e
 
 
+@tool_errors()
 async def create_component_row_configuration(
     ctx: Context,
     name: Annotated[
@@ -676,6 +685,7 @@ async def create_component_row_configuration(
         raise e
 
 
+@tool_errors()
 async def update_component_root_configuration(
     ctx: Context,
     name: Annotated[
@@ -783,6 +793,7 @@ async def update_component_root_configuration(
         raise e
 
 
+@tool_errors()
 async def update_component_row_configuration(
     ctx: Context,
     name: Annotated[
@@ -901,6 +912,7 @@ async def update_component_row_configuration(
         raise e
 
 
+@tool_errors()
 async def get_component_configuration_examples(
     ctx: Context,
     component_id: Annotated[
@@ -944,6 +956,7 @@ async def get_component_configuration_examples(
     return markdown
 
 
+@tool_errors()
 async def find_component_id(
     ctx: Context,
     query: Annotated[

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -8,7 +8,6 @@ from pydantic import Field
 from keboola_mcp_server.client import JsonDict, KeboolaClient, SuggestedComponent
 from keboola_mcp_server.errors import tool_errors
 from keboola_mcp_server.tools.components.model import (
-    Component,
     ComponentConfigurationOutput,
     ComponentConfigurationResponse,
     ComponentDetail,
@@ -209,7 +208,8 @@ async def get_component_detail(
             -> returns the details of the component/transformation configuration pair
     """
     client = KeboolaClient.from_state(ctx.session.state)
-    return await _get_component_details(component_id=component_id, client=client)
+    component = await _get_component_details(component_id=component_id, client=client)
+    return ComponentDetail.from_component_response(component)
 
 
 @tool_errors()
@@ -273,7 +273,9 @@ async def get_component_configuration_details(
         }
     )
     # Create Component Configuration Output Object
-    return ComponentConfigurationOutput.from_component_configuration_response(configuration_response, component)
+    return ComponentConfigurationOutput.from_component_configuration_response(
+        configuration_response,
+        ComponentDetail.from_component_response(component))
 
 
 @tool_errors()
@@ -380,7 +382,7 @@ async def create_sql_transformation(
         new_raw_transformation_configuration |
         {
             'component_id': transformation_id,
-            'component': Component.from_component_detail(component),
+            'component': component,
         }
     )
 
@@ -466,7 +468,7 @@ async def update_sql_transformation_configuration(
         updated_raw_configuration |
         {
             'component_id': transformation.component_id,
-            'component': Component.from_component_detail(transformation),
+            'component': transformation,
         }
     )
 

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Annotated, Any, Optional, Sequence, cast
 
+from httpx import HTTPStatusError
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field
 
@@ -913,7 +914,12 @@ async def get_component_configuration_examples(
             -> returns a markdown formatted string with configuration examples
     """
     client = KeboolaClient.from_state(ctx.session.state)
-    raw_component = await client.ai_service_client.get_component_detail(component_id)
+    try:
+        raw_component = await client.ai_service_client.get_component_detail(component_id)
+    except HTTPStatusError:
+        LOG.exception(f'Error when getting component details: {component_id}')
+        return ''
+
     root_examples = raw_component.get('rootConfigurationExamples') or []
     row_examples = raw_component.get('rowConfigurationExamples') or []
 

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -10,7 +10,6 @@ from keboola_mcp_server.tools.components.model import (
     Component,
     ComponentConfigurationMetadata,
     ComponentConfigurationResponse,
-    ComponentDetail,
     ComponentType,
     ComponentWithConfigurations,
     ReducedComponent,
@@ -148,24 +147,22 @@ async def _retrieve_components_configurations_by_ids(
 async def _get_component_details(
     client: KeboolaClient,
     component_id: str,
-) -> ComponentDetail:
+) -> Component:
     """
-    Utility function to retrieve the component details by component ID, used in tools:
-    - get_component_configuration_details
+    Retrieve component details by component ID.
 
     First tries to get component details from the AI service catalog. If the component
-    is not found (404) or returns empty data (private components), falls back to using the
+    is not found (404) or returns empty data (private components), it falls back to using the
     Storage API endpoint.
 
-    :param component_id: The ID of the Keboola component/transformation you want details about
-    :param client: The Keboola client
-    :return: The component details
+    :param component_id: ID of the Keboola component/transformation to get details for
+    :param client: Keboola client instance
+    :return: Component instance containing the component information
     """
-    component_info: Component
     try:
         raw_component = await client.ai_service_client.get_component_detail(component_id=component_id)
         LOG.info(f'Retrieved component details for component {component_id} from AI service catalog.')
-        component_info = Component.model_validate(raw_component)
+        return Component.model_validate(raw_component)
     except HTTPStatusError as e:
         if e.response.status_code == 404:
             LOG.info(
@@ -176,12 +173,10 @@ async def _get_component_details(
             endpoint = f'branch/{client.storage_client.branch_id}/components/{component_id}'
             raw_component = await client.storage_client.get(endpoint=endpoint)
             LOG.info(f'Retrieved component details for component {component_id} from Storage API.')
-            component_info = Component.model_validate(raw_component)
+            return Component.model_validate(raw_component)
         else:
             # If it's not a 404, re-raise the error
             raise
-
-    return ComponentDetail.from_component_response(component_info)
 
 
 def _get_sql_transformation_id_from_sql_dialect(

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -145,25 +145,6 @@ async def _retrieve_components_configurations_by_ids(
     return components_with_configurations
 
 
-async def _get_component_flags(client: KeboolaClient, component_id: str) -> list[str]:
-    """
-    Utility function to retrieve the component flags by component ID.
-
-
-    :param client: The Keboola client
-    :param component_id: The ID of the Keboola component you want details about
-    """
-    available_components = await client.storage_client.get('', params={'exclude': 'componentDetails'})
-
-    # retrieve component info
-    component_info = next(
-        (component for component in available_components.get('components', []) if component['id'] == component_id),
-        {},
-    )
-
-    return component_info.get('flags', [])
-
-
 async def _get_component_details(
     client: KeboolaClient,
     component_id: str,
@@ -185,8 +166,6 @@ async def _get_component_details(
         raw_component = await client.ai_service_client.get_component_detail(component_id=component_id)
         LOG.info(f'Retrieved component details for component {component_id} from AI service catalog.')
         component_info = Component.model_validate(raw_component)
-        component_info.flags = await _get_component_flags(client, component_id)
-        # get component flags
     except HTTPStatusError as e:
         if e.response.status_code == 404:
             LOG.info(

--- a/tests/tools/components/conftest.py
+++ b/tests/tools/components/conftest.py
@@ -79,6 +79,8 @@ def mock_component() -> dict[str, Any]:
         'configurationSchema': {},
         'configurationDescription': 'Extract data from AWS S3',
         'emptyConfiguration': {},
+        'rootConfigurationExamples': [{'foo': 'root'}],
+        'rowConfigurationExamples': [{'foo': 'row'}],
     }
 
 

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -1,6 +1,5 @@
 
 from typing import Any, Callable
-from unittest.mock import call
 
 import pytest
 from mcp.server.fastmcp import Context
@@ -236,7 +235,7 @@ async def test_get_component_configuration_details(
     keboola_client.ai_service_client = mocker.MagicMock()
     keboola_client.ai_service_client.get_component_detail = mocker.AsyncMock(return_value=mock_component)
     keboola_client.storage_client.configuration_detail = mocker.AsyncMock(return_value=mock_configuration)
-    keboola_client.storage_client.get = mocker.AsyncMock(side_effect=[{'components': []}, mock_metadata])
+    keboola_client.storage_client.get = mocker.AsyncMock(return_value=mock_metadata)
 
     result = await get_component_configuration_details(
         component_id='keboola.ex-aws-s3', configuration_id='123', ctx=context
@@ -257,13 +256,11 @@ async def test_get_component_configuration_details(
 
     keboola_client.ai_service_client.get_component_detail.assert_called_once_with(component_id=mock_component['id'])
 
-    keboola_client.storage_client.get.assert_has_calls(calls=[
-        call('', params={'exclude': 'componentDetails'}),
-        call(endpoint=f'branch/{mock_branch_id}/'
-                      f'components/{mock_component["id"]}/'
-                      f'configs/{mock_configuration["id"]}/'
-                      'metadata')
-    ])
+    keboola_client.storage_client.get.assert_called_once_with(
+        endpoint=f'branch/{mock_branch_id}/'
+                 f'components/{mock_component["id"]}/'
+                 f'configs/{mock_configuration["id"]}/'
+                 'metadata')
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -24,6 +24,7 @@ from keboola_mcp_server.tools.components.model import (
     ComponentDetail,
     ReducedComponentDetail,
 )
+from keboola_mcp_server.tools.components.tools import get_component_configuration_examples
 from keboola_mcp_server.tools.sql import WorkspaceManager
 
 
@@ -436,3 +437,40 @@ async def test_update_transformation_configuration(
         updated_description=None,
         is_disabled=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_get_component_configuration_examples(
+        mocker: MockerFixture,
+        mcp_context_components_configs: Context,
+        mock_component: dict[str, Any],
+):
+    context = mcp_context_components_configs
+    keboola_client = KeboolaClient.from_state(context.session.state)
+
+    # Setup mock to return test data
+    keboola_client.ai_service_client = mocker.MagicMock()
+    keboola_client.ai_service_client.get_component_detail = mocker.AsyncMock(return_value=mock_component)
+
+    text = await get_component_configuration_examples(component_id='keboola.ex-aws-s3', ctx=context)
+    assert text == """# Configuration Examples for `keboola.ex-aws-s3`
+
+## Root Configuration Examples
+
+1. Root Configuration:
+```json
+{
+  "foo": "root"
+}
+```
+
+## Row Configuration Examples
+
+1. Row Configuration:
+```json
+{
+  "foo": "row"
+}
+```
+
+"""

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -319,9 +319,7 @@ async def test_create_transformation_configuration(
         {
             **configuration,
             'component_id': expected_component_id,
-            # TODO: fix this -- we don't compare the flags, because Component.from_component_detail() function
-            #  cannot set flags correctly
-            'component': {**component, 'flags': []}
+            'component': {**component}
         }
     )
 


### PR DESCRIPTION
This links `get_component_configuration_examples()` tool to `GET /docs/components/{component_id}` endpoint in AI Service which pulls `ComponentInfo` data including the configuration examples from KaiBot.