### PR TITLE
Kab 1008 schema error handlers - required field unification and button type skip in the schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.26.0"
+version = "0.27.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/resources/root_parameters_invalid.json
+++ b/tests/resources/root_parameters_invalid.json
@@ -1,0 +1,6 @@
+{
+    "qdrant_settings": {
+      "url": "http://localhost:666",
+      "#api_key": "test-api-key"
+    }
+  }

--- a/tests/resources/root_parameters_schema.json
+++ b/tests/resources/root_parameters_schema.json
@@ -1,0 +1,337 @@
+{
+    "type": "object",
+    "title": "Embeddings Configuration",
+    "required": [
+      "embedding_settings"
+    ],
+    "properties": {
+      "qdrant_settings": {
+        "type": "object",
+        "title": "Qdrant Settings",
+        "options": {
+          "dependencies": {
+            "db_type": "qdrant"
+          }
+        },
+        "required": [
+          "url",
+          "#api_key"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "URL",
+            "description": "Qdrant instance URL"
+          },
+          "#api_key": {
+            "type": "string",
+            "title": "API Key",
+            "format": "password"
+          }
+        }
+      },
+      "embedding_settings": {
+        "type": "object",
+        "title": "Embedding Service Settings",
+        "required": [
+          "provider_type"
+        ],
+        "properties": {
+          "provider_type": {
+            "enum": [
+              "openai",
+              "azure_openai",
+              "cohere",
+              "huggingface_hub",
+              "google_vertex",
+              "bedrock"
+            ],
+            "type": "string",
+            "title": "Embedding Provider",
+            "options": {
+              "tooltip": "Choose the AI service that will generate embeddings"
+            },
+            "enumNames": [
+              "OpenAI",
+              "Azure OpenAI",
+              "Cohere",
+              "HuggingFace Hub",
+              "Google Vertex AI",
+              "AWS Bedrock"
+            ],
+            "description": "Select the embedding service to use"
+          },
+          "azure_settings": {
+            "type": "object",
+            "title": "Azure OpenAI Settings",
+            "options": {
+              "dependencies": {
+                "provider_type": "azure_openai"
+              }
+            },
+            "required": [
+              "deployment_name",
+              "#api_key",
+              "azure_endpoint"
+            ],
+            "properties": {
+              "#api_key": {
+                "type": "string",
+                "title": "API Key",
+                "format": "password"
+              },
+              "api_version": {
+                "type": "string",
+                "title": "API Version",
+                "default": "2024-02-01"
+              },
+              "azure_endpoint": {
+                "type": "string",
+                "title": "Azure Endpoint",
+                "options": {
+                  "inputAttributes": {
+                    "placeholder": "https://<your-endpoint>.openai.azure.com/"
+                  }
+                },
+                "description": "Your Azure OpenAI endpoint URL"
+              },
+              "deployment_name": {
+                "type": "string",
+                "title": "Deployment Name",
+                "description": "Enter your Azure OpenAI deployment name"
+              }
+            }
+          },
+          "cohere_settings": {
+            "type": "object",
+            "title": "Cohere Settings",
+            "options": {
+              "dependencies": {
+                "provider_type": "cohere"
+              }
+            },
+            "required": [
+              "model",
+              "#api_key"
+            ],
+            "properties": {
+              "model": {
+                "enum": [
+                  "embed-english-v3.0",
+                  "embed-english-light-v3.0",
+                  "embed-multilingual-v3.0",
+                  "embed-multilingual-light-v3.0"
+                ],
+                "type": "string",
+                "title": "Model",
+                "default": "embed-english-v3.0",
+                "options": {
+                  "tooltip": "Light models are faster but less accurate"
+                },
+                "description": "Select the Cohere embedding model"
+              },
+              "#api_key": {
+                "type": "string",
+                "title": "API Key",
+                "format": "password"
+              }
+            }
+          },
+          "openai_settings": {
+            "type": "object",
+            "title": "OpenAI Settings",
+            "options": {
+              "dependencies": {
+                "provider_type": "openai"
+              }
+            },
+            "required": [
+              "model",
+              "#api_key"
+            ],
+            "properties": {
+              "model": {
+                "enum": [
+                  "text-embedding-3-small",
+                  "text-embedding-3-large",
+                  "text-embedding-ada-002"
+                ],
+                "type": "string",
+                "title": "Model",
+                "default": "text-embedding-3-small",
+                "options": {
+                  "tooltip": "text-embedding-3-small is recommended for most use cases"
+                },
+                "description": "Select the OpenAI embedding model"
+              },
+              "#api_key": {
+                "type": "string",
+                "title": "API Key",
+                "format": "password"
+              }
+            }
+          },
+          "bedrock_settings": {
+            "type": "object",
+            "title": "AWS Bedrock Settings",
+            "options": {
+              "dependencies": {
+                "provider_type": "bedrock"
+              }
+            },
+            "required": [
+              "#aws_access_key",
+              "#aws_secret_key",
+              "region",
+              "model_id"
+            ],
+            "properties": {
+              "region": {
+                "enum": [
+                  "us-east-1",
+                  "us-west-2",
+                  "ap-southeast-1",
+                  "ap-northeast-1",
+                  "eu-central-1"
+                ],
+                "type": "string",
+                "title": "AWS Region",
+                "description": "AWS region where Bedrock is available"
+              },
+              "model_id": {
+                "enum": [
+                  "amazon.titan-embed-text-v1",
+                  "amazon.titan-embed-g1-text-02",
+                  "cohere.embed-english-v3",
+                  "cohere.embed-multilingual-v3"
+                ],
+                "type": "string",
+                "title": "Model ID",
+                "default": "amazon.titan-embed-text-v1",
+                "description": "Bedrock model identifier"
+              },
+              "#aws_access_key": {
+                "type": "string",
+                "title": "AWS Access Key",
+                "format": "password"
+              },
+              "#aws_secret_key": {
+                "type": "string",
+                "title": "AWS Secret Key",
+                "format": "password"
+              }
+            }
+          },
+          "huggingface_settings": {
+            "type": "object",
+            "title": "HuggingFace Hub Settings",
+            "options": {
+              "dependencies": {
+                "provider_type": "huggingface_hub"
+              }
+            },
+            "required": [
+              "model",
+              "#api_key"
+            ],
+            "properties": {
+              "model": {
+                "type": "string",
+                "title": "Model Name",
+                "default": "sentence-transformers/all-mpnet-base-v2",
+                "options": {
+                  "tooltip": "Recommended models: all-mpnet-base-v2, all-MiniLM-L6-v2, bge-large-en-v1.5",
+                  "inputAttributes": {
+                    "placeholder": "sentence-transformers/all-mpnet-base-v2"
+                  }
+                },
+                "description": "Enter the HuggingFace model name"
+              },
+              "#api_key": {
+                "type": "string",
+                "title": "API Key",
+                "format": "password"
+              },
+              "show_progress": {
+                "type": "boolean",
+                "title": "Show Progress",
+                "default": false,
+                "description": "Whether to show a progress bar during embedding generation"
+              },
+              "normalize_embeddings": {
+                "type": "boolean",
+                "title": "Normalize Embeddings",
+                "default": true,
+                "description": "Whether to normalize the computed embeddings to unit length"
+              }
+            }
+          },
+          "google_vertex_settings": {
+            "type": "object",
+            "title": "Google Vertex AI Settings",
+            "options": {
+              "dependencies": {
+                "provider_type": "google_vertex"
+              }
+            },
+            "required": [
+              "#credentials",
+              "project"
+            ],
+            "properties": {
+              "project": {
+                "type": "string",
+                "title": "Project ID",
+                "description": "Google Cloud project ID"
+              },
+              "location": {
+                "type": "string",
+                "title": "Location",
+                "default": "us-central1",
+                "description": "Google Cloud region"
+              },
+              "model_name": {
+                "type": "string",
+                "title": "Model Name",
+                "default": "textembedding-gecko@latest",
+                "description": "Vertex AI model name"
+              },
+              "#credentials": {
+                "type": "string",
+                "title": "Service Account JSON",
+                "format": "password",
+                "description": "Google Cloud service account credentials JSON"
+              }
+            }
+          }
+        },
+        "propertyOrder": 200
+      },
+      "test_database_connection": {
+        "type": "kunda",
+        "format": "sync-action",
+        "options": {
+          "async": {
+            "cache": false,
+            "label": "Test Connection to Vector Store Database",
+            "action": "testVectorStoreConnection"
+          },
+          "hidden": true
+        }
+      },
+      "test_embedding_service_connection": {
+        "type": "kunda",
+        "format": "sync-action",
+        "options": {
+          "async": {
+            "cache": false,
+            "label": "Test Connection to Embedding Service",
+            "action": "testEmbeddingServiceConnection"
+          },
+          "hidden": true
+        },
+        "propertyOrder": 300
+      }
+    }
+  }
+  

--- a/tests/resources/root_parameters_valid.json
+++ b/tests/resources/root_parameters_valid.json
@@ -1,0 +1,9 @@
+{
+    "embedding_settings": {
+      "provider_type": "openai",
+      "openai_settings": {
+        "model": "text-embedding-3-small",
+        "#api_key": "test-api-key"
+      }
+    }
+  }

--- a/tests/resources/row_parameters_invalid.json
+++ b/tests/resources/row_parameters_invalid.json
@@ -1,0 +1,24 @@
+{
+    "_metadata_": {
+      "table": {
+        "id": "tbl_123",
+        "name": "customers",
+        "columns": ["name", "email", "notes"],
+        "primaryKey": ["email"]
+      }
+    },
+    "destination": {
+      "collection_name": "customer_notes",
+      "load_type": "incremental_load"
+    },
+    "advanced_options": {
+      "batch_size": 0,
+      "enable_chunking": true,
+      "chunking_settings": {
+        "chunk_size": 9000,
+        "chunk_overlap": -10,
+        "chunk_strategy": "sentence"
+      }
+    }
+  }
+  

--- a/tests/resources/row_parameters_schema.json
+++ b/tests/resources/row_parameters_schema.json
@@ -1,0 +1,186 @@
+{
+  "type": "object",
+  "title": "Vector Store Configuration",
+  "required": [
+    "text_column"
+  ],
+  "properties": {
+    "_metadata_": {
+      "type": "object",
+      "options": {
+        "hidden": true
+      },
+      "properties": {
+        "table": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "columns": {
+              "type": "array"
+            },
+            "primaryKey": {
+              "type": "array"
+            }
+          }
+        }
+      }
+    },
+    "destination": {
+      "type": "object",
+      "title": "Destination",
+      "options": [],
+      "required": [
+        "collection_name"
+      ],
+      "properties": {
+        "load_type": {
+          "enum": [
+            "full_load",
+            "incremental_load"
+          ],
+          "type": "string",
+          "title": "Load Type",
+          "format": "checkbox",
+          "default": "full_load",
+          "options": {
+            "enum_titles": [
+              "Full Load",
+              "Incremental Load"
+            ]
+          },
+          "description": "If Full load is used, the destination table will be overwritten every run. If incremental load is used, data will be upserted into the destination table. Tables with a primary key will have rows updated, tables without a primary key will have rows appended.",
+          "propertyOrder": 30
+        },
+        "primary_key": {
+          "type": "string",
+          "title": "Primary Key Column",
+          "watch": {
+            "columns": "_metadata_.table.columns"
+          },
+          "options": {
+            "dependencies": {
+              "load_type": "incremental_load"
+            }
+          },
+          "required": false,
+          "enumSource": "columns",
+          "description": "Choose a column to use as unique identifier for upserts.",
+          "propertyOrder": 30
+        },
+        "collection_name": {
+          "type": "string",
+          "title": "Collection Name",
+          "default": "keboola_embeddings",
+          "propertyOrder": 10
+        },
+        "metadata_columns": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Column Name",
+            "watch": {
+              "columns": "_metadata_.table.columns"
+            },
+            "enumSource": "columns"
+          },
+          "title": "Metadata Columns",
+          "format": "select",
+          "options": {
+            "tags": true
+          },
+          "required": false,
+          "description": "Choose columns to save to the vector store database as metadata.",
+          "uniqueItems": true,
+          "propertyOrder": 20
+        }
+      },
+      "propertyOrder": 300
+    },
+    "text_column": {
+      "type": "string",
+      "title": "Embed column name",
+      "watch": {
+        "columns": "_metadata_.table.columns"
+      },
+      "required": true,
+      "enumSource": "columns",
+      "description": "Choose a column to embed data",
+      "propertyOrder": 1
+    },
+    "advanced_options": {
+      "type": "object",
+      "title": "Advanced Options",
+      "properties": {
+        "batch_size": {
+          "type": "integer",
+          "title": "Batch Size",
+          "default": 100,
+          "maximum": 1000,
+          "minimum": 1,
+          "description": "Number of texts to process in one batch",
+          "propertyOrder": 20
+        },
+        "enable_chunking": {
+          "type": "boolean",
+          "title": "Enable Text Chunking",
+          "format": "checkbox",
+          "default": false,
+          "description": "Split long texts into smaller chunks before embedding",
+          "propertyOrder": 30
+        },
+        "chunking_settings": {
+          "type": "object",
+          "title": "Chunking Settings",
+          "options": {
+            "dependencies": {
+              "enable_chunking": true
+            }
+          },
+          "properties": {
+            "chunk_size": {
+              "type": "integer",
+              "title": "Chunk Size",
+              "default": 1000,
+              "maximum": 8000,
+              "minimum": 100,
+              "description": "Maximum number of characters in each chunk",
+              "propertyOrder": 50
+            },
+            "chunk_overlap": {
+              "type": "integer",
+              "title": "Chunk Overlap",
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 0,
+              "description": "Number of characters to overlap between chunks",
+              "propertyOrder": 60
+            },
+            "chunk_strategy": {
+              "enum": [
+                "character",
+                "sentence",
+                "word",
+                "paragraph"
+              ],
+              "type": "string",
+              "title": "Chunking Strategy",
+              "default": "paragraph",
+              "options": {
+                "tooltip": "Paragraph is recommended for most use cases"
+              },
+              "description": "How to split the text into chunks",
+              "propertyOrder": 70
+            }
+          },
+          "propertyOrder": 40
+        }
+      },
+      "propertyOrder": 200
+    }
+  }
+}

--- a/tests/resources/row_parameters_valid.json
+++ b/tests/resources/row_parameters_valid.json
@@ -1,0 +1,26 @@
+{
+    "_metadata_": {
+      "table": {
+        "id": "tbl_123",
+        "name": "customers",
+        "columns": ["name", "email", "notes"],
+        "primaryKey": ["email"]
+      }
+    },
+    "text_column": "notes",
+    "destination": {
+      "collection_name": "customer_notes",
+      "load_type": "incremental_load",
+      "primary_key": "email",
+      "metadata_columns": ["name"]
+    },
+    "advanced_options": {
+      "batch_size": 100,
+      "enable_chunking": true,
+      "chunking_settings": {
+        "chunk_size": 1000,
+        "chunk_overlap": 100,
+        "chunk_strategy": "paragraph"
+      }
+    }
+  }

--- a/tests/tools/components/test_utils_validation.py
+++ b/tests/tools/components/test_utils_validation.py
@@ -1,0 +1,94 @@
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from keboola_mcp_server.client import JsonDict, KeboolaClient
+from keboola_mcp_server.tools._validate import validate_parameters, validate_storage
+from keboola_mcp_server.tools.components import utils
+
+
+@pytest.mark.parametrize(
+    ('input_storage', 'output_storage'),
+    [
+        ({'input': {}, 'output': {}}, {'input': {}, 'output': {}}),
+        ({'storage': {'input': {}, 'output': {}}}, {'input': {}, 'output': {}}),
+        ({}, {}),  # we expect passing when no storage is provided
+        (None, None),  # we expect passing when no storage is provided
+    ],
+)
+def test_validate_storage_configuration_output(input_storage: Optional[JsonDict], output_storage: Optional[JsonDict]):
+    """testing normalized and returned structures {storage: {...}} vs {...}"""
+    if input_storage is not None:
+        result = validate_storage(input_storage)
+        expected = {'storage': output_storage}
+        assert result == expected  # we expect wrapped structure (normalized)
+
+    result = utils.validate_storage_configuration(input_storage)
+    expected = output_storage  # we expect unwrapped structure
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('input_parameters', 'output_parameters'),
+    [
+        ({'a': 1}, {'a': 1}),
+        ({'parameters': {'a': 1, 'b': 2}}, {'a': 1, 'b': 2}),
+    ],
+)
+async def test_validate_root_parameters_configuration_output(
+    mocker, input_parameters: JsonDict, output_parameters: JsonDict, keboola_client: KeboolaClient
+):
+    """testing normalized and returned structures {parameters: {...}} vs {...}"""
+    accepting_schema = {'type': 'object', 'additionalProperties': True}  # accepts any json object
+    result = validate_parameters(input_parameters, accepting_schema)
+    expected = {'parameters': output_parameters}
+    assert result == expected  # we expect wrapped structure (normalized)
+
+    component = MagicMock()
+    component.configuration_schema = accepting_schema
+    mocker.patch('keboola_mcp_server.tools.components.utils._get_component', new=AsyncMock(return_value=component))
+    result = await utils.validate_root_parameters_configuration(keboola_client, input_parameters, 'component-id')
+    expected = output_parameters  # we expect unwrapped structure
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('input_parameters', 'output_parameters'),
+    [
+        ({'a': 1}, {'a': 1}),
+        ({'parameters': {'a': 1, 'b': 2}}, {'a': 1, 'b': 2}),
+    ],
+)
+async def test_validate_row_parameters_configuration_output(
+    mocker, input_parameters: JsonDict, output_parameters: JsonDict, keboola_client: KeboolaClient
+):
+    """testing normalized and returned structures {parameters: {...}} vs {...}"""
+    accepting_schema = {'type': 'object', 'additionalProperties': True}  # accepts any json object
+    result = validate_parameters(input_parameters, accepting_schema)
+    expected = {'parameters': output_parameters}
+    assert result == expected  # we expect wrapped structure (normalized)
+
+    component = MagicMock()
+    component.configuration_schema = accepting_schema
+    mocker.patch('keboola_mcp_server.tools.components.utils._get_component', new=AsyncMock(return_value=component))
+    result = await utils.validate_row_parameters_configuration(keboola_client, input_parameters, 'component-id')
+    expected = output_parameters  # we expect unwrapped structure
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('input_schema', [(None, {})])
+async def test_validate_parameters_configuration_no_schema(
+    mocker, input_schema: Optional[JsonDict], keboola_client: KeboolaClient
+):
+    """We expect passing the validation when no schema is provided"""
+    input_parameters: JsonDict = {'a': 1}
+    component = MagicMock()
+    component.configuration_row_schema = input_schema
+    mocker.patch('keboola_mcp_server.tools.components.utils._get_component', new=AsyncMock(return_value=component))
+    result = await utils.validate_row_parameters_configuration(keboola_client, input_parameters, 'component-id')
+    expected = input_parameters  # we expect unwrapped structure
+    assert result == expected

--- a/tests/tools/components/test_utils_validation.py
+++ b/tests/tools/components/test_utils_validation.py
@@ -80,7 +80,7 @@ async def test_validate_row_parameters_configuration_output(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('input_schema', [(None, {})])
+@pytest.mark.parametrize('input_schema', [None, {}])
 async def test_validate_parameters_configuration_no_schema(
     mocker, input_schema: Optional[JsonDict], keboola_client: KeboolaClient
 ):

--- a/tests/tools/test_validate.py
+++ b/tests/tools/test_validate.py
@@ -211,16 +211,12 @@ def test_validate_row_parameters(schema_path: str, data_path: str, valid: bool):
         data = json.load(f)
     if valid:
         try:
-            _validate._validate_json_against_schema(
-                data, schema, validate_fn=_validate.KeboolaParametersValidator.validate
-            )
+            _validate.validate_parameters(data, schema)
         except jsonschema.ValidationError:
             pytest.fail('ValidationError was raised when it should not have been')
     else:
         with pytest.raises(jsonschema.ValidationError):
-            _validate._validate_json_against_schema(
-                data, schema, validate_fn=_validate.KeboolaParametersValidator.validate
-            )
+            _validate.validate_parameters(data, schema)
 
 
 @pytest.mark.parametrize(
@@ -241,13 +237,9 @@ def test_validate_root_parameters(schema_path: str, data_path: str, valid: bool)
         data = json.load(f)
     if valid:
         try:
-            _validate._validate_json_against_schema(
-                data, schema, validate_fn=_validate.KeboolaParametersValidator.validate
-            )
+            _validate.validate_parameters(data, schema)
         except jsonschema.ValidationError:
             pytest.fail('ValidationError was raised when it should not have been')
     else:
         with pytest.raises(jsonschema.ValidationError):
-            _validate._validate_json_against_schema(
-                data, schema, validate_fn=_validate.KeboolaParametersValidator.validate
-            )
+            _validate.validate_parameters(data, schema)


### PR DESCRIPTION
We add custom JsonSchema validator so that:
- when schema contains objects of button type, objects are skipped
- when required field equals to true or false we convert it to the empty list [] since the requirement property is captured already in its parent object.
Both problems caused errors when initializing schemas - making it unable to validate json data.