### PR TITLE
Kab 1108 storage necessity validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.32.2"
+version = "0.32.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -456,7 +456,13 @@ async def update_sql_transformation_configuration(
     sql_transformation_id = _get_sql_transformation_id_from_sql_dialect(await get_sql_dialect(ctx))
     LOG.info(f'SQL transformation ID: {sql_transformation_id}')
 
-    validate_storage_configuration(storage=storage, initial_message='The "storage" field is not valid.')
+    transformation = await _get_component(client=client, component_id=sql_transformation_id)
+
+    storage = validate_storage_configuration(
+        component=transformation,
+        storage=storage,
+        initial_message='The "storage" field is not valid.',
+    )
 
     updated_configuration = {
         'parameters': parameters.model_dump(),
@@ -473,7 +479,6 @@ async def update_sql_transformation_configuration(
         is_disabled=is_disabled,
     )
 
-    transformation = await _get_component(client=client, component_id=sql_transformation_id)
     updated_transformation_configuration = ComponentConfigurationResponse.model_validate(
         updated_raw_configuration
         | {
@@ -549,11 +554,16 @@ async def create_component_root_configuration(
 
     LOG.info(f'Creating new configuration: {name} for component: {component_id}.')
 
-    storage_cfg = validate_storage_configuration(storage=storage, initial_message='The "storage" field is not valid.')
-    parameters = await validate_root_parameters_configuration(
-        client=client,
+    component = await _get_component(client=client, component_id=component_id)
+
+    storage_cfg = validate_storage_configuration(
+        component=component,
+        storage=storage,
+        initial_message='The "storage" field is not valid.',
+    )
+    parameters = validate_root_parameters_configuration(
+        component=component,
         parameters=parameters,
-        component_id=component_id,
         initial_message='The "parameters" field is not valid.',
     )
 
@@ -647,11 +657,16 @@ async def create_component_row_configuration(
         f'and configuration {configuration_id}.'
     )
 
-    storage_cfg = validate_storage_configuration(storage=storage, initial_message='The "storage" field is not valid.')
-    parameters = await validate_row_parameters_configuration(
-        client=client,
+    component = await _get_component(client=client, component_id=component_id)
+
+    storage_cfg = validate_storage_configuration(
+        component=component,
+        storage=storage,
+        initial_message='The "storage" field is not valid.',
+    )
+    parameters = validate_row_parameters_configuration(
+        component=component,
         parameters=parameters,
-        component_id=component_id,
         initial_message='The "parameters" field is not valid.',
     )
 
@@ -752,11 +767,16 @@ async def update_component_root_configuration(
 
     LOG.info(f'Updating configuration: {name} for component: {component_id} and configuration ID {configuration_id}.')
 
-    storage_cfg = validate_storage_configuration(storage=storage, initial_message='The "storage" field is not valid.')
-    parameters = await validate_root_parameters_configuration(
-        client=client,
+    component = await _get_component(client=client, component_id=component_id)
+
+    storage_cfg = validate_storage_configuration(
+        component=component,
+        storage=storage,
+        initial_message='The "storage" field is not valid.',
+    )
+    parameters = validate_root_parameters_configuration(
+        component=component,
         parameters=parameters,
-        component_id=component_id,
         initial_message='The "parameters" field is not valid.',
     )
 
@@ -857,11 +877,17 @@ async def update_component_row_configuration(
         f'Updating configuration row: {name} for component: {component_id}, configuration id {configuration_id} '
         f'and row id {configuration_row_id}.'
     )
-    storage_cfg = validate_storage_configuration(storage=storage, initial_message='The "storage" field is not valid.')
-    parameters = await validate_row_parameters_configuration(
-        client=client,
+
+    component = await _get_component(client=client, component_id=component_id)
+
+    storage_cfg = validate_storage_configuration(
+        component=component,
+        storage=storage,
+        initial_message='The "storage" field is not valid.',
+    )
+    parameters = validate_row_parameters_configuration(
+        component=component,
         parameters=parameters,
-        component_id=component_id,
         initial_message='Field "parameters" is not valid.\n',
     )
 

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -357,8 +357,8 @@ def _validate_storage_necessity(
         # necessary storage for writer and transformation components
         if component.component_type in ['writer', 'transformation']:
             raise ValueError(
-                f'Storage configuration is empty, but it is required for component {component.component_id} of type '
-                f'{component.component_type}.'
+                f'Storage configuration cannot be empty for component {component.component_id} of type '
+                f'{component.component_type}. Please provide the storage configuration within the tool call.'
             )
 
 

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -394,6 +394,7 @@ async def test_update_transformation_configuration(
 
     new_config = {'blocks': [{'name': 'Blocks', 'codes': [{'name': 'Code 0', 'script': ['SELECT * FROM test']}]}]}
     new_change_description = 'foo fooo'
+    new_storage = {'input': {'tables': []}, 'output': {'tables': []}}
     mock_configuration['configuration'] = new_config
     mock_configuration['changeDescription'] = new_change_description
     mock_component['id'] = expected_component_id
@@ -406,7 +407,7 @@ async def test_update_transformation_configuration(
         mock_configuration['id'],
         new_change_description,
         parameters=TransformationConfiguration.Parameters.model_validate(new_config),
-        storage={},
+        storage=new_storage,
         updated_description=str(),
         is_disabled=False,
     )
@@ -417,12 +418,12 @@ async def test_update_transformation_configuration(
     assert updated_configuration.configuration_id == mock_configuration['id']
     assert updated_configuration.change_description == new_change_description
 
-    keboola_client.ai_service_client.get_component_detail.assert_called_once_with(component_id=expected_component_id)
+    keboola_client.ai_service_client.get_component_detail.assert_called_with(component_id=expected_component_id)
     keboola_client.storage_client.configuration_update.assert_called_once_with(
         component_id=expected_component_id,
         configuration_id=mock_configuration['id'],
         change_description=new_change_description,
-        configuration={'parameters': new_config, 'storage': {}},
+        configuration={'parameters': new_config, 'storage': new_storage},
         updated_description=None,
         is_disabled=False,
     )

--- a/tests/tools/components/test_utils_validation.py
+++ b/tests/tools/components/test_utils_validation.py
@@ -49,7 +49,7 @@ def test_validate_storage_necessity(
     if is_valid:
         utils._validate_storage_necessity(storage=storage, component=component)
     else:
-        with pytest.raises(ValueError, match='Storage configuration is empty') as exception:
+        with pytest.raises(ValueError, match='Storage configuration cannot be empty') as exception:
             utils._validate_storage_necessity(storage=storage, component=component)
         assert f'{component.component_id}' in str(exception)
         assert f'{component.component_type}' in str(exception)

--- a/tests/tools/components/test_utils_validation.py
+++ b/tests/tools/components/test_utils_validation.py
@@ -1,10 +1,10 @@
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from keboola_mcp_server.client import JsonDict, KeboolaClient
 from keboola_mcp_server.tools.components import utils
+from keboola_mcp_server.tools.components.model import AllComponentTypes, Component
 
 
 @pytest.mark.parametrize(
@@ -17,11 +17,42 @@ from keboola_mcp_server.tools.components import utils
         ({'storage': None}, {}),  # we expect passing when no storage is provided
     ],
 )
-def test_validate_storage_configuration_output(input_storage: Optional[JsonDict], output_storage: Optional[JsonDict]):
+def test_validate_storage_configuration_output(
+    mock_component: dict, input_storage: Optional[JsonDict], output_storage: Optional[JsonDict]
+):
     """testing normalized and returned structures {storage: {...}} vs {...}"""
-    result = utils.validate_storage_configuration(input_storage)
+    component_raw = mock_component.copy()
+    component_raw['type'] = 'extractor'  # set storage to {} to pass the validation for storage necessity
+    component = Component.model_validate(component_raw)
+    result = utils.validate_storage_configuration(input_storage, component)
     expected = output_storage  # we expect unwrapped structure
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('component_type', 'storage', 'is_valid'),
+    [
+        ('writer', {}, False),
+        ('transformation', {}, False),
+        ('extractor', {}, True),
+        ('application', {}, True),
+        ('storage', {'input': {'tables': []}, 'output': {'tables': []}}, True),
+    ],
+)
+def test_validate_storage_necessity(
+    mock_component: dict, component_type: AllComponentTypes, storage: Optional[JsonDict], is_valid: bool
+):
+    """testing storage necessity validation"""
+    component_raw = mock_component.copy()
+    component_raw['type'] = component_type
+    component = Component.model_validate(component_raw)
+    if is_valid:
+        utils._validate_storage_necessity(storage=storage, component=component)
+    else:
+        with pytest.raises(ValueError, match='Storage configuration is empty') as exception:
+            utils._validate_storage_necessity(storage=storage, component=component)
+        assert f'{component.component_id}' in str(exception)
+        assert f'{component.component_type}' in str(exception)
 
 
 @pytest.mark.asyncio
@@ -33,14 +64,13 @@ def test_validate_storage_configuration_output(input_storage: Optional[JsonDict]
     ],
 )
 async def test_validate_root_parameters_configuration_output(
-    mocker, input_parameters: JsonDict, output_parameters: JsonDict, keboola_client: KeboolaClient
+    mock_component: dict, input_parameters: JsonDict, output_parameters: JsonDict, keboola_client: KeboolaClient
 ):
     """testing returned format structures  {...}"""
     accepting_schema = {'type': 'object', 'additionalProperties': True}  # accepts any json object
-    component = MagicMock()
+    component = Component.model_validate(mock_component)
     component.configuration_schema = accepting_schema
-    mocker.patch('keboola_mcp_server.tools.components.utils._get_component', new=AsyncMock(return_value=component))
-    result = await utils.validate_root_parameters_configuration(keboola_client, input_parameters, 'component-id')
+    result = utils.validate_root_parameters_configuration(input_parameters, component)
     expected = output_parameters  # we expect unwrapped structure
     assert result == expected
 
@@ -54,14 +84,13 @@ async def test_validate_root_parameters_configuration_output(
     ],
 )
 async def test_validate_row_parameters_configuration_output(
-    mocker, input_parameters: JsonDict, output_parameters: JsonDict, keboola_client: KeboolaClient
+    mock_component: dict, input_parameters: JsonDict, output_parameters: JsonDict, keboola_client: KeboolaClient
 ):
     """testing normalized and returned structures {parameters: {...}} vs {...}"""
     accepting_schema = {'type': 'object', 'additionalProperties': True}  # accepts any json object
-    component = MagicMock()
-    component.configuration_schema = accepting_schema
-    mocker.patch('keboola_mcp_server.tools.components.utils._get_component', new=AsyncMock(return_value=component))
-    result = await utils.validate_row_parameters_configuration(keboola_client, input_parameters, 'component-id')
+    component = Component.model_validate(mock_component)
+    component.configuration_row_schema = accepting_schema
+    result = utils.validate_row_parameters_configuration(input_parameters, component)
     expected = output_parameters  # we expect unwrapped structure
     assert result == expected
 
@@ -69,13 +98,12 @@ async def test_validate_row_parameters_configuration_output(
 @pytest.mark.asyncio
 @pytest.mark.parametrize('input_schema', [None, {}])
 async def test_validate_parameters_configuration_no_schema(
-    mocker, input_schema: Optional[JsonDict], keboola_client: KeboolaClient
+    mock_component: dict, input_schema: Optional[JsonDict], keboola_client: KeboolaClient
 ):
     """We expect passing the validation when no schema is provided"""
     input_parameters: JsonDict = {'a': 1}
-    component = MagicMock()
+    component = Component.model_validate(mock_component)
     component.configuration_row_schema = input_schema
-    mocker.patch('keboola_mcp_server.tools.components.utils._get_component', new=AsyncMock(return_value=component))
-    result = await utils.validate_row_parameters_configuration(keboola_client, input_parameters, 'component-id')
+    result = utils.validate_row_parameters_configuration(input_parameters, component)
     expected = input_parameters  # we expect unwrapped structure
     assert result == expected


### PR DESCRIPTION
We add validation of storage config necessity - During testing, we encountered the bot tried to update transformation without storage, it has to be forbidden.

See the error message. 
![Screenshot 2025-06-06 140816](https://github.com/user-attachments/assets/79caa69d-1eda-4079-bef8-c45f5656626a)
![Screenshot 2025-06-06 152715](https://github.com/user-attachments/assets/8cc12467-edb6-4174-8fec-d71171129477)
