### PR TITLE
allow running github actions in ci for pull_requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
-on:
-  push:
-  pull_request:
-
+on: [ push, pull_request ]
 concurrency: ci-${{ github.ref }}
 
 permissions:


### PR DESCRIPTION
We enable running github actions on pull requests in hte ci pipeline to allow it on PRs of forks