### PR TITLE
feat: Allow updating production Helm chart, cleanup Docker tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,9 @@ jobs:
           images: |
             ${{ env.SERVICE_IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=sha,format=long
-            type=raw,value=dev-${{ github.sha }},enable=${{ github.event_name == 'pull_request' }}
             type=raw,value=production-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
             type=raw,value=canary-orion-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.') }}
 
       - name: Docker login
@@ -55,9 +53,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Trigger image tag update
+      - name: Trigger image tag update for canary-orion
         uses: ./.github/actions/trigger-image-tag-update
+        if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.')
         with:
           helm-chart: "mcp-server"
           image-tag: canary-orion-${{ github.sha }}
+          github-app-private-key: ${{ secrets.GITOPS_KBC_STACKS_TRIGGER_APP_PVK }}
+
+      - name: Trigger image tag update for production
+        uses: ./.github/actions/trigger-image-tag-update
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.')
+        with:
+          helm-chart: "mcp-server"
+          image-tag: production-${{ github.sha }}
           github-app-private-key: ${{ secrets.GITOPS_KBC_STACKS_TRIGGER_APP_PVK }}


### PR DESCRIPTION
This should ensure CI/CD for production deployments.

- `v*` tags produce `production-*` tag for production stacks.
- `v*` tags also produce `latest` tag.
- `v*-dev.*` tags prodduce `canary-orion-*` tag for Orion stack.

Removed some never-true tags from `docker/metadata-action` step.