### PR TITLE
AI-1328: Add guidance that SQL queries should not start with comments

### DIFF
--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -37,7 +37,7 @@ async def get_sql_dialect(
 
 @tool_errors()
 async def query_data(
-    sql_query: Annotated[str, Field(description='SQL SELECT query to run.')],
+    sql_query: Annotated[str, Field(description='SQL SELECT query to run, MUST NOT start with comment')],
     query_name: Annotated[
         str,
         Field(


### PR DESCRIPTION
## Summary
- Updated the `sql_query` parameter description in `query_data` tool to explicitly state that queries MUST NOT start with comment
- Provides clear guidance to users and LLMs about proper SQL query formatting

## Test plan
- [x] Flake8 linting passes
- [x] No functional changes, only documentation update

🤖 Generated with [Claude Code](https://claude.ai/code)