### PR TITLE
feat: Add storage events integration

### DIFF
--- a/integtests/conftest.py
+++ b/integtests/conftest.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import random
+import uuid
 from contextlib import _AsyncGeneratorContextManager, asynccontextmanager
 from dataclasses import dataclass
 from multiprocessing import Process
@@ -270,6 +271,12 @@ def configs(keboola_project: ProjectDef) -> list[ConfigDef]:
 @pytest.fixture
 def keboola_client(storage_api_token: str, storage_api_url: str) -> KeboolaClient:
     return KeboolaClient(storage_api_token=storage_api_token, storage_api_url=storage_api_url)
+
+
+@pytest.fixture
+def unique_id() -> str:
+    """Generates a unique ID string for test resources."""
+    return str(uuid.uuid4())[:8]
 
 
 @pytest.fixture

--- a/integtests/test_storage_tools.py
+++ b/integtests/test_storage_tools.py
@@ -1,9 +1,12 @@
 import csv
+import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastmcp import Context
 
 from integtests.conftest import BucketDef, TableDef
+from keboola_mcp_server.client import AsyncStorageClient, RawKeboolaClient, KeboolaClient
 from keboola_mcp_server.tools.storage import (
     BucketDetail,
     TableDetail,
@@ -77,3 +80,114 @@ async def test_retrieve_bucket_tables(mcp_context: Context, tables: list[TableDe
         result_table_ids = {table.id for table in result}
         expected_table_ids = {table.table_id for table in expected_tables}
         assert result_table_ids == expected_table_ids
+
+
+@pytest.mark.asyncio
+@patch.object(RawKeboolaClient, "_send_event_after_request", new_callable=AsyncMock)
+async def test_storage_modifying_operations_trigger_event_sending(
+    mock_send_event: AsyncMock, 
+    keboola_client: KeboolaClient,
+    unique_id: str
+):
+    """
+    Tests that actual Storage API modifying operations (create, update, delete config)
+    trigger the _send_event_after_request method with the correct context.
+    We mock _send_event_after_request to avoid actual event sending during tests.
+    """
+    storage_client: AsyncStorageClient = keboola_client.storage_client
+    test_component_id = "keboola.python-transformation"
+    config_name = f"mcp-event-integ-test-{unique_id}"
+    branch_id = storage_client.branch_id
+
+    created_config_id = None
+
+    try:
+        # 1. Create Configuration (POST)
+        create_data = {
+            "name": config_name,
+            "description": "Integration test for MCP event logging - create.",
+            "configuration": {"parameters": {"script": "print('created')"}}
+        }
+        mcp_context_create = {
+            "tool_name": "integ_test_create_config",
+            "tool_args": {"component_id": test_component_id, "data_summary": "config_create_payload"},
+        }
+        
+        created_config = await storage_client.create_component_root_configuration(
+            component_id=test_component_id,
+            data=create_data,
+            mcp_context=mcp_context_create
+        )
+        created_config_id = created_config["id"]
+        assert created_config_id
+
+        mock_send_event.assert_any_call(
+            http_method="POST",
+            endpoint=f"branch/{branch_id}/components/{test_component_id}/configs",
+            response_json=created_config,
+            error_obj=None,
+            duration_s=pytest.approx(0, abs=5),
+            mcp_context=mcp_context_create
+        )
+        initial_call_count = mock_send_event.call_count
+
+        # 2. Update Configuration (PUT)
+        update_data = {
+            "name": config_name,
+            "description": "Integration test for MCP event logging - update.",
+            "changeDescription": "Integ test update",
+            "configuration": {"parameters": {"script": "print('updated')"}}
+        }
+        mcp_context_update = {
+            "tool_name": "integ_test_update_config",
+            "tool_args": {"component_id": test_component_id, "config_id": created_config_id, "data_summary": "config_update_payload"},
+            "config_id_if_known": created_config_id
+        }
+
+        updated_config = await storage_client.update_component_root_configuration(
+            component_id=test_component_id,
+            config_id=created_config_id,
+            data=update_data,
+            mcp_context=mcp_context_update
+        )
+        assert updated_config["description"] == update_data["description"]
+        
+        # Check that send_event was called again
+        assert mock_send_event.call_count > initial_call_count
+        mock_send_event.assert_any_call(
+            http_method="PUT",
+            endpoint=f"branch/{branch_id}/components/{test_component_id}/configs/{created_config_id}",
+            response_json=updated_config,
+            error_obj=None,
+            duration_s=pytest.approx(0, abs=5),
+            mcp_context=mcp_context_update
+        )
+        update_call_count = mock_send_event.call_count
+
+    finally:
+        # 3. Delete Configuration (DELETE)
+        if created_config_id:
+            mcp_context_delete = {
+                "tool_name": "integ_test_delete_config",
+                "tool_args": {"component_id": test_component_id, "config_id": created_config_id},
+                "config_id_if_known": created_config_id
+            }
+            delete_endpoint = f"branch/{branch_id}/components/{test_component_id}/configs/{created_config_id}"
+            
+            # The SAPI delete for config returns an empty body on success (204 No Content typically)
+            # Our client normalizes this to an empty dict for the event if successful.
+            expected_delete_response_for_event = {}
+
+            await storage_client.delete(
+                endpoint=delete_endpoint,
+                mcp_context=mcp_context_delete
+            )
+            assert mock_send_event.call_count > update_call_count
+            mock_send_event.assert_any_call(
+                http_method="DELETE",
+                endpoint=delete_endpoint,
+                response_json=expected_delete_response_for_event, 
+                error_obj=None,
+                duration_s=pytest.approx(0, abs=5),
+                mcp_context=mcp_context_delete
+            )

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -3,6 +3,7 @@
 import importlib.metadata
 import logging
 import os
+import time
 from typing import Any, Mapping, Optional, Union, cast
 
 import httpx
@@ -27,6 +28,8 @@ class KeboolaClient:
     _PREFIX_STORAGE_API_URL = 'connection.'
     _PREFIX_QUEUE_API_URL = 'https://queue.'
     _PREFIX_AISERVICE_API_URL = 'https://ai.'
+
+    _MCP_SERVER_COMPONENT_ID = "keboola.mcp-server"
 
     @classmethod
     def from_state(cls, state: Mapping[str, Any]) -> 'KeboolaClient':
@@ -97,6 +100,8 @@ class RawKeboolaClient:
     and can be used to implement high-level functions in clients for individual services.
     """
 
+    _MCP_SERVER_COMPONENT_ID = "keboola.mcp-server"
+
     def __init__(
         self,
         base_api_url: str,
@@ -113,6 +118,17 @@ class RawKeboolaClient:
         self.timeout = timeout or httpx.Timeout(connect=5.0, read=60.0, write=10.0, pool=5.0)
         if headers:
             self.headers.update(headers)
+
+        # Derive project_id from the api_token (X-StorageApi-Token) once during initialization
+        try:
+            token_parts = api_token.split('-', 1) # Split only on the first hyphen
+            if not token_parts or not token_parts[0]: # Check for empty token or first part
+                raise ValueError("Token is empty or missing the project ID part.")
+            self.parsed_project_id: Union[int, str] = int(token_parts[0])
+        except (IndexError, ValueError) as e:
+            # Log conservatively, avoid logging the full token if not necessary for privacy/security
+            LOG.error(f"Could not derive project_id from X-StorageApi-Token in constructor. Error: {e}. Using 'unknown'.")
+            self.parsed_project_id = "unknown"
 
     async def get(
         self,
@@ -143,6 +159,7 @@ class RawKeboolaClient:
         endpoint: str,
         data: dict[str, Any] | None = None,
         headers: dict[str, Any] | None = None,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonStruct:
         """
         Makes a POST request to the service API.
@@ -150,23 +167,46 @@ class RawKeboolaClient:
         :param endpoint: API endpoint to call
         :param data: Request payload
         :param headers: Additional headers for the request
+        :param mcp_context: Optional context for MCP event logging
         :return: API response as dictionary
         """
-        headers = self.headers | (headers or {})
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.post(
-                f'{self.base_api_url}/{endpoint}',
-                headers=headers,
-                json=data or {},
-            )
-            response.raise_for_status()
-            return cast(JsonStruct, response.json())
+        request_headers = self.headers | (headers or {})
+        response_json: Optional[JsonStruct] = None
+        error_obj: Optional[Exception] = None
+        start_time = time.monotonic()
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f'{self.base_api_url}/{endpoint}',
+                    headers=request_headers,
+                    json=data or {},
+                )
+                response.raise_for_status()
+                response_json = cast(JsonStruct, response.json())
+                return response_json
+        except Exception as e:
+            error_obj = e
+            raise
+        finally:
+            duration_s = time.monotonic() - start_time
+            LOG.info(f"MCP: raw_client POST to /{endpoint} - duration {duration_s:.3f}s. Tool: {mcp_context.get('tool_name') if mcp_context else 'N/A'}. Full Context: {mcp_context}")
+            if mcp_context and self._should_send_event(endpoint):
+                await self._send_event_after_request(
+                    http_method="POST",
+                    endpoint=endpoint,
+                    response_json=response_json,
+                    error_obj=error_obj,
+                    duration_s=duration_s,
+                    mcp_context=mcp_context,
+                )
 
     async def put(
         self,
         endpoint: str,
         data: dict[str, Any] | None = None,
         headers: dict[str, Any] | None = None,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonStruct:
         """
         Makes a PUT request to the service API.
@@ -174,39 +214,158 @@ class RawKeboolaClient:
         :param endpoint: API endpoint to call
         :param data: Request payload
         :param headers: Additional headers for the request
+        :param mcp_context: Optional context for MCP event logging
         :return: API response as dictionary
         """
-        headers = self.headers | (headers or {})
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.put(
-                f'{self.base_api_url}/{endpoint}',
-                headers=headers,
-                json=data or {},
-            )
-            response.raise_for_status()
-            return cast(JsonStruct, response.json())
+        request_headers = self.headers | (headers or {})
+        response_json: Optional[JsonStruct] = None
+        error_obj: Optional[Exception] = None
+        start_time = time.monotonic()
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.put(
+                    f'{self.base_api_url}/{endpoint}',
+                    headers=request_headers,
+                    json=data or {},
+                )
+                response.raise_for_status()
+                response_json = cast(JsonStruct, response.json())
+                return response_json
+        except Exception as e:
+            error_obj = e
+            raise
+        finally:
+            duration_s = time.monotonic() - start_time
+            if mcp_context and self._should_send_event(endpoint):
+                await self._send_event_after_request(
+                    http_method="PUT",
+                    endpoint=endpoint,
+                    response_json=response_json,
+                    error_obj=error_obj,
+                    duration_s=duration_s,
+                    mcp_context=mcp_context,
+                )
 
     async def delete(
         self,
         endpoint: str,
         headers: dict[str, Any] | None = None,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonStruct:
         """
         Makes a DELETE request to the service API.
 
         :param endpoint: API endpoint to call
         :param headers: Additional headers for the request
+        :param mcp_context: Optional context for MCP event logging
         :return: API response as dictionary
         """
-        headers = self.headers | (headers or {})
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.delete(
-                f'{self.base_api_url}/{endpoint}',
-                headers=headers,
-            )
-            response.raise_for_status()
+        request_headers = self.headers | (headers or {})
+        response_json: Optional[JsonStruct] = None
+        error_obj: Optional[Exception] = None
+        start_time = time.monotonic()
 
-            return cast(JsonStruct, response.json())
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.delete(
+                    f'{self.base_api_url}/{endpoint}',
+                    headers=request_headers,
+                )
+                response.raise_for_status()
+                # Handle cases where DELETE might return no content or non-JSON content
+                if response.status_code == 204 or not response.content: # No Content
+                    response_json = {} # Or an appropriate representation
+                else:
+                    try:
+                        response_json = cast(JsonStruct, response.json())
+                    except ValueError: # Not JSON
+                        LOG.warning(f"DELETE request to {endpoint} did not return JSON. Status: {response.status_code}")
+                        response_json = {"status": response.status_code, "content": response.text}
+
+                return response_json # Return the potentially modified response_json
+        except Exception as e:
+            error_obj = e
+            raise
+        finally:
+            duration_s = time.monotonic() - start_time
+            if mcp_context and self._should_send_event(endpoint):
+                await self._send_event_after_request(
+                    http_method="DELETE",
+                    endpoint=endpoint,
+                    response_json=response_json,
+                    error_obj=error_obj,
+                    duration_s=duration_s,
+                    mcp_context=mcp_context,
+                )
+
+    def _should_send_event(self, endpoint: str) -> bool:
+        """Checks if an event should be sent for this operation."""
+        # Send events only if the base_api_url is for /v2/storage and the current endpoint is not 'events' itself
+        return self.base_api_url.endswith('/v2/storage') and endpoint != "events"
+
+    async def _send_event_after_request(
+        self,
+        http_method: str,
+        endpoint: str,
+        response_json: Optional[JsonStruct],
+        error_obj: Optional[Exception],
+        duration_s: float,
+        mcp_context: dict[str, Any],  # Assumed not None if we reach here
+    ) -> None:
+        """Constructs and sends an event to the Keboola Storage API."""
+        # project_id is now derived in the constructor and stored in self.parsed_project_id
+
+        event_payload: dict[str, Any] = {
+            "component": self._MCP_SERVER_COMPONENT_ID,
+            "message": f"MCP: {mcp_context['tool_name']} - {http_method} /v2/storage/{endpoint}",
+            "type": "error" if error_obj else "info",
+            "durationSeconds": round(duration_s, 3),
+            "params": {
+                "name": mcp_context["tool_name"],
+                "args": mcp_context["tool_args"], # Ensure this is JSON serializable
+            },
+            "results": {
+                "projectId": self.parsed_project_id, # Use the pre-parsed project_id
+            },
+        }
+        if "config_id" in mcp_context:
+            event_payload["configurationId"] = mcp_context["config_id"]
+        if "run_id" in mcp_context:
+            event_payload["runId"] = mcp_context["run_id"]
+
+        if error_obj:
+            event_payload["results"]["error"] = str(error_obj)
+        else:
+            event_payload["results"]["query"] = response_json # May need truncation/summarization
+
+        try:
+            event_headers = {
+                'X-StorageApi-Token': self.headers['X-StorageApi-Token'],
+                'Content-Type': 'application/json',
+            }
+            if 'User-Agent' in self.headers:
+                event_headers['User-Agent'] = self.headers['User-Agent']
+
+            event_post_url = f"{self.base_api_url}/events"
+            
+            LOG.debug(f"Attempting to send MCP event: {event_payload} to {event_post_url}")
+            # Use a new httpx.AsyncClient for sending the event
+            async with httpx.AsyncClient(timeout=self.timeout) as event_client:
+                response = await event_client.post(
+                    event_post_url,
+                    headers=event_headers,
+                    json=event_payload,
+                )
+                response.raise_for_status()
+                LOG.info(f"Successfully sent MCP event for {http_method} /v2/storage/{endpoint}")
+        except httpx.HTTPStatusError as e:
+            LOG.error(
+                f"Error sending MCP event for {http_method} /v2/storage/{endpoint}: "
+                f"HTTPStatusError {e.response.status_code} - {e.response.text}"
+            )
+        except Exception as e:
+            LOG.error(f"Unexpected error sending MCP event for {http_method} /v2/storage/{endpoint}: {e}")
 
 
 class KeboolaServiceClient:
@@ -257,41 +416,47 @@ class KeboolaServiceClient:
         self,
         endpoint: str,
         data: Optional[dict[str, Any]] = None,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonStruct:
         """
         Makes a POST request to the service API.
 
         :param endpoint: API endpoint to call
         :param data: Request payload
+        :param mcp_context: Optional context for MCP event logging
         :return: API response as dictionary
         """
-        return await self.raw_client.post(endpoint=endpoint, data=data)
+        return await self.raw_client.post(endpoint=endpoint, data=data, mcp_context=mcp_context)
 
     async def put(
         self,
         endpoint: str,
         data: Optional[dict[str, Any]] = None,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonStruct:
         """
         Makes a PUT request to the service API.
 
         :param endpoint: API endpoint to call
         :param data: Request payload
+        :param mcp_context: Optional context for MCP event logging
         :return: API response as dictionary
         """
-        return await self.raw_client.put(endpoint=endpoint, data=data)
+        return await self.raw_client.put(endpoint=endpoint, data=data, mcp_context=mcp_context)
 
     async def delete(
         self,
         endpoint: str,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonStruct:
         """
         Makes a DELETE request to the service API.
 
         :param endpoint: API endpoint to call
+        :param mcp_context: Optional context for MCP event logging
         :return: API response as dictionary
         """
-        return await self.raw_client.delete(endpoint=endpoint)
+        return await self.raw_client.delete(endpoint=endpoint, mcp_context=mcp_context)
 
 
 class AsyncStorageClient(KeboolaServiceClient):
@@ -416,6 +581,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         change_description: str,
         updated_description: Optional[str] = None,
         is_disabled: bool = False,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Updates a component configuration.
@@ -427,6 +593,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param updated_description: The entire description of the updated configuration, if None, the original
             description is preserved.
         :param is_disabled: Whether the configuration should be disabled.
+        :param mcp_context: Optional context for MCP event logging
         :return: The SAPI call response - updated configuration or raise an error.
         """
         endpoint = f'branch/{self.branch_id}/components/{component_id}/configs/{configuration_id}'
@@ -441,22 +608,24 @@ class AsyncStorageClient(KeboolaServiceClient):
         if is_disabled:
             payload['isDisabled'] = is_disabled
 
-        return cast(JsonDict, await self.put(endpoint=endpoint, data=payload))
+        return cast(JsonDict, await self.put(endpoint=endpoint, data=payload, mcp_context=mcp_context))
 
     async def create_component_root_configuration(
         self,
         data: dict[str, Any],
         component_id: str,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Creates a new configuration for a component.
 
         :param data: The configuration data to create.
         :param component_id: The ID of the component.
+        :param mcp_context: Optional context for MCP event logging
         :return: The SAPI call response - created configuration or raise an error.
         """
         return cast(
-            JsonDict, await self.post(endpoint=f'branch/{self.branch_id}/components/{component_id}/configs', data=data)
+            JsonDict, await self.post(endpoint=f'branch/{self.branch_id}/components/{component_id}/configs', data=data, mcp_context=mcp_context)
         )
 
     async def create_component_row_configuration(
@@ -464,6 +633,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         data: dict[str, Any],
         component_id: str,
         config_id: str,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Creates a new row configuration for a component configuration.
@@ -471,12 +641,13 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param data: The configuration data to create row configuration.
         :param component_id: The ID of the component.
         :param config_id: The ID of the configuration.
+        :param mcp_context: Optional context for MCP event logging
         :return: The SAPI call response - created row configuration or raise an error.
         """
         return cast(
             JsonDict,
             await self.post(
-                endpoint=f'branch/{self.branch_id}/components/{component_id}/configs/{config_id}/rows', data=data
+                endpoint=f'branch/{self.branch_id}/components/{component_id}/configs/{config_id}/rows', data=data, mcp_context=mcp_context
             ),
         )
 
@@ -485,6 +656,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         data: dict[str, Any],
         component_id: str,
         config_id: str,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Updates a component configuration.
@@ -492,12 +664,13 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param data: The configuration data to update.
         :param component_id: The ID of the component.
         :param config_id: The ID of the configuration.
+        :param mcp_context: Optional context for MCP event logging
         :return: The SAPI call response - updated configuration or raise an error.
         """
         return cast(
             JsonDict,
             await self.put(
-                endpoint=f'branch/{self.branch_id}/components/{component_id}/configs/{config_id}', data=data
+                endpoint=f'branch/{self.branch_id}/components/{component_id}/configs/{config_id}', data=data, mcp_context=mcp_context
             ),
         )
 
@@ -507,6 +680,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         component_id: str,
         config_id: str,
         configuration_row_id: str,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Updates a row configuration for a component configuration.
@@ -515,6 +689,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param component_id: The ID of the component.
         :param config_id: The ID of the configuration.
         :param configuration_row_id: The ID of the row.
+        :param mcp_context: Optional context for MCP event logging
         :return: The SAPI call response - updated row configuration or raise an error.
         """
         return cast(
@@ -523,6 +698,7 @@ class AsyncStorageClient(KeboolaServiceClient):
                 endpoint=f'branch/{self.branch_id}/components/{component_id}/configs/{config_id}'
                 f'/rows/{configuration_row_id}',
                 data=data,
+                mcp_context=mcp_context,
             ),
         )
 
@@ -531,6 +707,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         name: str,
         description: str,
         flow_configuration: dict[str, Any],
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Creates a new flow (orchestrator) configuration.
@@ -541,6 +718,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param name: The name of the flow
         :param description: The description of the flow
         :param flow_configuration: The flow configuration containing phases and tasks directly
+        :param mcp_context: Optional context for MCP event logging
         :return: The SAPI call response - created flow configuration or raise an error
         """
         data = {
@@ -550,7 +728,8 @@ class AsyncStorageClient(KeboolaServiceClient):
         }
         return await self.create_component_root_configuration(
             data=data,
-            component_id=ORCHESTRATOR_COMPONENT_ID
+            component_id=ORCHESTRATOR_COMPONENT_ID,
+            mcp_context=mcp_context,
         )
 
     async def update_flow_configuration(
@@ -560,6 +739,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         description: str,
         change_description: str,
         flow_configuration: dict[str, Any],
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Updates an existing flow (orchestrator) configuration.
@@ -571,6 +751,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param description: The updated description of the flow
         :param change_description: Description of the changes made
         :param flow_configuration: The updated flow configuration containing phases and tasks directly
+        :param mcp_context: Optional context for MCP event logging
         :return: The SAPI call response - updated flow configuration or raise an error
         """
         data = {
@@ -582,7 +763,8 @@ class AsyncStorageClient(KeboolaServiceClient):
         return await self.update_component_root_configuration(
             data=data,
             component_id=ORCHESTRATOR_COMPONENT_ID,
-            config_id=config_id
+            config_id=config_id,
+            mcp_context=mcp_context,
         )
 
     async def list_flow_configurations(self) -> list[JsonDict]:
@@ -671,12 +853,14 @@ class JobsQueueClient(KeboolaServiceClient):
         self,
         component_id: str,
         configuration_id: str,
+        mcp_context: Optional[dict[str, Any]] = None,
     ) -> JsonDict:
         """
         Creates a new job.
 
         :param component_id: The id of the component.
         :param configuration_id: The id of the configuration.
+        :param mcp_context: Optional context for MCP event logging
         :return: The response from the API call - created job or raise an error.
         """
         payload = {
@@ -684,7 +868,7 @@ class JobsQueueClient(KeboolaServiceClient):
             'config': configuration_id,
             'mode': 'run',
         }
-        return cast(JsonDict, await self.post(endpoint='jobs', data=payload))
+        return cast(JsonDict, await self.post(endpoint='jobs', data=payload, mcp_context=mcp_context))
 
     async def _search(self, params: dict[str, Any]) -> JsonList:
         """

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -356,6 +356,7 @@ async def create_sql_transformation(
                 'description': description,
                 'configuration': transformation_configuration_payload.model_dump(),
             },
+            mcp_context=ctx.mcp_context,
         ),
     )
 
@@ -439,6 +440,7 @@ async def update_sql_transformation_configuration(
         change_description=change_description,
         updated_description=updated_description if updated_description else None,
         is_disabled=is_disabled,
+        mcp_context=ctx.mcp_context,
     )
 
     transformation = await _get_component(client=client, component_id=sql_transformation_id)
@@ -527,6 +529,13 @@ async def create_component_root_configuration(
 
     configuration_payload = {'storage': storage, 'parameters': parameters}
 
+    # Construct the mcp_context for event logging
+    # using attributes from FastMCP's Context object
+    tool_event_context = {
+        "tool_name": "create_component_root_configuration",  # Typically holds the tool's registered name
+        "tool_args": parameters # Typically holds the resolved arguments for the tool
+    }
+
     new_raw_configuration = cast(
         dict[str, Any],
         await client.storage_client.create_component_root_configuration(
@@ -536,6 +545,7 @@ async def create_component_root_configuration(
                 'description': description,
                 'configuration': configuration_payload,
             },
+            mcp_context=tool_event_context, # Pass the constructed context
         ),
     )
 
@@ -646,6 +656,7 @@ async def create_component_row_configuration(
                 'description': description,
                 'configuration': configuration_payload,
             },
+            mcp_context=ctx.mcp_context,
         ),
     )
 
@@ -759,6 +770,7 @@ async def update_component_root_configuration(
                 'changeDescription': change_description,
                 'configuration': configuration_payload,
             },
+            mcp_context=ctx.mcp_context,
         ),
     )
 
@@ -879,6 +891,7 @@ async def update_component_row_configuration(
                 'changeDescription': change_description,
                 'configuration': configuration_payload,
             },
+            mcp_context=ctx.mcp_context,
         ),
     )
 

--- a/tests/test_client_events.py
+++ b/tests/test_client_events.py
@@ -1,0 +1,232 @@
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from keboola_mcp_server.client import RawKeboolaClient, JsonDict, JsonStruct
+
+# Base URL for testing storage related event sending
+STORAGE_API_URL_V2 = "https://connection.keboola.com/v2/storage"
+NON_STORAGE_API_URL = "https://queue.keboola.com"
+TEST_TOKEN = "test_token"
+
+
+@pytest.fixture
+def raw_client_storage_v2() -> RawKeboolaClient:
+    """Returns a RawKeboolaClient configured for /v2/storage."""
+    return RawKeboolaClient(base_api_url=STORAGE_API_URL_V2, api_token=TEST_TOKEN)
+
+
+@pytest.fixture
+def raw_client_non_storage() -> RawKeboolaClient:
+    """Returns a RawKeboolaClient configured for a non-storage URL."""
+    return RawKeboolaClient(base_api_url=NON_STORAGE_API_URL, api_token=TEST_TOKEN)
+
+
+class TestRawKeboolaClientEventLogic:
+    """Unit tests for event sending logic in RawKeboolaClient."""
+
+    def test_should_send_event_true_for_v2_storage_non_event_endpoint(self, raw_client_storage_v2: RawKeboolaClient):
+        """Test _should_send_event is True for /v2/storage and non-'events' endpoint."""
+        assert raw_client_storage_v2._should_send_event("tables") is True
+        assert raw_client_storage_v2._should_send_event("branch/my_branch/components/comp/configs") is True
+
+    def test_should_send_event_false_for_v2_storage_event_endpoint(self, raw_client_storage_v2: RawKeboolaClient):
+        """Test _should_send_event is False for /v2/storage and 'events' endpoint."""
+        assert raw_client_storage_v2._should_send_event("events") is False
+
+    def test_should_send_event_false_for_non_v2_storage_url(self, raw_client_non_storage: RawKeboolaClient):
+        """Test _should_send_event is False for non-/v2/storage URLs."""
+        assert raw_client_non_storage._should_send_event("jobs") is False
+
+    @pytest.mark.asyncio
+    async def test_send_event_after_request_success_payload(self, raw_client_storage_v2: RawKeboolaClient, mocker):
+        """Test the payload construction for a successful API call event."""
+        mock_http_post = mocker.patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+        
+        mcp_context = {
+            "tool_name": "test_tool",
+            "tool_args": {"arg1": "val1"},
+            "config_id_if_known": "cfg123",
+            "run_id_if_known": "run456",
+        }
+        response_json: JsonDict = {"id": "res1", "status": "ok"}
+        
+        await raw_client_storage_v2._send_event_after_request(
+            http_method="POST",
+            endpoint="tables",
+            response_json=response_json,
+            error_obj=None,
+            duration_s=1.234,
+            mcp_context=mcp_context,
+        )
+
+        mock_http_post.assert_called_once()
+        call_args = mock_http_post.call_args
+        assert call_args[0][0] == f"{STORAGE_API_URL_V2}/events"  # URL
+        
+        sent_payload = call_args[1]['json'] # kwargs['json']
+        assert sent_payload["componentId"] == RawKeboolaClient._MCP_SERVER_COMPONENT_ID
+        assert sent_payload["message"] == "MCP: test_tool - POST /v2/storage/tables"
+        assert sent_payload["type"] == "info"
+        assert sent_payload["durationSeconds"] == 1.234
+        assert sent_payload["params"]["name"] == "test_tool"
+        assert sent_payload["params"]["args"] == {"arg1": "val1"}
+        assert sent_payload["results"]["query_result"] == response_json
+        assert "error" not in sent_payload["results"]
+        assert sent_payload["configurationId"] == "cfg123"
+        assert sent_payload["runId"] == "run456"
+
+    @pytest.mark.asyncio
+    async def test_send_event_after_request_error_payload(self, raw_client_storage_v2: RawKeboolaClient, mocker):
+        """Test the payload construction for an errored API call event."""
+        mock_http_post = mocker.patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+        
+        mcp_context = {"tool_name": "error_tool", "tool_args": ["argA"]}
+        error = ValueError("Test error")
+        
+        await raw_client_storage_v2._send_event_after_request(
+            http_method="PUT",
+            endpoint="configs/conf1",
+            response_json=None,
+            error_obj=error,
+            duration_s=0.567,
+            mcp_context=mcp_context,
+        )
+
+        mock_http_post.assert_called_once()
+        sent_payload = mock_http_post.call_args[1]['json']
+        assert sent_payload["type"] == "error"
+        assert sent_payload["results"]["error"] == "Test error"
+        assert "query_result" not in sent_payload["results"]
+        assert "configurationId" not in sent_payload # Not in mcp_context
+        assert "runId" not in sent_payload # Not in mcp_context
+
+    @pytest.mark.asyncio
+    @patch.object(RawKeboolaClient, "_send_event_after_request", new_callable=AsyncMock)
+    async def test_post_triggers_event_on_success(self, mock_send_event_method: AsyncMock, raw_client_storage_v2: RawKeboolaClient, mocker):
+        """Test that RawKeboolaClient.post calls _send_event_after_request on success."""
+        mock_response_content: JsonDict = {"id": "new_resource", "status": "created"}
+        
+        # Mock the actual HTTP call for the main operation
+        mock_main_post = mocker.patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+        mock_main_post.return_value = MagicMock(spec=httpx.Response, status_code=201)
+        mock_main_post.return_value.json.return_value = mock_response_content
+        
+        mcp_context = {"tool_name": "creator_tool", "tool_args": {}}
+        endpoint = "some_resource"
+        data = {"key": "value"}
+
+        start_time = time.monotonic()
+        response = await raw_client_storage_v2.post(endpoint, data=data, mcp_context=mcp_context)
+        duration_s = time.monotonic() - start_time
+
+        assert response == mock_response_content
+        mock_send_event_method.assert_called_once()
+        
+        call_args = mock_send_event_method.call_args[1] # kwargs
+        assert call_args["http_method"] == "POST"
+        assert call_args["endpoint"] == endpoint
+        assert call_args["response_json"] == mock_response_content
+        assert call_args["error_obj"] is None
+        assert abs(call_args["duration_s"] - duration_s) < 0.1 # Check duration is close
+        assert call_args["mcp_context"] == mcp_context
+
+    @pytest.mark.asyncio
+    @patch.object(RawKeboolaClient, "_send_event_after_request", new_callable=AsyncMock)
+    async def test_put_triggers_event_on_http_error(self, mock_send_event_method: AsyncMock, raw_client_storage_v2: RawKeboolaClient, mocker):
+        """Test that RawKeboolaClient.put calls _send_event_after_request on HTTP error."""
+        # Mock the actual HTTP call for the main operation to raise an error
+        http_error = httpx.HTTPStatusError("Test HTTP Error", request=MagicMock(), response=MagicMock(status_code=400))
+        mock_main_put = mocker.patch("httpx.AsyncClient.put", new_callable=AsyncMock, side_effect=http_error)
+        
+        mcp_context = {"tool_name": "updater_tool", "tool_args": {}, "config_id_if_known": "cfg789"}
+        endpoint = "another_resource/id1"
+        data = {"field": "new_value"}
+
+        start_time = time.monotonic()
+        with pytest.raises(httpx.HTTPStatusError):
+            await raw_client_storage_v2.put(endpoint, data=data, mcp_context=mcp_context)
+        duration_s = time.monotonic() - start_time
+        
+        mock_send_event_method.assert_called_once()
+        call_args = mock_send_event_method.call_args[1]
+        assert call_args["http_method"] == "PUT"
+        assert call_args["endpoint"] == endpoint
+        assert call_args["response_json"] is None # Error occurred
+        assert call_args["error_obj"] is http_error
+        assert abs(call_args["duration_s"] - duration_s) < 0.1
+        assert call_args["mcp_context"] == mcp_context
+
+    @pytest.mark.asyncio
+    @patch.object(RawKeboolaClient, "_send_event_after_request", new_callable=AsyncMock)
+    async def test_delete_no_mcp_context_no_event(self, mock_send_event_method: AsyncMock, raw_client_storage_v2: RawKeboolaClient, mocker):
+        """Test that RawKeboolaClient.delete does NOT call event sender if no mcp_context."""
+        mock_main_delete = mocker.patch("httpx.AsyncClient.delete", new_callable=AsyncMock)
+        mock_main_delete.return_value = MagicMock(spec=httpx.Response, status_code=204, content=b"")
+
+        await raw_client_storage_v2.delete("resource_to_delete", mcp_context=None)
+        
+        mock_send_event_method.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch.object(RawKeboolaClient, "_send_event_after_request", new_callable=AsyncMock)
+    async def test_post_non_storage_url_no_event(self, mock_send_event_method: AsyncMock, raw_client_non_storage: RawKeboolaClient, mocker):
+        """Test that RawKeboolaClient.post does NOT call event sender if URL is not /v2/storage."""
+        mock_main_post = mocker.patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+        mock_main_post.return_value = MagicMock(spec=httpx.Response, status_code=200)
+        mock_main_post.return_value.json.return_value = {"jobId": 123}
+
+        mcp_context = {"tool_name": "job_runner", "tool_args": {}}
+        await raw_client_non_storage.post("jobs", data={}, mcp_context=mcp_context)
+        
+        mock_send_event_method.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_handles_no_content_response_for_event(self, raw_client_storage_v2: RawKeboolaClient, mocker):
+        """Test DELETE with 204 No Content correctly forms event payload (empty query_result)."""
+        mock_send_event = mocker.patch.object(raw_client_storage_v2, "_send_event_after_request", new_callable=AsyncMock)
+        
+        mock_main_delete = mocker.patch("httpx.AsyncClient.delete", new_callable=AsyncMock)
+        mock_main_delete.return_value = MagicMock(spec=httpx.Response, status_code=204, content=b"") # No content
+        
+        mcp_context = {"tool_name": "deleter_tool", "tool_args": {"id": "res_xyz"}}
+        endpoint = "foo/res_xyz"
+        
+        await raw_client_storage_v2.delete(endpoint, mcp_context=mcp_context)
+        
+        mock_send_event.assert_called_once()
+        call_args = mock_send_event.call_args[1]
+        assert call_args["http_method"] == "DELETE"
+        assert call_args["endpoint"] == endpoint
+        assert call_args["response_json"] == {} # Expect empty dict for 204 No Content
+        assert call_args["error_obj"] is None
+        assert call_args["mcp_context"] == mcp_context
+
+    @pytest.mark.asyncio
+    async def test_delete_handles_non_json_response_for_event(self, raw_client_storage_v2: RawKeboolaClient, mocker):
+        """Test DELETE with non-JSON response correctly forms event payload."""
+        mock_send_event = mocker.patch.object(raw_client_storage_v2, "_send_event_after_request", new_callable=AsyncMock)
+        
+        text_content = "Plain text response"
+        mock_main_delete = mocker.patch("httpx.AsyncClient.delete", new_callable=AsyncMock)
+        # Simulate a response that is successful (200) but not JSON
+        mock_response = MagicMock(spec=httpx.Response, status_code=200, content=text_content.encode('utf-8'), text=text_content)
+        mock_response.json.side_effect = ValueError("Not JSON") # Make .json() raise error
+        mock_main_delete.return_value = mock_response
+        
+        mcp_context = {"tool_name": "deleter_tool_non_json", "tool_args": {"id": "res_abc"}}
+        endpoint = "bar/res_abc"
+        
+        await raw_client_storage_v2.delete(endpoint, mcp_context=mcp_context)
+        
+        mock_send_event.assert_called_once()
+        call_args = mock_send_event.call_args[1]
+        assert call_args["http_method"] == "DELETE"
+        assert call_args["endpoint"] == endpoint
+        # Check that response_json in the event reflects the non-JSON nature
+        assert call_args["response_json"] == {"status": 200, "content": text_content}
+        assert call_args["error_obj"] is None
+        assert call_args["mcp_context"] == mcp_context 

--- a/uv.lock
+++ b/uv.lock
@@ -911,7 +911,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
- Extend RawClient API to contain storage event.
- Create mcp_context for tools execution, fill tool name and arguments of tools that were executed.
- Extend tests to check send storage events.