### PR TITLE
AI-331: use gzip to compress the authorization code, access and refresh tokens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.6.2"
+version = "1.6.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,7 +1,6 @@
 import time
 from typing import Any, Mapping
 
-import jwt
 import pytest
 from mcp.server.auth.provider import AccessToken, RefreshToken
 from mcp.shared.auth import OAuthClientInformationFull
@@ -62,6 +61,7 @@ class TestSimpleOAuthProvider:
             oauth_provider: SimpleOAuthProvider
     ):
         client_info = OAuthClientInformationFull(client_id='foo-client-id', redirect_uris=[AnyUrl('foo://bar')])
-        auth_code_str = jwt.encode(auth_code, key=key)
+        auth_code_str = oauth_provider._encode(auth_code, key=key)
+        print(f'len(auth_code_str)={len(auth_code_str)}')
         loaded_auth_code = await oauth_provider.load_authorization_code(client_info, auth_code_str)
         assert loaded_auth_code == expected

--- a/uv.lock
+++ b/uv.lock
@@ -844,7 +844,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.5.1"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
The authorization code, access and refresh tokens issued by the MCP server are still encrypted JSON Web Tokens, but their contents is `gzip`-ed to make the tokens shorter. The `gzip`-ed tokens are approximately 60% of their original size.

Apparently, even the modern Windows versions still have a limitation on the size of the command used for launching a process. This affects the max size of the redirect URI used for passing the authorization code back to the running CursorAI process. CursorAI uses `cursor://` protocol in its redirect URIs and the browsers handle that by starting another CursorAI process and passing it the redirect URL as a command-line parameter. The Windows OSes require this whole command to fit into a certain length (max chars).

Since the authorization code generated by our MCP server needs to contain all the information need later on to swap the authorization code for the access/refresh tokens it is a bit lengthy. The OAuth protocol itself allows that and does not restrict the tokens size in any way. But there are practical limits such as the max command-line size on Windows.

This could be of interest to @odinuv @tomasfejfar @romanbracinik .