### PR TITLE
KAB-984: add 'GET /' and 'GET /health-check' endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.19.0"
+version = "0.20.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -38,9 +38,12 @@ def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
         default='INFO',
         help='Logging level',
     )
-    parser.add_argument('--api-url', default='https://connection.keboola.com', help='Keboola Storage API URL.')
-    parser.add_argument('--storage-token', help='Keboola Storage API token.')
-    parser.add_argument('--workspace-schema', help='Keboola Storage API workspace schema.')
+    parser.add_argument(
+        '--api-url', default='https://connection.keboola.com', metavar='URL', help='Keboola Storage API URL.')
+    parser.add_argument('--storage-token', metavar='STR', help='Keboola Storage API token.')
+    parser.add_argument('--workspace-schema', metavar='STR', help='Keboola Storage API workspace schema.')
+    parser.add_argument('--host', default='0.0.0.0', metavar='STR', help='The host to listen on.')
+    parser.add_argument('--port', type=int, default=8000, metavar='INT', help='The port to listen on.')
 
     return parser.parse_args(args)
 
@@ -71,7 +74,11 @@ async def run_server(args: Optional[list[str]] = None) -> None:
         # Create and run server
         LOG.info(f'Creating server with config: {config}')
         keboola_mcp_server = create_server(config)
-        await keboola_mcp_server.run_async(transport=parsed_args.transport)
+        if parsed_args.transport == 'stdio':
+            await keboola_mcp_server.run_async(transport=parsed_args.transport)
+        else:
+            await keboola_mcp_server.run_async(
+                transport=parsed_args.transport, host=parsed_args.host, port=parsed_args.port)
     except Exception as e:
         LOG.exception(f'Server failed: {e}')
         sys.exit(1)

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -1,11 +1,16 @@
 """MCP server implementation for Keboola Connection."""
 
 import logging
+import os
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from importlib.metadata import distribution
 from typing import Callable, Optional
 
 from fastmcp import FastMCP
+from pydantic import AliasChoices, BaseModel, Field
+from starlette.requests import Request
+from starlette.responses import Response
 
 from keboola_mcp_server.config import Config
 from keboola_mcp_server.mcp import KeboolaMcpServer, ServerState
@@ -16,6 +21,37 @@ from keboola_mcp_server.tools.sql import add_sql_tools
 from keboola_mcp_server.tools.storage import add_storage_tools
 
 LOG = logging.getLogger(__name__)
+_MCP_VERSION = distribution('mcp').version
+_FASTMCP_VERSION = distribution('fastmcp').version
+_VERSION = distribution('keboola_mcp_server').version
+_DEFAULT_APP_VERSION = 'DEV'
+
+
+class StatusApiResp(BaseModel):
+    status: str
+
+
+class ServiceInfoApiResp(BaseModel):
+    app_name: str = Field(
+        default='KeboolaMcpServer',
+        validation_alias=AliasChoices('appName', 'app_name', 'app-name'),
+        serialization_alias='appName')
+    app_version: str = Field(
+        default=_DEFAULT_APP_VERSION,
+        validation_alias=AliasChoices('appVersion', 'app_version', 'app-version'),
+        serialization_alias='appVersion')
+    server_version: str = Field(
+        default=_VERSION,
+        validation_alias=AliasChoices('serverVersion', 'server_version', 'server-version'),
+        serialization_alias='serverVersion')
+    mcp_library_version: str = Field(
+        default=_MCP_VERSION,
+        validation_alias=AliasChoices('mcpLibraryVersion', 'mcp_library_version', 'mcp-library-version'),
+        serialization_alias='mcpLibraryVersion')
+    fastmcp_library_version: str = Field(
+        default=_FASTMCP_VERSION,
+        validation_alias=AliasChoices('fastmcpLibraryVersion', 'fastmcp_library_version', 'fastmcp-library-version'),
+        serialization_alias='fastmcpLibraryVersion')
 
 
 def create_keboola_lifespan(
@@ -63,6 +99,18 @@ def create_server(config: Optional[Config] = None) -> FastMCP:
     """
     # Initialize FastMCP server with system lifespan
     mcp = KeboolaMcpServer(name='Keboola Explorer', lifespan=create_keboola_lifespan(config))
+
+    @mcp.custom_route('/health-check', methods=['GET'])
+    async def get_status(_rq: Request) -> Response:
+        """Checks the service is up and running."""
+        resp = StatusApiResp(status='ok')
+        return Response(resp.model_dump_json(by_alias=True), media_type='application/json')
+
+    @mcp.custom_route('/', methods=['GET'])
+    async def get_info(_rq: Request) -> Response:
+        """Returns basic information about the service."""
+        resp = ServiceInfoApiResp(app_version=os.getenv('APP_VERSION') or _DEFAULT_APP_VERSION)
+        return Response(resp.model_dump_json(by_alias=True), media_type='application/json')
 
     add_component_tools(mcp)
     add_doc_tools(mcp)


### PR DESCRIPTION
This adds `GET /` and `GET /health-check` endpoints. The first one returns the servers implementation version (the one in `pyproject.toml`), value of `APP_VERSION` env variable (defaults to `DEV`) and the versions of `mcp` and `fastmcp` libraries. The second one returns a simple `{"status": "ok"}` message. 