### PR TITLE
Enforce TOOLS.md is up-to-date in build

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -818,16 +818,6 @@ EXAMPLES:
 ```json
 {
   "properties": {
-    "name": {
-      "description": "A short, descriptive name summarizing the purpose of the component configuration.",
-      "title": "Name",
-      "type": "string"
-    },
-    "description": {
-      "description": "The detailed description of the component configuration explaining its purpose and functionality.",
-      "title": "Description",
-      "type": "string"
-    },
     "change_description": {
       "description": "Description of the change made to the component configuration.",
       "title": "Change Description",
@@ -843,26 +833,37 @@ EXAMPLES:
       "title": "Configuration Id",
       "type": "string"
     },
+    "name": {
+      "default": null,
+      "description": "A short, descriptive name summarizing the purpose of the component configuration.",
+      "title": "Name",
+      "type": "string"
+    },
+    "description": {
+      "default": null,
+      "description": "The detailed description of the component configuration explaining its purpose and functionality.",
+      "title": "Description",
+      "type": "string"
+    },
     "parameters": {
       "additionalProperties": true,
-      "description": "The component configuration parameters, adhering to the root_configuration_schema schema",
+      "default": null,
+      "description": "The component configuration parameters, adhering to the root_configuration_schema schema. Only updated if provided.",
       "title": "Parameters",
       "type": "object"
     },
     "storage": {
       "additionalProperties": true,
-      "description": "The table and/or file input / output mapping of the component configuration. It is present only for components that are not row-based and have tables or file input mapping defined",
+      "default": null,
+      "description": "The table and/or file input / output mapping of the component configuration. It is present only for components that are not row-based and have tables or file input mapping defined. Only updated if provided.",
       "title": "Storage",
       "type": "object"
     }
   },
   "required": [
-    "name",
-    "description",
     "change_description",
     "component_id",
-    "configuration_id",
-    "parameters"
+    "configuration_id"
   ],
   "type": "object"
 }
@@ -894,16 +895,6 @@ EXAMPLES:
 ```json
 {
   "properties": {
-    "name": {
-      "description": "A short, descriptive name summarizing the purpose of the component configuration.",
-      "title": "Name",
-      "type": "string"
-    },
-    "description": {
-      "description": "The detailed description of the component configuration explaining its purpose and functionality.",
-      "title": "Description",
-      "type": "string"
-    },
     "change_description": {
       "description": "Description of the change made to the component configuration.",
       "title": "Change Description",
@@ -924,27 +915,38 @@ EXAMPLES:
       "title": "Configuration Row Id",
       "type": "string"
     },
+    "name": {
+      "default": null,
+      "description": "A short, descriptive name summarizing the purpose of the component configuration.",
+      "title": "Name",
+      "type": "string"
+    },
+    "description": {
+      "default": null,
+      "description": "The detailed description of the component configuration explaining its purpose and functionality.",
+      "title": "Description",
+      "type": "string"
+    },
     "parameters": {
       "additionalProperties": true,
-      "description": "The component row configuration parameters, adhering to the row_configuration_schema",
+      "default": null,
+      "description": "The component row configuration parameters, adhering to the row_configuration_schema. Only updated if provided.",
       "title": "Parameters",
       "type": "object"
     },
     "storage": {
       "additionalProperties": true,
-      "description": "The table and/or file input / output mapping of the component configuration. It is present only for components that have tables or file input mapping defined",
+      "default": null,
+      "description": "The table and/or file input / output mapping of the component configuration. It is present only for components that have tables or file input mapping defined. Only updated if provided.",
       "title": "Storage",
       "type": "object"
     }
   },
   "required": [
-    "name",
-    "description",
     "change_description",
     "component_id",
     "configuration_id",
-    "configuration_row_id",
-    "parameters"
+    "configuration_row_id"
   ],
   "type": "object"
 }
@@ -1066,15 +1068,31 @@ EXAMPLES:
       "type": "string"
     },
     "parameters": {
-      "$ref": "#/$defs/Parameters",
-      "description": "The updated \"parameters\" part of the transformation configuration that contains the newly applied settings and preserves all other existing settings.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Parameters"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The updated \"parameters\" part of the transformation configuration that contains the newly applied settings and preserves all other existing settings. Only updated if provided.",
       "title": "Parameters"
     },
     "storage": {
-      "additionalProperties": true,
-      "description": "The updated \"storage\" part of the transformation configuration that contains the newly applied settings and preserves all other existing settings.",
-      "title": "Storage",
-      "type": "object"
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The updated \"storage\" part of the transformation configuration that contains the newly applied settings and preserves all other existing settings. Only updated if provided.",
+      "title": "Storage"
     },
     "updated_description": {
       "default": "",
@@ -1091,9 +1109,7 @@ EXAMPLES:
   },
   "required": [
     "configuration_id",
-    "change_description",
-    "parameters",
-    "storage"
+    "change_description"
   ],
   "type": "object"
 }
@@ -1432,16 +1448,6 @@ EXAMPLES:
       "title": "Flow Type",
       "type": "string"
     },
-    "name": {
-      "description": "Updated flow name.",
-      "title": "Name",
-      "type": "string"
-    },
-    "description": {
-      "description": "Updated flow description.",
-      "title": "Description",
-      "type": "string"
-    },
     "phases": {
       "description": "Updated list of phase definitions.",
       "items": {
@@ -1464,13 +1470,37 @@ EXAMPLES:
       "description": "Description of changes made.",
       "title": "Change Description",
       "type": "string"
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Updated flow name. Only updated if provided.",
+      "title": "Name"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Updated flow description. Only updated if provided.",
+      "title": "Description"
     }
   },
   "required": [
     "configuration_id",
     "flow_type",
-    "name",
-    "description",
     "phases",
     "tasks",
     "change_description"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extend-ignore = ["E203", "W503", "I101"]
 
 [tool.tox]
 requires = ["tox>=4.23"]
-env_list = ["python", "black", "flake8"]
+env_list = ["python", "black", "flake8", "check-tools-docs"]
 labels = { cs-fix = ["black"], cs = ["flake8"] }
 
 [tool.tox.env_run_base]
@@ -176,3 +176,14 @@ deps = [
     "pep8-naming ~= 0.14",
 ]
 commands = [["flake8", "src/", "tests/", "integtests/"]]
+
+[tool.tox.env.check-tools-docs]
+description = "Check if TOOLS.md is up-to-date with tool definitions"
+extras = []
+package = "wheel"
+wheel_build_env = ".pkg"
+allowlist_externals = ["git"]
+commands = [
+    ["python", "-m", "keboola_mcp_server.generate_tool_docs"],
+    ["git", "diff", "--exit-code", "TOOLS.md"],
+]


### PR DESCRIPTION
## Summary
- Adds `check-tools-docs` tox environment that fails build if TOOLS.md is out-of-sync
- Automatically runs in CI via existing GitHub Actions workflow

## Test plan
- [x] Local test: `uv run --with tox tox -e check-tools-docs` passes when docs are current
- [x] Local test: build fails with clear diff when docs are outdated  
- [x] Full tox suite passes including new check

🤖 Generated with [Claude Code](https://claude.ai/code)