### PR TITLE
docs: update TOOLS.md and tools.py to clarify schema change requirements for transformations

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -956,11 +956,14 @@ CONSIDERATIONS:
 - The storage configuration must not be empty, and it should include input or output tables with correct mappings
   for the transformation.
 - When the behavior of the transformation is not changed, the updated_description can be empty string.
-- SCHEMA CHANGES: If the transformation update results in a destructive schema change to the output table 
-  (such as removing columns, changing column types, or renaming columns), you MUST inform the user that they 
-  need to manually delete the output table completely before running the updated transformation. Otherwise, 
-  the transformation will fail with a schema mismatch error. Non-destructive changes (adding new columns) 
-  typically do not require table deletion.
+- SCHEMA CHANGES: If the transformation update results in a destructive
+  schema change to the output table (such as removing columns, changing
+  column types, or renaming columns), you MUST inform the user that they
+  need to
+  manually delete the output table completely before running the updated
+  transformation. Otherwise, the transformation will fail with a schema
+  mismatch error. Non-destructive changes (adding new columns) typically do
+  not require table deletion.
 
 EXAMPLES:
 - user_input: `Can you edit this transformation configuration that [USER INTENT]?`

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -956,6 +956,11 @@ CONSIDERATIONS:
 - The storage configuration must not be empty, and it should include input or output tables with correct mappings
   for the transformation.
 - When the behavior of the transformation is not changed, the updated_description can be empty string.
+- SCHEMA CHANGES: If the transformation update results in a destructive schema change to the output table 
+  (such as removing columns, changing column types, or renaming columns), you MUST inform the user that they 
+  need to manually delete the output table completely before running the updated transformation. Otherwise, 
+  the transformation will fail with a schema mismatch error. Non-destructive changes (adding new columns) 
+  typically do not require table deletion.
 
 EXAMPLES:
 - user_input: `Can you edit this transformation configuration that [USER INTENT]?`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.15.0"
+version = "1.15.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -455,11 +455,14 @@ async def update_sql_transformation(
     - The storage configuration must not be empty, and it should include input or output tables with correct mappings
       for the transformation.
     - When the behavior of the transformation is not changed, the updated_description can be empty string.
-    - SCHEMA CHANGES: If the transformation update results in a destructive schema change to the output table 
-      (such as removing columns, changing column types, or renaming columns), you MUST inform the user that they 
-      need to manually delete the output table completely before running the updated transformation. Otherwise, 
-      the transformation will fail with a schema mismatch error. Non-destructive changes (adding new columns) 
-      typically do not require table deletion.
+    - SCHEMA CHANGES: If the transformation update results in a destructive
+      schema change to the output table (such as removing columns, changing
+      column types, or renaming columns), you MUST inform the user that they
+      need to
+      manually delete the output table completely before running the updated
+      transformation. Otherwise, the transformation will fail with a schema
+      mismatch error. Non-destructive changes (adding new columns) typically do
+      not require table deletion.
 
     EXAMPLES:
     - user_input: `Can you edit this transformation configuration that [USER INTENT]?`

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -455,6 +455,11 @@ async def update_sql_transformation(
     - The storage configuration must not be empty, and it should include input or output tables with correct mappings
       for the transformation.
     - When the behavior of the transformation is not changed, the updated_description can be empty string.
+    - SCHEMA CHANGES: If the transformation update results in a destructive schema change to the output table 
+      (such as removing columns, changing column types, or renaming columns), you MUST inform the user that they 
+      need to manually delete the output table completely before running the updated transformation. Otherwise, 
+      the transformation will fail with a schema mismatch error. Non-destructive changes (adding new columns) 
+      typically do not require table deletion.
 
     EXAMPLES:
     - user_input: `Can you edit this transformation configuration that [USER INTENT]?`


### PR DESCRIPTION
- Added guidance on handling destructive schema changes in transformations, emphasizing the need for users to manually delete output tables before running updates to avoid schema mismatch errors.