### PR TITLE
Create workspace with proper backend and login type

### DIFF
--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -874,10 +874,11 @@ class AsyncStorageClient(KeboolaServiceClient):
         return cast(JsonDict, await self.post(endpoint=f'tables/{table_id}/metadata', data=payload))
 
     async def workspace_create(
-        self, async_run: bool = True,
-        login_type: str = 'default',
-        backend: str = 'bigquery',
-        read_only_storage_access: bool = False
+        self,
+        login_type: str,
+        backend: str,
+        async_run: bool = True,
+        read_only_storage_access: bool = False,
     ) -> JsonDict:
         """
         Creates a new workspace.

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -293,16 +293,16 @@ class WorkspaceManager:
         resp = None
         if default_backend == 'snowflake':
             resp = await self._client.storage_client.workspace_create(
-                async_run=True,
                 login_type='snowflake-person-sso',
                 backend=default_backend,
+                async_run=True,
                 read_only_storage_access=True
             )
         elif default_backend == 'bigquery':
             resp = await self._client.storage_client.workspace_create(
-                async_run=True,
                 login_type='default',
                 backend=default_backend,
+                async_run=True,
                 read_only_storage_access=True
             )
         else:


### PR DESCRIPTION
Changes:

- Pass additional params to workspace creation
  - Use `default` for BigQuery
  - Use `snowflake-person-sso` for Snowflake 
