### PR TITLE
feat: Add ddtrace package for observability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "fastmcp ~= 2.2",
     "httpx ~= 0.28",
     "google-cloud-bigquery ~= 3.31",
+    "ddtrace ~= 3.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,10 @@ version = 1
 revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version >= '4'",
+    "python_full_version >= '3.13' and python_full_version < '4'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
@@ -129,6 +131,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/4a/89f2beab6757c900b15aa301227c9447feff7d327ff0595a2b74406a388c/botocore-1.38.21.tar.gz", hash = "sha256:08d5e9c00e5cc9e0ae0e60570846011789dc7f1d4ea094b3f3e3f3ae1ff2063a", size = 13904318, upload-time = "2025-05-21T19:27:59.79Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/bf/8e943894e0c9f898db63c6af4c590c153dff680bd02536777b0a543e94e5/botocore-1.38.21-py3-none-any.whl", hash = "sha256:567b4d338114174d0b41857002a4b1e8efb68f1654ed9f3ec6c34ebdef5e9eaf", size = 13564842, upload-time = "2025-05-21T19:27:53.955Z" },
+]
+
+[[package]]
+name = "bytecode"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/bb/51d95655573fefef01943b911875ddc94a2ff0a82167c4a831c11d248150/bytecode-0.16.2.tar.gz", hash = "sha256:f05020b6dc1f48cdadd946f7c3a03131ba0f312bd103767c5d75559de5c308f8", size = 103023, upload-time = "2025-04-14T13:39:25.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/98/2e09512abee834dc98afa3c167c04b042f2dd29846f5832da3fbe2907660/bytecode-0.16.2-py3-none-any.whl", hash = "sha256:0a7dea0387ec5cae5ec77578690c5ca7470c8a202c50ce64a426d86380cddd7f", size = 42029, upload-time = "2025-04-14T13:39:24.497Z" },
 ]
 
 [[package]]
@@ -410,12 +421,89 @@ wheels = [
 ]
 
 [[package]]
+name = "ddtrace"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode" },
+    { name = "envier" },
+    { name = "legacy-cgi", marker = "python_full_version >= '3.13'" },
+    { name = "opentelemetry-api" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/36/2fd3dc8e76ce901ac13237c91e6bb05b02cfa5aa09cfef9dbe535ad178df/ddtrace-3.8.0.tar.gz", hash = "sha256:426310e1797a000fdea01108354d8cb45588a72b35fb44ad0ab2dab966f20b9c", size = 6776320, upload-time = "2025-05-23T09:49:32.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/d3/b470affde6ff114729f3beffcdbed94608886702247d9daac2fbd4f5f0d0/ddtrace-3.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d2fc1be1837787b6f5410bfac613b0c35b046b9621e65b829d7875557f9387ef", size = 6927368, upload-time = "2025-05-23T09:47:11.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/0b/1e37ca443bd465beecaea6746c89f0416dda6611c086be0d1f4d818a1163/ddtrace-3.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:bd3522493d2754c12be9f7e4f1fcee7a61bccf237794592467b7b4a885d33daf", size = 7256752, upload-time = "2025-05-23T09:47:17.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ff/1a2043ececa63c5e2e7db63b306d1e60c8d9d6188c1645e740804f252f88/ddtrace-3.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:280018bca61d03b1ea0be691c02c32f05fb28cf0336b276e8cf370fd817902ef", size = 6313499, upload-time = "2025-05-23T09:47:18.966Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/23/b661056e4400addafc2d5fb5fb4c54a6dc925399614fba5c8d0cf4c8baad/ddtrace-3.8.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0254a2ad0f5318ad49906ef1618c83d07389e8ab3b250e945663b77b471f88d9", size = 3093268, upload-time = "2025-05-23T09:47:20.743Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cc/649cd1dc7940dfa0b70eb06cb3a4130b32b407c03bcaa1d99cadcbc81108/ddtrace-3.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f00e824a92545464e08bf5d7119fe6eff3e8fbc41f071d88ba222b3818c2e43", size = 6653339, upload-time = "2025-05-23T09:47:22.133Z" },
+    { url = "https://files.pythonhosted.org/packages/38/57/302b50c17ecf3cf3bef8bd624c58e1e74327927b411539ad05464759ed92/ddtrace-3.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7eb02953059255350a905e2ad3a6375014d243c5c52865be55371fb15c3c1686", size = 7266507, upload-time = "2025-05-23T09:47:23.614Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ce/74494d94535bd56f93caccf64bfbbfd41fb15d53c2ac0223b5dc21b6af52/ddtrace-3.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5c66e0aa186880ab0ed73a52af6ba55f5b10bdd5e607f50ff2e26bc5ba105cfa", size = 4234303, upload-time = "2025-05-23T09:47:25.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c9/df7aa3e5b4c57e353cc1f5f4dcdd7692dcce78bd7774b45626af13a09449/ddtrace-3.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6f7f30aefdb2db2196a951b9447e4758455a826cb03ebd7b33768f66457d081a", size = 7700669, upload-time = "2025-05-23T09:47:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7e/102d2005efddc856cd649015ca42d34b0e1400b765df74bd8f9fe25db3a3/ddtrace-3.8.0-cp310-cp310-win32.whl", hash = "sha256:b9b9ab4ba776e719bdce24b8d9690f1d7164c24360d5e02a3497a9a9de9f6e90", size = 5762935, upload-time = "2025-05-23T09:47:29.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/00/6b82e4ccbb60d114a9e0828dea2e19ad3456ab4c7b3545fd985457087ed1/ddtrace-3.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:df8a9ebb646247e574dc777f9d1246b14cbb7dafa622c79d6cc5db3408695969", size = 6579763, upload-time = "2025-05-23T09:47:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fc/2ae72ed4cf9b24c1710464b32bad8bff3ca0ea3dfcb66e60f199b1c1d974/ddtrace-3.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:67dde328a3f61fa3c1b8dde3aa0ef21e08ecd230f2a51e88b96a59b16b84252a", size = 6939365, upload-time = "2025-05-23T09:47:33.115Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/dd/cb57882beaf1f6b5ccef6f06ed6105678e135306449c54c8be92eb9debf5/ddtrace-3.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:07e8178a4fb34c81ae01bc003f643039c9af91b190af85359c8632d0222d9b5e", size = 7268805, upload-time = "2025-05-23T09:47:34.76Z" },
+    { url = "https://files.pythonhosted.org/packages/99/23/d455d475531520095855a289506313eece2ee15658c9168eda6c0d903c4f/ddtrace-3.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:006ba255d12ede3d36065db6880cb0ee567032db9576725a363b02516be51bc1", size = 6326314, upload-time = "2025-05-23T09:47:36.973Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e0/5a144bc3731a26c6250dff8a549abff2ec2e15e67b9bf10417590df5674a/ddtrace-3.8.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5de402fb2a90925f23b84e51351c05a56e371dd00d35911aaaae63c7a2be3bc", size = 3102110, upload-time = "2025-05-23T09:47:38.662Z" },
+    { url = "https://files.pythonhosted.org/packages/10/da/1600e198ec51881290581d60dffc75863c1f18055d5697217ce9d00498bb/ddtrace-3.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f01ce85b9ec7f4c4bd1f81b6e6b5791f5ec5f5a66fda690f8df6ba8e138814e", size = 6666773, upload-time = "2025-05-23T09:47:40.384Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f1/67118cbfca90a6a090a7baff0450d6a4193bed732567a2d8b8967f31dc4b/ddtrace-3.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ffbda9279699e24e505f789e170a9b790b6b1038f4cf3c825814ded35619ac47", size = 7280543, upload-time = "2025-05-23T09:47:42.118Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7c/55d6db1211f72f506f893d09317cf55ca9142dda570ea5ac3efafaa5448a/ddtrace-3.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ab8afc256743c357ae62226b76e9d5f79f0754caa532434b8da81469316e3acf", size = 4239054, upload-time = "2025-05-23T09:47:44.31Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/3c/93e39a589d5aaed4bdcc50ea5934a0c02beff7502a4a4ec53d676d243063/ddtrace-3.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3356b06f5b7e4f5b3d926fd650e81994328b447edd2efc29068da217bc29f78e", size = 7712619, upload-time = "2025-05-23T09:47:46.501Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1e/cf81b7fca8da0e9ac4d0c72738579140703920eea49079efe9c63f25db5f/ddtrace-3.8.0-cp311-cp311-win32.whl", hash = "sha256:c1c22219a165edd3d35c81b24c40b77d540bb9645db5a55334ccb001a83a41ff", size = 5763174, upload-time = "2025-05-23T09:47:48.4Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ca/9511ba220b6fa9c38f2b89138db9f1d0b1cf5e5cb5577e4bee17eea4569a/ddtrace-3.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ec4f58d51f845b354eee48ef37fd12e57c53eea5ebc9ad6743e0edb927d35be0", size = 6584713, upload-time = "2025-05-23T09:47:50.86Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/cce8b18b687002675edd2e2f84be7ff83907ba60a33c2ad317f1e1fcf245/ddtrace-3.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:57aa6ed3612aa2f801c6619f956f0656ffd54866e75ed43bc91d639342fd5a75", size = 6930925, upload-time = "2025-05-23T09:47:53.008Z" },
+    { url = "https://files.pythonhosted.org/packages/84/5c/b9a78f6005fdd94373aa83ec0cf3d7ddd16e8e15a16509dd4f71131e9806/ddtrace-3.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:a994175dbdda115ee222c45f801f3d09aee217ee7c1cedb07f858cdce88db1d8", size = 7261724, upload-time = "2025-05-23T09:47:55.204Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e3/d4a6ada840fb5b128115976e31f2f595a6de5e9a745318e62b6f77183df7/ddtrace-3.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9920542ecc0837a55aede496fe059bef7ccb10522bfa66cdd68cf5daa3140a5d", size = 6297973, upload-time = "2025-05-23T09:47:57.839Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/92/508607cf5231173c976ebcbe1e87d578b74141960ee9adf0f8b104391487/ddtrace-3.8.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8be52ed4cd5e76e7aea62cb000c0beb9a2b535167226360ffd6e47698ff54ac6", size = 3072375, upload-time = "2025-05-23T09:48:00.562Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/76/ba0f15c07d34e76dd8d78942d885a56e4e08fbfab6586abea409cf0bc976/ddtrace-3.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2246eeec232be59a80baf96ab6ff0b74ea142295173671ca7db4f9e7c7b3ddaf", size = 6640713, upload-time = "2025-05-23T09:48:02.481Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/d0/e851a978097a595ea0382d33802d135f23853d26beae149b00ab25ee2661/ddtrace-3.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f7b5cf1b0be6d07d5062695e9fc6575fbc86e0b816042975877800433801844", size = 7245369, upload-time = "2025-05-23T09:48:04.525Z" },
+    { url = "https://files.pythonhosted.org/packages/98/16/9d7d5bbaaf6c2727be2af6c37f52fe67b46e3af351e32c6d06cc6137247c/ddtrace-3.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8de80c83be4e9a91740824ad312d4989ca389f9630b9e48b0c3a193d31d99ace", size = 4202723, upload-time = "2025-05-23T09:48:06.761Z" },
+    { url = "https://files.pythonhosted.org/packages/89/46/3e2d52ef2aa4ca1834f16f316a4597eadbd56eef2e789bb18557b55fc084/ddtrace-3.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b651025865090982184803406b8a624b60cf81f3ccf0f922951e5c8e907f677b", size = 7688007, upload-time = "2025-05-23T09:48:08.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/59/e90c80ceb36a846e5a3f985259dbc9b760bb4c3f41c9ad98dd0939092046/ddtrace-3.8.0-cp312-cp312-win32.whl", hash = "sha256:606a9a7e5bab7046cb6dd876f54c4d2fdb408db4e15360e1cdcf4e018a74fc08", size = 5751839, upload-time = "2025-05-23T09:48:11.022Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ef/73c1bed9c9ffd474fcf654441c1c924f577593a546e0fd5d99b7524d22cb/ddtrace-3.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:14e6f76acadc81bfa0f813282050201ffa89fddfe2cac9bbd90966f45fca0ea3", size = 6575660, upload-time = "2025-05-23T09:48:13.175Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a4/9af7bce1983c733f03fdaf3e59d33b4c2a80c92f90f1ee94e90c6a700179/ddtrace-3.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:633de5a54345292499b364db44222ba10eb1bbfe6b734dc6f49a4518cb231b8d", size = 6921030, upload-time = "2025-05-23T09:48:15.38Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ff/2d1a56ca92bec77d52b60beebecbaa34c75454aafb07b9d190217422cfaf/ddtrace-3.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:2ee75472e9146909d3546341bec70744f2428a7f0070d1c71c69b8201ad17d75", size = 7253096, upload-time = "2025-05-23T09:48:18.083Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9c/a2e44e1874924f4e069154375725a97f06db1e3176711cf56d23b8d8cbe0/ddtrace-3.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a932c0fd6d126ec5d67e9b83d588ab8b1638dd6727e23e49dbda95a0b3595cf7", size = 6292144, upload-time = "2025-05-23T09:48:20.399Z" },
+    { url = "https://files.pythonhosted.org/packages/26/59/cdc30b89be48d817be347cfd6ab1a2017670ed6e150dce87f0f088b42250/ddtrace-3.8.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd4be4b7156c27f4b4ad0efa8ac182c7e490e00656c0e34f3acffe662f2a15b", size = 3066125, upload-time = "2025-05-23T09:48:22.668Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1f/9024382e9c2fac2156562726ff10dd35fc993a9d79be2fc62b91a768a162/ddtrace-3.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51194c2d46d9a998d471ba72f52d601ab48b3e4479861eb19f67e8514463e521", size = 6635255, upload-time = "2025-05-23T09:48:25.026Z" },
+    { url = "https://files.pythonhosted.org/packages/32/3e/ae12e97aeeb2debb554f626bd07457713f6f8b1f2cb8273fa2ba254a7327/ddtrace-3.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e9a964ab5eb4825de2c1f4451191fe2957985f15ea7a72c86375748c60336b5e", size = 7238724, upload-time = "2025-05-23T09:48:27.47Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4a/8ed90dd504ab5d4b7d28ae5e2b794a02f961fb3b4c174ca275895d010398/ddtrace-3.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:28f1dbf8020060f119e931a930503c76045f4a9e4fddc1289189019037a1e44d", size = 4197062, upload-time = "2025-05-23T09:48:29.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/9a0af9059800b79cef599e2621a41e98366c3c2a9f4883175e5a582f8b7e/ddtrace-3.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66dbc81886ad83c7dfa262ea616b8d3fd07ba0e33bd58371dd677f6c740572d2", size = 7683032, upload-time = "2025-05-23T09:48:32.188Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063, upload-time = "2024-10-22T09:56:47.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638, upload-time = "2024-10-22T09:56:45.968Z" },
 ]
 
 [[package]]
@@ -826,6 +914,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767, upload-time = "2025-01-20T22:21:30.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e", size = 26971, upload-time = "2025-01-20T22:21:29.177Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -885,6 +985,7 @@ name = "keboola-mcp-server"
 version = "0.19.1"
 source = { editable = "." }
 dependencies = [
+    { name = "ddtrace" },
     { name = "fastmcp" },
     { name = "google-cloud-bigquery" },
     { name = "httpx" },
@@ -922,6 +1023,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'codestyle'", specifier = "~=25.1" },
+    { name = "ddtrace", specifier = "~=3.0" },
     { name = "fastmcp", specifier = "~=2.2" },
     { name = "flake8", marker = "extra == 'codestyle'", specifier = "~=7.2" },
     { name = "flake8-bugbear", marker = "extra == 'codestyle'", specifier = "~=24.12" },
@@ -945,6 +1047,15 @@ requires-dist = [
     { name = "tox", marker = "extra == 'dev'", specifier = "~=4.23" },
 ]
 provides-extras = ["codestyle", "tests", "integtests", "dev"]
+
+[[package]]
+name = "legacy-cgi"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/ed/300cabc9693209d5a03e2ebc5eb5c4171b51607c08ed84a2b71c9015e0f3/legacy_cgi-2.6.3.tar.gz", hash = "sha256:4c119d6cb8e9d8b6ad7cc0ddad880552c62df4029622835d06dfd18f438a8154", size = 24401, upload-time = "2025-03-27T00:48:56.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/33/68c6c38193684537757e0d50a7ccb4f4656e5c2f7cd2be737a9d4a1bff71/legacy_cgi-2.6.3-py3-none-any.whl", hash = "sha256:6df2ea5ae14c71ef6f097f8b6372b44f6685283dc018535a75c924564183cdab", size = 19851, upload-time = "2025-03-27T00:48:55.366Z" },
+]
 
 [[package]]
 name = "markdown-it-py"
@@ -1015,6 +1126,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "importlib-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8d/1f5a45fbcb9a7d87809d460f09dc3399e3fbd31d7f3e14888345e9d29951/opentelemetry_api-1.33.1.tar.gz", hash = "sha256:1c6055fc0a2d3f23a50c7e17e16ef75ad489345fd3df1f8b8af7c0bbf8a109e8", size = 65002, upload-time = "2025-05-16T18:52:41.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/44/4c45a34def3506122ae61ad684139f0bbc4e00c39555d4f7e20e0e001c8a/opentelemetry_api-1.33.1-py3-none-any.whl", hash = "sha256:4db83ebcf7ea93e64637ec6ee6fabee45c5cbe4abd9cf3da95c43828ddb50b83", size = 65771, upload-time = "2025-05-16T18:52:17.419Z" },
 ]
 
 [[package]]
@@ -1736,4 +1860,86 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531, upload-time = "2025-01-14T10:35:45.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/d1/1daec934997e8b160040c78d7b31789f19b122110a75eca3d4e8da0049e1/wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984", size = 53307, upload-time = "2025-01-14T10:33:13.616Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/7b/13369d42651b809389c1a7153baa01d9700430576c81a2f5c5e460df0ed9/wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22", size = 38486, upload-time = "2025-01-14T10:33:15.947Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bf/e0105016f907c30b4bd9e377867c48c34dc9c6c0c104556c9c9126bd89ed/wrapt-1.17.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80dd7db6a7cb57ffbc279c4394246414ec99537ae81ffd702443335a61dbf3a7", size = 38777, upload-time = "2025-01-14T10:33:17.462Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/0f6e0679845cbf8b165e027d43402a55494779295c4b08414097b258ac87/wrapt-1.17.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a6e821770cf99cc586d33833b2ff32faebdbe886bd6322395606cf55153246c", size = 83314, upload-time = "2025-01-14T10:33:21.282Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/77/0576d841bf84af8579124a93d216f55d6f74374e4445264cb378a6ed33eb/wrapt-1.17.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b60fb58b90c6d63779cb0c0c54eeb38941bae3ecf7a73c764c52c88c2dcb9d72", size = 74947, upload-time = "2025-01-14T10:33:24.414Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ec/00759565518f268ed707dcc40f7eeec38637d46b098a1f5143bff488fe97/wrapt-1.17.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b870b5df5b71d8c3359d21be8f0d6c485fa0ebdb6477dda51a1ea54a9b558061", size = 82778, upload-time = "2025-01-14T10:33:26.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/7cffd26b1c607b0b0c8a9ca9d75757ad7620c9c0a9b4a25d3f8a1480fafc/wrapt-1.17.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4011d137b9955791f9084749cba9a367c68d50ab8d11d64c50ba1688c9b457f2", size = 81716, upload-time = "2025-01-14T10:33:27.372Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/09/dccf68fa98e862df7e6a60a61d43d644b7d095a5fc36dbb591bbd4a1c7b2/wrapt-1.17.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1473400e5b2733e58b396a04eb7f35f541e1fb976d0c0724d0223dd607e0f74c", size = 74548, upload-time = "2025-01-14T10:33:28.52Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/067021fa3c8814952c5e228d916963c1115b983e21393289de15128e867e/wrapt-1.17.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3cedbfa9c940fdad3e6e941db7138e26ce8aad38ab5fe9dcfadfed9db7a54e62", size = 81334, upload-time = "2025-01-14T10:33:29.643Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0d/9d4b5219ae4393f718699ca1c05f5ebc0c40d076f7e65fd48f5f693294fb/wrapt-1.17.2-cp310-cp310-win32.whl", hash = "sha256:582530701bff1dec6779efa00c516496968edd851fba224fbd86e46cc6b73563", size = 36427, upload-time = "2025-01-14T10:33:30.832Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6a/c5a83e8f61aec1e1aeef939807602fb880e5872371e95df2137142f5c58e/wrapt-1.17.2-cp310-cp310-win_amd64.whl", hash = "sha256:58705da316756681ad3c9c73fd15499aa4d8c69f9fd38dc8a35e06c12468582f", size = 38774, upload-time = "2025-01-14T10:33:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/a2aab2cbc7a665efab072344a8949a71081eed1d2f451f7f7d2b966594a2/wrapt-1.17.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58", size = 53308, upload-time = "2025-01-14T10:33:33.992Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ff/149aba8365fdacef52b31a258c4dc1c57c79759c335eff0b3316a2664a64/wrapt-1.17.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4db983e7bca53819efdbd64590ee96c9213894272c776966ca6306b73e4affda", size = 38488, upload-time = "2025-01-14T10:33:35.264Z" },
+    { url = "https://files.pythonhosted.org/packages/65/46/5a917ce85b5c3b490d35c02bf71aedaa9f2f63f2d15d9949cc4ba56e8ba9/wrapt-1.17.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9abc77a4ce4c6f2a3168ff34b1da9b0f311a8f1cfd694ec96b0603dff1c79438", size = 38776, upload-time = "2025-01-14T10:33:38.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/74/336c918d2915a4943501c77566db41d1bd6e9f4dbc317f356b9a244dfe83/wrapt-1.17.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b929ac182f5ace000d459c59c2c9c33047e20e935f8e39371fa6e3b85d56f4a", size = 83776, upload-time = "2025-01-14T10:33:40.678Z" },
+    { url = "https://files.pythonhosted.org/packages/09/99/c0c844a5ccde0fe5761d4305485297f91d67cf2a1a824c5f282e661ec7ff/wrapt-1.17.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f09b286faeff3c750a879d336fb6d8713206fc97af3adc14def0cdd349df6000", size = 75420, upload-time = "2025-01-14T10:33:41.868Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b0/9fc566b0fe08b282c850063591a756057c3247b2362b9286429ec5bf1721/wrapt-1.17.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7ed2d9d039bd41e889f6fb9364554052ca21ce823580f6a07c4ec245c1f5d6", size = 83199, upload-time = "2025-01-14T10:33:43.598Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/4b/71996e62d543b0a0bd95dda485219856def3347e3e9380cc0d6cf10cfb2f/wrapt-1.17.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:129a150f5c445165ff941fc02ee27df65940fcb8a22a61828b1853c98763a64b", size = 82307, upload-time = "2025-01-14T10:33:48.499Z" },
+    { url = "https://files.pythonhosted.org/packages/39/35/0282c0d8789c0dc9bcc738911776c762a701f95cfe113fb8f0b40e45c2b9/wrapt-1.17.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1fb5699e4464afe5c7e65fa51d4f99e0b2eadcc176e4aa33600a3df7801d6662", size = 75025, upload-time = "2025-01-14T10:33:51.191Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6d/90c9fd2c3c6fee181feecb620d95105370198b6b98a0770cba090441a828/wrapt-1.17.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9a2bce789a5ea90e51a02dfcc39e31b7f1e662bc3317979aa7e5538e3a034f72", size = 81879, upload-time = "2025-01-14T10:33:52.328Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fa/9fb6e594f2ce03ef03eddbdb5f4f90acb1452221a5351116c7c4708ac865/wrapt-1.17.2-cp311-cp311-win32.whl", hash = "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317", size = 36419, upload-time = "2025-01-14T10:33:53.551Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/fb1773491a253cbc123c5d5dc15c86041f746ed30416535f2a8df1f4a392/wrapt-1.17.2-cp311-cp311-win_amd64.whl", hash = "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3", size = 38773, upload-time = "2025-01-14T10:33:56.323Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/bd/ab55f849fd1f9a58ed7ea47f5559ff09741b25f00c191231f9f059c83949/wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925", size = 53799, upload-time = "2025-01-14T10:33:57.4Z" },
+    { url = "https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392", size = 38821, upload-time = "2025-01-14T10:33:59.334Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40", size = 38919, upload-time = "2025-01-14T10:34:04.093Z" },
+    { url = "https://files.pythonhosted.org/packages/73/54/3bfe5a1febbbccb7a2f77de47b989c0b85ed3a6a41614b104204a788c20e/wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d", size = 88721, upload-time = "2025-01-14T10:34:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cb/7262bc1b0300b4b64af50c2720ef958c2c1917525238d661c3e9a2b71b7b/wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b", size = 80899, upload-time = "2025-01-14T10:34:09.82Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98", size = 89222, upload-time = "2025-01-14T10:34:11.258Z" },
+    { url = "https://files.pythonhosted.org/packages/09/28/2e45a4f4771fcfb109e244d5dbe54259e970362a311b67a965555ba65026/wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82", size = 86707, upload-time = "2025-01-14T10:34:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/dcb56bf5f32fcd4bd9aacc77b50a539abdd5b6536872413fd3f428b21bed/wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae", size = 79685, upload-time = "2025-01-14T10:34:15.043Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4e/eb8b353e36711347893f502ce91c770b0b0929f8f0bed2670a6856e667a9/wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9", size = 87567, upload-time = "2025-01-14T10:34:16.563Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/4fe749a54e7fae6e7146f1c7d914d28ef599dacd4416566c055564080fe2/wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9", size = 36672, upload-time = "2025-01-14T10:34:17.727Z" },
+    { url = "https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991", size = 38865, upload-time = "2025-01-14T10:34:19.577Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b9/0ffd557a92f3b11d4c5d5e0c5e4ad057bd9eb8586615cdaf901409920b14/wrapt-1.17.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125", size = 53800, upload-time = "2025-01-14T10:34:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ef/8be90a0b7e73c32e550c73cfb2fa09db62234227ece47b0e80a05073b375/wrapt-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998", size = 38824, upload-time = "2025-01-14T10:34:22.999Z" },
+    { url = "https://files.pythonhosted.org/packages/36/89/0aae34c10fe524cce30fe5fc433210376bce94cf74d05b0d68344c8ba46e/wrapt-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5", size = 38920, upload-time = "2025-01-14T10:34:25.386Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/24/11c4510de906d77e0cfb5197f1b1445d4fec42c9a39ea853d482698ac681/wrapt-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8", size = 88690, upload-time = "2025-01-14T10:34:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d7/cfcf842291267bf455b3e266c0c29dcb675b5540ee8b50ba1699abf3af45/wrapt-1.17.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6", size = 80861, upload-time = "2025-01-14T10:34:29.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/66/5d973e9f3e7370fd686fb47a9af3319418ed925c27d72ce16b791231576d/wrapt-1.17.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc", size = 89174, upload-time = "2025-01-14T10:34:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/8e17bb70f6ae25dabc1aaf990f86824e4fd98ee9cadf197054e068500d27/wrapt-1.17.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2", size = 86721, upload-time = "2025-01-14T10:34:32.91Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/f170dfb278fe1c30d0ff864513cff526d624ab8de3254b20abb9cffedc24/wrapt-1.17.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b", size = 79763, upload-time = "2025-01-14T10:34:34.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/de07243751f1c4a9b15c76019250210dd3486ce098c3d80d5f729cba029c/wrapt-1.17.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504", size = 87585, upload-time = "2025-01-14T10:34:36.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f0/13925f4bd6548013038cdeb11ee2cbd4e37c30f8bfd5db9e5a2a370d6e20/wrapt-1.17.2-cp313-cp313-win32.whl", hash = "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a", size = 36676, upload-time = "2025-01-14T10:34:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ae/743f16ef8c2e3628df3ddfd652b7d4c555d12c84b53f3d8218498f4ade9b/wrapt-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845", size = 38871, upload-time = "2025-01-14T10:34:39.13Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bc/30f903f891a82d402ffb5fda27ec1d621cc97cb74c16fea0b6141f1d4e87/wrapt-1.17.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192", size = 56312, upload-time = "2025-01-14T10:34:40.604Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/04/c97273eb491b5f1c918857cd26f314b74fc9b29224521f5b83f872253725/wrapt-1.17.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b", size = 40062, upload-time = "2025-01-14T10:34:45.011Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ca/3b7afa1eae3a9e7fefe499db9b96813f41828b9fdb016ee836c4c379dadb/wrapt-1.17.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0", size = 40155, upload-time = "2025-01-14T10:34:47.25Z" },
+    { url = "https://files.pythonhosted.org/packages/89/be/7c1baed43290775cb9030c774bc53c860db140397047cc49aedaf0a15477/wrapt-1.17.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306", size = 113471, upload-time = "2025-01-14T10:34:50.934Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/4ed894cf012b6d6aae5f5cc974006bdeb92f0241775addad3f8cd6ab71c8/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb", size = 101208, upload-time = "2025-01-14T10:34:52.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/0c30f2301ca94e655e5e057012e83284ce8c545df7661a78d8bfca2fac7a/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681", size = 109339, upload-time = "2025-01-14T10:34:53.489Z" },
+    { url = "https://files.pythonhosted.org/packages/75/56/05d000de894c4cfcb84bcd6b1df6214297b8089a7bd324c21a4765e49b14/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6", size = 110232, upload-time = "2025-01-14T10:34:55.327Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f8/c3f6b2cf9b9277fb0813418e1503e68414cd036b3b099c823379c9575e6d/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6", size = 100476, upload-time = "2025-01-14T10:34:58.055Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b1/0bb11e29aa5139d90b770ebbfa167267b1fc548d2302c30c8f7572851738/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f", size = 106377, upload-time = "2025-01-14T10:34:59.3Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e1/0122853035b40b3f333bbb25f1939fc1045e21dd518f7f0922b60c156f7c/wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555", size = 37986, upload-time = "2025-01-14T10:35:00.498Z" },
+    { url = "https://files.pythonhosted.org/packages/09/5e/1655cf481e079c1f22d0cabdd4e51733679932718dc23bf2db175f329b76/wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c", size = 40750, upload-time = "2025-01-14T10:35:03.378Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594, upload-time = "2025-01-14T10:35:44.018Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "0.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/05/51dcca9a9bf5e1bce52582683ce50980bcadbc4fa5143b9f2b19ab99958f/xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553", size = 51942, upload-time = "2024-10-16T06:10:29.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac", size = 9981, upload-time = "2024-10-16T06:10:27.649Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545, upload-time = "2024-11-10T15:05:20.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630, upload-time = "2024-11-10T15:05:19.275Z" },
 ]


### PR DESCRIPTION
Adds `ddtrace` package for wrapping uvicorn app.

Traces are being [collected](https://app.datadoghq.eu/apm/entity/service%3Amcp-server?env=dev-keboola-gcp-us-central1&fromUser=false&graphType=flamegraph&groupMapByOperation=null&operationName=starlette.request&shouldShowLegend=true&sort=time&spanKind=server&start=1747997721846&end=1748001321846&paused=false) now.

Logs will be enabled by https://github.com/keboola/kbc-stacks/pull/3554.