### PR TITLE
add project_id method to SAPI client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.32.1"
+version = "0.32.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -689,12 +689,12 @@ class AsyncStorageClient(KeboolaServiceClient):
 
     async def project_id(self) -> str:
         """
-        Checks the token privileges and returns information about the project to which the token belongs.
+        Retrieves the project id.
 
-        :return: Token and project information
+        :return: Project id.
         """
         raw_data = cast(JsonDict, await self.get(endpoint='tokens/verify'))
-        return raw_data['owner']['id']
+        return str(raw_data['owner']['id'])
 
 
 class JobsQueueClient(KeboolaServiceClient):

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -631,10 +631,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param config_id: The ID of the flow configuration to retrieve
         :return: Flow configuration details
         """
-        return await self.configuration_detail(
-            component_id=ORCHESTRATOR_COMPONENT_ID,
-            configuration_id=config_id
-        )
+        return await self.configuration_detail(component_id=ORCHESTRATOR_COMPONENT_ID, configuration_id=config_id)
 
     async def flow_list(self) -> list[JsonDict]:
         """
@@ -689,6 +686,15 @@ class AsyncStorageClient(KeboolaServiceClient):
         :return: Token and project information
         """
         return cast(JsonDict, await self.get(endpoint='tokens/verify'))
+
+    async def project_id(self) -> str:
+        """
+        Checks the token privileges and returns information about the project to which the token belongs.
+
+        :return: Token and project information
+        """
+        raw_data = cast(JsonDict, await self.get(endpoint='tokens/verify'))
+        return raw_data['owner']['id']
 
 
 class JobsQueueClient(KeboolaServiceClient):


### PR DESCRIPTION
Add a method to fetch the `project_id` specifically to SAPI client.