### PR TITLE
KAB-1123-transformation-fix-invalid-blocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.33.5"
+version = "0.33.6"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.33.6"
+version = "0.33.7"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -330,8 +330,8 @@ async def create_sql_transformation(
     statements.
 
     CONSIDERATIONS:
-    - Each SQL code block must include descriptive name that reflects the its purpose and group one or more executable
-      SQL statements serving the similar functionality.
+    - Each SQL code block must include descriptive name that reflects its purpose and group one or more executable
+      semantically related SQL statements.
     - Each SQL query statement must be executable and follow the current SQL dialect, which can be retrieved using
       appropriate tool.
     - When referring to the input tables within the SQL query, use fully qualified table names, which can be

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -304,12 +304,13 @@ async def create_sql_transformation(
             ),
         ),
     ],
-    code_blocks: Annotated[
+    sql_code_blocks: Annotated[
         Sequence[TransformationConfiguration.Parameters.Block.Code],
         Field(
             description=(
-                'The executable SQL query code blocks, each containing a descriptive name and a list of semantically '
-                'related statements written in the current SQL dialect. Each code block is a separate item in the list.'
+                'The executable SQL query code blocks, each containing a descriptive name and a sequence of '
+                'semantically related sql statements written in the current SQL dialect. Each sql statement is'
+                'executable and a separate item in the list of sql statements.'
             ),
         ),
     ],
@@ -329,10 +330,10 @@ async def create_sql_transformation(
     statements.
 
     CONSIDERATIONS:
-    - The SQL query statement is executable and must follow the current SQL dialect, which can be retrieved using
+    - Each SQL code block must include descriptive name that reflects the its purpose and group one or more executable
+      SQL statements serving the similar functionality.
+    - Each SQL query statement must be executable and follow the current SQL dialect, which can be retrieved using
       appropriate tool.
-    - Each SQL code block should include one or more SQL statements that share a similar purpose or meaning, and should
-      have a descriptive name that reflects that purpose.
     - When referring to the input tables within the SQL query, use fully qualified table names, which can be
       retrieved using appropriate tools.
     - When creating a new table within the SQL query (e.g. CREATE TABLE ...), use only the quoted table name without
@@ -361,7 +362,7 @@ async def create_sql_transformation(
     # Process the data to be stored in the transformation configuration - parameters(sql statements)
     # and storage (input and output tables)
     transformation_configuration_payload = _get_transformation_configuration(
-        codes=code_blocks, transformation_name=name, output_tables=created_table_names
+        codes=sql_code_blocks, transformation_name=name, output_tables=created_table_names
     )
 
     client = KeboolaClient.from_state(ctx.session.state)
@@ -371,7 +372,7 @@ async def create_sql_transformation(
         component_id=component_id,
         name=name,
         description=description,
-        configuration=transformation_configuration_payload.model_dump(),
+        configuration=transformation_configuration_payload.model_dump(by_alias=True),
     )
 
     component = await _get_component(client=client, component_id=component_id)
@@ -440,10 +441,13 @@ async def update_sql_transformation_configuration(
     configuration.
 
     CONSIDERATIONS:
-    - The parameters configuration must include blocks and codes of SQL statements.
-    - The Codes within the block should be semantically related and have a descriptive name.
-    - The SQL code statements should follow the current SQL dialect, which can be retrieved using appropriate tool.
-    - The storage configuration must not be empty, and it should include input and output tables with correct mappings.
+    - The parameters configuration must include blocks with codes of SQL statements. Using one block with many codes of
+      SQL statemetns is prefered and commonly used unless specified otherwise by the user.
+    - Each code contains SQL statements that are semantically related and have a descriptive name.
+    - Each SQL statement must be executable and follow the current SQL dialect, which can be retrieved using
+      appropriate tool.
+    - The storage configuration must not be empty, and it should include input or output tables with correct mappings
+      for the transformation.
     - When the behavior of the transformation is not changed, the updated_description can be empty string.
 
     EXAMPLES:
@@ -459,7 +463,7 @@ async def update_sql_transformation_configuration(
     validate_storage_configuration(storage=storage, initial_message='The "storage" field is not valid.')
 
     updated_configuration = {
-        'parameters': parameters.model_dump(),
+        'parameters': parameters.model_dump(by_alias=True),
         'storage': storage,
     }
 

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -4,7 +4,7 @@ import unicodedata
 from typing import Any, Optional, Sequence, Union, cast, get_args
 
 from httpx import HTTPStatusError
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 from keboola_mcp_server.client import JsonDict, KeboolaClient
 from keboola_mcp_server.tools._validate import validate_parameters, validate_storage
@@ -212,13 +212,21 @@ class TransformationConfiguration(BaseModel):
         """The parameters for the transformation."""
 
         class Block(BaseModel):
-            """The block for the transformation."""
+            """The transformation block."""
 
             class Code(BaseModel):
-                """The code for the transformation block."""
+                """The code block for the transformation block."""
 
-                name: str = Field(description='The name of the current code script')
-                script: list[str] = Field(description='List of current code statements')
+                name: str = Field(description='The name of the current code block describing the purpose of the block')
+                sql_statements: Sequence[str] = Field(
+                    description=(
+                        'The executable SQL query statements written in the current SQL dialect. '
+                        'Each statement must be executable and a separate item in the list.'
+                    ),
+                    # We use sql_statements for readability but serialize to script due to api expected request
+                    serialization_alias='script',
+                    validation_alias=AliasChoices('sql_statements', 'script'),
+                )
 
             name: str = Field(description='The name of the current block')
             codes: list[Code] = Field(description='The code scripts')

--- a/tests/tools/components/test_components.py
+++ b/tests/tools/components/test_components.py
@@ -298,8 +298,8 @@ async def test_create_transformation_configuration(
     bucket_name = _clean_bucket_name(transformation_name)
     description = mock_configuration['description']
     code_blocks = [
-        TransformationConfiguration.Parameters.Block.Code(name='Code 0', script=['SELECT * FROM test']),
-        TransformationConfiguration.Parameters.Block.Code(name='Code 1', script=['SELECT * FROM test2']),
+        TransformationConfiguration.Parameters.Block.Code(name='Code 0', sql_statements=['SELECT * FROM test']),
+        TransformationConfiguration.Parameters.Block.Code(name='Code 1', sql_statements=['SELECT * FROM test2']),
     ]
     created_table_name = 'test_table_1'
 
@@ -308,7 +308,7 @@ async def test_create_transformation_configuration(
         ctx=context,
         name=transformation_name,
         description=description,
-        code_blocks=code_blocks,
+        sql_code_blocks=code_blocks,
         created_table_names=[created_table_name],
     )
 
@@ -330,7 +330,7 @@ async def test_create_transformation_configuration(
                 'blocks': [
                     {
                         'name': 'Blocks',
-                        'codes': [{'name': code.name, 'script': code.script} for code in code_blocks],
+                        'codes': [{'name': code.name, 'script': code.sql_statements} for code in code_blocks],
                     }
                 ]
             },
@@ -366,8 +366,8 @@ async def test_create_transformation_configuration_fail(
             ctx=context,
             name='test_name',
             description='test_description',
-            code_blocks=[
-                TransformationConfiguration.Parameters.Block.Code(name='Code 0', script=['SELECT * FROM test'])
+            sql_code_blocks=[
+                TransformationConfiguration.Parameters.Block.Code(name='Code 0', sql_statements=['SELECT * FROM test'])
             ],
         )
 


### PR DESCRIPTION
We renamed a field in the sql transformation configuration model and updated description and instructions of the tool to be more understandable for the agent.  Renamed `script` to `sql_statements` and add explicit description that `each sql statement must be executable and follow current dialect` 