### PR TITLE
feat: add query_name parameter to query_data tool

### DIFF
--- a/integtests/test_errors.py
+++ b/integtests/test_errors.py
@@ -74,7 +74,7 @@ class TestHttpErrors:
             re.IGNORECASE
         )
         with pytest.raises(ValueError, match=match):
-            await query_data('INVALID SQL SYNTAX HERE', mcp_context)
+            await query_data('INVALID SQL SYNTAX HERE', 'Invalid SQL query.', mcp_context)
 
     @pytest.mark.asyncio
     async def test_concurrent_error_handling(self, mcp_context: Context):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.13.0"
+version = "1.14.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -5,13 +5,20 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from keboola_mcp_server.errors import tool_errors
 from keboola_mcp_server.mcp import with_session_state
 from keboola_mcp_server.workspace import SqlSelectData, WorkspaceManager
 
 LOG = logging.getLogger(__name__)
+
+
+class QueryDataOutput(BaseModel):
+    """Output model for SQL query results."""
+
+    query_name: str = Field(description='The name of the executed query')
+    csv_data: str = Field(description='The retrieved data in CSV format')
 
 
 def add_sql_tools(mcp: FastMCP) -> None:
@@ -34,8 +41,18 @@ async def get_sql_dialect(
 @with_session_state()
 async def query_data(
     sql_query: Annotated[str, Field(description='SQL SELECT query to run.')],
+    query_name: Annotated[
+        str,
+        Field(
+            description=(
+                'A concise, human-readable name for this query based on its purpose and what data it retrieves. '
+                'Use normal words with spaces (e.g., "Customer Orders Last Month", "Top Selling Products", '
+                '"User Activity Summary").'
+            )
+        ),
+    ],
     ctx: Context,
-) -> Annotated[str, Field(description='The retrieved data in a CSV format.')]:
+) -> Annotated[QueryDataOutput, Field(description='The query results with name and CSV data.')]:
     """
     Executes an SQL SELECT query to get the data from the underlying database.
     * When constructing the SQL SELECT query make sure to check the SQL dialect
@@ -62,7 +79,10 @@ async def query_data(
         writer.writeheader()
         writer.writerows(data.rows)
 
-        return output.getvalue()
+        return QueryDataOutput(
+            query_name=query_name,
+            csv_data=output.getvalue()
+        )
 
     else:
         raise ValueError(f'Failed to run SQL query, error: {result.message}')

--- a/uv.lock
+++ b/uv.lock
@@ -902,7 +902,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.13.0"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -902,7 +902,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.12.1"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Add required `query_name` parameter to `query_data` SQL tool
- Return structured output with both query name and CSV data
- Update all related tests to handle new parameter and output format

## Why this change is needed
MCP clients need to work with named query results for better tracking and identification. Having the query name come directly from the MCP server response makes client-side handling much simpler and more reliable than managing query names separately on the client side.

## Test plan
- [x] Unit tests pass with new parameter and structured output
- [x] Integration tests updated and passing
- [x] Code style checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)