### PR TITLE
Ai 1157 sql transformation create table

### DIFF
--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -321,18 +321,19 @@ async def create_sql_transformation(
         Sequence[str],
         Field(
             description=(
-                'An empty list or a list of created table names if and only if they are generated within SQL '
-                'statements (e.g., using `CREATE TABLE ...`).'
+                'A list of created table names if they are generated within the SQL query statements '
+                '(e.g., using `CREATE TABLE ...`).'
             ),
         ),
     ] = tuple(),
 ) -> Annotated[ComponentConfigurationResponse, Field(description='Newly created SQL Transformation Configuration.')]:
     """
     Creates an SQL transformation using the specified name, SQL query following the current SQL dialect, a detailed
-    description, and optionally a list of created table names if and only if they are generated within the SQL
-    statements.
+    description, and a list of created table names.
 
     CONSIDERATIONS:
+    - By default, SQL transformation must create at least one table to produce a result; omit only if the user 
+      explicitly indicates that no table creation is needed.
     - Each SQL code block must include descriptive name that reflects its purpose and group one or more executable
       semantically related SQL statements.
     - Each SQL query statement must be executable and follow the current SQL dialect, which can be retrieved using
@@ -348,11 +349,11 @@ async def create_sql_transformation(
     - Use when you want to create a new SQL transformation.
 
     EXAMPLES:
-    - user_input: `Can you save me the SQL query you generated as a new transformation?`
-        - set the sql_statements to the query, and set other parameters accordingly.
+    - user_input: `Can you create a new transformation out of this sql query?`
+        - set the sql_code_blocks to the query, and set other parameters accordingly.
         - returns the created SQL transformation configuration if successful.
     - user_input: `Generate me an SQL transformation which [USER INTENT]`
-        - set the sql_statements to the query based on the [USER INTENT], and set other parameters accordingly.
+        - set the sql_code_blocks to the query based on the [USER INTENT], and set other parameters accordingly.
         - returns the created SQL transformation configuration if successful.
     """
 

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -311,7 +311,7 @@ async def create_sql_transformation(
         Sequence[TransformationConfiguration.Parameters.Block.Code],
         Field(
             description=(
-                'The executable SQL query code blocks, each containing a descriptive name and a sequence of '
+                'The SQL query code blocks, each containing a descriptive name and a sequence of '
                 'semantically related sql statements written in the current SQL dialect. Each sql statement is'
                 'executable and a separate item in the list of sql statements.'
             ),
@@ -334,10 +334,10 @@ async def create_sql_transformation(
     CONSIDERATIONS:
     - By default, SQL transformation must create at least one table to produce a result; omit only if the user
       explicitly indicates that no table creation is needed.
-    - Each SQL code block must include descriptive name that reflects its purpose and group one or more executable
-      fully executable semantically related SQL statements.
-    - Each SQL query statement within a code block must be executable and follow the current SQL dialect, which can be
-      retrieved using appropriate tool.
+    - Each SQL code block must include descriptive name that reflects its purpose and group one or more semantically
+      related SQL statements.
+    - Each SQL query statement within a code block must be fully executable and follow the current SQL dialect, which
+      can be retrieved using appropriate tool.
     - When referring to the input tables within the SQL query, use fully qualified table names, which can be
       retrieved using appropriate tools.
     - When creating a new table within the SQL query (e.g. CREATE TABLE ...), use only the quoted table name without

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -332,7 +332,7 @@ async def create_sql_transformation(
     description, and a list of created table names.
 
     CONSIDERATIONS:
-    - By default, SQL transformation must create at least one table to produce a result; omit only if the user 
+    - By default, SQL transformation must create at least one table to produce a result; omit only if the user
       explicitly indicates that no table creation is needed.
     - Each SQL code block must include descriptive name that reflects its purpose and group one or more executable
       semantically related SQL statements.

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -335,9 +335,9 @@ async def create_sql_transformation(
     - By default, SQL transformation must create at least one table to produce a result; omit only if the user
       explicitly indicates that no table creation is needed.
     - Each SQL code block must include descriptive name that reflects its purpose and group one or more executable
-      semantically related SQL statements.
-    - Each SQL query statement must be executable and follow the current SQL dialect, which can be retrieved using
-      appropriate tool.
+      fully executable semantically related SQL statements.
+    - Each SQL query statement within a code block must be executable and follow the current SQL dialect, which can be
+      retrieved using appropriate tool.
     - When referring to the input tables within the SQL query, use fully qualified table names, which can be
       retrieved using appropriate tools.
     - When creating a new table within the SQL query (e.g. CREATE TABLE ...), use only the quoted table name without


### PR DESCRIPTION
We updated the description of the create_sql_transformation tool to include a instroction:
```- By default, SQL transformation must create at least one table to produce a result; omit only if the user
      explicitly indicates that no table creation is needed.```


See the result. However, the agent often creates semantically incorrect SQL queries but which fixes after the job failure.
![Screenshot 2025-06-26 161718](https://github.com/user-attachments/assets/d7b99a96-9494-44a3-8b81-b9986f640193)

 