### PR TITLE
feat: Introduce automatic versioning for tagged workflows

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -1,0 +1,49 @@
+name: 'Update Version in pyproject.toml'
+description: 'Automatically updates the version in pyproject.toml based on git tag'
+
+inputs:
+  version:
+    description: 'Version to set (without v prefix)'
+    required: true
+  file-path:
+    description: 'Path to pyproject.toml file'
+    required: false
+    default: 'pyproject.toml'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Update version in pyproject.toml
+      shell: bash
+      run: |
+        # Validate version format (semantic versioning)
+        if [[ ! ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$ ]]; then
+          echo "Error: Invalid version format. Expected semantic version (e.g., 1.2.3)"
+          exit 1
+        fi
+        
+        # Update the version in pyproject.toml
+        sed -i "s/^version = \".*\"/version = \"${{ inputs.version }}\"/" ${{ inputs.file-path }}
+        echo "✅ Updated ${{ inputs.file-path }} version to ${{ inputs.version }}"
+        
+        # Show the updated version for verification
+        echo "📋 Current version in ${{ inputs.file-path }}:"
+        grep "^version = " ${{ inputs.file-path }}
+
+    - name: Commit and push changes
+      shell: bash
+      run: |
+        # Configure git
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        
+        # Check if there are changes to commit
+        if git diff --quiet ${{ inputs.file-path }}; then
+          echo "ℹ️ No changes to commit - version already matches"
+        else
+          # Add and commit the changes
+          git add ${{ inputs.file-path }}
+          git commit -m "chore: update version to ${{ inputs.version }} [skip ci]"
+          git push
+          echo "✅ Committed and pushed version update"
+        fi 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,24 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Update version in pyproject.toml
+        uses: ./.github/actions/update-version
+        with:
+          version: ${{ steps.version.outputs.version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -1,0 +1,69 @@
+# Version Management
+
+This project automatically updates the version in `pyproject.toml` when a new git tag is created.
+
+## How It Works
+
+When you create a git tag with the format `v1.2.3`, the GitHub Actions workflow will:
+
+1. Extract the version number from the tag (removing the `v` prefix)
+2. Update the `version` field in `pyproject.toml`
+3. Commit and push the changes back to the repository
+4. Continue with the Docker build and push process
+
+## Usage
+
+### Creating a New Release
+
+1. **Create and push a new tag:**
+   ```bash
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+
+2. **The workflow will automatically:**
+   - Update `pyproject.toml` version to `1.2.3`
+   - Commit the change with message: `chore: update version to 1.2.3 [skip ci]`
+   - Build and push the Docker image
+
+### Manual Version Update
+
+If you need to update the version manually, change [project] version field in `pyproject.toml`:
+
+## Version Format
+
+The version must follow semantic versioning format:
+- `1.2.3` (major.minor.patch)
+- `1.2.3-alpha.1` (with pre-release suffix)
+- `1.2.3+build.1` (with build metadata)
+
+## Workflow Details
+
+The automatic version update happens in the `.github/workflows/release.yml` workflow:
+
+1. **Trigger:** Push of tags matching `v*` pattern
+2. **Version Extraction:** Removes `v` prefix from git tag
+3. **File Update:** Uses the reusable action `.github/actions/update-version`
+4. **Validation:** Ensures version format is valid
+5. **Commit:** Automatically commits and pushes the change
+
+## Troubleshooting
+
+### Version Not Updated
+- Ensure the tag format is correct (e.g., `v1.2.3`, not `1.2.3`)
+- Check that the workflow has `contents: write` permissions
+- Verify the tag was pushed to the repository
+
+### Invalid Version Format
+- The workflow validates semantic versioning format
+- Pre-release and build metadata are supported
+- Examples of valid versions: `1.2.3`, `1.2.3-alpha.1`, `1.2.3+build.1`
+
+### Manual Override
+If you need to manually set a version that doesn't match the tag:
+
+## Files Modified
+
+- `.github/workflows/release.yml` - Main workflow that triggers on tags
+- `.github/actions/update-version/action.yml` - Reusable action for version updates
+- `pyproject.toml` - Target file that gets updated 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.7.1"
+version = "1.8.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
* Current limitation is that `tagged` versions have changed version in `pyproject.toml`.
* The main branch have to have manually changed version