### PR TITLE
Kab 984 consolidate component models

### DIFF
--- a/integtests/components/test_tools.py
+++ b/integtests/components/test_tools.py
@@ -7,7 +7,7 @@ from integtests.conftest import ConfigDef
 from keboola_mcp_server.tools.components import (
     ComponentType,
     ComponentWithConfigurations,
-    get_component_configuration_details,
+    get_component_configuration,
     retrieve_components_configurations,
 )
 from keboola_mcp_server.tools.components.model import ComponentConfigurationOutput
@@ -17,23 +17,24 @@ LOG = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
 async def test_get_component_configuration_details(mcp_context: Context, configs: list[ConfigDef]):
-    """Tests that `get_component_configuration_details` returns a `ComponentConfiguration` instance."""
+    """Tests that `get_component_configuration` returns a `ComponentConfigurationOutput` instance."""
 
     for config in configs:
         assert config.configuration_id is not None
 
-        result = await get_component_configuration_details(
+        result = await get_component_configuration(
             component_id=config.component_id, configuration_id=config.configuration_id, ctx=mcp_context
         )
 
         assert isinstance(result, ComponentConfigurationOutput)
-        assert result.component_details is not None
-        assert result.component_details.component_id == config.component_id
-        assert result.component_details.component_type is not None
-        assert result.component_details.component_name is not None
+        assert result.component is not None
+        assert result.component.component_id == config.component_id
+        assert result.component.component_type is not None
+        assert result.component.component_name is not None
 
         assert result.root_configuration is not None
         assert result.root_configuration.configuration_id == config.configuration_id
+        assert result.root_configuration.component_id == config.component_id
 
 
 @pytest.mark.asyncio

--- a/integtests/components/test_tools.py
+++ b/integtests/components/test_tools.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-async def test_get_component_configuration_details(mcp_context: Context, configs: list[ConfigDef]):
+async def test_get_component_configuration(mcp_context: Context, configs: list[ConfigDef]):
     """Tests that `get_component_configuration` returns a `ComponentConfigurationOutput` instance."""
 
     for config in configs:

--- a/integtests/conftest.py
+++ b/integtests/conftest.py
@@ -157,9 +157,7 @@ def _create_configs(storage_client: SyncStorageClient) -> list[ConfigDef]:
 
 
 @pytest.fixture(scope='session')
-def keboola_project(
-    env_file_loaded: bool
-) -> Generator[ProjectDef, Any, None]:
+def keboola_project(env_file_loaded: bool) -> Generator[ProjectDef, Any, None]:
     """
     Sets up a Keboola project with items needed for integration tests,
     such as buckets, tables and configurations.
@@ -200,9 +198,7 @@ def keboola_project(
         storage_client.buckets.delete(bucket_id, force=True)
 
     for config in configs:
-        LOG.info(
-            f'Deleting config with component ID={config.component_id} and config ID={config.configuration_id}'
-        )
+        LOG.info(f'Deleting config with component ID={config.component_id} and config ID={config.configuration_id}')
         storage_client.configurations.delete(config.component_id, config.configuration_id)
 
 

--- a/src/keboola_mcp_server/tools/components/__init__.py
+++ b/src/keboola_mcp_server/tools/components/__init__.py
@@ -6,12 +6,12 @@ from keboola_mcp_server.tools.components.model import (
     ReducedComponent,
 )
 from keboola_mcp_server.tools.components.tools import (
-    GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME,
+    GET_COMPONENT_CONFIGURATION_TOOL_NAME,
     RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME,
     RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME,
     add_component_tools,
     create_sql_transformation,
-    get_component_configuration_details,
+    get_component_configuration,
     retrieve_components_configurations,
     retrieve_transformations_configurations,
     update_sql_transformation_configuration,

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -191,7 +191,7 @@ class ComponentConfigurationResponse(ComponentConfigurationResponseBase):
     )
     configuration_metadata: list[dict[str, Any]] = Field(
         description='The metadata of the component configuration',
-        default=[],
+        default_factory=list,
         validation_alias=AliasChoices(
             'metadata', 'configuration_metadata', 'configurationMetadata', 'configuration-metadata'
         ),
@@ -222,7 +222,7 @@ class ComponentRowConfiguration(ComponentConfigurationResponseBase):
     )
     configuration_metadata: list[dict[str, Any]] = Field(
         description='The metadata of the component configuration',
-        default=[],
+        default_factory=list,
         validation_alias=AliasChoices(
             'metadata', 'configuration_metadata', 'configurationMetadata', 'configuration-metadata'
         ),
@@ -247,7 +247,7 @@ class ComponentRootConfiguration(ComponentConfigurationResponseBase):
     )
     configuration_metadata: list[dict[str, Any]] = Field(
         description='The metadata of the component configuration',
-        default=list,
+        default_factory=list,
         validation_alias=AliasChoices(
             'metadata', 'configuration_metadata', 'configurationMetadata', 'configuration-metadata'
         ),

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -247,7 +247,7 @@ class ComponentRootConfiguration(ComponentConfigurationResponseBase):
     )
     configuration_metadata: list[dict[str, Any]] = Field(
         description='The metadata of the component configuration',
-        default=[],
+        default=list,
         validation_alias=AliasChoices(
             'metadata', 'configuration_metadata', 'configurationMetadata', 'configuration-metadata'
         ),

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -295,11 +295,11 @@ class ComponentConfigurationMetadata(BaseModel):
         """
         Create a ComponentConfigurationMetadata instance from a ComponentConfigurationResponse instance.
         """
-        root_configuration: ComponentConfigurationResponseBase = configuration
+        root_configuration = ComponentConfigurationResponseBase.model_validate(configuration.model_dump())
         row_configurations = None
         if configuration.rows:
             row_configurations = [
-                ComponentConfigurationResponse.model_validate(row) for row in configuration.rows if row is not None
+                ComponentConfigurationResponseBase.model_validate(row) for row in configuration.rows if row is not None
             ]
         return cls(root_configuration=root_configuration, row_configurations=row_configurations)
 

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -257,7 +257,8 @@ class ComponentRootConfiguration(ComponentConfigurationResponseBase):
 
 class ComponentConfigurationOutput(BaseModel):
     """
-    Output model for component configuration, containing the root configuration and optional row configurations.
+    The MCP tools' output model for component configuration, containing the root configuration and optional
+    row configurations.
     """
 
     root_configuration: ComponentRootConfiguration = Field(

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -11,14 +11,13 @@ from keboola_mcp_server.tools.components.model import (
     Component,
     ComponentConfigurationOutput,
     ComponentConfigurationResponse,
-    ComponentDetail,
     ComponentRootConfiguration,
     ComponentRowConfiguration,
     ComponentType,
     ComponentWithConfigurations,
 )
 from keboola_mcp_server.tools.components.utils import (
-    _get_component_details,
+    _get_component,
     _get_sql_transformation_id_from_sql_dialect,
     _get_transformation_configuration,
     _handle_component_types,
@@ -37,14 +36,14 @@ LOG = logging.getLogger(__name__)
 # providing the same functionality as described in the original tool names.
 RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME: str = 'retrieve_component_configurations'
 RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME: str = 'retrieve_transformations'
-GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME: str = 'get_component_configuration_details'
+GET_COMPONENT_CONFIGURATION_TOOL_NAME: str = 'get_component_configuration'
 
 
 def add_component_tools(mcp: FastMCP) -> None:
     """Add tools to the MCP server."""
 
-    mcp.add_tool(get_component_configuration_details, name=GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME)
-    LOG.info(f'Added tool: {GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME}.')
+    mcp.add_tool(get_component_configuration, name=GET_COMPONENT_CONFIGURATION_TOOL_NAME)
+    LOG.info(f'Added tool: {GET_COMPONENT_CONFIGURATION_TOOL_NAME}.')
 
     mcp.add_tool(retrieve_components_configurations, name=RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME)
     LOG.info(f'Added tool: {RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME}.')
@@ -61,8 +60,8 @@ def add_component_tools(mcp: FastMCP) -> None:
     mcp.add_tool(update_sql_transformation_configuration)
     LOG.info(f'Added tool: {update_sql_transformation_configuration.__name__}.')
 
-    mcp.add_tool(get_component_detail)
-    LOG.info(f'Added tool: {get_component_detail.__name__}.')
+    mcp.add_tool(get_component)
+    LOG.info(f'Added tool: {get_component.__name__}.')
 
     mcp.add_tool(create_component_root_configuration)
     LOG.info(f'Added tool: {create_component_root_configuration.__name__}.')
@@ -111,7 +110,7 @@ async def retrieve_components_configurations(
 ]:
     """
     Retrieves configurations of components present in the project,
-    optionally filtered by component types or specific component IDs
+    optionally filtered by component types or specific component IDs.
     If component_ids are supplied, only those components identified by the IDs are retrieved, disregarding
     component_types.
 
@@ -187,93 +186,100 @@ async def retrieve_transformations_configurations(
 
 
 @tool_errors()
-async def get_component_detail(
+async def get_component(
     ctx: Context,
-    component_id: Annotated[str, Field(description='Unique identifier of the Keboola component/transformation')],
+    component_id: Annotated[str, Field(description='ID of the component/transformation')],
 ) -> Annotated[
-    ComponentDetail,
+    Component,
     Field(
-        description='Detailed information about a Keboola component.',
+        description='The component.',
     ),
 ]:
     """
-    Gets detailed information about a specific Keboola component given component ID.
+    Gets information about a specific component given its ID.
+
     USAGE:
-        - Use when you want to see the details of a specific component to get its documentation, configuration schemas
-        ,etc. Especially in situation when the users asks to create or update a component configuration.
-        This tool is mainly for internal use by the agent.
+        - Use when you want to see the details of a specific component to get its documentation, configuration schemas,
+          etc. Especially in situation when the users asks to create or update a component configuration.
+          This tool is mainly for internal use by the agent.
+
     EXAMPLES:
         - user_input: `Create a generic extractor configuration for x`
             -> Set the component_id if you know it or find the component_id by find_component_id
                or docs use tool and set it
-            -> returns the details of the component/transformation configuration pair
+            -> returns the component
     """
     client = KeboolaClient.from_state(ctx.session.state)
-    return await _get_component_details(component_id=component_id, client=client)
+    return await _get_component(component_id=component_id, client=client)
 
 
 @tool_errors()
-async def get_component_configuration_details(
-    component_id: Annotated[str, Field(description='Unique identifier of the Keboola component/transformation')],
+async def get_component_configuration(
+    component_id: Annotated[str, Field(description='ID of the component/transformation')],
     configuration_id: Annotated[
         str,
         Field(
-            description='Unique identifier of the Keboola component/transformation configuration you want details '
-            'about',
+            description='ID of the component/transformation configuration',
         ),
     ],
     ctx: Context,
 ) -> Annotated[
     ComponentConfigurationOutput,
     Field(
-        description='Detailed information about a Keboola component/transformation and its configuration.',
+        description='The component/transformation and its configuration.',
     ),
 ]:
     """
-    Gets detailed information about a specific Keboola component configuration given component/transformation ID and
-    configuration ID.
+    Gets information about a specific component/transformation configuration.
 
     USAGE:
-    - Use when you want to see the details of a specific component/transformation configuration.
+    - Use when you want to see the configuration of a specific component/transformation.
 
     EXAMPLES:
     - user_input: `give me details about this configuration`
         - set component_id and configuration_id to the specific component/transformation ID and configuration ID
           if you know it
-        - returns the details of the component/transformation configuration pair
+        - returns the component/transformation configuration pair
     """
-
     client = KeboolaClient.from_state(ctx.session.state)
-
-    # Get Component Details
-    component = await _get_component_details(client=client, component_id=component_id)
-    # Get Configuration Details
-    raw_configuration = await client.storage_client.configuration_detail(
-        component_id=component_id, configuration_id=configuration_id
+    component = await _get_component(client=client, component_id=component_id)
+    raw_configuration = cast(
+        JsonDict,
+        await client.storage_client.get(
+            endpoint=f'branch/{client.storage_client.branch_id}/components/{component_id}/configs/{configuration_id}'
+        ),
     )
-    LOG.info(f'Retrieved configuration details for {component_id} component with configuration {configuration_id}.')
-
-    # Get Configuration Metadata if exists
-    endpoint = (
-        f'branch/{client.storage_client.branch_id}/components/{component_id}/configs/{configuration_id}/metadata'
-    )
-    r_metadata = await client.storage_client.get(endpoint=endpoint)
-    if r_metadata:
-        LOG.info(
-            f'Retrieved configuration metadata for {component_id} component with configuration {configuration_id}.'
-        )
-    else:
-        LOG.info(f'No metadata found for {component_id} component with configuration {configuration_id}.')
-    # Create Component Configuration Detail Object
     configuration_response = ComponentConfigurationResponse.model_validate(
-        {
-            **raw_configuration,
-            'component_id': component_id,
-            'metadata': r_metadata,
-        }
+        {**raw_configuration, 'component_id': component_id}
     )
-    # Create Component Configuration Output Object
-    return ComponentConfigurationOutput.from_component_configuration_response(configuration_response, component)
+
+    # Create root configuration
+    root_configuration = ComponentRootConfiguration(
+        **configuration_response.model_dump(exclude={'configuration'}),
+        root_configuration=configuration_response.configuration.get('parameters', {}),
+        storage=configuration_response.configuration.get('storage'),
+    )
+
+    # Create row configurations if they exist
+    row_configurations = None
+    if configuration_response.rows:
+        row_configurations = []
+        for row in configuration_response.rows:
+            if row is None:
+                continue
+            row_configuration = ComponentRowConfiguration(
+                **row,
+                component_id=configuration_response.component_id,
+                row_configuration=row.get('configuration', {}).get('parameters', {}),
+                storage=row.get('configuration', {}).get('storage'),
+            )
+            row_configurations.append(row_configuration)
+
+    return ComponentConfigurationOutput(
+        root_configuration=root_configuration,
+        row_configurations=row_configurations,
+        component=component,
+    )
 
 
 @tool_errors()
@@ -373,15 +379,15 @@ async def create_sql_transformation(
                     'description': description,
                     'configuration': transformation_configuration_payload.model_dump(),
                 },
-            )
+            ),
         )
 
-        component = await _get_component_details(client=client, component_id=transformation_id)
+        component = await _get_component(client=client, component_id=transformation_id)
         new_transformation_configuration = ComponentConfigurationResponse.model_validate(
-            new_raw_transformation_configuration |
-            {
+            new_raw_transformation_configuration
+            | {
                 'component_id': transformation_id,
-                'component': Component.from_component_detail(component),
+                'component': component,
             }
         )
 
@@ -400,12 +406,12 @@ async def update_sql_transformation_configuration(
     ctx: Context,
     configuration_id: Annotated[
         str,
-        Field(description='Unique identifier of the Keboola transformation configuration you want to update'),
+        Field(description='ID of the transformation configuration to update'),
     ],
     change_description: Annotated[
         str,
         Field(
-            description='Detailed description of the new changes to the transformation configuration.',
+            description='Description of the changes made to the transformation configuration.',
         ),
     ],
     updated_configuration: Annotated[
@@ -420,7 +426,7 @@ async def update_sql_transformation_configuration(
     updated_description: Annotated[
         str,
         Field(
-            description='Updated existing transformation description reflecting the changes made in the behavior of '
+            description='Updated transformation description reflecting the changes made in the behavior of '
             'the transformation. If no behavior changes are made, empty string preserves the original description.',
         ),
     ] = '',
@@ -466,12 +472,12 @@ async def update_sql_transformation_configuration(
             is_disabled=is_disabled,
         )
 
-        transformation = await _get_component_details(client=client, component_id=sql_transformation_id)
+        transformation = await _get_component(client=client, component_id=sql_transformation_id)
         updated_transformation_configuration = ComponentConfigurationResponse.model_validate(
-            updated_raw_configuration |
-            {
+            updated_raw_configuration
+            | {
                 'component_id': transformation.component_id,
-                'component': Component.from_component_detail(transformation),
+                'component': transformation,
             }
         )
 
@@ -526,23 +532,24 @@ async def create_component_root_configuration(
 ) -> Annotated[
     ComponentRootConfiguration,
     Field(
-        description='Created component root configuration object,',
+        description='Created component root configuration.',
     ),
 ]:
     """
     Creates a component configuration using the specified name, component ID, configuration JSON, and description.
+
     CONSIDERATIONS:
         The root_configuration JSON object must follow the root_configuration_schema of the specified component.
         It can also adhere to the appropriate configuration examples if available.
 
     USAGE:
         - Use when you want to create a new root configuration for a specific component.
+
     EXAMPLES:
         - user_input: `Create a new configuration for component X with these settings`
             -> set the component_id and configuration parameters accordingly
             -> returns the created component configuration if successful.
     """
-
     client = KeboolaClient.from_state(ctx.session.state)
 
     LOG.info(f'Creating new configuration: {name} for component: {component_id}.')
@@ -625,7 +632,7 @@ async def create_component_row_configuration(
 ) -> Annotated[
     ComponentRowConfiguration,
     Field(
-        description='Created component row configuration object,',
+        description='Created component row configuration.',
     ),
 ]:
     """
@@ -637,13 +644,13 @@ async def create_component_row_configuration(
         It can also adhere to the appropriate configuration examples if available.
 
     USAGE:
-        - Use when you want to create a new root configuration for a specific component.
+        - Use when you want to create a new row configuration for a specific component configuration.
+
     EXAMPLES:
         - user_input: `Create a new configuration for component X with these settings`
-            -> set the component_id and configuration parameters accordingly
+            -> set the component_id, configuration_id and configuration parameters accordingly
             -> returns the created component configuration if successful.
     """
-
     client = KeboolaClient.from_state(ctx.session.state)
 
     LOG.info(
@@ -737,23 +744,25 @@ async def update_component_root_configuration(
 ) -> Annotated[
     ComponentRootConfiguration,
     Field(
-        description='Created component root configuration object,',
+        description='Updated component root configuration.',
     ),
 ]:
     """
     Updates a specific component configuration using given by component ID, and configuration ID.
+
     CONSIDERATIONS:
         The root_configuration JSON object must follow the root_configuration_schema of the specified component.
         It can also adhere to the appropriate configuration examples if available.
+
     USAGE:
         - Use when you want to update a root configuration of a specific component.
+
     EXAMPLES:
         - user_input: `Update a configuration for component X and configuration ID 1234 with these settings`
             -> set the component_id, configuration_id and configuration parameters accordingly.
             -> set the change_description to the description of the change made to the component configuration.
-            -> returns the created component configuration if successful.
+            -> returns the updated component configuration if successful.
     """
-
     client = KeboolaClient.from_state(ctx.session.state)
 
     LOG.info(f'Updating configuration: {name} for component: {component_id} and configuration ID {configuration_id}.')
@@ -783,13 +792,13 @@ async def update_component_root_configuration(
         )
 
         LOG.info(
-            f'Created new configuration for component "{component_id}" with configuration id '
+            f'Updated configuration for component "{component_id}" with configuration id '
             f'"{new_configuration.configuration_id}".'
         )
 
         return new_configuration
     except Exception as e:
-        LOG.exception(f'Error when creating new component configuration: {e}')
+        LOG.exception(f'Error when updating component configuration: {e}')
         raise e
 
 
@@ -850,7 +859,7 @@ async def update_component_row_configuration(
 ) -> Annotated[
     ComponentRowConfiguration,
     Field(
-        description='Created component row configuration object,',
+        description='Updated component row configuration.',
     ),
 ]:
     """
@@ -863,12 +872,12 @@ async def update_component_row_configuration(
 
     USAGE:
         - Use when you want to update a row configuration for a specific component and configuration.
+
     EXAMPLES:
         - user_input: `Update a configuration row of configuration ID 123 for component X with these settings`
             -> set the component_id, configuration_id, configuration_row_id and configuration parameters accordingly
-            -> returns the created component configuration if successful.
+            -> returns the updated component configuration if successful.
     """
-
     client = KeboolaClient.from_state(ctx.session.state)
 
     LOG.info(
@@ -902,13 +911,13 @@ async def update_component_row_configuration(
         )
 
         LOG.info(
-            f'Created new configuration for component "{component_id}" with configuration id '
+            f'Updated configuration for component "{component_id}" with configuration id '
             f'"{new_configuration.configuration_id}".'
         )
 
         return new_configuration
     except Exception as e:
-        LOG.exception(f'Error when creating new component configuration: {e}')
+        LOG.exception(f'Error when updating component configuration: {e}')
         raise e
 
 
@@ -928,9 +937,11 @@ async def get_component_configuration_examples(
     ),
 ]:
     """
-    Retrieves sample configuration examples for a specific component from a JSONL file.
+    Retrieves sample configuration examples for a specific component.
+
     USAGE:
         - Use when you want to see example configurations for a specific component.
+
     EXAMPLES:
         - user_input: `Show me example configurations for component X`
             -> set the component_id parameter accordingly
@@ -945,12 +956,12 @@ async def get_component_configuration_examples(
 
     if root_examples:
         markdown += '## Root Configuration Examples\n\n'
-        for i, example in enumerate(root_examples, 1):
+        for i, example in enumerate(root_examples, start=1):
             markdown += f'{i}. Root Configuration:\n```json\n{json.dumps(example, indent=2)}\n```\n\n'
 
     if row_examples:
         markdown += '## Row Configuration Examples\n\n'
-        for i, example in enumerate(row_examples, 1):
+        for i, example in enumerate(row_examples, start=1):
             markdown += f'{i}. Row Configuration:\n```json\n{json.dumps(example, indent=2)}\n```\n\n'
 
     return markdown
@@ -968,8 +979,10 @@ async def find_component_id(
 ) -> list[SuggestedComponent]:
     """
     Returns list of component IDs that match the given query.
+
     USAGE:
         - Use when you want to find the component for a specific purpose.
+
     EXAMPLES:
         - user_input: `I am looking for a salesforce extractor component`
             -> returns a list of component IDs that match the query, ordered by relevance/best match.

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -234,10 +234,10 @@ class TransformationConfiguration(BaseModel):
                 destination: Optional[str] = Field(description='The destination table name', default=None)
                 source: Optional[str] = Field(description='The source table name', default=None)
 
-            tables: list[Table] = Field(description='The tables used in the transformation', default=[])
+            tables: list[Table] = Field(description='The tables used in the transformation', default_factory=list)
 
-        input: Destination = Field(description='The input tables for the transformation', default=Destination())
-        output: Destination = Field(description='The output tables for the transformation', default=Destination())
+        input: Destination = Field(description='The input tables for the transformation', default_factory=Destination)
+        output: Destination = Field(description='The output tables for the transformation', default_factory=Destination)
 
     parameters: Parameters = Field(description='The parameters for the transformation')
     storage: Storage = Field(description='The storage configuration for the transformation')

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -10,11 +10,9 @@ from keboola_mcp_server.tools.components.model import (
     Component,
     ComponentConfigurationMetadata,
     ComponentConfigurationResponse,
-    ComponentDetail,
     ComponentType,
     ComponentWithConfigurations,
     ReducedComponent,
-    ReducedComponentDetail,
 )
 
 LOG = logging.getLogger(__name__)
@@ -24,8 +22,9 @@ def _handle_component_types(
     types: Optional[Union[ComponentType, Sequence[ComponentType]]],
 ) -> Sequence[ComponentType]:
     """
-    Utility function to handle the component types [extractors, writers, applications, all]
+    Utility function to handle the component types [extractors, writers, applications, all].
     If the types include "all", it will be removed and the remaining types will be returned.
+
     :param types: The component types/type to process.
     :return: The processed component types.
     """
@@ -40,20 +39,22 @@ async def _retrieve_components_configurations_by_types(
     client: KeboolaClient, component_types: Sequence[AllComponentTypes]
 ) -> list[ComponentWithConfigurations]:
     """
-    Utility function to retrieve components with configurations by types - used in tools:
+    Utility function to retrieve components with configurations by types.
+
+    Used in tools:
     - retrieve_components_configurations
     - retrieve_transformation_configurations
+
     :param client: The Keboola client
     :param component_types: The component types/type to retrieve
-    :return: a list of items, each containing a component and its associated configurations
+    :return: A list of items, each containing a component and its associated configurations
     """
-
     endpoint = f'branch/{client.storage_client.branch_id}/components'
     # retrieve components by types - unable to use list of types as parameter, we need to iterate over types
 
     components_with_configurations = []
+
     for _type in component_types:
-        # retrieve components by type with configurations
         params = {
             'include': 'configuration',
             'componentType': _type,
@@ -79,14 +80,11 @@ async def _retrieve_components_configurations_by_types(
 
             components_with_configurations.append(
                 ComponentWithConfigurations(
-                    component=ReducedComponentDetail.from_component_response(
-                        ReducedComponent.model_validate(raw_component)
-                    ),
+                    component=ReducedComponent.model_validate(raw_component),
                     configurations=configurations_metadata,
                 )
             )
 
-    # perform logging
     total_configurations = sum(len(component.configurations) for component in components_with_configurations)
     LOG.info(
         f'Found {len(components_with_configurations)} components with total of {total_configurations} configurations '
@@ -99,18 +97,21 @@ async def _retrieve_components_configurations_by_ids(
     client: KeboolaClient, component_ids: Sequence[str]
 ) -> list[ComponentWithConfigurations]:
     """
-    Utility function to retrieve components with configurations by component IDs - used in tools:
+    Utility function to retrieve components with configurations by component IDs.
+
+    Used in tools:
     - retrieve_components_configurations
     - retrieve_transformation_configurations
+
     :param client: The Keboola client
     :param component_ids: The component IDs to retrieve
-    :return: a list of items, each containing a component and its associated configurations
+    :return: A list of items, each containing a component and its associated configurations
     """
     components_with_configurations = []
     for component_id in component_ids:
         # retrieve configurations for component ids
         raw_configurations = await client.storage_client.configuration_list(component_id=component_id)
-        # retrieve component details
+        # retrieve components
         raw_component = cast(
             JsonDict,
             await client.storage_client.get(
@@ -129,14 +130,11 @@ async def _retrieve_components_configurations_by_ids(
 
         components_with_configurations.append(
             ComponentWithConfigurations(
-                component=ReducedComponentDetail.from_component_response(
-                    ReducedComponent.model_validate(raw_component)
-                ),
+                component=ReducedComponent.model_validate(raw_component),
                 configurations=configurations_metadata,
             )
         )
 
-    # perform logging
     total_configurations = sum(len(component.configurations) for component in components_with_configurations)
     LOG.info(
         f'Found {len(components_with_configurations)} components with total of {total_configurations} configurations '
@@ -145,27 +143,28 @@ async def _retrieve_components_configurations_by_ids(
     return components_with_configurations
 
 
-async def _get_component_details(
+async def _get_component(
     client: KeboolaClient,
     component_id: str,
-) -> ComponentDetail:
+) -> Component:
     """
-    Utility function to retrieve the component details by component ID, used in tools:
-    - get_component_configuration_details
+    Utility function to retrieve a component by ID.
 
-    First tries to get component details from the AI service catalog. If the component
+    First tries to get component from the AI service catalog. If the component
     is not found (404) or returns empty data (private components), falls back to using the
     Storage API endpoint.
 
-    :param component_id: The ID of the Keboola component/transformation you want details about
+    Used in tools:
+    - get_component_configuration_details
+
     :param client: The Keboola client
-    :return: The component details
+    :param component_id: The ID of the component to retrieve
+    :return: The component
     """
-    component_info: Component
     try:
         raw_component = await client.ai_service_client.get_component_detail(component_id=component_id)
-        LOG.info(f'Retrieved component details for component {component_id} from AI service catalog.')
-        component_info = Component.model_validate(raw_component)
+        LOG.info(f'Retrieved component {component_id} from AI service catalog.')
+        return Component.model_validate(raw_component)
     except HTTPStatusError as e:
         if e.response.status_code == 404:
             LOG.info(
@@ -175,13 +174,11 @@ async def _get_component_details(
 
             endpoint = f'branch/{client.storage_client.branch_id}/components/{component_id}'
             raw_component = await client.storage_client.get(endpoint=endpoint)
-            LOG.info(f'Retrieved component details for component {component_id} from Storage API.')
-            component_info = Component.model_validate(raw_component)
+            LOG.info(f'Retrieved component {component_id} from Storage API.')
+            return Component.model_validate(raw_component)
         else:
             # If it's not a 404, re-raise the error
             raise
-
-    return ComponentDetail.from_component_response(component_info)
 
 
 def _get_sql_transformation_id_from_sql_dialect(
@@ -189,6 +186,7 @@ def _get_sql_transformation_id_from_sql_dialect(
 ) -> str:
     """
     Utility function to retrieve the SQL transformation ID from the given SQL dialect.
+
     :param sql_dialect: The SQL dialect
     :return: The SQL transformation ID
     :raises ValueError: If the SQL dialect is not supported
@@ -251,12 +249,12 @@ def _get_transformation_configuration(
     """
     Utility function to set the transformation configuration from code statements.
     It creates the expected configuration for the transformation, parameters and storage.
+
     :param statements: The code statements (sql for now)
     :param transformation_name: The name of the transformation from which the bucket name is derived as in the UI
     :param output_tables: The output tables of the transformation, created by the code statements
-    :return: dictionary with parameters and storage following the TransformationConfiguration schema
+    :return: Dictionary with parameters and storage following the TransformationConfiguration schema
     """
-    # init Storage Configuration with empty input and output tables
     storage = TransformationConfiguration.Storage()
     # build parameters configuration out of code statements
     parameters = TransformationConfiguration.Parameters(

--- a/src/keboola_mcp_server/tools/storage.py
+++ b/src/keboola_mcp_server/tools/storage.py
@@ -172,15 +172,14 @@ async def get_table_detail(
     raw_table = await client.storage_client.table_detail(table_id)
     raw_columns = cast(list[str], raw_table.get('columns', []))
     column_info = [
-        TableColumnInfo(name=col, quoted_name=await workspace_manager.get_quoted_name(col))
-        for col in raw_columns
+        TableColumnInfo(name=col, quoted_name=await workspace_manager.get_quoted_name(col)) for col in raw_columns
     ]
 
     table_fqn = await workspace_manager.get_table_fqn(raw_table)
 
     return TableDetail.model_validate(
-        raw_table |
-        {
+        raw_table
+        | {
             'columns': column_info,
             'fully_qualified_name': table_fqn.identifier if table_fqn else None,
         }
@@ -242,9 +241,7 @@ async def update_table_description(
     }
     response = cast(JsonDict, await client.storage_client.post(endpoint=metadata_endpoint, data=data))
     raw_metadata = cast(list[JsonDict], response.get('metadata', []))
-    description_entry = next(
-        entry for entry in raw_metadata if entry.get('key') == MetadataField.DESCRIPTION.value
-    )
+    description_entry = next(entry for entry in raw_metadata if entry.get('key') == MetadataField.DESCRIPTION.value)
 
     return UpdateDescriptionResponse.model_validate(description_entry)
 
@@ -279,9 +276,7 @@ async def update_column_description(
     response = cast(JsonDict, await client.storage_client.post(endpoint=metadata_endpoint, data=data))
     column_metadata = cast(dict[str, list[JsonDict]], response.get('columnsMetadata', {}))
     description_entry = next(
-        entry
-        for entry in column_metadata.get(column_name, [])
-        if entry.get('key') == MetadataField.DESCRIPTION.value
+        entry for entry in column_metadata.get(column_name, []) if entry.get('key') == MetadataField.DESCRIPTION.value
     )
 
     return UpdateDescriptionResponse.model_validate(description_entry)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,7 @@ import pytest
 
 from keboola_mcp_server.server import create_server
 from keboola_mcp_server.tools.components import (
-    GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME,
+    GET_COMPONENT_CONFIGURATION_TOOL_NAME,
     RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME,
     RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME,
 )
@@ -20,9 +20,9 @@ class TestServer:
             'docs_query',
             'find_component_id',
             'get_bucket_detail',
-            GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME,
+            'get_component',
+            GET_COMPONENT_CONFIGURATION_TOOL_NAME,
             'get_component_configuration_examples',
-            'get_component_detail',
             'get_job_detail',
             'get_sql_dialect',
             'get_table_detail',

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -312,7 +312,7 @@ async def test_create_transformation_configuration(
         {
             **configuration,
             'component_id': expected_component_id,
-            'component': {**component, 'flags': ['flag1', 'flag2']},
+            'component': {**component}
         }
     )
 

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -108,6 +108,7 @@ async def test_retrieve_components_configurations_by_types(
     assert_retrieve_components(result, mock_components, mock_configurations)
 
     # Verify the calls were made with the correct arguments
+    # TODO: use `assert_has_calls`
     calls = keboola_client.storage_client.get.call_args_list
     assert len(calls) == 3
     assert calls[0].args[0] == f'branch/{mock_branch_id}/components'
@@ -143,6 +144,7 @@ async def test_retrieve_transformations_configurations(
     assert_retrieve_components(result, [mock_component], mock_configurations)
 
     # Verify the calls were made with the correct arguments
+    # TODO: use `assert_has_calls`
     calls = keboola_client.storage_client.get.call_args_list
     assert len(calls) == 1
     assert calls[0].args[0] == f'branch/{mock_branch_id}/components'
@@ -174,6 +176,7 @@ async def test_retrieve_components_configurations_from_ids(
     # Verify the calls were made with the correct arguments
     keboola_client.storage_client.configuration_list.assert_called_once_with(component_id=mock_component['id'])
     calls = keboola_client.storage_client.get.call_args_list
+    # TODO: use `assert_has_calls`
     assert len(calls) == 1
     assert calls[0].kwargs['endpoint'] == f'branch/{mock_branch_id}/components/{mock_component["id"]}'
 
@@ -246,6 +249,7 @@ async def test_get_component_configuration(
 
     # Verify the calls were made with the correct arguments
     calls = keboola_client.storage_client.get.call_args_list
+    # TODO: use `assert_has_calls`
     assert len(calls) == 1
     assert calls[0].kwargs['endpoint'] == (
         f"branch/{mock_branch_id}/components/{mock_component['id']}/configs/{mock_configuration['id']}"


### PR DESCRIPTION
This PR refactors component tools by eliminating ComponentDetails and ReducedComponentDetails classes and using Component and ReducedComponent instead. Additional mentions/naming that refers to details is also removed. 