### PR TITLE
Setup black as cs-fix and alias flake8 to cs

### DIFF
--- a/integtests/conftest.py
+++ b/integtests/conftest.py
@@ -91,9 +91,7 @@ def env_file_loaded() -> bool:
 
 
 @pytest.fixture(scope='session')
-def env_init(
-    env_file_loaded: bool, storage_api_token: str, storage_api_url: str, workspace_schema: str
-) -> bool:
+def env_init(env_file_loaded: bool, storage_api_token: str, storage_api_url: str, workspace_schema: str) -> bool:
     # We reset the development environment variables to the values of the integtest environment variables.
     os.environ[DEV_STORAGE_API_URL_ENV_VAR] = storage_api_url
     os.environ[DEV_STORAGE_TOKEN_ENV_VAR] = storage_api_token
@@ -209,16 +207,16 @@ def _create_configs(storage_client: SyncStorageClient) -> list[ConfigDef]:
 def _sync_storage_client(storage_api_token: str, storage_api_url: str) -> SyncStorageClient:
     client = SyncStorageClient(storage_api_url, storage_api_token)
     token_info = client.tokens.verify()
-    LOG.info(f'Authorized as "{token_info["description"]}" ({token_info["id"]}) '
-             f'to project "{token_info["owner"]["name"]}" ({token_info["owner"]["id"]}) '
-             f'at "{client.root_url}" stack.')
+    LOG.info(
+        f'Authorized as "{token_info["description"]}" ({token_info["id"]}) '
+        f'to project "{token_info["owner"]["name"]}" ({token_info["owner"]["id"]}) '
+        f'at "{client.root_url}" stack.'
+    )
     return client
 
 
 @pytest.fixture(scope='session')
-def keboola_project(
-    env_init: bool, storage_api_token: str, storage_api_url: str
-) -> Generator[ProjectDef, Any, None]:
+def keboola_project(env_init: bool, storage_api_token: str, storage_api_url: str) -> Generator[ProjectDef, Any, None]:
     """
     Sets up a Keboola project with items needed for integration tests,
     such as buckets, tables and configurations.
@@ -308,8 +306,11 @@ def workspace_manager(keboola_client: KeboolaClient, workspace_schema: str) -> W
 
 @pytest.fixture
 def mcp_context(
-    mocker, keboola_client: KeboolaClient, workspace_manager: WorkspaceManager, keboola_project: ProjectDef,
-    mcp_config: Config
+    mocker,
+    keboola_client: KeboolaClient,
+    workspace_manager: WorkspaceManager,
+    keboola_project: ProjectDef,
+    mcp_config: Config,
 ) -> Context:
     """
     MCP context containing the Keboola client and workspace manager.

--- a/integtests/test_errors.py
+++ b/integtests/test_errors.py
@@ -31,7 +31,7 @@ class TestHttpErrors:
             r'API error: The bucket "non.existent.bucket" was not found in the project "\d+"\n'
             r'Exception ID: .+\n'
             r'When contacting Keboola support please provide the exception ID\.',
-            re.IGNORECASE
+            re.IGNORECASE,
         )
         with pytest.raises(httpx.HTTPStatusError, match=match):
             await get_bucket('non.existent.bucket', mcp_context)
@@ -45,7 +45,7 @@ class TestHttpErrors:
             r'API error: Job "999999999" not found\n'
             r'Exception ID: .+\n'
             r'When contacting Keboola support please provide the exception ID\.',
-            re.IGNORECASE
+            re.IGNORECASE,
         )
         with pytest.raises(httpx.HTTPStatusError, match=match):
             await get_job('999999999', mcp_context)
@@ -60,7 +60,7 @@ class TestHttpErrors:
             r'API error: Request contents is not valid\n'
             r'Exception ID: .+\n'
             r'When contacting Keboola support please provide the exception ID\.',
-            re.IGNORECASE
+            re.IGNORECASE,
         )
         with pytest.raises(httpx.HTTPStatusError, match=match):
             await docs_query(ctx=mcp_context, query='')
@@ -70,7 +70,7 @@ class TestHttpErrors:
         match = re.compile(
             r'Failed to run SQL query, error: An exception occurred while executing a query: SQL compilation error:\n'
             r"syntax error line 1 at position 0 unexpected 'INVALID'\.",
-            re.IGNORECASE
+            re.IGNORECASE,
         )
         with pytest.raises(ValueError, match=match):
             await query_data('INVALID SQL SYNTAX HERE', 'Invalid SQL query.', mcp_context)
@@ -89,7 +89,7 @@ class TestHttpErrors:
             r'API error: The bucket "non.existent.bucket.\d" was not found in the project "\d+"\n'
             r'Exception ID: .+\n'
             r'When contacting Keboola support please provide the exception ID\.',
-            re.IGNORECASE
+            re.IGNORECASE,
         )
 
         unexpected_errors: list[str] = []
@@ -117,16 +117,19 @@ class TestStorageEvents:
         raise ValueError('Intentional error in bar tool.')
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(('tool_name', 'event_message', 'event_type'), [
-        ('foo', 'MCP tool "foo" call succeeded.', 'success'),
-        ('bar', 'MCP tool "bar" call failed. ValueError: Intentional error in bar tool.', 'error'),
-    ])
+    @pytest.mark.parametrize(
+        ('tool_name', 'event_message', 'event_type'),
+        [
+            ('foo', 'MCP tool "foo" call succeeded.', 'success'),
+            ('bar', 'MCP tool "bar" call failed. ValueError: Intentional error in bar tool.', 'error'),
+        ],
+    )
     async def test_event_emitted(self, tool_name: str, event_message: str, event_type: str, mcp_context: Context):
         mcp_context.session_id = 'deadbee'
         mcp_context.session.client_params = InitializeRequestParams(
             protocolVersion='1',
             capabilities=ClientCapabilities(),
-            clientInfo=Implementation(name='integtest', version='1.2.3')
+            clientInfo=Implementation(name='integtest', version='1.2.3'),
         )
         unique = uuid.uuid4().hex
         tool_func = getattr(self, tool_name)
@@ -142,7 +145,7 @@ class TestStorageEvents:
             params={
                 'component': 'keboola.mcp-server.tool',
                 'q': f'message:"MCP tool "{tool_name}" call*"',
-                'limit': 10
+                'limit': 10,
             },
         )
         emitted_event = self._find_event(events, tool_name=tool_name, param_name='unique', param_value=unique)
@@ -160,7 +163,7 @@ class TestStorageEvents:
 
     @staticmethod
     def _find_event(
-            events: list[Mapping[str, Any]], *, tool_name: str, param_name: str, param_value: str
+        events: list[Mapping[str, Any]], *, tool_name: str, param_name: str, param_value: str
     ) -> Mapping[str, Any] | None:
         for event in events:
             event_tool = event['params']['tool']

--- a/integtests/test_validate.py
+++ b/integtests/test_validate.py
@@ -9,6 +9,7 @@ received from the LLM Agent.
 update of the component) assuming that the validation of json object against the schema had been correct. That is the
 reason why we are having those tests.
 """
+
 import logging
 from typing import cast
 

--- a/integtests/test_workspace.py
+++ b/integtests/test_workspace.py
@@ -13,7 +13,7 @@ LOG = logging.getLogger(__name__)
 
 @pytest.fixture
 def dynamic_manager(
-        keboola_client: KeboolaClient, sync_storage_client: SyncStorageClient, workspace_schema: str
+    keboola_client: KeboolaClient, sync_storage_client: SyncStorageClient, workspace_schema: str
 ) -> Generator[WorkspaceManager, Any, None]:
     storage_client = sync_storage_client
     token_info = storage_client.tokens.verify()
@@ -33,11 +33,14 @@ def dynamic_manager(
     workspaces = storage_client.workspaces.list()
     # ignore the static workspaces
     workspaces = [
-        w for w in workspaces
-        if all([
-            w['connection']['schema'] != workspace_schema,
-            w.get('creatorToken', {}).get('description') != 'Background Indexing Token'
-        ])
+        w
+        for w in workspaces
+        if all(
+            [
+                w['connection']['schema'] != workspace_schema,
+                w.get('creatorToken', {}).get('description') != 'Background Indexing Token',
+            ]
+        )
     ]
     if workspaces:
         pytest.fail(

--- a/integtests/tools/components/test_tools.py
+++ b/integtests/tools/components/test_tools.py
@@ -615,24 +615,26 @@ async def test_create_sql_transformation(mcp_context: Context, keboola_project: 
         assert created_transformation.description == test_description
         assert created_transformation.component_id == expected_component_id
         assert created_transformation.configuration_id is not None
-        expected_links = frozenset([
-            Link(
-                type='ui-detail',
-                title=f'Configuration: {test_name}',
-                url=(
-                    f'https://connection.keboola.com/admin/projects/{project_id}/components/'
-                    f'{expected_component_id}/{created_transformation.configuration_id}'
+        expected_links = frozenset(
+            [
+                Link(
+                    type='ui-detail',
+                    title=f'Configuration: {test_name}',
+                    url=(
+                        f'https://connection.keboola.com/admin/projects/{project_id}/components/'
+                        f'{expected_component_id}/{created_transformation.configuration_id}'
+                    ),
                 ),
-            ),
-            Link(
-                type='ui-dashboard',
-                title=f'{expected_component_id} Configurations Dashboard',
-                url=(
-                    f'https://connection.keboola.com/admin/projects/{project_id}/components/'
-                    f'{expected_component_id}'
+                Link(
+                    type='ui-dashboard',
+                    title=f'{expected_component_id} Configurations Dashboard',
+                    url=(
+                        f'https://connection.keboola.com/admin/projects/{project_id}/components/'
+                        f'{expected_component_id}'
+                    ),
                 ),
-            ),
-        ])
+            ]
+        )
 
         assert frozenset(created_transformation.links) == expected_links
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,21 @@ keboola-mcp-server = "keboola_mcp_server.cli:main"
 target-version = ["py310"]
 skip-string-normalization = true
 line-length = 120
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
 
 [tool.isort]
 profile = "black"
@@ -97,7 +112,8 @@ extend-ignore = ["E203", "W503", "I101"]
 
 [tool.tox]
 requires = ["tox>=4.23"]
-env_list = ["python", "flake8"]
+env_list = ["python", "black", "flake8"]
+labels = { cs-fix = ["black"], cs = ["flake8"] }
 
 [tool.tox.env_run_base]
 description = "Run tests"
@@ -136,6 +152,14 @@ commands = [
         ], extend = true },
     ],
 ]
+
+[tool.tox.env.black]
+description = "Fix code formatting using black"
+package = "skip"
+deps = [
+    "black ~= 25.1",
+]
+commands = [["black", "src/", "tests/", "integtests/"]]
 
 [tool.tox.env.flake8]
 description = "Run code style check using flake8"

--- a/src/keboola_mcp_server/__main__.py
+++ b/src/keboola_mcp_server/__main__.py
@@ -1,4 +1,5 @@
 """Main entry point for the Keboola MCP server."""
+
 from keboola_mcp_server.cli import main
 
 if __name__ == '__main__':

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -22,7 +22,7 @@ def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog='python -m keboola-mcp-server',
         description='Keboola MCP Server',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         '--transport',
@@ -42,17 +42,19 @@ def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
         help=(
             'Keboola Storage API URL using format of https://connection.<REGION>.keboola.com. Example: For AWS region '
             '"eu-central-1", use: https://connection.eu-central-1.keboola.com'
-        )
+        ),
     )
     parser.add_argument('--storage-token', metavar='STR', help='Keboola Storage API token.')
     parser.add_argument('--workspace-schema', metavar='STR', help='Keboola Storage API workspace schema.')
     parser.add_argument('--host', default='localhost', metavar='STR', help='The host to listen on.')
     parser.add_argument('--port', type=int, default=8000, metavar='INT', help='The port to listen on.')
     parser.add_argument(
-        '--accept-secrets-in-url', action='store_true',
+        '--accept-secrets-in-url',
+        action='store_true',
         help='(NOT RECOMMENDED) Read Storage API token and other configuration parameters from the query part '
-             'of the MCP server URL. Please note that the URL query parameters are not secure '
-             'for sending sensitive information.')
+        'of the MCP server URL. Please note that the URL query parameters are not secure '
+        'for sending sensitive information.',
+    )
     parser.add_argument('--log-config', type=pathlib.Path, metavar='PATH', help='Logging config file.')
 
     return parser.parse_args(args)
@@ -95,7 +97,7 @@ async def run_server(args: Optional[list[str]] = None) -> None:
                 port=parsed_args.port,
                 # Adding ForwardSlashMiddleware in KeboolaMcpServer's constructor doesn't seem to have any effect.
                 # See https://github.com/jlowin/fastmcp/pull/896 for the related changes in the fastmcp==2.9.0 library.
-                middleware=[Middleware(ForwardSlashMiddleware)]
+                middleware=[Middleware(ForwardSlashMiddleware)],
             )
     except Exception as e:
         LOG.exception(f'Server failed: {e}')

--- a/src/keboola_mcp_server/errors.py
+++ b/src/keboola_mcp_server/errors.py
@@ -30,6 +30,7 @@ class _JsonWrapper(BaseModel):
     Uses Pydantic's serialization to handle complex objects as well as simple types like int, float, bool, str, etc.
     Primary use case is serializing tool function parameters for Keboola Storage API events.
     """
+
     data: Any  # The arbitrary object to be JSON serialized
 
     @classmethod
@@ -38,7 +39,7 @@ class _JsonWrapper(BaseModel):
 
 
 async def _trigger_event(
-        func: Callable, args: tuple, kwargs: dict, exception: Exception | None, execution_time: float
+    func: Callable, args: tuple, kwargs: dict, exception: Exception | None, execution_time: float
 ) -> None:
     # TODO: This is not always correct. In general tool functions can be registered
     #  in the MCP server under different names.
@@ -52,8 +53,10 @@ async def _trigger_event(
     assert ctx_param_name, f'The tool function {tool_name} must have a "Context" parameter.'
 
     ctx = bound_args.arguments.get(ctx_param_name)
-    assert isinstance(ctx, Context), (f'The tool function {tool_name} has invalid "{ctx_param_name}" parameter. '
-                                      f'Expecting instance of "Context", got {type(ctx)}.')
+    assert isinstance(ctx, Context), (
+        f'The tool function {tool_name} has invalid "{ctx_param_name}" parameter. '
+        f'Expecting instance of "Context", got {type(ctx)}.'
+    )
 
     server_state = ServerState.from_context(ctx)
     user_agent: str | None = None

--- a/src/keboola_mcp_server/links.py
+++ b/src/keboola_mcp_server/links.py
@@ -78,16 +78,10 @@ class ProjectLinksManager:
             title=f'{component_name} Configurations Dashboard', url=self._url(f'components/{component_id}')
         )
 
-    def get_used_components_link(
-        self
-    ) -> Link:
-        return Link.dashboard(
-            title='Used Components Dashboard', url=self._url('components/configurations')
-        )
+    def get_used_components_link(self) -> Link:
+        return Link.dashboard(title='Used Components Dashboard', url=self._url('components/configurations'))
 
-    def get_configuration_links(
-        self, component_id: str, configuration_id: str, configuration_name: str
-    ) -> list[Link]:
+    def get_configuration_links(self, component_id: str, configuration_id: str, configuration_name: str) -> list[Link]:
         return [
             self.get_component_config_link(
                 component_id=component_id, configuration_id=configuration_id, configuration_name=configuration_name
@@ -97,9 +91,7 @@ class ProjectLinksManager:
 
     # --- Transformations ---
     def get_transformations_dashboard_link(self) -> Link:
-        return Link.dashboard(
-            title='Transformations dashboard', url=self._url('transformations-v2')
-        )
+        return Link.dashboard(title='Transformations dashboard', url=self._url('transformations-v2'))
 
     # --- Jobs ---
     def get_job_detail_link(self, job_id: str) -> Link:

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -3,6 +3,7 @@ This module overrides FastMCP.add_tool() to improve conversion of tool function 
 into tool descriptions.
 It also provides a decorator that MCP tool functions can use to inject session state into their Context parameter.
 """
+
 import dataclasses
 import logging
 import os
@@ -99,10 +100,11 @@ class SessionStateMiddleware(fmw.Middleware):
 
     Note: HTTP headers and URL query parameters are only used when the server runs on HTTP-based transport.
     """
+
     async def on_message(
-            self,
-            context: fmw.MiddlewareContext[Any],
-            call_next: fmw.CallNext[Any, Any],
+        self,
+        context: fmw.MiddlewareContext[Any],
+        call_next: fmw.CallNext[Any, Any],
     ) -> Any:
         """
         Manages session state in the Context parameter. This middleware sets up the session state for all the other
@@ -142,12 +144,13 @@ class SessionStateMiddleware(fmw.Middleware):
                 if user := http_rq.scope.get('user'):
                     LOG.debug(f'Injecting bearer and SAPI tokens: user={user}, access_token={user.access_token}')
                     assert isinstance(user, AuthenticatedUser), f'Expecting AuthenticatedUser, got: {type(user)}'
-                    assert isinstance(user.access_token, ProxyAccessToken), \
-                        f'Expecting ProxyAccessToken, got: {type(user.access_token)}'
+                    assert isinstance(
+                        user.access_token, ProxyAccessToken
+                    ), f'Expecting ProxyAccessToken, got: {type(user.access_token)}'
                     config = dataclasses.replace(
                         config,
                         storage_token=user.access_token.sapi_token,
-                        bearer_token=user.access_token.delegate.token
+                        bearer_token=user.access_token.delegate.token,
                     )
 
             # TODO: We could probably get rid of the 'state' attribute set on ctx.session and just
@@ -200,6 +203,7 @@ class ToolsFilteringMiddleware(fmw.Middleware):
     The middleware also intercepts the `on_call_tool()` call and raises an exception if a call is attempted to a tool
     that is not available in the current project.
     """
+
     @staticmethod
     async def get_project_features(ctx: Context) -> set[str]:
         assert isinstance(ctx, Context), f'Expecting Context, got {type(ctx)}.'
@@ -208,9 +212,7 @@ class ToolsFilteringMiddleware(fmw.Middleware):
         return set(filter(None, token_info.get('owner', {}).get('features', [])))
 
     async def on_list_tools(
-            self,
-            context: MiddlewareContext[mt.ListToolsRequest],
-            call_next: CallNext[mt.ListToolsRequest, list[Tool]]
+        self, context: MiddlewareContext[mt.ListToolsRequest], call_next: CallNext[mt.ListToolsRequest, list[Tool]]
     ) -> list[Tool]:
         tools = await call_next(context)
         features = await self.get_project_features(context.fastmcp_context)
@@ -233,17 +235,19 @@ class ToolsFilteringMiddleware(fmw.Middleware):
         return tools
 
     async def on_call_tool(
-            self,
-            context: MiddlewareContext[mt.CallToolRequestParams],
-            call_next: CallNext[mt.CallToolRequestParams, mt.CallToolResult]
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, mt.CallToolResult],
     ) -> mt.CallToolResult:
         tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
         features = await self.get_project_features(context.fastmcp_context)
 
         if 'global-search' not in features:
             if tool.name == 'search':
-                raise ToolError('The "search" tool is not available in this project. '
-                                'Please ask Keboola support to enable "Global Search" feature.')
+                raise ToolError(
+                    'The "search" tool is not available in this project. '
+                    'Please ask Keboola support to enable "Global Search" feature.'
+                )
 
         # TODO: uncomment and adjust when WAII tools are implemented
         # if 'waii-integration' not in features:

--- a/src/keboola_mcp_server/prompts/add_prompts.py
+++ b/src/keboola_mcp_server/prompts/add_prompts.py
@@ -1,4 +1,5 @@
 """Module to add prompts to the Keboola MCP server."""
+
 from fastmcp.prompts import Prompt
 
 from keboola_mcp_server.mcp import KeboolaMcpServer

--- a/src/keboola_mcp_server/prompts/keboola_prompts.py
+++ b/src/keboola_mcp_server/prompts/keboola_prompts.py
@@ -49,7 +49,7 @@ the names of real example buckets, tables & configurations that are within the p
 • Provide real-world examples the project can handle
 • Connect technical capabilities to business outcomes
 
-Please provide a comprehensive analysis with specific examples and names from the actual project data."""
+Please provide a comprehensive analysis with specific examples and names from the actual project data.""",
         )
     ]
 
@@ -103,7 +103,7 @@ any issues, risks, or optimization opportunities.
 • Long-term optimization strategies
 • Best practices implementation suggestions
 
-Please provide specific findings with component and table names and actionable recommendations."""
+Please provide specific findings with component and table names and actionable recommendations.""",
         )
     ]
 
@@ -157,7 +157,7 @@ async def data_quality_assessment() -> List[Message]:
 • Data governance suggestions
 
 Please analyze the actual project data and provide specific findings with table names,
-metrics, and actionable recommendations."""
+metrics, and actionable recommendations.""",
         )
     ]
 
@@ -211,7 +211,7 @@ identify potential vulnerabilities and security best practice violations.
 • Security best practices implementation
 • Compliance enhancement suggestions
 
-Please provide specific findings with component and bucket names and prioritized security recommendations."""
+Please provide specific findings with component and bucket names and prioritized security recommendations.""",
         )
     ]
 
@@ -266,7 +266,7 @@ identify optimization opportunities.
 • Resource allocation recommendations
 
 Please analyze actual project performance data and provide specific
-recommendations with component names and expected performance improvements."""
+recommendations with component names and expected performance improvements.""",
         )
     ]
 
@@ -321,7 +321,7 @@ project, their configurations, and usage patterns.
 • Efficiency improvement suggestions
 
 Please provide specific details including component names, configuration IDs, and
-actionable insights for project optimization."""
+actionable insights for project optimization.""",
         )
     ]
 
@@ -376,7 +376,7 @@ provide troubleshooting recommendations.
 • Monitoring and alerting enhancements
 
 Please analyze actual error logs and job histories to provide specific error
-instances with component names and detailed troubleshooting guidance."""
+instances with component names and detailed troubleshooting guidance.""",
         )
     ]
 
@@ -437,14 +437,13 @@ project that can be used for onboarding, maintenance, and knowledge sharing.
 • Development and testing procedures
 
 Please create detailed, professional documentation using actual project data
-including specific names, configurations, and real examples."""
+including specific names, configurations, and real examples.""",
         )
     ]
 
 
 async def generate_project_descriptions(
-    focus_area: str = 'all',
-    include_technical_details: bool = True
+    focus_area: str = 'all', include_technical_details: bool = True
 ) -> List[Message]:
     """Generate comprehensive descriptions for all tables and buckets in a Keboola project.
 
@@ -463,7 +462,7 @@ async def generate_project_descriptions(
     focus_instruction = {
         'buckets': 'Focus specifically on bucket-level descriptions and organization.',
         'tables': 'Focus specifically on table-level descriptions and data structures.',
-        'all': 'Provide comprehensive descriptions for both buckets and tables.'
+        'all': 'Provide comprehensive descriptions for both buckets and tables.',
     }.get(focus_area, 'Provide comprehensive descriptions for both buckets and tables.')
 
     # Pre-calculate conditional sections to avoid long lines
@@ -508,7 +507,7 @@ For each table, provide:
 • Recommendations for improving descriptions
 • Suggestions for better data organization
 
-Please analyze the actual project data and provide specific, actionable descriptions for each component."""
+Please analyze the actual project data and provide specific, actionable descriptions for each component.""",
         )
     ]
 
@@ -531,15 +530,13 @@ Please help me:
 4. Recommend debugging approaches
 5. Provide best practices for transformation development
 
-What specific information would you need to effectively debug this transformation?"""
+What specific information would you need to effectively debug this transformation?""",
         )
     ]
 
 
 async def create_data_pipeline_plan(
-    source_description: str,
-    target_description: str,
-    requirements: str = ''
+    source_description: str, target_description: str, requirements: str = ''
 ) -> List[Message]:
     """Generate a prompt to create a data pipeline plan.
 
@@ -583,7 +580,7 @@ Please help me design a comprehensive data pipeline plan that includes:
    - Scalability recommendations
    - Maintenance and documentation
 
-Please provide a detailed, step-by-step implementation plan with specific Keboola components and configurations."""
+Please provide a detailed, step-by-step implementation plan with specific Keboola components and configurations.""",
         )
     ]
 
@@ -627,15 +624,13 @@ I need help with:
    - Trade-offs between approaches
    - Scalability considerations
 
-Please provide the optimized query with explanations for each improvement."""
+Please provide the optimized query with explanations for each improvement.""",
         )
     ]
 
 
 async def troubleshoot_component_error(
-    component_name: str,
-    error_message: str,
-    component_type: str = 'unknown'
+    component_name: str, error_message: str, component_type: str = 'unknown'
 ) -> List[Message]:
     """Generate a prompt to troubleshoot a component error.
 
@@ -676,6 +671,6 @@ Please help me:
    - Logs or metrics to check
    - Related components that might be affected
 
-Please provide a comprehensive troubleshooting guide with specific actions I can take."""
+Please provide a comprehensive troubleshooting guide with specific actions I can take.""",
         )
     ]

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -1,4 +1,5 @@
 """MCP server implementation for Keboola Connection."""
+
 import dataclasses
 import logging
 import os
@@ -37,19 +38,23 @@ class ServiceInfoApiResp(BaseModel):
     app_name: str = Field(
         default='KeboolaMcpServer',
         validation_alias=AliasChoices('appName', 'app_name', 'app-name'),
-        serialization_alias='appName')
+        serialization_alias='appName',
+    )
     app_version: str = Field(
-        validation_alias=AliasChoices('appVersion', 'app_version', 'app-version'),
-        serialization_alias='appVersion')
+        validation_alias=AliasChoices('appVersion', 'app_version', 'app-version'), serialization_alias='appVersion'
+    )
     server_version: str = Field(
         validation_alias=AliasChoices('serverVersion', 'server_version', 'server-version'),
-        serialization_alias='serverVersion')
+        serialization_alias='serverVersion',
+    )
     mcp_library_version: str = Field(
         validation_alias=AliasChoices('mcpLibraryVersion', 'mcp_library_version', 'mcp-library-version'),
-        serialization_alias='mcpLibraryVersion')
+        serialization_alias='mcpLibraryVersion',
+    )
     fastmcp_library_version: str = Field(
         validation_alias=AliasChoices('fastmcpLibraryVersion', 'fastmcp_library_version', 'fastmcp-library-version'),
-        serialization_alias='fastmcpLibraryVersion')
+        serialization_alias='fastmcpLibraryVersion',
+    )
 
 
 def create_keboola_lifespan(

--- a/src/keboola_mcp_server/tools/components/api_models.py
+++ b/src/keboola_mcp_server/tools/components/api_models.py
@@ -113,8 +113,7 @@ class ConfigurationAPIResponse(BaseModel):
         description='The nested configuration object containing parameters and storage'
     )
     rows: Optional[list[dict[str, Any]]] = Field(
-        default=None,
-        description='The row configurations within this configuration'
+        default=None, description='The row configurations within this configuration'
     )
     change_description: Optional[str] = Field(
         default=None,

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -31,6 +31,7 @@ from individual tasks:
 ## Legacy Models
 - ComponentConfigurationResponseBase: Base class used by Flow tools (FlowConfigurationResponse)
 """
+
 from datetime import datetime
 from typing import Any, List, Literal, Optional, Union
 
@@ -52,6 +53,7 @@ AllComponentTypes = Union[ComponentType, TransformationType]
 # COMPONENT MODELS
 # ============================================================================
 
+
 class ComponentCapabilities(BaseModel):
     """
     Component capabilities derived from developer portal flags.
@@ -63,30 +65,12 @@ class ComponentCapabilities(BaseModel):
     - OAuth: Requires OAuth authentication setup
     """
 
-    is_row_based: bool = Field(
-        default=False,
-        description='Whether the component supports row configurations'
-    )
-    has_table_input: bool = Field(
-        default=False,
-        description='Whether the component can read from tables'
-    )
-    has_table_output: bool = Field(
-        default=False,
-        description='Whether the component can write to tables'
-    )
-    has_file_input: bool = Field(
-        default=False,
-        description='Whether the component can read from files'
-    )
-    has_file_output: bool = Field(
-        default=False,
-        description='Whether the component can write to files'
-    )
-    requires_oauth: bool = Field(
-        default=False,
-        description='Whether the component requires OAuth authorization'
-    )
+    is_row_based: bool = Field(default=False, description='Whether the component supports row configurations')
+    has_table_input: bool = Field(default=False, description='Whether the component can read from tables')
+    has_table_output: bool = Field(default=False, description='Whether the component can write to tables')
+    has_file_input: bool = Field(default=False, description='Whether the component can read from files')
+    has_file_output: bool = Field(default=False, description='Whether the component can write to files')
+    requires_oauth: bool = Field(default=False, description='Whether the component requires OAuth authorization')
 
     @classmethod
     def from_flags(cls, flags: list[str]) -> 'ComponentCapabilities':
@@ -98,10 +82,9 @@ class ComponentCapabilities(BaseModel):
         """
         return cls(
             is_row_based='genericDockerUI-rows' in flags,
-            has_table_input=any(flag in flags for flag in [
-                'genericDockerUI-tableInput',
-                'genericDockerUI-simpleTableInput'
-            ]),
+            has_table_input=any(
+                flag in flags for flag in ['genericDockerUI-tableInput', 'genericDockerUI-simpleTableInput']
+            ),
             has_table_output='genericDockerUI-tableOutput' in flags,
             has_file_input='genericDockerUI-fileInput' in flags,
             has_file_output='genericDockerUI-fileOutput' in flags,
@@ -201,6 +184,7 @@ class Component(BaseModel):
 # CONFIGURATION MODELS
 # ============================================================================
 
+
 class ConfigurationRoot(BaseModel):
     """
     Complete configuration root with all data.
@@ -209,6 +193,7 @@ class ConfigurationRoot(BaseModel):
     credentials, global parameters, and shared storage mappings. For row-based
     components, this contains the common settings that apply to all rows.
     """
+
     component_id: str = Field(description='The ID of the component')
     configuration_id: str = Field(description='The ID of this configuration root')
     name: str = Field(description='The name of the configuration')
@@ -220,12 +205,10 @@ class ConfigurationRoot(BaseModel):
         description='The configuration parameters, adhering to the configuration root schema'
     )
     storage: Optional[dict[str, Any]] = Field(
-        default=None,
-        description='The table and/or file input/output mapping configuration'
+        default=None, description='The table and/or file input/output mapping configuration'
     )
     configuration_metadata: list[dict[str, Any]] = Field(
-        default_factory=list,
-        description='Configuration metadata including MCP tracking'
+        default_factory=list, description='Configuration metadata including MCP tracking'
     )
 
     @classmethod
@@ -261,6 +244,7 @@ class ConfigurationRow(BaseModel):
     For row-based components, each row typically handles a specific data source,
     destination, or transformation operation.
     """
+
     component_id: str = Field(description='The ID of the component')
     configuration_id: str = Field(description='The ID of the corresponding configuration root')
     configuration_row_id: str = Field(description='The ID of this configuration row')
@@ -273,13 +257,9 @@ class ConfigurationRow(BaseModel):
         description='The configuration row parameters, adhering to the configuration row schema'
     )
     storage: Optional[dict[str, Any]] = Field(
-        default=None,
-        description='The table and/or file input/output mapping configuration'
+        default=None, description='The table and/or file input/output mapping configuration'
     )
-    configuration_metadata: list[dict[str, Any]] = Field(
-        default_factory=list,
-        description='Configuration row metadata'
-    )
+    configuration_metadata: list[dict[str, Any]] = Field(default_factory=list, description='Configuration row metadata')
 
     @classmethod
     def from_api_row_data(
@@ -316,6 +296,7 @@ class ConfigurationRow(BaseModel):
 
 class ConfigurationRootSummary(BaseModel):
     """Lightweight configuration root for list operations."""
+
     component_id: str = Field(description='The ID of the component')
     configuration_id: str = Field(description='The ID of this configuration root')
     name: str = Field(description='The name of the configuration')
@@ -338,6 +319,7 @@ class ConfigurationRootSummary(BaseModel):
 
 class ConfigurationRowSummary(BaseModel):
     """Lightweight configuration row for list operations."""
+
     component_id: str = Field(description='The ID of the component')
     configuration_id: str = Field(description='The ID of the corresponding configuration root')
     row_configuration_id: str = Field(description='The ID of this configuration row')
@@ -373,12 +355,10 @@ class ConfigurationSummary(BaseModel):
     but with lightweight summary data. Used by list operations where many
     configurations are returned.
     """
-    configuration_root: ConfigurationRootSummary = Field(
-        description='The configuration root summary'
-    )
+
+    configuration_root: ConfigurationRootSummary = Field(description='The configuration root summary')
     configuration_rows: Optional[list[ConfigurationRowSummary]] = Field(
-        default=None,
-        description='The configuration row summaries'
+        default=None, description='The configuration row summaries'
     )
 
     @classmethod
@@ -419,21 +399,15 @@ class Configuration(BaseModel):
     component context and UI links. Used by get operations where detailed
     configuration information is needed.
     """
-    configuration_root: ConfigurationRoot = Field(
-        description='The complete configuration root'
-    )
+
+    configuration_root: ConfigurationRoot = Field(description='The complete configuration root')
     configuration_rows: Optional[list[ConfigurationRow]] = Field(
-        default=None,
-        description='The complete configuration rows'
+        default=None, description='The complete configuration rows'
     )
     component: Optional[ComponentSummary] = Field(
-        default=None,
-        description='The component this configuration belongs to'
+        default=None, description='The component this configuration belongs to'
     )
-    links: list[Link] = Field(
-        default_factory=list,
-        description='Navigation links for the web interface'
-    )
+    links: list[Link] = Field(default_factory=list, description='Navigation links for the web interface')
 
     @classmethod
     def from_api_response(
@@ -478,6 +452,7 @@ class Configuration(BaseModel):
 # TOOL OUTPUT MODELS
 # ============================================================================
 
+
 class ConfigToolOutput(BaseModel):
     """Standard response model for configuration tool operations."""
 
@@ -502,7 +477,8 @@ class ListConfigsOutput(BaseModel):
     """Response model for list_configs tool."""
 
     components_with_configurations: List[ComponentWithConfigurations] = Field(
-        description='The groupings of components and their respective configurations.')
+        description='The groupings of components and their respective configurations.'
+    )
     links: List[Link] = Field(
         description='The list of links relevant to the listing of components with configurations.',
     )
@@ -512,7 +488,8 @@ class ListTransformationsOutput(BaseModel):
     """Response model for list_transformations tool."""
 
     components_with_configurations: List[ComponentWithConfigurations] = Field(
-        description='The groupings of transformation components and their respective configurations.')
+        description='The groupings of transformation components and their respective configurations.'
+    )
     links: List[Link] = Field(
         description='The list of links relevant to the listing of transformation components with configurations.',
     )
@@ -521,6 +498,7 @@ class ListTransformationsOutput(BaseModel):
 # ============================================================================
 # LEGACY MODELS (minimal set for Flow tools compatibility)
 # ============================================================================
+
 
 class ComponentConfigurationResponseBase(BaseModel):
     """

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -25,6 +25,7 @@ component-related operations in the MCP server.
 - `create_sql_transformation`: Create new SQL transformations with code blocks
 - `update_sql_transformation`: Update existing SQL transformation configurations
 """
+
 import json
 import logging
 from datetime import datetime, timezone
@@ -74,6 +75,7 @@ LOG = logging.getLogger(__name__)
 # ============================================================================
 # TOOL REGISTRATION
 # ============================================================================
+
 
 def add_component_tools(mcp: KeboolaMcpServer) -> None:
     """Add tools to the MCP server."""
@@ -148,9 +150,7 @@ async def list_configs(
         components_with_configurations = await list_configs_by_ids(client, component_ids)
     links = [links_manager.get_used_components_link()]
 
-    return ListConfigsOutput(
-        components_with_configurations=components_with_configurations, links=links
-    )
+    return ListConfigsOutput(components_with_configurations=components_with_configurations, links=links)
 
 
 @tool_errors()
@@ -191,14 +191,13 @@ async def list_transformations(
 
     links = [links_manager.get_transformations_dashboard_link()]
 
-    return ListTransformationsOutput(
-        components_with_configurations=components_with_configurations, links=links
-    )
+    return ListTransformationsOutput(components_with_configurations=components_with_configurations, links=links)
 
 
 # ============================================================================
 # COMPONENT DISCOVERY TOOLS
 # ============================================================================
+
 
 @tool_errors()
 async def get_component(

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -19,6 +19,7 @@ This module contains helper functions and utilities used across the component to
 ## Data Models
 - TransformationConfiguration: Pydantic model for SQL transformation structure
 """
+
 import logging
 import re
 import unicodedata
@@ -52,6 +53,7 @@ BIGQUERY_TRANSFORMATION_ID = 'keboola.google-bigquery-transformation'
 # COMPONENT TYPE HANDLING
 # ============================================================================
 
+
 def handle_component_types(
     types: Optional[Union[ComponentType, Sequence[ComponentType]]],
 ) -> Sequence[ComponentType]:
@@ -72,6 +74,7 @@ def handle_component_types(
 # ============================================================================
 # CONFIGURATION LISTING UTILITIES
 # ============================================================================
+
 
 async def list_configs_by_types(
     client: KeboolaClient, component_types: Sequence[AllComponentTypes]
@@ -98,16 +101,13 @@ async def list_configs_by_types(
         # Process each component and its configurations
         for raw_component in raw_components_with_configurations_by_type:
             raw_configuration_responses = [
-                ConfigurationAPIResponse.model_validate(
-                    raw_configuration | {'component_id': raw_component['id']}
-                )
+                ConfigurationAPIResponse.model_validate(raw_configuration | {'component_id': raw_component['id']})
                 for raw_configuration in cast(list[JsonDict], raw_component.get('configurations', []))
             ]
 
             # Convert to domain models
             configuration_summaries = [
-                ConfigurationSummary.from_api_response(api_config)
-                for api_config in raw_configuration_responses
+                ConfigurationSummary.from_api_response(api_config) for api_config in raw_configuration_responses
             ]
 
             # Process component
@@ -129,9 +129,7 @@ async def list_configs_by_types(
     return components_with_configurations
 
 
-async def list_configs_by_ids(
-    client: KeboolaClient, component_ids: Sequence[str]
-) -> list[ComponentWithConfigurations]:
+async def list_configs_by_ids(client: KeboolaClient, component_ids: Sequence[str]) -> list[ComponentWithConfigurations]:
     """
     Retrieve components with their configurations filtered by specific component IDs.
 
@@ -160,8 +158,7 @@ async def list_configs_by_ids(
             for raw_configuration in raw_configurations
         ]
         configuration_summaries = [
-            ConfigurationSummary.from_api_response(api_config)
-            for api_config in raw_configuration_responses
+            ConfigurationSummary.from_api_response(api_config) for api_config in raw_configuration_responses
         ]
 
         components_with_configurations.append(
@@ -182,6 +179,7 @@ async def list_configs_by_ids(
 # ============================================================================
 # COMPONENT FETCHING
 # ============================================================================
+
 
 async def fetch_component(
     client: KeboolaClient,
@@ -230,6 +228,7 @@ async def fetch_component(
 # ============================================================================
 # SQL TRANSFORMATION UTILITIES
 # ============================================================================
+
 
 def get_sql_transformation_id_from_sql_dialect(
     sql_dialect: str,

--- a/src/keboola_mcp_server/tools/flow/model.py
+++ b/src/keboola_mcp_server/tools/flow/model.py
@@ -58,6 +58,7 @@ class FlowConfigurationResponse(ComponentConfigurationResponseBase):
     """
     Detailed information about a Keboola Flow Configuration, extending the base configuration response.
     """
+
     version: int = Field(description='The version of the flow configuration')
     configuration: FlowConfiguration = Field(description='The flow configuration containing phases and tasks')
     change_description: Optional[str] = Field(

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -139,6 +139,7 @@ class ListJobsOutput(BaseModel):
     jobs: list[JobListItem] = Field(..., description='List of jobs.')
     links: list[Link] = Field(..., description='Links relevant to the jobs listing.')
 
+
 # End of Job Base Models ########################################
 
 # MCP tools ########################################

--- a/src/keboola_mcp_server/tools/oauth.py
+++ b/src/keboola_mcp_server/tools/oauth.py
@@ -56,18 +56,17 @@ async def create_oauth_url(
     storage_api_url = client.storage_client.base_api_url
 
     # Generate OAuth URL
-    query_params = urlencode({
-        'token': sapi_token,
-        'sapiUrl': storage_api_url
-    })
+    query_params = urlencode({'token': sapi_token, 'sapiUrl': storage_api_url})
     fragment = f'/{component_id}/{config_id}'
 
-    oauth_url = urlunsplit((
-        'https',  # scheme
-        'external.keboola.com',  # netloc
-        '/oauth/index.html',  # path
-        query_params,  # query
-        fragment  # fragment
-    ))
+    oauth_url = urlunsplit(
+        (
+            'https',  # scheme
+            'external.keboola.com',  # netloc
+            '/oauth/index.html',  # path
+            query_params,  # query
+            fragment,  # fragment
+        )
+    )
 
     return oauth_url

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -26,26 +26,14 @@ def add_project_tools(mcp: FastMCP) -> None:
 
 
 class ProjectInfo(BaseModel):
-    project_id: str | int = Field(
-        ...,
-        description='The id of the project.'
-    )
-    project_name: str = Field(
-        ...,
-        description='The name of the project.'
-    )
+    project_id: str | int = Field(..., description='The id of the project.')
+    project_name: str = Field(..., description='The name of the project.')
     project_description: str = Field(
         ...,
         description='The description of the project.',
     )
-    organization_id: str | int = Field(
-        ...,
-        description='The ID of the organization this project belongs to.'
-    )
-    sql_dialect: str = Field(
-        ...,
-        description='The sql dialect used in the project.'
-    )
+    organization_id: str | int = Field(..., description='The ID of the organization this project belongs to.')
+    sql_dialect: str = Field(..., description='The sql dialect used in the project.')
     links: list[Link] = Field(..., description='The links relevant to the project.')
 
 
@@ -68,8 +56,7 @@ async def get_project_info(
 
     metadata = await storage.branch_metadata_get()
     description = cast(
-        str,
-        next((item['value'] for item in metadata if item.get('key') == MetadataField.PROJECT_DESCRIPTION), '')
+        str, next((item['value'] for item in metadata if item.get('key') == MetadataField.PROJECT_DESCRIPTION), '')
     )
 
     sql_dialect = await WorkspaceManager.from_state(ctx.session.state).get_sql_dialect()

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -78,10 +78,7 @@ async def query_data(
         writer.writeheader()
         writer.writerows(data.rows)
 
-        return QueryDataOutput(
-            query_name=query_name,
-            csv_data=output.getvalue()
-        )
+        return QueryDataOutput(query_name=query_name, csv_data=output.getvalue())
 
     else:
         raise ValueError(f'Failed to run SQL query, error: {result.message}')

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -296,14 +296,11 @@ class WorkspaceManager:
                 login_type='snowflake-person-sso',
                 backend=default_backend,
                 async_run=True,
-                read_only_storage_access=True
+                read_only_storage_access=True,
             )
         elif default_backend == 'bigquery':
             resp = await self._client.storage_client.workspace_create(
-                login_type='default',
-                backend=default_backend,
-                async_run=True,
-                read_only_storage_access=True
+                login_type='default', backend=default_backend, async_run=True, read_only_storage_access=True
             )
         else:
             raise ValueError(f'Unexpected default backend: {default_backend}')
@@ -320,8 +317,10 @@ class WorkspaceManager:
             job_status = job_info['status']
 
             duration = time.perf_counter() - start_ts
-            LOG.info(f'Job info: job_id={job_id}, status={job_status}, '
-                     f'duration={duration:.2f} seconds, timeout={timeout_sec:.2f} seconds')
+            LOG.info(
+                f'Job info: job_id={job_id}, status={job_status}, '
+                f'duration={duration:.2f} seconds, timeout={timeout_sec:.2f} seconds'
+            )
 
             if job_info['status'] == 'success':
                 assert 'results' in job_info, f'Expected `results` in job info: {job_info}'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,10 +75,12 @@ class TestConfig:
 
     def test_no_token_password_in_repr(self) -> None:
         config = Config(storage_token='foo')
-        assert str(config) == ("Config(storage_api_url=None, storage_token='****', workspace_schema=None, "
-                               'accept_secrets_in_url=None, oauth_client_id=None, oauth_client_secret=None, '
-                               'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
-                               'jwt_secret=None, bearer_token=None)')
+        assert str(config) == (
+            "Config(storage_api_url=None, storage_token='****', workspace_schema=None, "
+            'accept_secrets_in_url=None, oauth_client_id=None, oauth_client_secret=None, '
+            'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
+            'jwt_secret=None, bearer_token=None)'
+        )
 
     def test_url_field(self):
         config = Config(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -16,8 +16,10 @@ from keboola_mcp_server.mcp import ServerState
 @pytest.fixture
 def function_with_value_error():
     """A function that raises ValueError for testing general error handling."""
+
     async def func(_ctx: Context):
         raise ValueError('Simulated ValueError')
+
     return func
 
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -27,9 +27,7 @@ class TestSimpleOAuthProvider:
         )
 
     @staticmethod
-    def authorization_code(
-            *, scopes: list[str] | None = None, expires_at: float | None = None
-    ) -> Mapping[str, Any]:
+    def authorization_code(*, scopes: list[str] | None = None, expires_at: float | None = None) -> Mapping[str, Any]:
         auth_code = _ExtendedAuthorizationCode(
             code='foo',
             scopes=scopes or [],
@@ -46,38 +44,57 @@ class TestSimpleOAuthProvider:
         return auth_code_raw
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(('auth_code', 'key', 'expected'), [
-        # valid, no scopes
-        (code := authorization_code(), JWT_KEY, _ExtendedAuthorizationCode.model_validate(code)),
-        # valid, scopes
-        (code := authorization_code(scopes=['foo', 'bar']), JWT_KEY, _ExtendedAuthorizationCode.model_validate(code)),
-        # expired, no scopes
-        (code := authorization_code(expires_at=1), JWT_KEY, _ExtendedAuthorizationCode.model_validate(code)),
-        # wrong encryption key
-        (code := authorization_code(), '!@#$%^&', None),
-    ])
+    @pytest.mark.parametrize(
+        ('auth_code', 'key', 'expected'),
+        [
+            # valid, no scopes
+            (code := authorization_code(), JWT_KEY, _ExtendedAuthorizationCode.model_validate(code)),
+            # valid, scopes
+            (
+                code := authorization_code(scopes=['foo', 'bar']),
+                JWT_KEY,
+                _ExtendedAuthorizationCode.model_validate(code),
+            ),
+            # expired, no scopes
+            (code := authorization_code(expires_at=1), JWT_KEY, _ExtendedAuthorizationCode.model_validate(code)),
+            # wrong encryption key
+            (code := authorization_code(), '!@#$%^&', None),
+        ],
+    )
     async def test_load_authorization_code(
-            self, auth_code: Mapping[str, Any], key: str, expected: _ExtendedAuthorizationCode,
-            oauth_provider: SimpleOAuthProvider
+        self,
+        auth_code: Mapping[str, Any],
+        key: str,
+        expected: _ExtendedAuthorizationCode,
+        oauth_provider: SimpleOAuthProvider,
     ):
         client_info = OAuthClientInformationFull(client_id='foo-client-id', redirect_uris=[AnyUrl('foo://bar')])
         auth_code_str = oauth_provider._encode(auth_code, key=key)
         loaded_auth_code = await oauth_provider.load_authorization_code(client_info, auth_code_str)
         assert loaded_auth_code == expected
 
-    @pytest.mark.parametrize(('raw_at', 'raw_rt', 'scopes', 'at_expires_in', 'rt_expires_in'), [
-        ('foo', 'bar', ['email'], 3600, 168 * 3600),
-        ('foo', 'bar', ['user', 'email'], 3600, 168 * 3600),
-        ('foo', 'bar', [], 3600, 168 * 3600),
-        ('foo', 'bar', [], 1, 3600),  # 168 * 1 second rounded up to the nearest hour -> 3600
-        ('foo', 'bar', [], 7200, 168 * 3600),
-    ])
+    @pytest.mark.parametrize(
+        ('raw_at', 'raw_rt', 'scopes', 'at_expires_in', 'rt_expires_in'),
+        [
+            ('foo', 'bar', ['email'], 3600, 168 * 3600),
+            ('foo', 'bar', ['user', 'email'], 3600, 168 * 3600),
+            ('foo', 'bar', [], 3600, 168 * 3600),
+            ('foo', 'bar', [], 1, 3600),  # 168 * 1 second rounded up to the nearest hour -> 3600
+            ('foo', 'bar', [], 7200, 168 * 3600),
+        ],
+    )
     def test_read_oauth_tokens(
-            self, raw_at: str, raw_rt: str, scopes: list[str], at_expires_in: int, rt_expires_in: int,
-            oauth_provider: SimpleOAuthProvider
+        self,
+        raw_at: str,
+        raw_rt: str,
+        scopes: list[str],
+        at_expires_in: int,
+        rt_expires_in: int,
+        oauth_provider: SimpleOAuthProvider,
     ):
         access_token, refresh_token = oauth_provider._read_oauth_tokens(
-            data={'access_token': raw_at, 'refresh_token': raw_rt, 'expires_in': at_expires_in}, scopes=scopes)
+            data={'access_token': raw_at, 'refresh_token': raw_rt, 'expires_in': at_expires_in}, scopes=scopes
+        )
 
         assert access_token.token == raw_at
         assert access_token.scopes == scopes

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,9 +121,10 @@ async def test_with_session_state(config: Config, envs: dict[str, Any], mocker):
     os_mock = mocker.patch('keboola_mcp_server.server.os')
     os_mock.environ = envs
 
-    mocker.patch('keboola_mcp_server.client.AsyncStorageClient.verify_token', return_value={
-        'owner': {'features': ['global-search', 'waii-integration', 'conditional-flows']}
-    })
+    mocker.patch(
+        'keboola_mcp_server.client.AsyncStorageClient.verify_token',
+        return_value={'owner': {'features': ['global-search', 'waii-integration', 'conditional-flows']}},
+    )
 
     # create MCP server with the initial Config
     mcp = create_server(config)
@@ -173,9 +174,10 @@ async def test_keboola_injection_and_lifespan(
     config = Config.from_dict(cfg_dict)
 
     mocker.patch('keboola_mcp_server.server.os.environ', os_environ_params)
-    mocker.patch('keboola_mcp_server.client.AsyncStorageClient.verify_token', return_value={
-        'owner': {'features': ['global-search', 'waii-integration', 'conditional-flows']}
-    })
+    mocker.patch(
+        'keboola_mcp_server.client.AsyncStorageClient.verify_token',
+        return_value={'owner': {'features': ['global-search', 'waii-integration', 'conditional-flows']}},
+    )
 
     server = create_server(config)
 

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -77,10 +77,7 @@ def assert_retrieve_components() -> Callable[
         # assert configurations list details
         assert all(len(component.configurations) == len(configurations) for component in components_with_configurations)
         assert all(
-            all(
-                isinstance(config.configuration_root, ConfigurationRootSummary)
-                for config in component.configurations
-            )
+            all(isinstance(config.configuration_root, ConfigurationRootSummary) for config in component.configurations)
             for component in components_with_configurations
         )
         # use zip to iterate over the result and mock_configurations since we artificially mock the .get method

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -126,9 +126,7 @@ async def test_list_jobs(
 
 
 @pytest.mark.asyncio
-async def test_get_job(
-    mocker: MockerFixture, mcp_context_client: Context, mock_job: dict[str, Any], iso_format: str
-):
+async def test_get_job(mocker: MockerFixture, mcp_context_client: Context, mock_job: dict[str, Any], iso_format: str):
     """Tests get_job_detail tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)

--- a/tests/tools/test_oauth.py
+++ b/tests/tools/test_oauth.py
@@ -20,9 +20,7 @@ def mock_token_response() -> Mapping[str, Any]:
 
 
 @pytest.mark.asyncio
-async def test_create_oauth_url_success(
-    mcp_context_client: Context, mock_token_response: Mapping[str, Any]
-) -> None:
+async def test_create_oauth_url_success(mcp_context_client: Context, mock_token_response: Mapping[str, Any]) -> None:
     """Test successful OAuth URL creation."""
     # Mock the storage client's token_create method to return the token response
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
@@ -94,9 +92,7 @@ async def test_create_oauth_url_token_creation_failure(
     """Test OAuth URL creation when token creation fails."""
     # Mock the storage client to raise an exception
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client.token_create.side_effect = Exception(
-        'Token creation failed'
-    )
+    keboola_client.storage_client.token_create.side_effect = Exception('Token creation failed')
 
     with pytest.raises(Exception, match='Token creation failed'):
         await create_oauth_url(

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -32,14 +32,12 @@ async def test_get_project_info(mocker: MockerFixture, mcp_context_client: Conte
 
     project_id = 'proj-123'
     base_url = 'https://connection.test.keboola.com'
-    links = [
-        Link(type='ui-detail', title='Project Dashboard', url=f'{base_url}/admin/projects/{project_id}')
-    ]
+    links = [Link(type='ui-detail', title='Project Dashboard', url=f'{base_url}/admin/projects/{project_id}')]
     mock_links_manager = mocker.Mock()
     mock_links_manager.get_project_links.return_value = links
     mocker.patch(
         'keboola_mcp_server.tools.project.ProjectLinksManager.from_client',
-        new=mocker.AsyncMock(return_value=mock_links_manager)
+        new=mocker.AsyncMock(return_value=mock_links_manager),
     )
 
     # Call the tool

--- a/tests/tools/test_storage.py
+++ b/tests/tools/test_storage.py
@@ -54,7 +54,7 @@ def mock_table_data() -> Mapping[str, Any]:
         'rows_count': 100,
         'data_size_bytes': 1000,
         'columns': ['id', 'name', 'value'],
-        'bucket': {'id': 1}
+        'bucket': {'id': 1},
     }
 
     return {
@@ -409,8 +409,6 @@ async def test_update_column_description_success(
     keboola_client.storage_client.table_metadata_update.assert_called_once_with(
         table_id='in.c-test.test-table',
         columns_metadata={
-            'text': [
-                {'key': MetadataField.DESCRIPTION, 'value': 'Updated column description', 'columnName': 'text'}
-            ]
+            'text': [{'key': MetadataField.DESCRIPTION, 'value': 'Updated column description', 'columnName': 'text'}]
         },
     )


### PR DESCRIPTION
## Summary
- Set up black code formatter as a code style fixer (cs-fix) in tox configuration
- Added alias for flake8 as "cs" for code style checking
- Configured black with proper settings in pyproject.toml including exclude patterns
- Applied black formatting to all Python files in src/, tests/, and integtests/ directories

## Test plan
- [x] Black formatting has been applied to all Python files
- [x] Tox configuration updated with new environments
- [x] Code style checks pass with flake8

🤖 Generated with [Claude Code](https://claude.ai/code)