### PR TITLE
feat: add context parameter to all MCP tools

### DIFF
--- a/integtests/tools/components/test_tools.py
+++ b/integtests/tools/components/test_tools.py
@@ -47,7 +47,10 @@ async def test_get_config(mcp_context: Context, configs: list[ConfigDef]):
         assert config.configuration_id is not None
 
         configuration = await get_config(
-            component_id=config.component_id, configuration_id=config.configuration_id, ctx=mcp_context
+            ctx=mcp_context,
+            context='Integration test get config',
+            component_id=config.component_id,
+            configuration_id=config.configuration_id,
         )
 
         assert isinstance(configuration, Configuration)
@@ -73,7 +76,9 @@ async def test_list_configs_by_ids(mcp_context: Context, configs: list[ConfigDef
     component_ids = list({config.component_id for config in configs})
     assert len(component_ids) > 0
 
-    result = await list_configs(ctx=mcp_context, component_ids=component_ids)
+    result = await list_configs(
+        ctx=mcp_context, context='Integration test list configs by IDs', component_ids=component_ids
+    )
 
     # Verify result structure and content
     assert isinstance(result, ListConfigsOutput)
@@ -98,7 +103,9 @@ async def test_list_configs_by_types(mcp_context: Context, configs: list[ConfigD
 
     component_types: list[ComponentType] = ['extractor']
 
-    result = await list_configs(ctx=mcp_context, component_types=component_types)
+    result = await list_configs(
+        ctx=mcp_context, context='Integration test list configs by types', component_types=component_types
+    )
 
     assert isinstance(result, ListConfigsOutput)
     # Currently, we only have extractor components in the project
@@ -130,6 +137,7 @@ async def test_create_config(mcp_context: Context, configs: list[ConfigDef], keb
     # Create the configuration
     created_config = await create_config(
         ctx=mcp_context,
+        context='Integration test create config',
         name=test_name,
         description=test_description,
         component_id=component_id,
@@ -225,6 +233,7 @@ async def test_update_config(mcp_context: Context, configs: list[ConfigDef], keb
     # Create the initial configuration
     created_config = await create_config(
         ctx=mcp_context,
+        context='Integration test create config for update',
         name=initial_name,
         description=initial_description,
         component_id=component_id,
@@ -237,6 +246,7 @@ async def test_update_config(mcp_context: Context, configs: list[ConfigDef], keb
         # Update the configuration
         updated_config = await update_config(
             ctx=mcp_context,
+            context='Integration test update config',
             name=updated_name,
             description=updated_description,
             change_description=change_description,
@@ -338,6 +348,7 @@ async def test_add_config_row(mcp_context: Context, configs: list[ConfigDef], ke
     # First create a root configuration to add row to
     root_config = await create_config(
         ctx=mcp_context,
+        context='Integration test create root config for row',
         name=root_config_name,
         description=root_config_description,
         component_id=component_id,
@@ -350,6 +361,7 @@ async def test_add_config_row(mcp_context: Context, configs: list[ConfigDef], ke
         # Create the row configuration
         created_row_config = await add_config_row(
             ctx=mcp_context,
+            context='Integration test add config row',
             name=row_name,
             description=row_description,
             component_id=component_id,
@@ -463,6 +475,7 @@ async def test_update_config_row(mcp_context: Context, configs: list[ConfigDef],
     # First create a root configuration
     root_config = await create_config(
         ctx=mcp_context,
+        context='Integration test create root config for row update',
         name=root_config_name,
         description=root_config_description,
         component_id=component_id,
@@ -477,6 +490,7 @@ async def test_update_config_row(mcp_context: Context, configs: list[ConfigDef],
         # Create a row configuration
         initial_row_config = await add_config_row(
             ctx=mcp_context,
+            context='Integration test add initial config row for update',
             name=initial_row_name,
             description=initial_row_description,
             component_id=component_id,
@@ -497,6 +511,7 @@ async def test_update_config_row(mcp_context: Context, configs: list[ConfigDef],
         # Update the row configuration
         updated_row_config = await update_config_row(
             ctx=mcp_context,
+            context='Integration test update config row',
             name=updated_row_name,
             description=updated_row_description,
             change_description=change_description,
@@ -598,12 +613,13 @@ async def test_create_sql_transformation(mcp_context: Context, keboola_project: 
     # Create the SQL transformation
     created_transformation = await create_sql_transformation(
         ctx=mcp_context,
+        context='Integration test create SQL transformation',
         name=test_name,
         description=test_description,
         sql_code_blocks=test_sql_code_blocks,
         created_table_names=test_created_table_names,
     )
-    sql_dialect = await get_sql_dialect(mcp_context)
+    sql_dialect = await get_sql_dialect(mcp_context, 'Integration test get SQL dialect for transformation')
     expected_component_id = get_sql_transformation_id_from_sql_dialect(sql_dialect)
     project_id = keboola_project.project_id
 
@@ -715,6 +731,7 @@ async def test_update_sql_transformation(mcp_context: Context, keboola_project: 
     # Create the initial transformation
     created_transformation = await create_sql_transformation(
         ctx=mcp_context,
+        context='Integration test create initial SQL transformation for update',
         name=initial_name,
         description=initial_description,
         sql_code_blocks=initial_sql_code_blocks,
@@ -722,7 +739,7 @@ async def test_update_sql_transformation(mcp_context: Context, keboola_project: 
     )
 
     project_id = keboola_project.project_id
-    sql_dialect = await get_sql_dialect(mcp_context)
+    sql_dialect = await get_sql_dialect(mcp_context, 'Integration test get SQL dialect for update')
     sql_component_id = get_sql_transformation_id_from_sql_dialect(sql_dialect)
 
     try:
@@ -762,6 +779,7 @@ async def test_update_sql_transformation(mcp_context: Context, keboola_project: 
         # Update the transformation
         updated_transformation = await update_sql_transformation(
             ctx=mcp_context,
+            context='Integration test update SQL transformation',
             configuration_id=created_transformation.configuration_id,
             change_description=change_description,
             parameters=updated_parameters,
@@ -884,7 +902,7 @@ async def test_update_sql_transformation(mcp_context: Context, keboola_project: 
 @pytest.mark.asyncio
 async def test_list_transformations(mcp_context: Context):
     """Tests that `list_transformations` returns transformation configurations."""
-    result = await list_transformations(ctx=mcp_context)
+    result = await list_transformations(ctx=mcp_context, context='Integration test list transformations')
 
     assert isinstance(result, ListTransformationsOutput)
     for item in result.components_with_configurations:
@@ -912,6 +930,7 @@ async def test_list_transformations_by_ids(mcp_context: Context):
     # Create the transformation
     created_transformation = await create_sql_transformation(
         ctx=mcp_context,
+        context='Integration test create transformation for list by IDs',
         name=transformation_name,
         description=transformation_description,
         sql_code_blocks=sql_code_blocks,
@@ -920,7 +939,11 @@ async def test_list_transformations_by_ids(mcp_context: Context):
 
     try:
         transformation_ids = [created_transformation.component_id]
-        result = await list_transformations(ctx=mcp_context, transformation_ids=transformation_ids)
+        result = await list_transformations(
+            ctx=mcp_context,
+            context='Integration test list transformations by IDs',
+            transformation_ids=transformation_ids,
+        )
 
         assert isinstance(result, ListTransformationsOutput)
         assert len(result.components_with_configurations) == 1
@@ -950,7 +973,7 @@ async def test_get_component(mcp_context: Context, configs: list[ConfigDef]):
     test_config = configs[0]
     component_id = test_config.component_id
 
-    result = await get_component(component_id=component_id, ctx=mcp_context)
+    result = await get_component(ctx=mcp_context, context='Integration test get component', component_id=component_id)
 
     assert isinstance(result, Component)
     assert result.component_id == test_config.component_id
@@ -962,7 +985,9 @@ async def test_get_config_examples(mcp_context: Context, configs: list[ConfigDef
     test_config = configs[0]
     component_id = test_config.component_id
 
-    result = await get_config_examples(component_id=component_id, ctx=mcp_context)
+    result = await get_config_examples(
+        ctx=mcp_context, context='Integration test get config examples', component_id=component_id
+    )
 
     # Verify the result is a markdown formatted string
     assert isinstance(result, str)
@@ -975,6 +1000,10 @@ async def test_get_config_examples(mcp_context: Context, configs: list[ConfigDef
 async def test_get_config_examples_with_invalid_component(mcp_context: Context):
     """Tests that `get_config_examples` handles non-existent components properly."""
 
-    result = await get_config_examples(ctx=mcp_context, component_id='completely-non-existent-component-12345')
+    result = await get_config_examples(
+        ctx=mcp_context,
+        context='Integration test get config examples invalid',
+        component_id='completely-non-existent-component-12345',
+    )
 
     assert result == ''

--- a/integtests/tools/flow/test_tools.py
+++ b/integtests/tools/flow/test_tools.py
@@ -55,6 +55,7 @@ async def test_create_and_retrieve_flow(mcp_context: Context, configs: list[Conf
 
     created = await create_flow(
         ctx=mcp_context,
+        context='Integration test create and retrieve flow',
         name=flow_name,
         description=flow_description,
         phases=phases,
@@ -76,10 +77,10 @@ async def test_create_and_retrieve_flow(mcp_context: Context, configs: list[Conf
         assert set(created.links) == set(expected_links)
 
         # Verify the flow is listed in the list_flows tool
-        result = await list_flows(mcp_context)
+        result = await list_flows(mcp_context, 'Integration test list flows')
         assert any(f.name == flow_name for f in result.flows)
         found = [f for f in result.flows if f.id == flow_id][0]
-        detail = await get_flow(mcp_context, configuration_id=found.id)
+        detail = await get_flow(mcp_context, 'Integration test get flow', configuration_id=found.id)
 
         assert isinstance(detail, FlowConfigurationResponse)
         assert detail.component_id == ORCHESTRATOR_COMPONENT_ID
@@ -133,6 +134,7 @@ async def test_update_flow(mcp_context: Context, configs: list[ConfigDef]) -> No
     flow_description = 'Initial description.'
     created = await create_flow(
         ctx=mcp_context,
+        context='Integration test create flow for update',
         name=flow_name,
         description=flow_description,
         phases=phases,
@@ -151,6 +153,7 @@ async def test_update_flow(mcp_context: Context, configs: list[ConfigDef]) -> No
         ]
         updated = await update_flow(
             ctx=mcp_context,
+            context='Integration test update flow',
             configuration_id=created.flow_id,
             name=new_name,
             description=new_description,
@@ -186,7 +189,7 @@ async def test_list_flows_empty(mcp_context: Context) -> None:
     Retrieve flows when none exist (should not error, may return empty list).
     :param mcp_context: The test context fixture.
     """
-    flows = await list_flows(mcp_context)
+    flows = await list_flows(mcp_context, 'Integration test list flows empty')
     assert isinstance(flows, ListFlowsOutput)
 
 
@@ -195,7 +198,7 @@ async def test_get_flow_schema(mcp_context: Context) -> None:
     """
     Test that get_flow_schema returns the flow configuration JSON schema.
     """
-    schema_result = await get_flow_schema(mcp_context)
+    schema_result = await get_flow_schema(mcp_context, 'Integration test get flow schema')
 
     assert isinstance(schema_result, str)
     assert schema_result.startswith('```json\n')
@@ -238,6 +241,7 @@ async def test_create_flow_invalid_structure(mcp_context: Context, configs: list
     with pytest.raises(ValueError, match='depends on non-existent phase'):
         await create_flow(
             ctx=mcp_context,
+            context='Integration test create invalid flow',
             name='Invalid Flow',
             description='Should fail',
             phases=phases,

--- a/integtests/tools/test_doc.py
+++ b/integtests/tools/test_doc.py
@@ -9,7 +9,7 @@ async def test_docs_query(mcp_context: Context) -> None:
     """Tests that `docs_query` returns a valid `DocsAnswer` with text and source URLs."""
     query = 'What is Keboola Connection?'
 
-    result = await docs_query(ctx=mcp_context, query=query)
+    result = await docs_query(ctx=mcp_context, context='Integration test documentation query', query=query)
 
     assert isinstance(result, DocsAnswer)
     assert len(result.text) > 0, 'Answer text should not be empty'

--- a/integtests/tools/test_jobs.py
+++ b/integtests/tools/test_jobs.py
@@ -36,6 +36,7 @@ async def _wait_for_job_in_list(
     for attempt in range(max_retries):
         result = await list_jobs(
             ctx=mcp_context,
+            context='Integration test job listing',
             component_id=component_id,
             config_id=config_id,
             limit=10,
@@ -64,7 +65,12 @@ async def test_list_jobs_with_component_and_config_filter(mcp_context: Context, 
     component_id = test_config.component_id
     configuration_id = test_config.configuration_id
 
-    job = await run_job(ctx=mcp_context, component_id=component_id, configuration_id=configuration_id)
+    job = await run_job(
+        ctx=mcp_context,
+        context='Integration test job run',
+        component_id=component_id,
+        configuration_id=configuration_id,
+    )
 
     # Wait for the job to appear in the list (handles race condition)
     result = await _wait_for_job_in_list(
@@ -96,7 +102,12 @@ async def test_run_job_and_get_job(mcp_context: Context, configs: list[ConfigDef
     component_id = test_config.component_id
     configuration_id = test_config.configuration_id
 
-    started_job = await run_job(ctx=mcp_context, component_id=component_id, configuration_id=configuration_id)
+    started_job = await run_job(
+        ctx=mcp_context,
+        context='Integration test job run and get',
+        component_id=component_id,
+        configuration_id=configuration_id,
+    )
 
     # Verify the started job response
     assert isinstance(started_job, JobDetail)
@@ -119,7 +130,7 @@ async def test_run_job_and_get_job(mcp_context: Context, configs: list[ConfigDef
         ]
     )
 
-    job_detail = await get_job(job_id=started_job.id, ctx=mcp_context)
+    job_detail = await get_job(ctx=mcp_context, context='Integration test get job details', job_id=started_job.id)
 
     # Verify the job detail response
     assert isinstance(job_detail, JobDetail)
@@ -156,10 +167,15 @@ async def test_get_job(mcp_context: Context, configs: list[ConfigDef], keboola_p
     configuration_id = test_config.configuration_id
 
     # Create a specific job to test get_job with
-    created_job = await run_job(ctx=mcp_context, component_id=component_id, configuration_id=configuration_id)
+    created_job = await run_job(
+        ctx=mcp_context,
+        context='Integration test get job',
+        component_id=component_id,
+        configuration_id=configuration_id,
+    )
 
     # Now test get_job on the job we just created
-    job_detail = await get_job(job_id=created_job.id, ctx=mcp_context)
+    job_detail = await get_job(ctx=mcp_context, context='Integration test get job by ID', job_id=created_job.id)
 
     # Verify all expected fields are present
     assert isinstance(job_detail, JobDetail)
@@ -197,6 +213,7 @@ async def test_run_job_with_newly_created_config(
     # Create a new configuration for testing
     new_config = await create_config(
         ctx=mcp_context,
+        context='Integration test config creation for job run',
         name='Test Config for Job Run',
         description='Test configuration created for job run test',
         component_id=component_id,
@@ -207,7 +224,10 @@ async def test_run_job_with_newly_created_config(
     try:
         # Run a job on the new configuration
         started_job = await run_job(
-            ctx=mcp_context, component_id=component_id, configuration_id=new_config.configuration_id
+            ctx=mcp_context,
+            context='Integration test job run with new config',
+            component_id=component_id,
+            configuration_id=new_config.configuration_id,
         )
 
         # Verify the job was started successfully
@@ -232,7 +252,9 @@ async def test_run_job_with_newly_created_config(
         )
 
         # Verify job can be retrieved
-        job_detail = await get_job(job_id=started_job.id, ctx=mcp_context)
+        job_detail = await get_job(
+            ctx=mcp_context, context='Integration test get job for new config', job_id=started_job.id
+        )
         assert isinstance(job_detail, JobDetail)
         assert job_detail.id == started_job.id
         assert job_detail.component_id == component_id

--- a/integtests/tools/test_project.py
+++ b/integtests/tools/test_project.py
@@ -7,7 +7,7 @@ from keboola_mcp_server.tools.project import ProjectInfo, get_project_info
 
 @pytest.mark.asyncio
 async def test_get_project_info(mcp_context: Context, keboola_project) -> None:
-    result = await get_project_info(mcp_context)
+    result = await get_project_info(mcp_context, 'Integration test project info')
 
     assert isinstance(result, ProjectInfo)
     assert str(result.project_id) == str(keboola_project.project_id)

--- a/integtests/tools/test_search.py
+++ b/integtests/tools/test_search.py
@@ -30,7 +30,12 @@ async def test_global_search_end_to_end(
 
     # Search for test items by name prefix 'test' which should match our test data
     result = await search(
-        ctx=mcp_context, name_prefixes=['test'], item_types=tuple(), limit=50, offset=0  # Search all types
+        ctx=mcp_context,
+        context='Integration test global search',
+        name_prefixes=['test'],
+        item_types=tuple(),
+        limit=50,
+        offset=0,  # Search all types
     )
 
     # Verify the result structure
@@ -85,7 +90,7 @@ async def test_find_component_id(mcp_context: Context):
     query = 'generic extractor'
     generic_extractor_id = 'ex-generic-v2'
 
-    result = await find_component_id(query=query, ctx=mcp_context)
+    result = await find_component_id(ctx=mcp_context, context='Integration test find component ID', query=query)
 
     assert isinstance(result, list)
     assert len(result) > 0

--- a/integtests/tools/test_sql.py
+++ b/integtests/tools/test_sql.py
@@ -15,18 +15,24 @@ LOG = logging.getLogger(__name__)
 async def test_query_data(mcp_context: Context):
     """Tests basic functionality of SQL tools: get_sql_dialect and query_data."""
 
-    dialect = await get_sql_dialect(ctx=mcp_context)
+    dialect = await get_sql_dialect(ctx=mcp_context, context='Integration test SQL dialect')
     assert dialect in ['Snowflake', 'Bigquery']
 
-    buckets_listing = await list_buckets(ctx=mcp_context)
+    buckets_listing = await list_buckets(ctx=mcp_context, context='Integration test list buckets for SQL')
 
-    tables_listing = await list_tables(bucket_id=buckets_listing.buckets[0].id, ctx=mcp_context)
-    table = await get_table(table_id=tables_listing.tables[0].id, ctx=mcp_context)
+    tables_listing = await list_tables(
+        ctx=mcp_context, context='Integration test list tables for SQL', bucket_id=buckets_listing.buckets[0].id
+    )
+    table = await get_table(
+        ctx=mcp_context, context='Integration test get table for SQL', table_id=tables_listing.tables[0].id
+    )
 
     assert table.fully_qualified_name is not None, 'Table should have fully qualified name'
 
     sql_query = f'SELECT COUNT(*) as row_count FROM {table.fully_qualified_name}'
-    result = await query_data(sql_query=sql_query, query_name='Row Count Query', ctx=mcp_context)
+    result = await query_data(
+        ctx=mcp_context, context='Integration test SQL query', sql_query=sql_query, query_name='Row Count Query'
+    )
 
     # Verify result is structured output
     assert isinstance(result, QueryDataOutput)
@@ -54,4 +60,9 @@ async def test_query_data_invalid_query(mcp_context: Context):
     invalid_sql = 'INVALID SQL SYNTAX SELECT * FROM'
 
     with pytest.raises(ValueError, match='Failed to run SQL query'):
-        await query_data(sql_query=invalid_sql, query_name='Invalid Query Test', ctx=mcp_context)
+        await query_data(
+            ctx=mcp_context,
+            context='Integration test invalid SQL query',
+            sql_query=invalid_sql,
+            query_name='Invalid Query Test',
+        )

--- a/integtests/tools/test_storage.py
+++ b/integtests/tools/test_storage.py
@@ -28,7 +28,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.asyncio
 async def test_list_buckets(mcp_context: Context, buckets: list[BucketDef]):
     """Tests that `list_buckets` returns a list of `BucketDetail` instances."""
-    result = await list_buckets(mcp_context)
+    result = await list_buckets(mcp_context, 'Integration test list buckets')
 
     assert isinstance(result, ListBucketsOutput)
     for item in result.buckets:
@@ -41,7 +41,7 @@ async def test_list_buckets(mcp_context: Context, buckets: list[BucketDef]):
 async def test_get_bucket(mcp_context: Context, buckets: list[BucketDef]):
     """Tests that for each test bucket, `get_bucket` returns a `BucketDetail` instance."""
     for bucket in buckets:
-        result = await get_bucket(bucket.bucket_id, mcp_context)
+        result = await get_bucket(mcp_context, 'Integration test get bucket', bucket.bucket_id)
         assert isinstance(result, BucketDetail)
         assert result.id == bucket.bucket_id
 
@@ -55,7 +55,7 @@ async def test_get_table(mcp_context: Context, tables: list[TableDef]):
             reader = csv.reader(f)
             columns = frozenset(next(reader))
 
-        result = await get_table(table.table_id, mcp_context)
+        result = await get_table(mcp_context, 'Integration test get table', table.table_id)
         assert isinstance(result, TableDetail)
         assert result.id == table.table_id
         assert result.name == table.table_name
@@ -74,7 +74,7 @@ async def test_list_tables(mcp_context: Context, tables: list[TableDef], buckets
         tables_by_bucket[table.bucket_id].append(table)
 
     for bucket in buckets:
-        result = await list_tables(bucket.bucket_id, mcp_context)
+        result = await list_tables(mcp_context, 'Integration test list tables', bucket.bucket_id)
 
         assert isinstance(result, ListTablesOutput)
         for item in result.tables:
@@ -97,7 +97,9 @@ async def test_update_bucket_description(mcp_context: Context, buckets: list[Buc
     md_id: str | None = None
     client = KeboolaClient.from_state(mcp_context.session.state)
     try:
-        result = await update_bucket_description(bucket.bucket_id, 'New Description', mcp_context)
+        result = await update_bucket_description(
+            mcp_context, 'Integration test update bucket description', bucket.bucket_id, 'New Description'
+        )
         assert isinstance(result, UpdateDescriptionOutput)
         assert result.description == 'New Description'
 
@@ -118,7 +120,9 @@ async def test_update_table_description(mcp_context: Context, tables: list[Table
     md_id: str | None = None
     client = KeboolaClient.from_state(mcp_context.session.state)
     try:
-        result = await update_table_description(table.table_id, 'New Description', mcp_context)
+        result = await update_table_description(
+            mcp_context, 'Integration test update table description', table.table_id, 'New Description'
+        )
         assert isinstance(result, UpdateDescriptionOutput)
         assert result.description == 'New Description'
 
@@ -146,7 +150,9 @@ async def test_update_column_description(mcp_context: Context, tables: list[Tabl
     test_description = 'New Column Description'
 
     # Test the update_column_description function
-    result = await update_column_description(table.table_id, column_name, test_description, mcp_context)
+    result = await update_column_description(
+        mcp_context, 'Integration test update column description', table.table_id, column_name, test_description
+    )
     LOG.error(result)
 
     # Verify the function returns expected result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "jsonschema ~= 4.23",
     "pyjwt ~= 2.10",
     "json-log-formatter ~= 1.0",
+    "kbcstorage>=0.9.2",
 ]
 [project.optional-dependencies]
 codestyle = [

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -106,6 +106,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
 @with_session_state()
 async def list_configs(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     component_types: Annotated[
         Sequence[ComponentType],
         Field(description='List of component types to filter by. If none, return all components.'),
@@ -158,6 +159,7 @@ async def list_configs(
 @with_session_state()
 async def list_transformations(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     transformation_ids: Annotated[
         Sequence[str],
         Field(description='List of transformation component IDs to retrieve configurations for.'),
@@ -206,6 +208,7 @@ async def list_transformations(
 @with_session_state()
 async def get_component(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     component_id: Annotated[str, Field(description='ID of the component/transformation')],
 ) -> Annotated[Component, Field(description='The component.')]:
     """
@@ -230,6 +233,8 @@ async def get_component(
 @tool_errors()
 @with_session_state()
 async def get_config(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     component_id: Annotated[str, Field(description='ID of the component/transformation')],
     configuration_id: Annotated[
         str,
@@ -237,7 +242,6 @@ async def get_config(
             description='ID of the component/transformation configuration',
         ),
     ],
-    ctx: Context,
 ) -> Annotated[Configuration, Field(description='The component/transformation and its configuration.')]:
     """
     Gets information about a specific component/transformation configuration.
@@ -287,6 +291,7 @@ async def get_config(
 @with_session_state()
 async def create_sql_transformation(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     name: Annotated[
         str,
         Field(
@@ -353,7 +358,7 @@ async def create_sql_transformation(
 
     # Get the SQL dialect to use the correct transformation ID (Snowflake or BigQuery)
     # This can raise an exception if workspace is not set or different backend than BigQuery or Snowflake is used
-    sql_dialect = await get_sql_dialect(ctx)
+    sql_dialect = await get_sql_dialect(ctx, 'Getting SQL dialect for transformation creation')
     component_id = get_sql_transformation_id_from_sql_dialect(sql_dialect)
     LOG.info(f'SQL dialect: {sql_dialect}, using transformation ID: {component_id}')
 
@@ -405,6 +410,7 @@ async def create_sql_transformation(
 @with_session_state()
 async def update_sql_transformation(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     configuration_id: Annotated[str, Field(description='ID of the transformation configuration to update')],
     change_description: Annotated[
         str,
@@ -464,7 +470,9 @@ async def update_sql_transformation(
     """
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
-    sql_transformation_id = get_sql_transformation_id_from_sql_dialect(await get_sql_dialect(ctx))
+    sql_transformation_id = get_sql_transformation_id_from_sql_dialect(
+        await get_sql_dialect(ctx, 'Getting SQL dialect for transformation update')
+    )
     LOG.info(f'SQL transformation ID: {sql_transformation_id}')
 
     api_component = await fetch_component(client=client, component_id=sql_transformation_id)
@@ -524,6 +532,7 @@ async def update_sql_transformation(
 @with_session_state()
 async def create_config(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     name: Annotated[
         str,
         Field(
@@ -626,6 +635,7 @@ async def create_config(
 @with_session_state()
 async def add_config_row(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     name: Annotated[
         str,
         Field(
@@ -746,6 +756,7 @@ async def add_config_row(
 @with_session_state()
 async def update_config(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     name: Annotated[
         str,
         Field(
@@ -859,6 +870,7 @@ async def update_config(
 @with_session_state()
 async def update_config_row(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     name: Annotated[
         str,
         Field(description='A short, descriptive name summarizing the purpose of the component configuration.'),
@@ -975,6 +987,7 @@ async def update_config_row(
 @with_session_state()
 async def get_config_examples(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     component_id: Annotated[str, Field(description='The ID of the component to get configuration examples for.')],
 ) -> Annotated[
     str,

--- a/src/keboola_mcp_server/tools/doc.py
+++ b/src/keboola_mcp_server/tools/doc.py
@@ -35,10 +35,17 @@ class DocsAnswer(BaseModel):
 @with_session_state()
 async def docs_query(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     query: Annotated[str, Field(description='Natural language query to search for in the documentation.')],
 ) -> Annotated[DocsAnswer, Field(description='The retrieved documentation.')]:
     """
     Answers a question using the Keboola documentation as a source.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - 'Understanding OAuth setup process for Google Analytics extractor'
+    - 'Finding documentation on Storage API bucket permissions'
+    - 'Learning about transformation development best practices'
+    - 'Researching configuration options for specific component'
     """
     client = KeboolaClient.from_state(ctx.session.state)
     answer = await client.ai_service_client.docs_question(query)

--- a/src/keboola_mcp_server/tools/flow/tools.py
+++ b/src/keboola_mcp_server/tools/flow/tools.py
@@ -42,7 +42,10 @@ def add_flow_tools(mcp: FastMCP) -> None:
 
 @tool_errors()
 @with_session_state()
-async def get_flow_schema(_ctx: Context) -> Annotated[str, Field(description='The configuration schema of Flow.')]:
+async def get_flow_schema(
+    _ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
+) -> Annotated[str, Field(description='The configuration schema of Flow.')]:
     """Returns the JSON schema that defines the structure of Flow configurations."""
     # The _ctx: Context parameter is there for @tool_errors to be able to emit SAPI events.
     LOG.info('Returning flow configuration schema')
@@ -53,6 +56,7 @@ async def get_flow_schema(_ctx: Context) -> Annotated[str, Field(description='Th
 @with_session_state()
 async def create_flow(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     name: Annotated[str, Field(description='A short, descriptive name for the flow.')],
     description: Annotated[str, Field(description='Detailed description of the flow purpose.')],
     phases: Annotated[list[dict[str, Any]], Field(description='List of phase definitions.')],
@@ -121,6 +125,7 @@ async def create_flow(
 @with_session_state()
 async def update_flow(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     configuration_id: Annotated[str, Field(description='ID of the flow configuration to update.')],
     name: Annotated[str, Field(description='Updated flow name.')],
     description: Annotated[str, Field(description='Updated flow description.')],
@@ -188,6 +193,7 @@ async def update_flow(
 @with_session_state()
 async def list_flows(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     flow_ids: Annotated[
         Sequence[str], Field(default_factory=tuple, description='The configuration IDs of the flows to retrieve.')
     ] = tuple(),
@@ -220,6 +226,7 @@ async def list_flows(
 @with_session_state()
 async def get_flow(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     configuration_id: Annotated[str, Field(description='ID of the flow configuration to retrieve.')],
 ) -> Annotated[FlowConfigurationResponse, Field(description='Detailed flow configuration.')]:
     """Gets detailed information about a specific flow configuration."""

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -156,6 +156,7 @@ SORT_ORDER_VALUES = Literal['asc', 'desc']
 @with_session_state()
 async def list_jobs(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     status: Annotated[
         JOB_STATUS,
         Field(
@@ -201,6 +202,12 @@ async def list_jobs(
     Retrieves all jobs in the project, or filter jobs by a specific component_id or config_id, with optional status
     filtering. Additional parameters support pagination (limit, offset) and sorting (sort_by, sort_order).
 
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Monitoring recent job execution status for data pipeline"
+    - "Checking failed jobs to troubleshoot extraction issues"
+    - "Reviewing transformation job history for audit purposes"
+    - "Finding jobs for specific component configuration analysis"
+
     USAGE:
     - Use when you want to list jobs for a given component_id and optionally for given config_id.
     - Use when you want to list all jobs in the project or filter them by status.
@@ -237,15 +244,22 @@ async def list_jobs(
 @tool_errors()
 @with_session_state()
 async def get_job(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     job_id: Annotated[
         str,
         Field(description='The unique identifier of the job whose details should be retrieved.'),
     ],
-    ctx: Context,
 ) -> Annotated[JobDetail, Field(JobDetail, description='The detailed information about the job.')]:
     """
     Retrieves detailed information about a specific job, identified by the job_id, including its status, parameters,
     results, and any relevant metadata.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Investigating failed transformation job to identify root cause"
+    - "Getting detailed results from successful data extraction job"
+    - "Reviewing job parameters to understand configuration settings"
+    - "Checking job execution logs for troubleshooting purposes"
 
     EXAMPLES:
     - If job_id = "123", then the details of the job with id "123" will be retrieved.
@@ -263,6 +277,7 @@ async def get_job(
 @with_session_state()
 async def run_job(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     component_id: Annotated[
         str,
         Field(description='The ID of the component or transformation for which to start a job.'),
@@ -271,6 +286,12 @@ async def run_job(
 ) -> Annotated[JobDetail, Field(description='The newly started job details.')]:
     """
     Starts a new job for a given component or transformation.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Executing data extraction job for updated source system"
+    - "Running transformation to process new customer data batch"
+    - "Starting orchestration workflow for scheduled data pipeline"
+    - "Triggering component job after configuration changes made"
     """
     client = KeboolaClient.from_state(ctx.session.state)
 

--- a/src/keboola_mcp_server/tools/oauth.py
+++ b/src/keboola_mcp_server/tools/oauth.py
@@ -25,14 +25,21 @@ def add_oauth_tools(mcp: KeboolaMcpServer) -> None:
 @tool_errors()
 @with_session_state()
 async def create_oauth_url(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     component_id: Annotated[
         str, Field(description='The component ID to grant access to (e.g., "keboola.ex-google-analytics-v4").')
     ],
     config_id: Annotated[str, Field(description='The configuration ID for the component.')],
-    ctx: Context,
 ) -> str:
     """
     Generates an OAuth authorization URL for a Keboola component configuration.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Setting up OAuth authorization for Google Analytics data extraction"
+    - "Generating authorization link for Gmail extractor configuration"
+    - "Creating OAuth URL for Salesforce component authentication setup"
+    - "Establishing OAuth connection for third-party API data source"
 
     When using this tool, be very concise in your response. Just guide the user to click the
     authorization link.

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -54,8 +54,16 @@ class ProjectInfo(BaseModel):
 @with_session_state()
 async def get_project_info(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
 ) -> Annotated[ProjectInfo, Field(description='Structured project info.')]:
-    """Return structured project information pulled from multiple endpoints."""
+    """Return structured project information pulled from multiple endpoints.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Getting project details for initial setup and configuration"
+    - "Retrieving project info to understand workspace and organization context"
+    - "Checking project metadata for compliance and audit requirements"
+    - "Obtaining project details for documentation and reporting purposes"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
     storage = client.storage_client

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -102,6 +102,7 @@ class GlobalSearchOutput(BaseModel):
 @with_session_state()
 async def search(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     name_prefixes: Annotated[list[str], Field(description='Name prefixes to match against item names.')],
     item_types: Annotated[
         Sequence[ItemType], Field(description='Optional list of keboola item types to filter by.')
@@ -121,6 +122,12 @@ async def search(
     """
     Searches for Keboola items in the production branch of the current project whose names match the given prefixes,
     potentially narrowed down by item type, limited and paginated. Results are ordered by relevance, then creation time.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Finding tables containing customer data for analysis pipeline"
+    - "Searching for specific component configurations to review setup"
+    - "Locating transformations related to data processing workflow"
+    - "Finding storage buckets for data organization and cleanup"
 
     Considerations:
     - The search is purely name-based, and an item is returned when its name or any word in the name starts with any
@@ -153,10 +160,17 @@ async def search(
 @with_session_state()
 async def find_component_id(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     query: Annotated[str, Field(description='Natural language query to find the requested component.')],
 ) -> list[SuggestedComponent]:
     """
     Returns list of component IDs that match the given query.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Setting up data extraction from Salesforce CRM system"
+    - "Finding appropriate writer component for target database system"
+    - "Identifying transformation component for data processing requirements"
+    - "Locating extractor component for third-party API integration"
 
     USAGE:
     - Use when you want to find the component for a specific purpose.

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -32,14 +32,24 @@ def add_sql_tools(mcp: FastMCP) -> None:
 @with_session_state()
 async def get_sql_dialect(
     ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
 ) -> Annotated[str, Field(description='The SQL dialect of the project database')]:
-    """Gets the name of the SQL dialect used by Keboola project's underlying database."""
+    """Gets the name of the SQL dialect used by Keboola project's underlying database.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Determining correct SQL syntax for database query construction"
+    - "Checking dialect compatibility for transformation development"
+    - "Understanding database type for query optimization purposes"
+    - "Verifying SQL dialect before writing data analysis queries"
+    """
     return await WorkspaceManager.from_state(ctx.session.state).get_sql_dialect()
 
 
 @tool_errors()
 @with_session_state()
 async def query_data(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     sql_query: Annotated[str, Field(description='SQL SELECT query to run.')],
     query_name: Annotated[
         str,
@@ -51,10 +61,16 @@ async def query_data(
             )
         ),
     ],
-    ctx: Context,
 ) -> Annotated[QueryDataOutput, Field(description='The query results with name and CSV data.')]:
     """
     Executes an SQL SELECT query to get the data from the underlying database.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Analyzing customer data to identify purchasing patterns and trends"
+    - "Extracting sales metrics for quarterly business performance review"
+    - "Querying product data to support inventory management decisions"
+    - "Retrieving user activity data for behavioral analysis report"
+
     * When constructing the SQL SELECT query make sure to check the SQL dialect
       used by the Keboola project's underlying database.
     * When referring to tables always use fully qualified table names that include the database name,

--- a/src/keboola_mcp_server/tools/storage.py
+++ b/src/keboola_mcp_server/tools/storage.py
@@ -167,9 +167,18 @@ class UpdateDescriptionOutput(BaseModel):
 @tool_errors()
 @with_session_state()
 async def get_bucket(
-    bucket_id: Annotated[str, Field(description='Unique ID of the bucket.')], ctx: Context
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
+    bucket_id: Annotated[str, Field(description='Unique ID of the bucket.')],
 ) -> BucketDetail:
-    """Gets detailed information about a specific bucket."""
+    """Gets detailed information about a specific bucket.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Reviewing bucket configuration for data storage optimization"
+    - "Getting bucket details to understand data organization structure"
+    - "Checking bucket metadata for data governance compliance"
+    - "Retrieving bucket information for data pipeline setup"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
     assert isinstance(client, KeboolaClient)
@@ -182,8 +191,18 @@ async def get_bucket(
 
 @tool_errors()
 @with_session_state()
-async def list_buckets(ctx: Context) -> ListBucketsOutput:
-    """Retrieves information about all buckets in the project."""
+async def list_buckets(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
+) -> ListBucketsOutput:
+    """Retrieves information about all buckets in the project.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Getting overview of all storage buckets for data inventory"
+    - "Listing buckets to understand current data organization structure"
+    - "Reviewing bucket configuration for data governance audit"
+    - "Checking available buckets for data pipeline planning"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
 
@@ -203,9 +222,18 @@ async def list_buckets(ctx: Context) -> ListBucketsOutput:
 @tool_errors()
 @with_session_state()
 async def get_table(
-    table_id: Annotated[str, Field(description='Unique ID of the table.')], ctx: Context
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
+    table_id: Annotated[str, Field(description='Unique ID of the table.')],
 ) -> TableDetail:
-    """Gets detailed information about a specific table including its DB identifier and column information."""
+    """Gets detailed information about a specific table including its DB identifier and column information.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Getting table schema information for SQL query construction"
+    - "Reviewing table structure for data analysis planning"
+    - "Checking table metadata for data quality assessment"
+    - "Retrieving column details for transformation development"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
@@ -228,9 +256,18 @@ async def get_table(
 @tool_errors()
 @with_session_state()
 async def list_tables(
-    bucket_id: Annotated[str, Field(description='Unique ID of the bucket.')], ctx: Context
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
+    bucket_id: Annotated[str, Field(description='Unique ID of the bucket.')],
 ) -> ListTablesOutput:
-    """Retrieves all tables in a specific bucket with their basic information."""
+    """Retrieves all tables in a specific bucket with their basic information.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Listing tables in bucket to understand available data sources"
+    - "Getting table inventory for data pipeline development planning"
+    - "Reviewing table structure for data analysis project setup"
+    - "Checking available tables for transformation input selection"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
     # TODO: requesting "metadata" to get the table description;
@@ -247,14 +284,22 @@ async def list_tables(
 @tool_errors()
 @with_session_state()
 async def update_bucket_description(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     bucket_id: Annotated[str, Field(description='The ID of the bucket to update.')],
     description: Annotated[str, Field(description='The new description for the bucket.')],
-    ctx: Context,
 ) -> Annotated[
     UpdateDescriptionOutput,
     Field(description='The response object of the Bucket description update.'),
 ]:
-    """Updates the description for a given Keboola bucket."""
+    """Updates the description for a given Keboola bucket.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Adding documentation to bucket for better data organization"
+    - "Updating bucket description to reflect current data content"
+    - "Setting descriptive metadata for data governance compliance"
+    - "Documenting bucket purpose for team collaboration"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
     links_manger = await ProjectLinksManager.from_client(client)
 
@@ -272,14 +317,22 @@ async def update_bucket_description(
 @tool_errors()
 @with_session_state()
 async def update_table_description(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     table_id: Annotated[str, Field(description='The ID of the table to update.')],
     description: Annotated[str, Field(description='The new description for the table.')],
-    ctx: Context,
 ) -> Annotated[
     UpdateDescriptionOutput,
     Field(description='The response object of the Table description update.'),
 ]:
-    """Updates the description for a given Keboola table."""
+    """Updates the description for a given Keboola table.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Adding documentation to table for data dictionary maintenance"
+    - "Updating table description to clarify data content and usage"
+    - "Setting table metadata for data catalog and discovery"
+    - "Documenting table structure for team knowledge sharing"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
     response = await client.storage_client.table_metadata_update(
         table_id=table_id,
@@ -295,15 +348,23 @@ async def update_table_description(
 @tool_errors()
 @with_session_state()
 async def update_column_description(
+    ctx: Context,
+    context: Annotated[str, Field(description='Brief explanation of why this tool call is being made (8-15 words)')],
     table_id: Annotated[str, Field(description='The ID of the table that contains the column.')],
     column_name: Annotated[str, Field(description='The name of the column to update.')],
     description: Annotated[str, Field(description='The new description for the column.')],
-    ctx: Context,
 ) -> Annotated[
     UpdateDescriptionOutput,
     Field(description='The response object of the column description update.'),
 ]:
-    """Updates the description for a given column in a Keboola table."""
+    """Updates the description for a given column in a Keboola table.
+
+    'context' parameter provides reasoning for why the call is being made. Examples:
+    - "Adding column documentation for data dictionary completion"
+    - "Updating column description to clarify data field meaning"
+    - "Setting column metadata for data lineage and documentation"
+    - "Documenting column purpose for analytical team understanding"
+    """
     client = KeboolaClient.from_state(ctx.session.state)
 
     response = await client.storage_client.table_metadata_update(

--- a/tests/test_context_parameter_enforcement.py
+++ b/tests/test_context_parameter_enforcement.py
@@ -1,0 +1,210 @@
+
+"""Tests to ensure all MCP tool functions have the required context parameter."""
+
+import inspect
+from typing import get_type_hints
+
+import pytest
+
+from keboola_mcp_server.tools import (
+    components,
+    doc,
+    jobs,
+    oauth,
+    project,
+    search,
+    sql,
+    storage,
+)
+from keboola_mcp_server.tools.flow import tools as flow_tools
+
+
+def get_all_tool_functions():
+    """
+    Discover all tool functions across all tool modules.
+
+    Returns a list of tuples: (module_name, function_name, function_object)
+    """
+    tool_modules = [
+        ('doc', doc),
+        ('jobs', jobs),
+        ('oauth', oauth),
+        ('project', project),
+        ('search', search),
+        ('sql', sql),
+        ('storage', storage),
+        ('components', components),
+        ('flow.tools', flow_tools),
+    ]
+
+    tool_functions = []
+
+    for module_name, module in tool_modules:
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+
+            # Check if it's a function and not a private/internal function
+            if (
+                callable(attr)
+                and not attr_name.startswith('_')
+                and hasattr(attr, '__module__')
+                and attr.__module__ and module_name in attr.__module__
+            ):
+                # Get the function signature to check for ctx parameter
+                try:
+                    sig = inspect.signature(attr)
+                    # Only include functions that have a 'ctx' or '_ctx' parameter (these are tool functions)
+                    if 'ctx' in sig.parameters or '_ctx' in sig.parameters:
+                        tool_functions.append((module_name, attr_name, attr))
+                except (ValueError, TypeError):
+                    # Skip functions we can't inspect
+                    continue
+
+    return tool_functions
+
+
+class TestContextParameterEnforcement:
+    """Test suite to ensure all tool functions have the required context parameter."""
+
+    @pytest.mark.parametrize(('module_name', 'func_name', 'func'), get_all_tool_functions())
+    def test_tool_has_context_parameter(self, module_name, func_name, func):
+        """Test that each tool function has a context parameter with correct type and description."""
+        sig = inspect.signature(func)
+
+        # Check that context parameter exists
+        assert 'context' in sig.parameters, (
+            f"Tool function {module_name}.{func_name} is missing the required 'context' parameter"
+        )
+
+        context_param = sig.parameters['context']
+
+        # Check that context parameter comes after ctx parameter (or _ctx)
+        param_names = list(sig.parameters.keys())
+        if 'ctx' in param_names:
+            ctx_index = param_names.index('ctx')
+        elif '_ctx' in param_names:
+            ctx_index = param_names.index('_ctx')
+        else:
+            raise AssertionError(f"Tool function {module_name}.{func_name} must have 'ctx' or '_ctx' parameter")
+
+        context_index = param_names.index('context')
+
+        assert context_index == ctx_index + 1, (
+            f"Tool function {module_name}.{func_name} must have 'context' parameter "
+            f"immediately after 'ctx'/'_ctx' parameter. Current order: {param_names}"
+        )
+
+        # Check that context parameter has no default value (is required)
+        assert context_param.default == inspect.Parameter.empty, (
+            f'{module_name}.{func_name} context parameter must be required (no default value)'
+        )
+
+        # Check type annotation
+        type_hints = get_type_hints(func, include_extras=True)
+        assert 'context' in type_hints, (
+            f'Tool function {module_name}.{func_name} context parameter must have type annotation'
+        )
+
+        context_type = type_hints['context']
+
+        # Check that it's Annotated[str, Field(...)]
+        assert hasattr(context_type, '__origin__') or hasattr(context_type, '__metadata__'), (
+            f'Tool function {module_name}.{func_name} context parameter must use Annotated type'
+        )
+
+        # Check if it's an Annotated type (works across different Python/typing versions)
+        is_annotated = (
+            (hasattr(context_type, '__origin__') and context_type.__origin__ is not None) or
+            hasattr(context_type, '__metadata__')
+        )
+        assert is_annotated, (
+            f'Tool function {module_name}.{func_name} context parameter must use Annotated[str, Field(...)]'
+        )
+
+        # Check that the first type argument is str
+        if hasattr(context_type, '__args__') and context_type.__args__:
+            assert context_type.__args__[0] is str, (
+                f'Tool function {module_name}.{func_name} context parameter must be Annotated[str, ...]'
+            )
+
+        # Check that it has a Field annotation with description
+        field_found = False
+        field_description = None
+
+        # Check args (normal case)
+        if hasattr(context_type, '__args__') and len(context_type.__args__) > 1:
+            for arg in context_type.__args__[1:]:
+                if hasattr(arg, 'description') and hasattr(arg, '__class__') and 'Field' in str(arg.__class__):
+                    field_found = True
+                    field_description = arg.description
+                    break
+
+        # Check metadata (alternative case)
+        if not field_found and hasattr(context_type, '__metadata__'):
+            for arg in context_type.__metadata__:
+                if hasattr(arg, 'description') and hasattr(arg, '__class__') and 'Field' in str(arg.__class__):
+                    field_found = True
+                    field_description = arg.description
+                    break
+
+        assert field_found, (
+            f'Tool function {module_name}.{func_name} context parameter must have Field annotation with description'
+        )
+
+        # Check that Field has description
+        assert field_description, (
+            f'Tool function {module_name}.{func_name} context parameter Field must have description'
+        )
+
+        # Check that description mentions the expected content
+        description = field_description.lower()
+        expected_phrases = ['brief explanation', 'tool call']
+        for phrase in expected_phrases:
+            assert phrase in description, (
+                f'{module_name}.{func_name} context parameter description should mention '
+                f'{phrase!r}. Got: {field_description}'
+            )
+
+    def test_all_expected_tools_found(self):
+        """Test that we found all expected tool functions."""
+        tool_functions = get_all_tool_functions()
+
+        # Expected minimum number of tool functions (as of current implementation)
+        # This will help catch if tools are accidentally removed or not discovered
+        expected_minimum = 33
+
+        actual_count = len(tool_functions)
+        assert actual_count >= expected_minimum, (
+            f'Expected at least {expected_minimum} tool functions, but found only {actual_count}. '
+            f'Found functions: {[(m, f) for m, f, _ in tool_functions]}'
+        )
+
+        # Check that all expected modules have at least one tool function
+        expected_modules = {
+            'doc', 'jobs', 'oauth', 'project', 'search', 'sql', 'storage', 'components', 'flow.tools'
+        }
+        found_modules = {module_name for module_name, _, _ in tool_functions}
+
+        missing_modules = expected_modules - found_modules
+        assert not missing_modules, f'No tool functions found in expected modules: {missing_modules}'
+
+    def test_function_discovery_consistency(self):
+        """Test that our function discovery is working consistently."""
+        tool_functions = get_all_tool_functions()
+
+        # Check that we found some specific known functions
+        known_functions = [
+            ('doc', 'docs_query'),
+            ('jobs', 'list_jobs'),
+            ('oauth', 'create_oauth_url'),
+            ('storage', 'get_bucket'),
+            ('components', 'create_config'),
+        ]
+
+        found_functions = [(module_name, func_name) for module_name, func_name, _ in tool_functions]
+
+        for expected_module, expected_func in known_functions:
+            assert (expected_module, expected_func) in found_functions, (
+                f'Expected to find {expected_module}.{expected_func} but it was not discovered. '
+                f'This might indicate an issue with the function discovery logic.'
+            )

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -119,7 +119,7 @@ async def test_list_configs_by_types(
         side_effect=[[{**component, 'configurations': mock_configurations}] for component in mock_components]
     )
 
-    result = await list_configs(ctx=context, component_types=[])
+    result = await list_configs(ctx=context, context='Test listing configs by types', component_types=[])
 
     assert_retrieve_components(result, mock_components, mock_configurations)
 
@@ -150,7 +150,7 @@ async def test_list_transformations(
         return_value=[{**mock_component, 'configurations': mock_configurations}]
     )
 
-    result = await list_transformations(context)
+    result = await list_transformations(context, 'Test listing transformations')
 
     assert_retrieve_components(result, [mock_component], mock_configurations)
 
@@ -175,7 +175,7 @@ async def test_list_configs_from_ids(
     keboola_client.storage_client.configuration_list = mocker.AsyncMock(return_value=mock_configurations)
     keboola_client.storage_client.component_detail = mocker.AsyncMock(return_value=mock_component)
 
-    result = await list_configs(context, component_ids=[mock_component['id']])
+    result = await list_configs(context, 'Test listing configs from IDs', component_ids=[mock_component['id']])
 
     assert_retrieve_components(result, [mock_component], mock_configurations)
 
@@ -199,7 +199,9 @@ async def test_list_transformations_from_ids(
     keboola_client.storage_client.configuration_list = mocker.AsyncMock(return_value=mock_configurations)
     keboola_client.storage_client.component_detail = mocker.AsyncMock(return_value=mock_component)
 
-    result = await list_transformations(context, transformation_ids=[mock_component['id']])
+    result = await list_transformations(
+        context, 'Test listing transformations from IDs', transformation_ids=[mock_component['id']]
+    )
 
     assert_retrieve_components(result, [mock_component], mock_configurations)
 
@@ -230,9 +232,10 @@ async def test_get_config(
     )
 
     result = await get_config(
+        ctx=context,
+        context='Test getting config',
         component_id=mock_component['id'],
         configuration_id=mock_configuration['id'],
-        ctx=context,
     )
 
     assert isinstance(result, Configuration)
@@ -310,6 +313,7 @@ async def test_create_sql_transformation(
     # Test the create_sql_transformation tool
     new_transformation_configuration = await create_sql_transformation(
         ctx=context,
+        context='Test creating SQL transformation',
         name=transformation_name,
         description=description,
         sql_code_blocks=code_blocks,
@@ -364,6 +368,7 @@ async def test_create_sql_transformation_fail(
     with pytest.raises(ValueError, match='Unsupported SQL dialect'):
         _ = await create_sql_transformation(
             ctx=context,
+            context='Test creating SQL transformation failure',
             name='test_name',
             description='test_description',
             sql_code_blocks=[
@@ -404,6 +409,7 @@ async def test_update_sql_transformation(
 
     updated_configuration = await update_sql_transformation(
         context,
+        'Test updating SQL transformation',
         mock_configuration['id'],
         new_change_description,
         parameters=TransformationConfiguration.Parameters.model_validate(new_config),
@@ -441,7 +447,9 @@ async def test_get_config_examples(
     keboola_client.ai_service_client = mocker.MagicMock()
     keboola_client.ai_service_client.get_component_detail = mocker.AsyncMock(return_value=mock_component)
 
-    text = await get_config_examples(component_id='keboola.ex-aws-s3', ctx=context)
+    text = await get_config_examples(
+        ctx=context, context='Test getting config examples', component_id='keboola.ex-aws-s3'
+    )
     assert (
         text
         == """# Configuration Examples for `keboola.ex-aws-s3`
@@ -497,6 +505,7 @@ async def test_create_config(
     # Test the create_component_root_configuration tool
     result = await create_config(
         ctx=context,
+        context='Test creating config',
         name=name,
         description=description,
         component_id=component_id,
@@ -549,6 +558,7 @@ async def test_add_config_row(
     # Test the create_component_row_configuration tool
     result = await add_config_row(
         ctx=context,
+        context='Test adding config row',
         name=name,
         description=description,
         component_id=component_id,
@@ -605,6 +615,7 @@ async def test_update_config(
     # Test the update_component_root_configuration tool
     result = await update_config(
         ctx=context,
+        context='Test updating config',
         name=name,
         description=description,
         change_description=change_description,
@@ -662,6 +673,7 @@ async def test_update_config_row(
     # Test the update_component_row_configuration tool
     result = await update_config_row(
         ctx=context,
+        context='Test updating config row',
         name=name,
         description=description,
         change_description=change_description,

--- a/tests/tools/flow/test_tools.py
+++ b/tests/tools/flow/test_tools.py
@@ -44,6 +44,7 @@ class TestFlowTools:
 
         result = await create_flow(
             ctx=mcp_context_client,
+            context='Test flow creation',
             name='Test Flow',
             description='Test flow description',
             phases=sample_phases,
@@ -83,7 +84,7 @@ class TestFlowTools:
             return_value=[mock_raw_flow_config, mock_empty_flow_config]
         )
 
-        result = await list_flows(ctx=mcp_context_client)
+        result = await list_flows(ctx=mcp_context_client, context='Test listing all flows')
 
         assert isinstance(result, ListFlowsOutput)
         assert len(result.flows) == 2
@@ -101,7 +102,9 @@ class TestFlowTools:
         keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
         keboola_client.storage_client.flow_detail = mocker.AsyncMock(return_value=mock_raw_flow_config)
 
-        result = await list_flows(ctx=mcp_context_client, flow_ids=['21703284'])
+        result = await list_flows(
+            ctx=mcp_context_client, context='Test listing specific flows', flow_ids=['21703284']
+        )
 
         assert len(result.flows) == 1
         assert result.flows[0].id == '21703284'
@@ -122,7 +125,11 @@ class TestFlowTools:
 
         keboola_client.storage_client.flow_detail = mocker.AsyncMock(side_effect=mock_get_flow)
 
-        result = await list_flows(ctx=mcp_context_client, flow_ids=['21703284', 'nonexistent'])
+        result = await list_flows(
+            ctx=mcp_context_client,
+            context='Test listing flows with missing ID',
+            flow_ids=['21703284', 'nonexistent'],
+        )
 
         assert len(result.flows) == 1
         assert result.flows[0].id == '21703284'
@@ -135,7 +142,9 @@ class TestFlowTools:
         keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
         keboola_client.storage_client.flow_detail = mocker.AsyncMock(return_value=mock_raw_flow_config)
 
-        result = await get_flow(ctx=mcp_context_client, configuration_id='21703284')
+        result = await get_flow(
+            ctx=mcp_context_client, context='Test getting flow details', configuration_id='21703284'
+        )
 
         assert isinstance(result, FlowConfigurationResponse)
         assert result.component_id == ORCHESTRATOR_COMPONENT_ID
@@ -164,6 +173,7 @@ class TestFlowTools:
 
         result = await update_flow(
             ctx=mcp_context_client,
+            context='Test flow update',
             configuration_id='21703284',
             name='Updated Flow',
             description='Updated description',
@@ -206,6 +216,7 @@ class TestFlowEdgeCases:
         with pytest.raises(ValueError, match='depends on non-existent phase'):
             await create_flow(
                 ctx=mcp_context_client,
+                context='Test create flow with invalid structure',
                 name='Invalid Flow',
                 description='Invalid flow',
                 phases=invalid_phases,
@@ -255,6 +266,7 @@ async def test_complete_flow_workflow(mocker: MockerFixture, mcp_context_client:
 
     created = await create_flow(
         ctx=mcp_context_client,
+        context='Test complete flow workflow creation',
         name='Integration Test Flow',
         description='Flow for integration testing',
         phases=[],
@@ -262,12 +274,13 @@ async def test_complete_flow_workflow(mocker: MockerFixture, mcp_context_client:
     )
     assert isinstance(created, FlowToolResponse)
 
-    result = await list_flows(ctx=mcp_context_client)
+    result = await list_flows(ctx=mcp_context_client, context='Test complete flow workflow listing')
     assert len(result.flows) == 1
     assert result.flows[0].name == 'Integration Test Flow'
 
     updated = await update_flow(
         ctx=mcp_context_client,
+        context='Test complete flow workflow update',
         configuration_id='123456',
         name='Integration Test Flow',
         description='Updated flow for integration testing',
@@ -277,7 +290,11 @@ async def test_complete_flow_workflow(mocker: MockerFixture, mcp_context_client:
     )
     assert isinstance(updated, FlowToolResponse)
 
-    detail = await get_flow(ctx=mcp_context_client, configuration_id='123456')
+    detail = await get_flow(
+        ctx=mcp_context_client,
+        context='Test complete flow workflow get details',
+        configuration_id='123456',
+    )
     assert isinstance(detail, FlowConfigurationResponse)
     assert len(detail.configuration.phases) == 1
     assert len(detail.configuration.tasks) == 1

--- a/tests/tools/test_doc.py
+++ b/tests/tools/test_doc.py
@@ -27,7 +27,7 @@ async def test_docs_query(
     keboola_client.ai_service_client.docs_question = mocker.AsyncMock(return_value=mock_docs_response)
 
     query = 'How do I create a transformation?'
-    result = await docs_query(context, query)
+    result = await docs_query(context, 'Test documentation query', query)
 
     assert isinstance(result, DocsAnswer)
     assert result.text == mock_docs_response.text

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -86,7 +86,7 @@ async def test_list_jobs(
     keboola_client = KeboolaClient.from_state(context.session.state)
     keboola_client.jobs_queue_client.search_jobs_by = mocker.AsyncMock(return_value=mock_jobs)
 
-    result = await list_jobs(context)
+    result = await list_jobs(context, 'Test listing jobs')
 
     assert isinstance(result, ListJobsOutput)
     assert len(result.jobs) == 2
@@ -134,7 +134,7 @@ async def test_get_job(
     keboola_client = KeboolaClient.from_state(context.session.state)
     keboola_client.jobs_queue_client.get_job_detail = mocker.AsyncMock(return_value=mock_job)
 
-    result = await get_job(ctx=context, job_id='123')
+    result = await get_job(ctx=context, context='Test getting job details', job_id='123')
 
     assert isinstance(result, JobDetail)
     assert result.id == mock_job['id']
@@ -170,7 +170,12 @@ async def test_list_jobs_with_component_and_config_id(
     keboola_client = KeboolaClient.from_state(context.session.state)
     keboola_client.jobs_queue_client.search_jobs_by = mocker.AsyncMock(return_value=mock_jobs)
 
-    result = await list_jobs(ctx=context, component_id='keboola.ex-aws-s3', config_id='config-123')
+    result = await list_jobs(
+        ctx=context,
+        context='Test listing jobs with component and config',
+        component_id='keboola.ex-aws-s3',
+        config_id='config-123',
+    )
 
     assert len(result.jobs) == 2
     assert all(isinstance(job, JobListItem) for job in result.jobs)
@@ -198,7 +203,9 @@ async def test_list_jobs_with_component_id_without_config_id(
     keboola_client = KeboolaClient.from_state(context.session.state)
     keboola_client.jobs_queue_client.search_jobs_by = mocker.AsyncMock(return_value=mock_jobs)
 
-    result = await list_jobs(ctx=context, component_id='keboola.ex-aws-s3')
+    result = await list_jobs(
+        ctx=context, context='Test listing jobs with component only', component_id='keboola.ex-aws-s3'
+    )
 
     assert len(result.jobs) == 2
     assert all(isinstance(job, JobListItem) for job in result.jobs)
@@ -234,7 +241,9 @@ async def test_run_job(
 
     component_id = mock_job['component']
     configuration_id = mock_job['config']
-    job_detail = await run_job(ctx=context, component_id=component_id, configuration_id=configuration_id)
+    job_detail = await run_job(
+        ctx=context, context='Test running job', component_id=component_id, configuration_id=configuration_id
+    )
 
     assert isinstance(job_detail, JobDetail)
     assert job_detail.result == {}
@@ -265,7 +274,12 @@ async def test_run_job_fail(mocker: MockerFixture, mcp_context_client: Context, 
     configuration_id = mock_job['config']
 
     with pytest.raises(HTTPError):
-        await run_job(ctx=context, component_id=component_id, configuration_id=configuration_id)
+        await run_job(
+            ctx=context,
+            context='Test running job failure',
+            component_id=component_id,
+            configuration_id=configuration_id,
+        )
 
     keboola_client.jobs_queue_client.create_job.assert_called_once_with(
         component_id=component_id,

--- a/tests/tools/test_oauth.py
+++ b/tests/tools/test_oauth.py
@@ -32,7 +32,9 @@ async def test_create_oauth_url_success(
     component_id = 'keboola.ex-google-analytics-v4'
     config_id = 'config-123'
 
-    result = await create_oauth_url(component_id=component_id, config_id=config_id, ctx=mcp_context_client)
+    result = await create_oauth_url(
+        ctx=mcp_context_client, context='Test OAuth URL creation', component_id=component_id, config_id=config_id
+    )
 
     # Verify the storage client was called with correct parameters
     keboola_client.storage_client.token_create.assert_called_once_with(
@@ -74,7 +76,12 @@ async def test_create_oauth_url_different_components(
     keboola_client.storage_client.token_create.return_value = mock_token_response
     keboola_client.storage_client.base_api_url = 'https://connection.test.keboola.com'
 
-    result = await create_oauth_url(component_id=component_id, config_id=config_id, ctx=mcp_context_client)
+    result = await create_oauth_url(
+        ctx=mcp_context_client,
+        context='Test OAuth URL for different components',
+        component_id=component_id,
+        config_id=config_id,
+    )
 
     # Verify component-specific parameters were used
     assert isinstance(result, str)
@@ -100,7 +107,10 @@ async def test_create_oauth_url_token_creation_failure(
 
     with pytest.raises(Exception, match='Token creation failed'):
         await create_oauth_url(
-            component_id='keboola.ex-google-analytics-v4', config_id='config-123', ctx=mcp_context_client
+            ctx=mcp_context_client,
+            context='Test OAuth URL token creation failure',
+            component_id='keboola.ex-google-analytics-v4',
+            config_id='config-123',
         )
 
 
@@ -117,5 +127,8 @@ async def test_create_oauth_url_missing_token_in_response(mcp_context_client: Co
 
     with pytest.raises(KeyError):
         await create_oauth_url(
-            component_id='keboola.ex-google-analytics-v4', config_id='config-123', ctx=mcp_context_client
+            ctx=mcp_context_client,
+            context='Test OAuth URL missing token response',
+            component_id='keboola.ex-google-analytics-v4',
+            config_id='config-123',
         )

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -43,7 +43,7 @@ async def test_get_project_info(mocker: MockerFixture, mcp_context_client: Conte
     )
 
     # Call the tool
-    result = await get_project_info(mcp_context_client)
+    result = await get_project_info(mcp_context_client, 'Test getting project info')
     assert isinstance(result, ProjectInfo)
     assert result.project_id == 'proj-123'
     assert result.project_name == 'Test Project'

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -275,6 +275,7 @@ class TestGlobalSearchTool:
 
         result = await search(
             ctx=mcp_context_client,
+            context='Test global search with parameters',
             name_prefixes=['test', 'table'],
             item_types=('table', 'configuration'),
             limit=20,
@@ -311,7 +312,7 @@ class TestGlobalSearchTool:
         mock_response = GlobalSearchResponse.model_validate(mock_global_search_response)
         keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=mock_response)
 
-        result = await search(ctx=mcp_context_client, name_prefixes=['test'])
+        result = await search(ctx=mcp_context_client, context='Test default search parameters', name_prefixes=['test'])
 
         assert isinstance(result, GlobalSearchOutput)
 
@@ -332,7 +333,9 @@ class TestGlobalSearchTool:
         keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=mock_response)
 
         # Test with limit too high
-        await search(ctx=mcp_context_client, name_prefixes=['test'], limit=200)
+        await search(
+            ctx=mcp_context_client, context='Test search limit out of range', name_prefixes=['test'], limit=200
+        )
 
         # Should use default limit
         keboola_client.storage_client.global_search.assert_called_with(
@@ -341,7 +344,9 @@ class TestGlobalSearchTool:
 
         # Test with limit too low
         keboola_client.storage_client.global_search.reset_mock()
-        await search(ctx=mcp_context_client, name_prefixes=['test'], limit=0)
+        await search(
+            ctx=mcp_context_client, context='Test search with invalid limit', name_prefixes=['test'], limit=0
+        )
 
         # Should use default limit
         keboola_client.storage_client.global_search.assert_called_with(
@@ -359,7 +364,12 @@ class TestGlobalSearchTool:
         mock_response = GlobalSearchResponse.model_validate(mock_global_search_response)
         keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=mock_response)
 
-        await search(ctx=mcp_context_client, name_prefixes=['test'], offset=-10)
+        await search(
+            ctx=mcp_context_client,
+            context='Test search with negative offset',
+            name_prefixes=['test'],
+            offset=-10,
+        )
 
         # Should use offset 0
         keboola_client.storage_client.global_search.assert_called_once_with(
@@ -373,7 +383,7 @@ class TestGlobalSearchTool:
         keboola_client.storage_client.is_enabled = mocker.AsyncMock(return_value=False)
 
         with pytest.raises(ValueError, match='Global search is not enabled'):
-            await search(ctx=mcp_context_client, name_prefixes=['test'])
+            await search(ctx=mcp_context_client, context='Test search feature not enabled', name_prefixes=['test'])
 
     @pytest.mark.asyncio
     async def test_global_search_joins_prefixes(
@@ -386,7 +396,9 @@ class TestGlobalSearchTool:
         mock_response = GlobalSearchResponse.model_validate(mock_global_search_response)
         keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=mock_response)
 
-        await search(ctx=mcp_context_client, name_prefixes=['test', 'table', 'data'])
+        await search(
+            ctx=mcp_context_client, context='Test search joins prefixes', name_prefixes=['test', 'table', 'data']
+        )
 
         # Should join with spaces
         keboola_client.storage_client.global_search.assert_called_once_with(
@@ -404,7 +416,9 @@ class TestGlobalSearchTool:
         mock_response = GlobalSearchResponse.model_validate(mock_global_search_response)
         keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=mock_response)
 
-        await search(ctx=mcp_context_client, name_prefixes=['test'], limit=75)
+        await search(
+            ctx=mcp_context_client, context='Test search with valid limit', name_prefixes=['test'], limit=75
+        )
 
         # Should use the provided limit
         keboola_client.storage_client.global_search.assert_called_once_with(

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -55,7 +55,7 @@ async def test_query_data(
     workspace_manager.execute_query.return_value = result
     mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = workspace_manager
 
-    result = await query_data(query, query_name, mcp_context_client)
+    result = await query_data(mcp_context_client, 'Test SQL query execution', query, query_name)
     assert isinstance(result, QueryDataOutput)
     assert result.query_name == query_name
     assert result.csv_data == expected_csv
@@ -68,7 +68,7 @@ async def test_get_sql_dialect(dialect: str, mcp_context_client: Context, mocker
     workspace_manager.get_sql_dialect.return_value = dialect
     mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = workspace_manager
 
-    result = await get_sql_dialect(mcp_context_client)
+    result = await get_sql_dialect(mcp_context_client, 'Test getting SQL dialect')
     assert result == dialect
 
 

--- a/tests/tools/test_storage.py
+++ b/tests/tools/test_storage.py
@@ -181,7 +181,7 @@ async def test_get_bucket(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.storage_client.bucket_detail = mocker.AsyncMock(return_value=expected_bucket)
 
-    result = await get_bucket(bucket_id, mcp_context_client)
+    result = await get_bucket(mcp_context_client, 'Test getting bucket', bucket_id)
 
     assert isinstance(result, BucketDetail)
     assert result.id == expected_bucket['id']
@@ -222,7 +222,7 @@ async def test_list_buckets(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.storage_client.bucket_list = mocker.AsyncMock(return_value=mock_buckets)
 
-    result = await list_buckets(mcp_context_client)
+    result = await list_buckets(mcp_context_client, 'Test listing buckets')
 
     assert isinstance(result, ListBucketsOutput)
     assert len(result.buckets) == len(mock_buckets)
@@ -259,7 +259,7 @@ async def test_get_table(
     workspace_manager = WorkspaceManager.from_state(mcp_context_client.session.state)
     workspace_manager.get_table_fqn = mocker.AsyncMock(return_value=mock_table_data['additional_data']['table_fqn'])
     workspace_manager.get_quoted_name.side_effect = lambda name: f'#{name}#'
-    result = await get_table(mock_table_data['raw_table_data']['id'], mcp_context_client)
+    result = await get_table(mcp_context_client, 'Test getting table', mock_table_data['raw_table_data']['id'])
 
     assert isinstance(result, TableDetail)
     assert result.id == mock_table_data['raw_table_data']['id']
@@ -322,7 +322,7 @@ async def test_list_tables(
     """Test list_tables tool."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.storage_client.bucket_table_list = mocker.AsyncMock(return_value=sapi_response)
-    result = await list_tables('bucket-id', mcp_context_client)
+    result = await list_tables(mcp_context_client, 'Test listing tables', 'bucket-id')
     assert isinstance(result, ListTablesOutput)
     assert result.tables == expected
     keboola_client.storage_client.bucket_table_list.assert_called_once_with('bucket-id', include=['metadata'])
@@ -340,9 +340,10 @@ async def test_update_bucket_description_success(
     )
 
     result = await update_bucket_description(
+        ctx=mcp_context_client,
+        context='Test updating bucket description',
         bucket_id='in.c-test.bucket-id',
         description='Updated bucket description',
-        ctx=mcp_context_client,
     )
 
     assert isinstance(result, UpdateDescriptionOutput)
@@ -368,9 +369,10 @@ async def test_update_table_description_success(
     )
 
     result = await update_table_description(
+        ctx=mcp_context_client,
+        context='Test updating table description',
         table_id='in.c-test.test-table',
         description='Updated table description',
-        ctx=mcp_context_client,
     )
 
     assert isinstance(result, UpdateDescriptionOutput)
@@ -396,10 +398,11 @@ async def test_update_column_description_success(
     )
 
     result = await update_column_description(
+        ctx=mcp_context_client,
+        context='Test updating column description',
         table_id='in.c-test.test-table',
         column_name='text',
         description='Updated column description',
-        ctx=mcp_context_client,
     )
 
     assert isinstance(result, UpdateDescriptionOutput)

--- a/uv.lock
+++ b/uv.lock
@@ -909,6 +909,7 @@ dependencies = [
     { name = "httpx" },
     { name = "json-log-formatter" },
     { name = "jsonschema" },
+    { name = "kbcstorage" },
     { name = "mcp" },
     { name = "pyjwt" },
 ]
@@ -959,6 +960,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'codestyle'", specifier = "~=6.0" },
     { name = "json-log-formatter", specifier = "~=1.0" },
     { name = "jsonschema", specifier = "~=4.23" },
+    { name = "kbcstorage", specifier = ">=0.9.2" },
     { name = "kbcstorage", marker = "extra == 'integtests'", specifier = "~=0.9" },
     { name = "mcp", specifier = "==1.11.0" },
     { name = "pep8-naming", marker = "extra == 'codestyle'", specifier = "~=0.14" },


### PR DESCRIPTION
## Summary

Add required `context` parameter to all 33 MCP tool functions for monitoring and debugging tool usage patterns. The parameter provides a brief explanation (8-15 words) of why each tool call is being made.

## Why

In order to be able to display short context of why the tool has been used in the timeline and gain more insights into MCP Server usage patterns. The parameter won't be used in the tool itself - its sole purpose is to keep track of why the tool was called.

This enables:
- **Timeline functionality** - Display reasoning for each tool call in user interfaces
- **Usage insights** - Better understanding of how users interact with MCP tools
- **Debugging support** - Clear context for troubleshooting tool usage

## Changes

- Add `context` parameter to all tool functions with proper type annotations
- Parameter specification: `"Brief explanation of why this tool call is being made (8-15 words)"`
- Update all 287 unit tests and integration tests to include context parameter  
- Create automated enforcement test to ensure future tools include the parameter
- Handle edge case with `_ctx` parameter in `get_flow_schema` function

## Examples

The context parameter provides reasoning for tool calls:
- "Setting up Salesforce extractor for customer analysis project"
- "Checking existing configurations before creating new one" 
- "Analyzing customer data to identify top segments"
- "Executing transformation to calculate customer metrics"

## Test Plan

- [x] All 287 unit tests pass
- [x] All flake8 code style checks pass
- [x] Context parameter enforcement test validates all 33 functions
- [x] Integration tests updated (require credentials to run)

Related: [AI-1310](https://keboola.atlassian.net/browse/AI-1310)

🤖 Generated with [Claude Code](https://claude.ai/code)