### PR TITLE
fix: use proper URL encoding in OAuth URL generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.15.0"
+version = "1.15.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/oauth.py
+++ b/src/keboola_mcp_server/tools/oauth.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Annotated
+from urllib.parse import urlencode, urlunsplit
 
 from fastmcp import Context
 from fastmcp.tools import FunctionTool
@@ -56,9 +57,18 @@ async def create_oauth_url(
     storage_api_url = client.storage_client.base_api_url
 
     # Generate OAuth URL
-    oauth_url = (
-        f'https://external.keboola.com/oauth/index.html?token={sapi_token}'
-        f'&sapiUrl={storage_api_url}#/{component_id}/{config_id}'
-    )
+    query_params = urlencode({
+        'token': sapi_token,
+        'sapiUrl': storage_api_url
+    })
+    fragment = f'/{component_id}/{config_id}'
+
+    oauth_url = urlunsplit((
+        'https',  # scheme
+        'external.keboola.com',  # netloc
+        '/oauth/index.html',  # path
+        query_params,  # query
+        fragment  # fragment
+    ))
 
     return oauth_url

--- a/tests/tools/test_oauth.py
+++ b/tests/tools/test_oauth.py
@@ -47,7 +47,7 @@ async def test_create_oauth_url_success(
     expected_url = (
         f'https://external.keboola.com/oauth/index.html'
         f'?token=KBC_TOKEN_12345'
-        f'&sapiUrl=https://connection.test.keboola.com'
+        f'&sapiUrl=https%3A%2F%2Fconnection.test.keboola.com'
         f'#/{component_id}/{config_id}'
     )
     assert result == expected_url


### PR DESCRIPTION
## Summary
- Replace manual string concatenation with `urllib.parse.urlencode()` and `urllib.parse.urlunsplit()`
- Ensures proper URL encoding of query parameters (prevents injection vulnerabilities)
- Updates tests to validate encoded URLs

## Test plan
- [x] All existing OAuth tests pass
- [x] Code follows flake8 style guidelines
- [x] Manual verification of URL encoding behavior

Addresses: https://github.com/keboola/mcp-server/pull/211#discussion_r2236413883

<img width="324" height="809" alt="image" src="https://github.com/user-attachments/assets/295e3fc5-62cf-49d9-b463-667eb595e0e8" />


🤖 Generated with [Claude Code](https://claude.ai/code)