### PR TITLE
AI-1336 annotate tools

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -67,7 +67,7 @@ potentially narrowed down by item type, limited and paginated.
 # Component Tools
 <a name="add_config_row"></a>
 ## add_config_row
-**Annotations**: 
+**Annotations**: ``
 
 **Tags**: `components`
 
@@ -143,7 +143,7 @@ EXAMPLES:
 ---
 <a name="create_config"></a>
 ## create_config
-**Annotations**: 
+**Annotations**: ``
 
 **Tags**: `components`
 
@@ -212,7 +212,7 @@ EXAMPLES:
 ---
 <a name="create_sql_transformation"></a>
 ## create_sql_transformation
-**Annotations**: 
+**Annotations**: ``
 
 **Tags**: `components`
 
@@ -903,7 +903,7 @@ Answers a question using the Keboola documentation as a source.
 # Flow Tools
 <a name="create_conditional_flow"></a>
 ## create_conditional_flow
-**Annotations**: 
+**Annotations**: ``
 
 **Tags**: `flows`
 
@@ -973,7 +973,7 @@ USE CASES:
 ---
 <a name="create_flow"></a>
 ## create_flow
-**Annotations**: 
+**Annotations**: ``
 
 **Tags**: `flows`
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,18 +3,18 @@ This document provides details about the tools available in the Keboola MCP serv
 
 ## Index
 
-### Storage Tools
+### [Storage Tools](#storage-tools)
 - [get_bucket](#get_bucket): Gets detailed information about a specific bucket.
 - [get_table](#get_table): Gets detailed information about a specific table including its DB identifier and column information.
 - [list_buckets](#list_buckets): Retrieves information about all buckets in the project.
 - [list_tables](#list_tables): Retrieves all tables in a specific bucket with their basic information.
 - [update_description](#update_description): Updates the description for a Keboola storage item.
 
-### SQL Tools
+### [SQL Tools](#sql-tools)
 - [get_sql_dialect](#get_sql_dialect): Gets the name of the SQL dialect used by Keboola project's underlying database.
 - [query_data](#query_data): Executes an SQL SELECT query to get the data from the underlying database.
 
-### Component Tools
+### [Component Tools](#component-tools)
 - [add_config_row](#add_config_row): Creates a component configuration row in the specified configuration_id, using the specified name,
 component ID, configuration JSON, and description.
 - [create_config](#create_config): Creates a root component configuration using the specified name, component ID, configuration JSON, and description.
@@ -33,7 +33,7 @@ component ID, configuration JSON, and description.
 - [update_sql_transformation](#update_sql_transformation): Updates an existing SQL transformation configuration, optionally updating the description and disabling the
 configuration.
 
-### Flow Tools
+### [Flow Tools](#flow-tools)
 - [create_conditional_flow](#create_conditional_flow): Creates a new **conditional flow** configuration in Keboola.
 - [create_flow](#create_flow): Creates a new flow configuration in Keboola.
 - [get_flow](#get_flow): Gets detailed information about a specific flow configuration.
@@ -42,17 +42,17 @@ configuration.
 - [list_flows](#list_flows): Retrieves flow configurations from the project.
 - [update_flow](#update_flow): Updates an existing flow configuration in Keboola.
 
-### Jobs Tools
+### [Jobs Tools](#jobs-tools)
 - [get_job](#get_job): Retrieves detailed information about a specific job, identified by the job_id, including its status, parameters,
 results, and any relevant metadata.
 - [list_jobs](#list_jobs): Retrieves all jobs in the project, or filter jobs by a specific component_id or config_id, with optional status
 filtering.
 - [run_job](#run_job): Starts a new job for a given component or transformation.
 
-### Documentation Tools
+### [Documentation Tools](#documentation-tools)
 - [docs_query](#docs_query): Answers a question using the Keboola documentation as a source.
 
-### Other Tools
+### [Other Tools](#other-tools)
 - [create_oauth_url](#create_oauth_url): Generates an OAuth authorization URL for a Keboola component configuration.
 - [get_project_info](#get_project_info): Return structured project information pulled from multiple endpoints.
 - [search](#search): Searches for Keboola items in the production branch of the current project whose names match the given prefixes,
@@ -63,6 +63,8 @@ potentially narrowed down by item type, limited and paginated.
 # Storage Tools
 <a name="get_bucket"></a>
 ## get_bucket
+**Annotations**: `read-only`
+
 **Description**:
 
 Gets detailed information about a specific bucket.
@@ -88,6 +90,8 @@ Gets detailed information about a specific bucket.
 ---
 <a name="get_table"></a>
 ## get_table
+**Annotations**: `read-only`
+
 **Description**:
 
 Gets detailed information about a specific table including its DB identifier and column information.
@@ -113,6 +117,8 @@ Gets detailed information about a specific table including its DB identifier and
 ---
 <a name="list_buckets"></a>
 ## list_buckets
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves information about all buckets in the project.
@@ -129,6 +135,8 @@ Retrieves information about all buckets in the project.
 ---
 <a name="list_tables"></a>
 ## list_tables
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves all tables in a specific bucket with their basic information.
@@ -154,6 +162,8 @@ Retrieves all tables in a specific bucket with their basic information.
 ---
 <a name="update_description"></a>
 ## update_description
+**Annotations**: `destructive, idempotent`
+
 **Description**:
 
 Updates the description for a Keboola storage item.
@@ -226,6 +236,8 @@ Usage examples:
 # SQL Tools
 <a name="get_sql_dialect"></a>
 ## get_sql_dialect
+**Annotations**: `read-only`
+
 **Description**:
 
 Gets the name of the SQL dialect used by Keboola project's underlying database.
@@ -242,6 +254,8 @@ Gets the name of the SQL dialect used by Keboola project's underlying database.
 ---
 <a name="query_data"></a>
 ## query_data
+**Annotations**: `read-only`
+
 **Description**:
 
 Executes an SQL SELECT query to get the data from the underlying database.
@@ -314,6 +328,8 @@ DATA VALIDATION:
 # Component Tools
 <a name="add_config_row"></a>
 ## add_config_row
+**Annotations**: `non-destructive, non-idempotent`
+
 **Description**:
 
 Creates a component configuration row in the specified configuration_id, using the specified name,
@@ -386,6 +402,8 @@ EXAMPLES:
 ---
 <a name="create_config"></a>
 ## create_config
+**Annotations**: `non-destructive, non-idempotent`
+
 **Description**:
 
 Creates a root component configuration using the specified name, component ID, configuration JSON, and description.
@@ -451,6 +469,8 @@ EXAMPLES:
 ---
 <a name="create_sql_transformation"></a>
 ## create_sql_transformation
+**Annotations**: `non-destructive, non-idempotent`
+
 **Description**:
 
 Creates an SQL transformation using the specified name, SQL query following the current SQL dialect, a detailed
@@ -552,6 +572,8 @@ EXAMPLES:
 ---
 <a name="find_component_id"></a>
 ## find_component_id
+**Annotations**: `read-only`
+
 **Description**:
 
 Returns list of component IDs that match the given query.
@@ -584,6 +606,8 @@ EXAMPLES:
 ---
 <a name="get_component"></a>
 ## get_component
+**Annotations**: `read-only`
+
 **Description**:
 
 Gets information about a specific component given its ID.
@@ -620,6 +644,8 @@ EXAMPLES:
 ---
 <a name="get_config"></a>
 ## get_config
+**Annotations**: `read-only`
+
 **Description**:
 
 Gets information about a specific component/transformation configuration.
@@ -660,6 +686,8 @@ EXAMPLES:
 ---
 <a name="get_config_examples"></a>
 ## get_config_examples
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves sample configuration examples for a specific component.
@@ -693,6 +721,8 @@ EXAMPLES:
 ---
 <a name="list_configs"></a>
 ## list_configs
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves configurations of components present in the project,
@@ -753,6 +783,8 @@ EXAMPLES:
 ---
 <a name="list_transformations"></a>
 ## list_transformations
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves transformation configurations in the project, optionally filtered by specific transformation IDs.
@@ -794,6 +826,8 @@ EXAMPLES:
 ---
 <a name="update_config"></a>
 ## update_config
+**Annotations**: `destructive, idempotent`
+
 **Description**:
 
 Updates a specific root component configuration using given by component ID, and configuration ID.
@@ -872,6 +906,8 @@ EXAMPLES:
 ---
 <a name="update_config_row"></a>
 ## update_config_row
+**Annotations**: `destructive, idempotent`
+
 **Description**:
 
 Updates a specific component configuration row in the specified configuration_id, using the specified name,
@@ -955,6 +991,8 @@ EXAMPLES:
 ---
 <a name="update_sql_transformation"></a>
 ## update_sql_transformation
+**Annotations**: `destructive, idempotent`
+
 **Description**:
 
 Updates an existing SQL transformation configuration, optionally updating the description and disabling the
@@ -1107,6 +1145,8 @@ EXAMPLES:
 # Flow Tools
 <a name="create_conditional_flow"></a>
 ## create_conditional_flow
+**Annotations**: `non-destructive, non-idempotent`
+
 **Description**:
 
 Creates a new **conditional flow** configuration in Keboola.
@@ -1173,6 +1213,8 @@ USE CASES:
 ---
 <a name="create_flow"></a>
 ## create_flow
+**Annotations**: `non-destructive, non-idempotent`
+
 **Description**:
 
 Creates a new flow configuration in Keboola.
@@ -1251,6 +1293,8 @@ EXAMPLES:
 ---
 <a name="get_flow"></a>
 ## get_flow
+**Annotations**: `read-only`
+
 **Description**:
 
 Gets detailed information about a specific flow configuration.
@@ -1276,6 +1320,8 @@ Gets detailed information about a specific flow configuration.
 ---
 <a name="get_flow_examples"></a>
 ## get_flow_examples
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves examples of valid flow configurations.
@@ -1310,6 +1356,8 @@ CONSIDERATIONS:
 ---
 <a name="get_flow_schema"></a>
 ## get_flow_schema
+**Annotations**: `read-only`
+
 **Description**:
 
 Returns the JSON schema for the given flow type in markdown format.
@@ -1348,6 +1396,8 @@ Usage:
 ---
 <a name="list_flows"></a>
 ## list_flows
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves flow configurations from the project. Optionally filtered by IDs.
@@ -1374,6 +1424,8 @@ Retrieves flow configurations from the project. Optionally filtered by IDs.
 ---
 <a name="update_flow"></a>
 ## update_flow
+**Annotations**: `destructive, idempotent`
+
 **Description**:
 
 Updates an existing flow configuration in Keboola.
@@ -1487,6 +1539,8 @@ EXAMPLES:
 # Jobs Tools
 <a name="get_job"></a>
 ## get_job
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves detailed information about a specific job, identified by the job_id, including its status, parameters,
@@ -1516,6 +1570,8 @@ EXAMPLES:
 ---
 <a name="list_jobs"></a>
 ## list_jobs
+**Annotations**: `read-only`
+
 **Description**:
 
 Retrieves all jobs in the project, or filter jobs by a specific component_id or config_id, with optional status
@@ -1614,6 +1670,8 @@ EXAMPLES:
 ---
 <a name="run_job"></a>
 ## run_job
+**Annotations**: `non-destructive, non-idempotent`
+
 **Description**:
 
 Starts a new job for a given component or transformation.
@@ -1647,6 +1705,8 @@ Starts a new job for a given component or transformation.
 # Documentation Tools
 <a name="docs_query"></a>
 ## docs_query
+**Annotations**: `read-only`
+
 **Description**:
 
 Answers a question using the Keboola documentation as a source.
@@ -1674,6 +1734,8 @@ Answers a question using the Keboola documentation as a source.
 # Other Tools
 <a name="create_oauth_url"></a>
 ## create_oauth_url
+**Annotations**: `non-destructive, non-idempotent`
+
 **Description**:
 
 Generates an OAuth authorization URL for a Keboola component configuration.
@@ -1711,6 +1773,8 @@ configuration is created e.g. keboola.ex-google-analytics-v4 and keboola.ex-gmai
 ---
 <a name="get_project_info"></a>
 ## get_project_info
+**Annotations**: `read-only`
+
 **Description**:
 
 Return structured project information pulled from multiple endpoints.
@@ -1727,6 +1791,8 @@ Return structured project information pulled from multiple endpoints.
 ---
 <a name="search"></a>
 ## search
+**Annotations**: `read-only`
+
 **Description**:
 
 Searches for Keboola items in the production branch of the current project whose names match the given prefixes,

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -65,7 +65,7 @@ potentially narrowed down by item type, limited and paginated.
 ## get_bucket
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `storage`**Description**:
 
 Gets detailed information about a specific bucket.
 
@@ -92,7 +92,7 @@ Gets detailed information about a specific bucket.
 ## get_table
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `storage`**Description**:
 
 Gets detailed information about a specific table including its DB identifier and column information.
 
@@ -119,7 +119,7 @@ Gets detailed information about a specific table including its DB identifier and
 ## list_buckets
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `storage`**Description**:
 
 Retrieves information about all buckets in the project.
 
@@ -137,7 +137,7 @@ Retrieves information about all buckets in the project.
 ## list_tables
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `storage`**Description**:
 
 Retrieves all tables in a specific bucket with their basic information.
 
@@ -164,7 +164,7 @@ Retrieves all tables in a specific bucket with their basic information.
 ## update_description
 **Annotations**: `destructive, idempotent`
 
-**Description**:
+**Tags**: `storage`**Description**:
 
 Updates the description for a Keboola storage item.
 
@@ -238,7 +238,7 @@ Usage examples:
 ## get_sql_dialect
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `sql`**Description**:
 
 Gets the name of the SQL dialect used by Keboola project's underlying database.
 
@@ -256,7 +256,7 @@ Gets the name of the SQL dialect used by Keboola project's underlying database.
 ## query_data
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `sql`**Description**:
 
 Executes an SQL SELECT query to get the data from the underlying database.
 
@@ -330,7 +330,7 @@ DATA VALIDATION:
 ## add_config_row
 **Annotations**: `non-destructive, non-idempotent`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Creates a component configuration row in the specified configuration_id, using the specified name,
 component ID, configuration JSON, and description.
@@ -404,7 +404,7 @@ EXAMPLES:
 ## create_config
 **Annotations**: `non-destructive, non-idempotent`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Creates a root component configuration using the specified name, component ID, configuration JSON, and description.
 
@@ -471,7 +471,7 @@ EXAMPLES:
 ## create_sql_transformation
 **Annotations**: `non-destructive, non-idempotent`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Creates an SQL transformation using the specified name, SQL query following the current SQL dialect, a detailed
 description, and a list of created table names.
@@ -574,7 +574,7 @@ EXAMPLES:
 ## find_component_id
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `search`**Description**:
 
 Returns list of component IDs that match the given query.
 
@@ -608,7 +608,7 @@ EXAMPLES:
 ## get_component
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Gets information about a specific component given its ID.
 
@@ -646,7 +646,7 @@ EXAMPLES:
 ## get_config
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Gets information about a specific component/transformation configuration.
 
@@ -688,7 +688,7 @@ EXAMPLES:
 ## get_config_examples
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Retrieves sample configuration examples for a specific component.
 
@@ -723,7 +723,7 @@ EXAMPLES:
 ## list_configs
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Retrieves configurations of components present in the project,
 optionally filtered by component types or specific component IDs.
@@ -785,7 +785,7 @@ EXAMPLES:
 ## list_transformations
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Retrieves transformation configurations in the project, optionally filtered by specific transformation IDs.
 
@@ -828,7 +828,7 @@ EXAMPLES:
 ## update_config
 **Annotations**: `destructive, idempotent`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Updates a specific root component configuration using given by component ID, and configuration ID.
 
@@ -908,7 +908,7 @@ EXAMPLES:
 ## update_config_row
 **Annotations**: `destructive, idempotent`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Updates a specific component configuration row in the specified configuration_id, using the specified name,
 component ID, configuration JSON, and description.
@@ -993,7 +993,7 @@ EXAMPLES:
 ## update_sql_transformation
 **Annotations**: `destructive, idempotent`
 
-**Description**:
+**Tags**: `components`**Description**:
 
 Updates an existing SQL transformation configuration, optionally updating the description and disabling the
 configuration.
@@ -1147,7 +1147,7 @@ EXAMPLES:
 ## create_conditional_flow
 **Annotations**: `non-destructive, non-idempotent`
 
-**Description**:
+**Tags**: `flows`**Description**:
 
 Creates a new **conditional flow** configuration in Keboola.
 
@@ -1215,7 +1215,7 @@ USE CASES:
 ## create_flow
 **Annotations**: `non-destructive, non-idempotent`
 
-**Description**:
+**Tags**: `flows`**Description**:
 
 Creates a new flow configuration in Keboola.
 A flow is a special type of Keboola component that orchestrates the execution of other components. It defines
@@ -1295,7 +1295,7 @@ EXAMPLES:
 ## get_flow
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `flows`**Description**:
 
 Gets detailed information about a specific flow configuration.
 
@@ -1322,7 +1322,7 @@ Gets detailed information about a specific flow configuration.
 ## get_flow_examples
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `flows`**Description**:
 
 Retrieves examples of valid flow configurations.
 
@@ -1358,7 +1358,7 @@ CONSIDERATIONS:
 ## get_flow_schema
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `flows`**Description**:
 
 Returns the JSON schema for the given flow type in markdown format.
 `keboola.flow` = conditional flows
@@ -1398,7 +1398,7 @@ Usage:
 ## list_flows
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `flows`**Description**:
 
 Retrieves flow configurations from the project. Optionally filtered by IDs.
 
@@ -1426,7 +1426,7 @@ Retrieves flow configurations from the project. Optionally filtered by IDs.
 ## update_flow
 **Annotations**: `destructive, idempotent`
 
-**Description**:
+**Tags**: `flows`**Description**:
 
 Updates an existing flow configuration in Keboola.
 
@@ -1541,7 +1541,7 @@ EXAMPLES:
 ## get_job
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `jobs`**Description**:
 
 Retrieves detailed information about a specific job, identified by the job_id, including its status, parameters,
 results, and any relevant metadata.
@@ -1572,7 +1572,7 @@ EXAMPLES:
 ## list_jobs
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `jobs`**Description**:
 
 Retrieves all jobs in the project, or filter jobs by a specific component_id or config_id, with optional status
 filtering. Additional parameters support pagination (limit, offset) and sorting (sort_by, sort_order).
@@ -1672,7 +1672,7 @@ EXAMPLES:
 ## run_job
 **Annotations**: `non-destructive, non-idempotent`
 
-**Description**:
+**Tags**: `jobs`**Description**:
 
 Starts a new job for a given component or transformation.
 
@@ -1707,7 +1707,7 @@ Starts a new job for a given component or transformation.
 ## docs_query
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `docs`**Description**:
 
 Answers a question using the Keboola documentation as a source.
 
@@ -1736,7 +1736,7 @@ Answers a question using the Keboola documentation as a source.
 ## create_oauth_url
 **Annotations**: `non-destructive, non-idempotent`
 
-**Description**:
+**Tags**: `oauth`**Description**:
 
 Generates an OAuth authorization URL for a Keboola component configuration.
 
@@ -1775,7 +1775,7 @@ configuration is created e.g. keboola.ex-google-analytics-v4 and keboola.ex-gmai
 ## get_project_info
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `project`**Description**:
 
 Return structured project information pulled from multiple endpoints.
 
@@ -1793,7 +1793,7 @@ Return structured project information pulled from multiple endpoints.
 ## search
 **Annotations**: `read-only`
 
-**Description**:
+**Tags**: `search`**Description**:
 
 Searches for Keboola items in the production branch of the current project whose names match the given prefixes,
 potentially narrowed down by item type, limited and paginated. Results are ordered by relevance, then creation time.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -67,7 +67,7 @@ potentially narrowed down by item type, limited and paginated.
 # Component Tools
 <a name="add_config_row"></a>
 ## add_config_row
-**Annotations**: ``
+**Annotations**: 
 
 **Tags**: `components`
 
@@ -143,7 +143,7 @@ EXAMPLES:
 ---
 <a name="create_config"></a>
 ## create_config
-**Annotations**: ``
+**Annotations**: 
 
 **Tags**: `components`
 
@@ -212,7 +212,7 @@ EXAMPLES:
 ---
 <a name="create_sql_transformation"></a>
 ## create_sql_transformation
-**Annotations**: ``
+**Annotations**: 
 
 **Tags**: `components`
 
@@ -903,7 +903,7 @@ Answers a question using the Keboola documentation as a source.
 # Flow Tools
 <a name="create_conditional_flow"></a>
 ## create_conditional_flow
-**Annotations**: ``
+**Annotations**: 
 
 **Tags**: `flows`
 
@@ -973,7 +973,7 @@ USE CASES:
 ---
 <a name="create_flow"></a>
 ## create_flow
-**Annotations**: ``
+**Annotations**: 
 
 **Tags**: `flows`
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,24 +3,12 @@ This document provides details about the tools available in the Keboola MCP serv
 
 ## Index
 
-### [Storage Tools](#storage-tools)
-- [get_bucket](#get_bucket): Gets detailed information about a specific bucket.
-- [get_table](#get_table): Gets detailed information about a specific table including its DB identifier and column information.
-- [list_buckets](#list_buckets): Retrieves information about all buckets in the project.
-- [list_tables](#list_tables): Retrieves all tables in a specific bucket with their basic information.
-- [update_description](#update_description): Updates the description for a Keboola storage item.
-
-### [SQL Tools](#sql-tools)
-- [get_sql_dialect](#get_sql_dialect): Gets the name of the SQL dialect used by Keboola project's underlying database.
-- [query_data](#query_data): Executes an SQL SELECT query to get the data from the underlying database.
-
-### [Component Tools](#component-tools)
+### Component Tools
 - [add_config_row](#add_config_row): Creates a component configuration row in the specified configuration_id, using the specified name,
 component ID, configuration JSON, and description.
 - [create_config](#create_config): Creates a root component configuration using the specified name, component ID, configuration JSON, and description.
 - [create_sql_transformation](#create_sql_transformation): Creates an SQL transformation using the specified name, SQL query following the current SQL dialect, a detailed
 description, and a list of created table names.
-- [find_component_id](#find_component_id): Returns list of component IDs that match the given query.
 - [get_component](#get_component): Gets information about a specific component given its ID.
 - [get_config](#get_config): Gets information about a specific component/transformation configuration.
 - [get_config_examples](#get_config_examples): Retrieves sample configuration examples for a specific component.
@@ -33,7 +21,10 @@ component ID, configuration JSON, and description.
 - [update_sql_transformation](#update_sql_transformation): Updates an existing SQL transformation configuration, optionally updating the description and disabling the
 configuration.
 
-### [Flow Tools](#flow-tools)
+### Documentation Tools
+- [docs_query](#docs_query): Answers a question using the Keboola documentation as a source.
+
+### Flow Tools
 - [create_conditional_flow](#create_conditional_flow): Creates a new **conditional flow** configuration in Keboola.
 - [create_flow](#create_flow): Creates a new flow configuration in Keboola.
 - [get_flow](#get_flow): Gets detailed information about a specific flow configuration.
@@ -42,295 +33,45 @@ configuration.
 - [list_flows](#list_flows): Retrieves flow configurations from the project.
 - [update_flow](#update_flow): Updates an existing flow configuration in Keboola.
 
-### [Jobs Tools](#jobs-tools)
+### Jobs Tools
 - [get_job](#get_job): Retrieves detailed information about a specific job, identified by the job_id, including its status, parameters,
 results, and any relevant metadata.
 - [list_jobs](#list_jobs): Retrieves all jobs in the project, or filter jobs by a specific component_id or config_id, with optional status
 filtering.
 - [run_job](#run_job): Starts a new job for a given component or transformation.
 
-### [Documentation Tools](#documentation-tools)
-- [docs_query](#docs_query): Answers a question using the Keboola documentation as a source.
-
-### [Other Tools](#other-tools)
+### OAuth Tools
 - [create_oauth_url](#create_oauth_url): Generates an OAuth authorization URL for a Keboola component configuration.
+
+### Project Tools
 - [get_project_info](#get_project_info): Return structured project information pulled from multiple endpoints.
+
+### SQL Tools
+- [get_sql_dialect](#get_sql_dialect): Gets the name of the SQL dialect used by Keboola project's underlying database.
+- [query_data](#query_data): Executes an SQL SELECT query to get the data from the underlying database.
+
+### Search Tools
+- [find_component_id](#find_component_id): Returns list of component IDs that match the given query.
 - [search](#search): Searches for Keboola items in the production branch of the current project whose names match the given prefixes,
 potentially narrowed down by item type, limited and paginated.
 
----
-
-# Storage Tools
-<a name="get_bucket"></a>
-## get_bucket
-**Annotations**: `read-only`
-
-**Tags**: `storage`**Description**:
-
-Gets detailed information about a specific bucket.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {
-    "bucket_id": {
-      "description": "Unique ID of the bucket.",
-      "title": "Bucket Id",
-      "type": "string"
-    }
-  },
-  "required": [
-    "bucket_id"
-  ],
-  "type": "object"
-}
-```
-
----
-<a name="get_table"></a>
-## get_table
-**Annotations**: `read-only`
-
-**Tags**: `storage`**Description**:
-
-Gets detailed information about a specific table including its DB identifier and column information.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {
-    "table_id": {
-      "description": "Unique ID of the table.",
-      "title": "Table Id",
-      "type": "string"
-    }
-  },
-  "required": [
-    "table_id"
-  ],
-  "type": "object"
-}
-```
-
----
-<a name="list_buckets"></a>
-## list_buckets
-**Annotations**: `read-only`
-
-**Tags**: `storage`**Description**:
-
-Retrieves information about all buckets in the project.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {},
-  "type": "object"
-}
-```
-
----
-<a name="list_tables"></a>
-## list_tables
-**Annotations**: `read-only`
-
-**Tags**: `storage`**Description**:
-
-Retrieves all tables in a specific bucket with their basic information.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {
-    "bucket_id": {
-      "description": "Unique ID of the bucket.",
-      "title": "Bucket Id",
-      "type": "string"
-    }
-  },
-  "required": [
-    "bucket_id"
-  ],
-  "type": "object"
-}
-```
-
----
-<a name="update_description"></a>
-## update_description
-**Annotations**: `destructive, idempotent`
-
-**Tags**: `storage`**Description**:
-
-Updates the description for a Keboola storage item.
-
-The tool supports three item types and validates the required identifiers based on the selected type:
-
-- item_type = "bucket": requires bucket_id
-- item_type = "table": requires table_id
-- item_type = "column": requires table_id and column_name
-
-Usage examples:
-- Update a bucket: item_type="bucket", bucket_id="in.c-my-bucket",
-  description="New bucket description"
-- Update a table: item_type="table", table_id="in.c-my-bucket.my-table",
-  description="New table description"
-- Update a column: item_type="column", table_id="in.c-my-bucket.my-table",
-  column_name="my_column", description="New column description"
-
-:return: The update result containing the stored description, timestamp, success flag, and optional links.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {
-    "item_type": {
-      "description": "Type of the item to update. One of: bucket, table, column.",
-      "enum": [
-        "bucket",
-        "table",
-        "column"
-      ],
-      "title": "Item Type",
-      "type": "string"
-    },
-    "description": {
-      "description": "The new description to set for the specified item.",
-      "title": "Description",
-      "type": "string"
-    },
-    "bucket_id": {
-      "default": "",
-      "description": "Bucket ID. Required when item_type is \"bucket\".",
-      "title": "Bucket Id",
-      "type": "string"
-    },
-    "table_id": {
-      "default": "",
-      "description": "Table ID. Required when item_type is \"table\" or \"column\".",
-      "title": "Table Id",
-      "type": "string"
-    },
-    "column_name": {
-      "default": "",
-      "description": "Column name. Required when item_type is \"column\".",
-      "title": "Column Name",
-      "type": "string"
-    }
-  },
-  "required": [
-    "item_type",
-    "description"
-  ],
-  "type": "object"
-}
-```
-
----
-
-# SQL Tools
-<a name="get_sql_dialect"></a>
-## get_sql_dialect
-**Annotations**: `read-only`
-
-**Tags**: `sql`**Description**:
-
-Gets the name of the SQL dialect used by Keboola project's underlying database.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {},
-  "type": "object"
-}
-```
-
----
-<a name="query_data"></a>
-## query_data
-**Annotations**: `read-only`
-
-**Tags**: `sql`**Description**:
-
-Executes an SQL SELECT query to get the data from the underlying database.
-
-CRITICAL SQL REQUIREMENTS:
-
-* ALWAYS check the SQL dialect first using get_sql_dialect tool before constructing queries
-* Do not include any comments in the SQL code
-
-DIALECT-SPECIFIC REQUIREMENTS:
-* Snowflake: Use double quotes for identifiers: "column_name", "table_name"
-* BigQuery: Use backticks for identifiers: `column_name`, `table_name`
-* Never mix quoting styles within a single query
-
-TABLE AND COLUMN REFERENCES:
-* Always use fully qualified table names that include database name, schema name and table name
-* Get fully qualified table names using table information tools - use exact format shown
-* Snowflake format: "DATABASE"."SCHEMA"."TABLE"
-* BigQuery format: `project`.`dataset`.`table`
-* Always use quoted column names when referring to table columns (exact quotes from table info)
-
-CTE (WITH CLAUSE) RULES:
-* ALL column references in main query MUST match exact case used in the CTE
-* If you alias a column as "project_id" in CTE, reference it as "project_id" in subsequent queries
-* For Snowflake: Unless columns are quoted in CTE, they become UPPERCASE. To preserve case, use quotes
-* Define all column aliases explicitly in CTEs
-* Quote identifiers in both CTE definition and references to preserve case
-
-FUNCTION COMPATIBILITY:
-* Snowflake: Use LISTAGG instead of STRING_AGG
-* Check data types before using date functions (DATE_TRUNC, EXTRACT require proper date/timestamp types)
-* Cast VARCHAR columns to appropriate types before using in date/numeric functions
-
-ERROR PREVENTION:
-* Never pass empty strings ('') where numeric or date values are expected
-* Use NULLIF or CASE statements to handle empty values
-* Always use TRY_CAST or similar safe casting functions when converting data types
-* Check for division by zero using NULLIF(denominator, 0)
-
-DATA VALIDATION:
-* When querying columns with categorical values, use query_data tool to inspect distinct values beforehand
-* Ensure valid filtering by checking actual data values first
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {
-    "sql_query": {
-      "description": "SQL SELECT query to run.",
-      "title": "Sql Query",
-      "type": "string"
-    },
-    "query_name": {
-      "description": "A concise, human-readable name for this query based on its purpose and what data it retrieves. Use normal words with spaces (e.g., \"Customer Orders Last Month\", \"Top Selling Products\", \"User Activity Summary\").",
-      "title": "Query Name",
-      "type": "string"
-    }
-  },
-  "required": [
-    "sql_query",
-    "query_name"
-  ],
-  "type": "object"
-}
-```
+### Storage Tools
+- [get_bucket](#get_bucket): Gets detailed information about a specific bucket.
+- [get_table](#get_table): Gets detailed information about a specific table including its DB identifier and column information.
+- [list_buckets](#list_buckets): Retrieves information about all buckets in the project.
+- [list_tables](#list_tables): Retrieves all tables in a specific bucket with their basic information.
+- [update_description](#update_description): Updates the description for a Keboola storage item.
 
 ---
 
 # Component Tools
 <a name="add_config_row"></a>
 ## add_config_row
-**Annotations**: `non-destructive, non-idempotent`
+**Annotations**: 
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Creates a component configuration row in the specified configuration_id, using the specified name,
 component ID, configuration JSON, and description.
@@ -402,9 +143,11 @@ EXAMPLES:
 ---
 <a name="create_config"></a>
 ## create_config
-**Annotations**: `non-destructive, non-idempotent`
+**Annotations**: 
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Creates a root component configuration using the specified name, component ID, configuration JSON, and description.
 
@@ -469,9 +212,11 @@ EXAMPLES:
 ---
 <a name="create_sql_transformation"></a>
 ## create_sql_transformation
-**Annotations**: `non-destructive, non-idempotent`
+**Annotations**: 
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Creates an SQL transformation using the specified name, SQL query following the current SQL dialect, a detailed
 description, and a list of created table names.
@@ -570,45 +315,13 @@ EXAMPLES:
 ```
 
 ---
-<a name="find_component_id"></a>
-## find_component_id
-**Annotations**: `read-only`
-
-**Tags**: `search`**Description**:
-
-Returns list of component IDs that match the given query.
-
-USAGE:
-- Use when you want to find the component for a specific purpose.
-
-EXAMPLES:
-- user_input: `I am looking for a salesforce extractor component`
-    - returns a list of component IDs that match the query, ordered by relevance/best match.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {
-    "query": {
-      "description": "Natural language query to find the requested component.",
-      "title": "Query",
-      "type": "string"
-    }
-  },
-  "required": [
-    "query"
-  ],
-  "type": "object"
-}
-```
-
----
 <a name="get_component"></a>
 ## get_component
 **Annotations**: `read-only`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Gets information about a specific component given its ID.
 
@@ -646,7 +359,9 @@ EXAMPLES:
 ## get_config
 **Annotations**: `read-only`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Gets information about a specific component/transformation configuration.
 
@@ -688,7 +403,9 @@ EXAMPLES:
 ## get_config_examples
 **Annotations**: `read-only`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Retrieves sample configuration examples for a specific component.
 
@@ -723,7 +440,9 @@ EXAMPLES:
 ## list_configs
 **Annotations**: `read-only`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Retrieves configurations of components present in the project,
 optionally filtered by component types or specific component IDs.
@@ -785,7 +504,9 @@ EXAMPLES:
 ## list_transformations
 **Annotations**: `read-only`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Retrieves transformation configurations in the project, optionally filtered by specific transformation IDs.
 
@@ -826,9 +547,11 @@ EXAMPLES:
 ---
 <a name="update_config"></a>
 ## update_config
-**Annotations**: `destructive, idempotent`
+**Annotations**: `destructive`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Updates a specific root component configuration using given by component ID, and configuration ID.
 
@@ -906,9 +629,11 @@ EXAMPLES:
 ---
 <a name="update_config_row"></a>
 ## update_config_row
-**Annotations**: `destructive, idempotent`
+**Annotations**: `destructive`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Updates a specific component configuration row in the specified configuration_id, using the specified name,
 component ID, configuration JSON, and description.
@@ -991,9 +716,11 @@ EXAMPLES:
 ---
 <a name="update_sql_transformation"></a>
 ## update_sql_transformation
-**Annotations**: `destructive, idempotent`
+**Annotations**: `destructive`
 
-**Tags**: `components`**Description**:
+**Tags**: `components`
+
+**Description**:
 
 Updates an existing SQL transformation configuration, optionally updating the description and disabling the
 configuration.
@@ -1142,12 +869,45 @@ EXAMPLES:
 
 ---
 
+# Documentation Tools
+<a name="docs_query"></a>
+## docs_query
+**Annotations**: `read-only`
+
+**Tags**: `docs`
+
+**Description**:
+
+Answers a question using the Keboola documentation as a source.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "query": {
+      "description": "Natural language query to search for in the documentation.",
+      "title": "Query",
+      "type": "string"
+    }
+  },
+  "required": [
+    "query"
+  ],
+  "type": "object"
+}
+```
+
+---
+
 # Flow Tools
 <a name="create_conditional_flow"></a>
 ## create_conditional_flow
-**Annotations**: `non-destructive, non-idempotent`
+**Annotations**: 
 
-**Tags**: `flows`**Description**:
+**Tags**: `flows`
+
+**Description**:
 
 Creates a new **conditional flow** configuration in Keboola.
 
@@ -1213,9 +973,11 @@ USE CASES:
 ---
 <a name="create_flow"></a>
 ## create_flow
-**Annotations**: `non-destructive, non-idempotent`
+**Annotations**: 
 
-**Tags**: `flows`**Description**:
+**Tags**: `flows`
+
+**Description**:
 
 Creates a new flow configuration in Keboola.
 A flow is a special type of Keboola component that orchestrates the execution of other components. It defines
@@ -1295,7 +1057,9 @@ EXAMPLES:
 ## get_flow
 **Annotations**: `read-only`
 
-**Tags**: `flows`**Description**:
+**Tags**: `flows`
+
+**Description**:
 
 Gets detailed information about a specific flow configuration.
 
@@ -1322,7 +1086,9 @@ Gets detailed information about a specific flow configuration.
 ## get_flow_examples
 **Annotations**: `read-only`
 
-**Tags**: `flows`**Description**:
+**Tags**: `flows`
+
+**Description**:
 
 Retrieves examples of valid flow configurations.
 
@@ -1358,7 +1124,9 @@ CONSIDERATIONS:
 ## get_flow_schema
 **Annotations**: `read-only`
 
-**Tags**: `flows`**Description**:
+**Tags**: `flows`
+
+**Description**:
 
 Returns the JSON schema for the given flow type in markdown format.
 `keboola.flow` = conditional flows
@@ -1398,7 +1166,9 @@ Usage:
 ## list_flows
 **Annotations**: `read-only`
 
-**Tags**: `flows`**Description**:
+**Tags**: `flows`
+
+**Description**:
 
 Retrieves flow configurations from the project. Optionally filtered by IDs.
 
@@ -1424,9 +1194,11 @@ Retrieves flow configurations from the project. Optionally filtered by IDs.
 ---
 <a name="update_flow"></a>
 ## update_flow
-**Annotations**: `destructive, idempotent`
+**Annotations**: `destructive`
 
-**Tags**: `flows`**Description**:
+**Tags**: `flows`
+
+**Description**:
 
 Updates an existing flow configuration in Keboola.
 
@@ -1541,7 +1313,9 @@ EXAMPLES:
 ## get_job
 **Annotations**: `read-only`
 
-**Tags**: `jobs`**Description**:
+**Tags**: `jobs`
+
+**Description**:
 
 Retrieves detailed information about a specific job, identified by the job_id, including its status, parameters,
 results, and any relevant metadata.
@@ -1572,7 +1346,9 @@ EXAMPLES:
 ## list_jobs
 **Annotations**: `read-only`
 
-**Tags**: `jobs`**Description**:
+**Tags**: `jobs`
+
+**Description**:
 
 Retrieves all jobs in the project, or filter jobs by a specific component_id or config_id, with optional status
 filtering. Additional parameters support pagination (limit, offset) and sorting (sort_by, sort_order).
@@ -1670,9 +1446,11 @@ EXAMPLES:
 ---
 <a name="run_job"></a>
 ## run_job
-**Annotations**: `non-destructive, non-idempotent`
+**Annotations**: `destructive`
 
-**Tags**: `jobs`**Description**:
+**Tags**: `jobs`
+
+**Description**:
 
 Starts a new job for a given component or transformation.
 
@@ -1702,41 +1480,14 @@ Starts a new job for a given component or transformation.
 
 ---
 
-# Documentation Tools
-<a name="docs_query"></a>
-## docs_query
-**Annotations**: `read-only`
-
-**Tags**: `docs`**Description**:
-
-Answers a question using the Keboola documentation as a source.
-
-
-**Input JSON Schema**:
-```json
-{
-  "properties": {
-    "query": {
-      "description": "Natural language query to search for in the documentation.",
-      "title": "Query",
-      "type": "string"
-    }
-  },
-  "required": [
-    "query"
-  ],
-  "type": "object"
-}
-```
-
----
-
-# Other Tools
+# OAuth Tools
 <a name="create_oauth_url"></a>
 ## create_oauth_url
-**Annotations**: `non-destructive, non-idempotent`
+**Annotations**: `destructive`
 
-**Tags**: `oauth`**Description**:
+**Tags**: `oauth`
+
+**Description**:
 
 Generates an OAuth authorization URL for a Keboola component configuration.
 
@@ -1771,11 +1522,15 @@ configuration is created e.g. keboola.ex-google-analytics-v4 and keboola.ex-gmai
 ```
 
 ---
+
+# Project Tools
 <a name="get_project_info"></a>
 ## get_project_info
 **Annotations**: `read-only`
 
-**Tags**: `project`**Description**:
+**Tags**: `project`
+
+**Description**:
 
 Return structured project information pulled from multiple endpoints.
 
@@ -1789,11 +1544,51 @@ Return structured project information pulled from multiple endpoints.
 ```
 
 ---
+
+# Search Tools
+<a name="find_component_id"></a>
+## find_component_id
+**Annotations**: `read-only`
+
+**Tags**: `search`
+
+**Description**:
+
+Returns list of component IDs that match the given query.
+
+USAGE:
+- Use when you want to find the component for a specific purpose.
+
+EXAMPLES:
+- user_input: `I am looking for a salesforce extractor component`
+    - returns a list of component IDs that match the query, ordered by relevance/best match.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "query": {
+      "description": "Natural language query to find the requested component.",
+      "title": "Query",
+      "type": "string"
+    }
+  },
+  "required": [
+    "query"
+  ],
+  "type": "object"
+}
+```
+
+---
 <a name="search"></a>
 ## search
 **Annotations**: `read-only`
 
-**Tags**: `search`**Description**:
+**Tags**: `search`
+
+**Description**:
 
 Searches for Keboola items in the production branch of the current project whose names match the given prefixes,
 potentially narrowed down by item type, limited and paginated. Results are ordered by relevance, then creation time.
@@ -1851,6 +1646,285 @@ Considerations:
   },
   "required": [
     "name_prefixes"
+  ],
+  "type": "object"
+}
+```
+
+---
+
+# SQL Tools
+<a name="get_sql_dialect"></a>
+## get_sql_dialect
+**Annotations**: `read-only`
+
+**Tags**: `sql`
+
+**Description**:
+
+Gets the name of the SQL dialect used by Keboola project's underlying database.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {},
+  "type": "object"
+}
+```
+
+---
+<a name="query_data"></a>
+## query_data
+**Annotations**: `read-only`
+
+**Tags**: `sql`
+
+**Description**:
+
+Executes an SQL SELECT query to get the data from the underlying database.
+
+CRITICAL SQL REQUIREMENTS:
+
+* ALWAYS check the SQL dialect first using get_sql_dialect tool before constructing queries
+* Do not include any comments in the SQL code
+
+DIALECT-SPECIFIC REQUIREMENTS:
+* Snowflake: Use double quotes for identifiers: "column_name", "table_name"
+* BigQuery: Use backticks for identifiers: `column_name`, `table_name`
+* Never mix quoting styles within a single query
+
+TABLE AND COLUMN REFERENCES:
+* Always use fully qualified table names that include database name, schema name and table name
+* Get fully qualified table names using table information tools - use exact format shown
+* Snowflake format: "DATABASE"."SCHEMA"."TABLE"
+* BigQuery format: `project`.`dataset`.`table`
+* Always use quoted column names when referring to table columns (exact quotes from table info)
+
+CTE (WITH CLAUSE) RULES:
+* ALL column references in main query MUST match exact case used in the CTE
+* If you alias a column as "project_id" in CTE, reference it as "project_id" in subsequent queries
+* For Snowflake: Unless columns are quoted in CTE, they become UPPERCASE. To preserve case, use quotes
+* Define all column aliases explicitly in CTEs
+* Quote identifiers in both CTE definition and references to preserve case
+
+FUNCTION COMPATIBILITY:
+* Snowflake: Use LISTAGG instead of STRING_AGG
+* Check data types before using date functions (DATE_TRUNC, EXTRACT require proper date/timestamp types)
+* Cast VARCHAR columns to appropriate types before using in date/numeric functions
+
+ERROR PREVENTION:
+* Never pass empty strings ('') where numeric or date values are expected
+* Use NULLIF or CASE statements to handle empty values
+* Always use TRY_CAST or similar safe casting functions when converting data types
+* Check for division by zero using NULLIF(denominator, 0)
+
+DATA VALIDATION:
+* When querying columns with categorical values, use query_data tool to inspect distinct values beforehand
+* Ensure valid filtering by checking actual data values first
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "sql_query": {
+      "description": "SQL SELECT query to run.",
+      "title": "Sql Query",
+      "type": "string"
+    },
+    "query_name": {
+      "description": "A concise, human-readable name for this query based on its purpose and what data it retrieves. Use normal words with spaces (e.g., \"Customer Orders Last Month\", \"Top Selling Products\", \"User Activity Summary\").",
+      "title": "Query Name",
+      "type": "string"
+    }
+  },
+  "required": [
+    "sql_query",
+    "query_name"
+  ],
+  "type": "object"
+}
+```
+
+---
+
+# Storage Tools
+<a name="get_bucket"></a>
+## get_bucket
+**Annotations**: `read-only`
+
+**Tags**: `storage`
+
+**Description**:
+
+Gets detailed information about a specific bucket.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "bucket_id": {
+      "description": "Unique ID of the bucket.",
+      "title": "Bucket Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "bucket_id"
+  ],
+  "type": "object"
+}
+```
+
+---
+<a name="get_table"></a>
+## get_table
+**Annotations**: `read-only`
+
+**Tags**: `storage`
+
+**Description**:
+
+Gets detailed information about a specific table including its DB identifier and column information.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "table_id": {
+      "description": "Unique ID of the table.",
+      "title": "Table Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "table_id"
+  ],
+  "type": "object"
+}
+```
+
+---
+<a name="list_buckets"></a>
+## list_buckets
+**Annotations**: `read-only`
+
+**Tags**: `storage`
+
+**Description**:
+
+Retrieves information about all buckets in the project.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {},
+  "type": "object"
+}
+```
+
+---
+<a name="list_tables"></a>
+## list_tables
+**Annotations**: `read-only`
+
+**Tags**: `storage`
+
+**Description**:
+
+Retrieves all tables in a specific bucket with their basic information.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "bucket_id": {
+      "description": "Unique ID of the bucket.",
+      "title": "Bucket Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "bucket_id"
+  ],
+  "type": "object"
+}
+```
+
+---
+<a name="update_description"></a>
+## update_description
+**Annotations**: `destructive`
+
+**Tags**: `storage`
+
+**Description**:
+
+Updates the description for a Keboola storage item.
+
+The tool supports three item types and validates the required identifiers based on the selected type:
+
+- item_type = "bucket": requires bucket_id
+- item_type = "table": requires table_id
+- item_type = "column": requires table_id and column_name
+
+Usage examples:
+- Update a bucket: item_type="bucket", bucket_id="in.c-my-bucket",
+  description="New bucket description"
+- Update a table: item_type="table", table_id="in.c-my-bucket.my-table",
+  description="New table description"
+- Update a column: item_type="column", table_id="in.c-my-bucket.my-table",
+  column_name="my_column", description="New column description"
+
+:return: The update result containing the stored description, timestamp, success flag, and optional links.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "item_type": {
+      "description": "Type of the item to update. One of: bucket, table, column.",
+      "enum": [
+        "bucket",
+        "table",
+        "column"
+      ],
+      "title": "Item Type",
+      "type": "string"
+    },
+    "description": {
+      "description": "The new description to set for the specified item.",
+      "title": "Description",
+      "type": "string"
+    },
+    "bucket_id": {
+      "default": "",
+      "description": "Bucket ID. Required when item_type is \"bucket\".",
+      "title": "Bucket Id",
+      "type": "string"
+    },
+    "table_id": {
+      "default": "",
+      "description": "Table ID. Required when item_type is \"table\" or \"column\".",
+      "title": "Table Id",
+      "type": "string"
+    },
+    "column_name": {
+      "default": "",
+      "description": "Column name. Required when item_type is \"column\".",
+      "title": "Column Name",
+      "type": "string"
+    }
+  },
+  "required": [
+    "item_type",
+    "description"
   ],
   "type": "object"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.17.1"
+version = "1.18.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/generate_tool_docs.py
+++ b/src/keboola_mcp_server/generate_tool_docs.py
@@ -79,7 +79,6 @@ class ToolDocumentationGenerator:
         for category in self._categorizer.get_categories():
             if not (tools := tools_by_category[category]):
                 continue
-
             f.write(f'\n### [{category.name}](#{self._generate_anchor(category.name)})\n')
             for tool in sorted(tools, key=attrgetter('name')):
                 anchor = self._generate_anchor(tool.name)
@@ -89,7 +88,7 @@ class ToolDocumentationGenerator:
 
     def _get_annotations(self, annotations: Optional[ToolAnnotations]) -> str:
         if annotations is None:
-            return ''
+            return '-'
         str_annotations = []
         if annotations.readOnlyHint:
             str_annotations.append('read-only')
@@ -97,6 +96,9 @@ class ToolDocumentationGenerator:
             str_annotations.append('destructive' if annotations.destructiveHint else 'non-destructive')
             str_annotations.append('idempotent' if annotations.idempotentHint else 'non-idempotent')
         return f'`{", ".join(str_annotations)}`'
+
+    def _get_tags(self, tags: set[str]) -> str:
+        return f'`{", ".join(tags)}`' if tags else '-'
 
     def _get_first_sentence(self, text: Optional[str]) -> str:
         """Extracts the first sentence from the given text."""
@@ -125,6 +127,8 @@ class ToolDocumentationGenerator:
                 f.write(f'## {tool.name}\n')
                 annotations = self._get_annotations(tool.annotations)
                 f.write(f'**Annotations**: {annotations}\n\n')
+                tags = self._get_tags(tool.tags)
+                f.write(f'**Tags**: {tags}')
                 f.write(f'**Description**:\n\n{tool.description}\n\n')
                 self._write_json_schema(f, tool)
                 f.write('\n---\n')

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -113,7 +113,13 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     )
 
     # Configuration management tools
-    mcp.add_tool(FunctionTool.from_function(create_config, tags={COMPONENT_TOOLS_TAG}))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_config,
+            tags={COMPONENT_TOOLS_TAG},
+            annotations=ToolAnnotations(destructiveHint=False),
+        )
+    )
     mcp.add_tool(
         FunctionTool.from_function(
             update_config,
@@ -125,6 +131,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             add_config_row,
             tags={COMPONENT_TOOLS_TAG},
+            annotations=ToolAnnotations(destructiveHint=False),
         )
     )
     mcp.add_tool(
@@ -148,6 +155,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             create_sql_transformation,
             tags={COMPONENT_TOOLS_TAG},
+            annotations=ToolAnnotations(destructiveHint=False),
         )
     )
     mcp.add_tool(

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -34,6 +34,7 @@ from typing import Annotated, Any, Sequence, cast
 from fastmcp import Context
 from fastmcp.tools import FunctionTool
 from httpx import HTTPStatusError
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from keboola_mcp_server.client import ConfigurationAPIResponse, JsonDict, KeboolaClient
@@ -79,21 +80,102 @@ LOG = logging.getLogger(__name__)
 def add_component_tools(mcp: KeboolaMcpServer) -> None:
     """Add tools to the MCP server."""
     # Component/Configuration discovery tools
-    mcp.add_tool(FunctionTool.from_function(get_component))
-    mcp.add_tool(FunctionTool.from_function(get_config))
-    mcp.add_tool(FunctionTool.from_function(list_configs, serializer=exclude_none_serializer))
-    mcp.add_tool(FunctionTool.from_function(get_config_examples))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_component,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_config,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            list_configs,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_config_examples,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
 
     # Configuration management tools
-    mcp.add_tool(FunctionTool.from_function(create_config))
-    mcp.add_tool(FunctionTool.from_function(update_config))
-    mcp.add_tool(FunctionTool.from_function(add_config_row))
-    mcp.add_tool(FunctionTool.from_function(update_config_row))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_config,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+            ),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            update_config,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+            ),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            add_config_row,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+            ),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            update_config_row,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+            ),
+        )
+    )
 
     # SQL transformation tools
-    mcp.add_tool(FunctionTool.from_function(list_transformations, serializer=exclude_none_serializer))
-    mcp.add_tool(FunctionTool.from_function(create_sql_transformation))
-    mcp.add_tool(FunctionTool.from_function(update_sql_transformation))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            list_transformations,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_sql_transformation,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+            ),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            update_sql_transformation,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+            ),
+        )
+    )
 
     LOG.info('Component tools added to the MCP server.')
 

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -71,6 +71,8 @@ from keboola_mcp_server.tools.validation import (
 
 LOG = logging.getLogger(__name__)
 
+COMPONENT_TOOLS_TAG = 'components'
+
 
 # ============================================================================
 # TOOL REGISTRATION
@@ -83,12 +85,14 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_component,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_config,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
         )
     )
@@ -96,12 +100,14 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             list_configs,
             serializer=exclude_none_serializer,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_config_examples,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
         )
     )
@@ -110,6 +116,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             create_config,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=False,
@@ -120,6 +127,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_config,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=True,
@@ -130,6 +138,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             add_config_row,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=False,
@@ -140,6 +149,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_config_row,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=True,
@@ -153,12 +163,14 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             list_transformations,
             serializer=exclude_none_serializer,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             create_sql_transformation,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=False,
@@ -169,6 +181,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_sql_transformation,
+            tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=True,

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -86,14 +86,14 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             get_component,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_config,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
     )
     mcp.add_tool(
@@ -101,60 +101,37 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
             list_configs,
             serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_config_examples,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
     )
 
     # Configuration management tools
-    mcp.add_tool(
-        FunctionTool.from_function(
-            create_config,
-            tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=False,
-                idempotentHint=False,
-            ),
-        )
-    )
+    mcp.add_tool(FunctionTool.from_function(create_config, tags={COMPONENT_TOOLS_TAG}))
     mcp.add_tool(
         FunctionTool.from_function(
             update_config,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=True,
-                idempotentHint=True,
-            ),
+            annotations=ToolAnnotations(destructiveHint=True),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             add_config_row,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=False,
-                idempotentHint=False,
-            ),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             update_config_row,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=True,
-                idempotentHint=True,
-            ),
+            annotations=ToolAnnotations(destructiveHint=True),
         )
     )
 
@@ -164,29 +141,20 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
             list_transformations,
             serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             create_sql_transformation,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=False,
-                idempotentHint=False,
-            ),
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             update_sql_transformation,
             tags={COMPONENT_TOOLS_TAG},
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=True,
-                idempotentHint=True,
-            ),
+            annotations=ToolAnnotations(destructiveHint=True),
         )
     )
 

--- a/src/keboola_mcp_server/tools/doc.py
+++ b/src/keboola_mcp_server/tools/doc.py
@@ -20,7 +20,7 @@ def add_doc_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             docs_query,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={DOC_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/doc.py
+++ b/src/keboola_mcp_server/tools/doc.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from keboola_mcp_server.client import KeboolaClient
@@ -13,12 +14,13 @@ LOG = logging.getLogger(__name__)
 
 def add_doc_tools(mcp: FastMCP) -> None:
     """Add tools to the MCP server."""
-    doc_tools = [
-        docs_query,
-    ]
-    for tool in doc_tools:
-        LOG.info(f'Adding tool {tool.__name__} to the MCP server.')
-        mcp.add_tool(FunctionTool.from_function(tool))
+    LOG.info(f'Adding tool {docs_query.__name__} to the MCP server.')
+    mcp.add_tool(
+        FunctionTool.from_function(
+            docs_query,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
 
     LOG.info('Doc tools initialized.')
 

--- a/src/keboola_mcp_server/tools/doc.py
+++ b/src/keboola_mcp_server/tools/doc.py
@@ -11,6 +11,8 @@ from keboola_mcp_server.errors import tool_errors
 
 LOG = logging.getLogger(__name__)
 
+DOC_TOOLS_TAG = 'docs'
+
 
 def add_doc_tools(mcp: FastMCP) -> None:
     """Add tools to the MCP server."""
@@ -19,6 +21,7 @@ def add_doc_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             docs_query,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={DOC_TOOLS_TAG},
         )
     )
 

--- a/src/keboola_mcp_server/tools/flow/tools.py
+++ b/src/keboola_mcp_server/tools/flow/tools.py
@@ -52,25 +52,10 @@ FLOW_TOOLS_TAG = 'flows'
 
 def add_flow_tools(mcp: FastMCP) -> None:
     """Add flow tools to the MCP server."""
-    mcp.add_tool(
-        FunctionTool.from_function(
-            create_flow,
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=False,
-                idempotentHint=False,
-            ),
-            tags={FLOW_TOOLS_TAG},
-        )
-    )
+    mcp.add_tool(FunctionTool.from_function(create_flow, tags={FLOW_TOOLS_TAG}))
     mcp.add_tool(
         FunctionTool.from_function(
             create_conditional_flow,
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=False,
-                idempotentHint=False,
-            ),
             tags={FLOW_TOOLS_TAG},
         )
     )
@@ -78,39 +63,35 @@ def add_flow_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             list_flows,
             serializer=exclude_none_serializer,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             update_flow,
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=True,
-                idempotentHint=True,
-            ),
+            annotations=ToolAnnotations(destructiveHint=True),
             tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_flow,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_flow_examples,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_flow_schema,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={FLOW_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/flow/tools.py
+++ b/src/keboola_mcp_server/tools/flow/tools.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, Sequence, cast
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from keboola_mcp_server import resources
@@ -49,13 +50,61 @@ LOG = logging.getLogger(__name__)
 
 def add_flow_tools(mcp: FastMCP) -> None:
     """Add flow tools to the MCP server."""
-    mcp.add_tool(FunctionTool.from_function(create_flow))
-    mcp.add_tool(FunctionTool.from_function(create_conditional_flow))
-    mcp.add_tool(FunctionTool.from_function(list_flows, serializer=exclude_none_serializer))
-    mcp.add_tool(FunctionTool.from_function(update_flow))
-    mcp.add_tool(FunctionTool.from_function(get_flow))
-    mcp.add_tool(FunctionTool.from_function(get_flow_examples))
-    mcp.add_tool(FunctionTool.from_function(get_flow_schema))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_flow,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+            ),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_conditional_flow,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+            ),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            list_flows,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            update_flow,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+            ),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_flow,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_flow_examples,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_flow_schema,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
 
     LOG.info('Flow tools initialized.')
 

--- a/src/keboola_mcp_server/tools/flow/tools.py
+++ b/src/keboola_mcp_server/tools/flow/tools.py
@@ -47,6 +47,8 @@ from keboola_mcp_server.tools.validation import validate_flow_configuration_agai
 
 LOG = logging.getLogger(__name__)
 
+FLOW_TOOLS_TAG = 'flows'
+
 
 def add_flow_tools(mcp: FastMCP) -> None:
     """Add flow tools to the MCP server."""
@@ -58,6 +60,7 @@ def add_flow_tools(mcp: FastMCP) -> None:
                 destructiveHint=False,
                 idempotentHint=False,
             ),
+            tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -68,6 +71,7 @@ def add_flow_tools(mcp: FastMCP) -> None:
                 destructiveHint=False,
                 idempotentHint=False,
             ),
+            tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -75,6 +79,7 @@ def add_flow_tools(mcp: FastMCP) -> None:
             list_flows,
             serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -85,24 +90,28 @@ def add_flow_tools(mcp: FastMCP) -> None:
                 destructiveHint=True,
                 idempotentHint=True,
             ),
+            tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_flow,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_flow_examples,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={FLOW_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_flow_schema,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={FLOW_TOOLS_TAG},
         )
     )
 

--- a/src/keboola_mcp_server/tools/flow/tools.py
+++ b/src/keboola_mcp_server/tools/flow/tools.py
@@ -52,11 +52,18 @@ FLOW_TOOLS_TAG = 'flows'
 
 def add_flow_tools(mcp: FastMCP) -> None:
     """Add flow tools to the MCP server."""
-    mcp.add_tool(FunctionTool.from_function(create_flow, tags={FLOW_TOOLS_TAG}))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_flow,
+            tags={FLOW_TOOLS_TAG},
+            annotations=ToolAnnotations(destructiveHint=False),
+        )
+    )
     mcp.add_tool(
         FunctionTool.from_function(
             create_conditional_flow,
             tags={FLOW_TOOLS_TAG},
+            annotations=ToolAnnotations(destructiveHint=False),
         )
     )
     mcp.add_tool(

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -25,7 +25,7 @@ def add_job_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_job,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={JOB_TOOLS_TAG},
         )
     )
@@ -33,18 +33,14 @@ def add_job_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             list_jobs,
             serializer=exclude_none_serializer,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={JOB_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             run_job,
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=False,
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(destructiveHint=True),
             tags={JOB_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -14,6 +14,8 @@ from keboola_mcp_server.mcp import KeboolaMcpServer, exclude_none_serializer
 
 LOG = logging.getLogger(__name__)
 
+JOB_TOOLS_TAG = 'jobs'
+
 
 # Add jobs tools to MCP SERVER ##################################
 
@@ -24,6 +26,7 @@ def add_job_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             get_job,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={JOB_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -31,6 +34,7 @@ def add_job_tools(mcp: KeboolaMcpServer) -> None:
             list_jobs,
             serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={JOB_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -41,6 +45,7 @@ def add_job_tools(mcp: KeboolaMcpServer) -> None:
                 destructiveHint=False,
                 idempotentHint=False,
             ),
+            tags={JOB_TOOLS_TAG},
         )
     )
 

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, Literal, Optional, Union
 
 from fastmcp import Context
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from keboola_mcp_server.client import KeboolaClient
@@ -19,9 +20,29 @@ LOG = logging.getLogger(__name__)
 
 def add_job_tools(mcp: KeboolaMcpServer) -> None:
     """Add job tools to the MCP server."""
-    mcp.add_tool(FunctionTool.from_function(get_job))
-    mcp.add_tool(FunctionTool.from_function(list_jobs, serializer=exclude_none_serializer))
-    mcp.add_tool(FunctionTool.from_function(run_job))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_job,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            list_jobs,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            run_job,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+            ),
+        )
+    )
 
     LOG.info('Job tools added to the MCP server.')
 

--- a/src/keboola_mcp_server/tools/oauth.py
+++ b/src/keboola_mcp_server/tools/oauth.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode, urlunsplit
 
 from fastmcp import Context
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from keboola_mcp_server.client import KeboolaClient
@@ -19,7 +20,16 @@ TOOL_GROUP_NAME = 'OAUTH'
 
 def add_oauth_tools(mcp: KeboolaMcpServer) -> None:
     """Adds OAuth tools to the MCP server."""
-    mcp.add_tool(FunctionTool.from_function(create_oauth_url))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_oauth_url,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+            ),
+        )
+    )
     LOG.info('OAuth tools added to the MCP server.')
 
 

--- a/src/keboola_mcp_server/tools/oauth.py
+++ b/src/keboola_mcp_server/tools/oauth.py
@@ -15,7 +15,7 @@ from keboola_mcp_server.mcp import KeboolaMcpServer
 
 LOG = logging.getLogger(__name__)
 
-TOOL_GROUP_NAME = 'OAUTH'
+OAUTH_TOOLS_TAG = 'oauth'
 
 
 def add_oauth_tools(mcp: KeboolaMcpServer) -> None:
@@ -28,6 +28,7 @@ def add_oauth_tools(mcp: KeboolaMcpServer) -> None:
                 destructiveHint=False,
                 idempotentHint=False,
             ),
+            tags={OAUTH_TOOLS_TAG},
         )
     )
     LOG.info('OAuth tools added to the MCP server.')

--- a/src/keboola_mcp_server/tools/oauth.py
+++ b/src/keboola_mcp_server/tools/oauth.py
@@ -23,11 +23,7 @@ def add_oauth_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             create_oauth_url,
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=False,
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(destructiveHint=True),
             tags={OAUTH_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -3,6 +3,7 @@ from typing import Annotated, cast
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from keboola_mcp_server.client import JsonDict, KeboolaClient
@@ -16,11 +17,14 @@ LOG = logging.getLogger(__name__)
 
 def add_project_tools(mcp: FastMCP) -> None:
     """Add project tools to the MCP server."""
-    project_tools = [get_project_info]
 
-    for tool in project_tools:
-        LOG.info(f'Adding tool {tool.__name__} to the MCP server.')
-        mcp.add_tool(FunctionTool.from_function(tool))
+    LOG.info(f'Adding tool {get_project_info.__name__} to the MCP server.')
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_project_info,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
 
     LOG.info('Project tools initialized.')
 

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -24,7 +24,7 @@ def add_project_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_project_info,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={PROJECT_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -14,6 +14,8 @@ from keboola_mcp_server.workspace import WorkspaceManager
 
 LOG = logging.getLogger(__name__)
 
+PROJECT_TOOLS_TAG = 'project'
+
 
 def add_project_tools(mcp: FastMCP) -> None:
     """Add project tools to the MCP server."""
@@ -23,6 +25,7 @@ def add_project_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             get_project_info,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={PROJECT_TOOLS_TAG},
         )
     )
 

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -16,6 +16,7 @@ LOG = logging.getLogger(__name__)
 SEARCH_TOOL_NAME = 'search'
 MAX_GLOBAL_SEARCH_LIMIT = 100
 DEFAULT_GLOBAL_SEARCH_LIMIT = 50
+SEARCH_TOOLS_TAG = 'search'
 
 
 def add_search_tools(mcp: FastMCP) -> None:
@@ -25,6 +26,7 @@ def add_search_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             find_component_id,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={SEARCH_TOOLS_TAG},
         )
     )
     LOG.info(f'Adding tool {search.__name__} to the MCP server.')
@@ -33,6 +35,7 @@ def add_search_tools(mcp: FastMCP) -> None:
             search,
             name=SEARCH_TOOL_NAME,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={SEARCH_TOOLS_TAG},
         )
     )
 

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -25,7 +25,7 @@ def add_search_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             find_component_id,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={SEARCH_TOOLS_TAG},
         )
     )
@@ -34,7 +34,7 @@ def add_search_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             search,
             name=SEARCH_TOOL_NAME,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={SEARCH_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Sequence
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from keboola_mcp_server.client import GlobalSearchResponse, ItemType, KeboolaClient, SuggestedComponent
@@ -19,13 +20,21 @@ DEFAULT_GLOBAL_SEARCH_LIMIT = 50
 
 def add_search_tools(mcp: FastMCP) -> None:
     """Add tools to the MCP server."""
-    search_tools = [
-        (find_component_id, None),
-        (search, SEARCH_TOOL_NAME),
-    ]
-    for tool_fn, tool_name in search_tools:
-        LOG.info(f'Adding tool {tool_fn.__name__} to the MCP server.')
-        mcp.add_tool(FunctionTool.from_function(tool_fn, name=tool_name))
+    LOG.info(f'Adding tool {find_component_id.__name__} to the MCP server.')
+    mcp.add_tool(
+        FunctionTool.from_function(
+            find_component_id,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    LOG.info(f'Adding tool {search.__name__} to the MCP server.')
+    mcp.add_tool(
+        FunctionTool.from_function(
+            search,
+            name=SEARCH_TOOL_NAME,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
 
     LOG.info('Search tools initialized.')
 

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -13,6 +13,8 @@ from keboola_mcp_server.workspace import SqlSelectData, WorkspaceManager
 
 LOG = logging.getLogger(__name__)
 
+SQL_TOOLS_TAG = 'sql'
+
 
 class QueryDataOutput(BaseModel):
     """Output model for SQL query results."""
@@ -27,12 +29,14 @@ def add_sql_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             query_data,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={SQL_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_sql_dialect,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={SQL_TOOLS_TAG},
         )
     )
     LOG.info('SQL tools added to the MCP server.')

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from keboola_mcp_server.errors import tool_errors
@@ -22,8 +23,18 @@ class QueryDataOutput(BaseModel):
 
 def add_sql_tools(mcp: FastMCP) -> None:
     """Add tools to the MCP server."""
-    mcp.add_tool(FunctionTool.from_function(query_data))
-    mcp.add_tool(FunctionTool.from_function(get_sql_dialect))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            query_data,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_sql_dialect,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
     LOG.info('SQL tools added to the MCP server.')
 
 

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -28,14 +28,14 @@ def add_sql_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             query_data,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={SQL_TOOLS_TAG},
         )
     )
     mcp.add_tool(
         FunctionTool.from_function(
             get_sql_dialect,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={SQL_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/storage.py
+++ b/src/keboola_mcp_server/tools/storage.py
@@ -26,7 +26,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_bucket,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={STORAGE_TOOLS_TAG},
         )
     )
@@ -34,7 +34,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             list_buckets,
             serializer=exclude_none_serializer,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={STORAGE_TOOLS_TAG},
         )
     )
@@ -42,7 +42,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             get_table,
             serializer=exclude_none_serializer,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={STORAGE_TOOLS_TAG},
         )
     )
@@ -50,7 +50,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             list_tables,
             serializer=exclude_none_serializer,
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
             tags={STORAGE_TOOLS_TAG},
         )
     )
@@ -58,11 +58,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             update_description,
             serializer=exclude_none_serializer,
-            annotations=ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=True,
-                idempotentHint=True,
-            ),
+            annotations=ToolAnnotations(destructiveHint=True),
             tags={STORAGE_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/storage.py
+++ b/src/keboola_mcp_server/tools/storage.py
@@ -18,7 +18,7 @@ from keboola_mcp_server.workspace import WorkspaceManager
 
 LOG = logging.getLogger(__name__)
 
-TOOL_GROUP_NAME = 'STORAGE'
+STORAGE_TOOLS_TAG = 'storage'
 
 
 def add_storage_tools(mcp: KeboolaMcpServer) -> None:
@@ -27,6 +27,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
         FunctionTool.from_function(
             get_bucket,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={STORAGE_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -34,6 +35,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
             list_buckets,
             serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={STORAGE_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -41,6 +43,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
             get_table,
             serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={STORAGE_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -48,6 +51,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
             list_tables,
             serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            tags={STORAGE_TOOLS_TAG},
         )
     )
     mcp.add_tool(
@@ -59,6 +63,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
                 destructiveHint=True,
                 idempotentHint=True,
             ),
+            tags={STORAGE_TOOLS_TAG},
         )
     )
 

--- a/src/keboola_mcp_server/tools/storage.py
+++ b/src/keboola_mcp_server/tools/storage.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Literal, Optional, cast
 
 from fastmcp import Context
 from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
 from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 from keboola_mcp_server.client import JsonDict, KeboolaClient, get_metadata_property
@@ -22,11 +23,44 @@ TOOL_GROUP_NAME = 'STORAGE'
 
 def add_storage_tools(mcp: KeboolaMcpServer) -> None:
     """Adds tools to the MCP server."""
-    mcp.add_tool(FunctionTool.from_function(get_bucket))
-    mcp.add_tool(FunctionTool.from_function(list_buckets, serializer=exclude_none_serializer))
-    mcp.add_tool(FunctionTool.from_function(get_table, serializer=exclude_none_serializer))
-    mcp.add_tool(FunctionTool.from_function(list_tables, serializer=exclude_none_serializer))
-    mcp.add_tool(FunctionTool.from_function(update_description, serializer=exclude_none_serializer))
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_bucket,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            list_buckets,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            get_table,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            list_tables,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            update_description,
+            serializer=exclude_none_serializer,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+            ),
+        )
+    )
 
     LOG.info('Storage tools added to the MCP server.')
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -265,7 +265,7 @@ async def test_tool_annotations_and_tags():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ('tool_name', 'expected_readonly', 'expected_destructive', 'expected_idempotent', 'tags'),
-    (
+    [
         # components
         ('get_component', True, None, None, {COMPONENT_TOOLS_TAG}),
         ('get_config', True, None, None, {COMPONENT_TOOLS_TAG}),
@@ -306,7 +306,7 @@ async def test_tool_annotations_and_tags():
         ('find_component_id', True, None, None, {SEARCH_TOOLS_TAG}),
         # oauth
         ('create_oauth_url', None, True, None, {OAUTH_TOOLS_TAG}),
-    ),
+    ],
 )
 async def test_tool_annotations_tags_values(
     tool_name: str,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -256,8 +256,11 @@ async def test_tool_annotations_and_tags():
             if tool.annotations.readOnlyHint:
                 assert tool.annotations.destructiveHint is None, f'{tool.name} has destructiveHint'
                 assert tool.annotations.idempotentHint is None, f'{tool.name} has idempotentHint'
-            if tool.annotations.destructiveHint:
+            elif tool.annotations.destructiveHint:
                 assert tool.annotations.readOnlyHint is None, f'{tool.name} has readOnlyHint'
+            elif tool.annotations.destructiveHint is False:
+                assert tool.annotations.destructiveHint is not None, f'{tool.name} does not have destructiveHint'
+                assert tool.annotations.idempotentHint is None, f'{tool.name} has idempotentHint'
             if tool.annotations.idempotentHint:
                 assert tool.annotations.readOnlyHint is None, f'{tool.name} has readOnlyHint'
 
@@ -271,12 +274,12 @@ async def test_tool_annotations_and_tags():
         ('get_config', True, None, None, {COMPONENT_TOOLS_TAG}),
         ('list_configs', True, None, None, {COMPONENT_TOOLS_TAG}),
         ('get_config_examples', True, None, None, {COMPONENT_TOOLS_TAG}),
-        ('create_config', None, None, None, {COMPONENT_TOOLS_TAG}),
+        ('create_config', None, False, None, {COMPONENT_TOOLS_TAG}),
         ('update_config', None, True, None, {COMPONENT_TOOLS_TAG}),
-        ('add_config_row', None, None, None, {COMPONENT_TOOLS_TAG}),
+        ('add_config_row', None, False, None, {COMPONENT_TOOLS_TAG}),
         ('update_config_row', None, True, None, {COMPONENT_TOOLS_TAG}),
         ('list_transformations', True, None, None, {COMPONENT_TOOLS_TAG}),
-        ('create_sql_transformation', None, None, None, {COMPONENT_TOOLS_TAG}),
+        ('create_sql_transformation', None, False, None, {COMPONENT_TOOLS_TAG}),
         ('update_sql_transformation', None, True, None, {COMPONENT_TOOLS_TAG}),
         # storage
         ('get_bucket', True, None, None, {STORAGE_TOOLS_TAG}),
@@ -285,8 +288,8 @@ async def test_tool_annotations_and_tags():
         ('list_tables', True, None, None, {STORAGE_TOOLS_TAG}),
         ('update_description', None, True, None, {STORAGE_TOOLS_TAG}),
         # flows
-        ('create_flow', None, None, None, {FLOW_TOOLS_TAG}),
-        ('create_conditional_flow', None, None, None, {FLOW_TOOLS_TAG}),
+        ('create_flow', None, False, None, {FLOW_TOOLS_TAG}),
+        ('create_conditional_flow', None, False, None, {FLOW_TOOLS_TAG}),
         ('list_flows', True, None, None, {FLOW_TOOLS_TAG}),
         ('update_flow', None, True, None, {FLOW_TOOLS_TAG}),
         ('get_flow', True, None, None, {FLOW_TOOLS_TAG}),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -252,80 +252,87 @@ async def test_tool_annotations_and_tags():
     tools = await server.get_tools()
     for tool in tools.values():
         assert tool.tags is not None, f'{tool.name} has no tags'
-        assert tool.annotations is not None, f'{tool.name} has no annotations'
-        assert tool.annotations.readOnlyHint is not None, f'{tool.name} has no readOnlyHint'
-        assert tool.annotations.destructiveHint is not None, f'{tool.name} has no destructiveHint'
-        if tool.annotations.readOnlyHint is False:  # if the tool is not read-only, it must have an idempotentHint value
-            assert tool.annotations.idempotentHint is not None, f'{tool.name} has no idempotentHint'
+        if tool.annotations is not None:
+            if tool.annotations.readOnlyHint:
+                assert tool.annotations.destructiveHint is None, f'{tool.name} has destructiveHint'
+                assert tool.annotations.idempotentHint is None, f'{tool.name} has idempotentHint'
+            if tool.annotations.destructiveHint:
+                assert tool.annotations.readOnlyHint is None, f'{tool.name} has readOnlyHint'
+            if tool.annotations.idempotentHint:
+                assert tool.annotations.readOnlyHint is None, f'{tool.name} has readOnlyHint'
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    'tool_info',
-    [
-        # (tool_name, expected_readonly, expected_destructive, expected_idempotent, tags)
-        (
-            # components
-            ('get_component', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('get_config', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('list_configs', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('get_config_examples', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('create_config', False, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('update_config', False, True, True, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('add_config_row', False, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('update_config_row', False, True, True, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('list_transformations', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('create_sql_transformation', False, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
-            ('update_sql_transformation', False, True, True, {f'{COMPONENT_TOOLS_TAG}'}),
-            # storage
-            ('get_bucket', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
-            ('list_buckets', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
-            ('get_table', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
-            ('list_tables', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
-            ('update_description', False, True, True, {f'{STORAGE_TOOLS_TAG}'}),
-            # flows
-            ('create_flow', False, False, False, {f'{FLOW_TOOLS_TAG}'}),
-            ('create_conditional_flow', False, False, False, {f'{FLOW_TOOLS_TAG}'}),
-            ('list_flows', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
-            ('update_flow', False, True, True, {f'{FLOW_TOOLS_TAG}'}),
-            ('get_flow', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
-            ('get_flow_examples', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
-            ('get_flow_schema', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
-            # sql
-            ('query_data', True, False, False, {f'{SQL_TOOLS_TAG}'}),
-            ('get_sql_dialect', True, False, False, {f'{SQL_TOOLS_TAG}'}),
-            # jobs
-            ('get_job', True, False, False, {f'{JOB_TOOLS_TAG}'}),
-            ('list_jobs', True, False, False, {f'{JOB_TOOLS_TAG}'}),
-            ('run_job', False, False, False, {f'{JOB_TOOLS_TAG}'}),
-            # project/doc/search
-            ('get_project_info', True, False, False, {f'{PROJECT_TOOLS_TAG}'}),
-            ('docs_query', True, False, False, {f'{DOC_TOOLS_TAG}'}),
-            ('search', True, False, False, {f'{SEARCH_TOOLS_TAG}'}),
-            ('find_component_id', True, False, False, {f'{SEARCH_TOOLS_TAG}'}),
-            # oauth
-            ('create_oauth_url', False, False, False, {f'{OAUTH_TOOLS_TAG}'}),
-        ),
-    ],
+    ('tool_name', 'expected_readonly', 'expected_destructive', 'expected_idempotent', 'tags'),
+    (
+        # components
+        ('get_component', True, None, None, {COMPONENT_TOOLS_TAG}),
+        ('get_config', True, None, None, {COMPONENT_TOOLS_TAG}),
+        ('list_configs', True, None, None, {COMPONENT_TOOLS_TAG}),
+        ('get_config_examples', True, None, None, {COMPONENT_TOOLS_TAG}),
+        ('create_config', None, None, None, {COMPONENT_TOOLS_TAG}),
+        ('update_config', None, True, None, {COMPONENT_TOOLS_TAG}),
+        ('add_config_row', None, None, None, {COMPONENT_TOOLS_TAG}),
+        ('update_config_row', None, True, None, {COMPONENT_TOOLS_TAG}),
+        ('list_transformations', True, None, None, {COMPONENT_TOOLS_TAG}),
+        ('create_sql_transformation', None, None, None, {COMPONENT_TOOLS_TAG}),
+        ('update_sql_transformation', None, True, None, {COMPONENT_TOOLS_TAG}),
+        # storage
+        ('get_bucket', True, None, None, {STORAGE_TOOLS_TAG}),
+        ('list_buckets', True, None, None, {STORAGE_TOOLS_TAG}),
+        ('get_table', True, None, None, {STORAGE_TOOLS_TAG}),
+        ('list_tables', True, None, None, {STORAGE_TOOLS_TAG}),
+        ('update_description', None, True, None, {STORAGE_TOOLS_TAG}),
+        # flows
+        ('create_flow', None, None, None, {FLOW_TOOLS_TAG}),
+        ('create_conditional_flow', None, None, None, {FLOW_TOOLS_TAG}),
+        ('list_flows', True, None, None, {FLOW_TOOLS_TAG}),
+        ('update_flow', None, True, None, {FLOW_TOOLS_TAG}),
+        ('get_flow', True, None, None, {FLOW_TOOLS_TAG}),
+        ('get_flow_examples', True, None, None, {FLOW_TOOLS_TAG}),
+        ('get_flow_schema', True, None, None, {FLOW_TOOLS_TAG}),
+        # sql
+        ('query_data', True, None, None, {SQL_TOOLS_TAG}),
+        ('get_sql_dialect', True, None, None, {SQL_TOOLS_TAG}),
+        # jobs
+        ('get_job', True, None, None, {JOB_TOOLS_TAG}),
+        ('list_jobs', True, None, None, {JOB_TOOLS_TAG}),
+        ('run_job', None, True, None, {JOB_TOOLS_TAG}),
+        # project/doc/search
+        ('get_project_info', True, None, None, {PROJECT_TOOLS_TAG}),
+        ('docs_query', True, None, None, {DOC_TOOLS_TAG}),
+        ('search', True, None, None, {SEARCH_TOOLS_TAG}),
+        ('find_component_id', True, None, None, {SEARCH_TOOLS_TAG}),
+        # oauth
+        ('create_oauth_url', None, True, None, {OAUTH_TOOLS_TAG}),
+    ),
 )
-async def test_tool_annotations_tags_values(tool_info: list[tuple[str, bool, bool, bool, set[str]]]) -> None:
+async def test_tool_annotations_tags_values(
+    tool_name: str,
+    expected_readonly: bool | None,
+    expected_destructive: bool | None,
+    expected_idempotent: bool | None,
+    tags: set[str],
+) -> None:
     """
     Test that the tool annotations are having the expected values.
     """
     server = create_server(Config())
     tools = await server.get_tools()
 
-    def normalize(value: Any) -> bool:
-        return False if value is None else bool(value)
+    # check tool registration
+    assert tool_name in tools, f'Missing tool registered: {tool_name}'
 
-    for tool_name, expected_readonly, expected_destructive, expected_idempotent, tags in tool_info:
-        assert tool_name in tools, f'Missing tool registered: {tool_name}'
-        tool = tools[tool_name]
+    # check annotations
+    tool = tools[tool_name]
+    if all(exp_val is None for exp_val in (expected_readonly, expected_destructive, expected_idempotent)):
+        assert tool.annotations is None, f'{tool_name} has annotations'
+    else:
         assert tool.annotations is not None, f'{tool_name} has no annotations'
-        assert normalize(tool.annotations.readOnlyHint) is expected_readonly, f'{tool_name}.readOnlyHint mismatch'
-        assert (
-            normalize(tool.annotations.destructiveHint) is expected_destructive
-        ), f'{tool_name}.destructiveHint mismatch'
-        assert normalize(tool.annotations.idempotentHint) is expected_idempotent, f'{tool_name}.idempotentHint mismatch'
+        assert tool.annotations.readOnlyHint is expected_readonly, f'{tool_name}.readOnlyHint mismatch'
+        assert tool.annotations.destructiveHint is expected_destructive, f'{tool_name}.destructiveHint mismatch'
+        assert tool.annotations.idempotentHint is expected_idempotent, f'{tool_name}.idempotentHint mismatch'
 
-        assert tool.tags == tags, f'{tool_name} tags mismatch'
+    # check tags
+    assert tool.tags == tags, f'{tool_name} tags mismatch'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -263,7 +263,6 @@ async def test_tool_annotations_and_tags():
             elif tool.annotations.destructiveHint:
                 assert tool.annotations.readOnlyHint is None, f'{tool.name} has readOnlyHint'
             elif tool.annotations.destructiveHint is False:
-                assert tool.annotations.destructiveHint is not None, f'{tool.name} does not have destructiveHint'
                 assert tool.annotations.idempotentHint is None, f'{tool.name} has idempotentHint'
             if tool.annotations.idempotentHint:
                 assert tool.annotations.readOnlyHint is None, f'{tool.name} has readOnlyHint'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,6 +11,15 @@ from keboola_mcp_server.client import KeboolaClient
 from keboola_mcp_server.config import Config
 from keboola_mcp_server.mcp import ServerState
 from keboola_mcp_server.server import create_server
+from keboola_mcp_server.tools.components.tools import COMPONENT_TOOLS_TAG
+from keboola_mcp_server.tools.doc import DOC_TOOLS_TAG
+from keboola_mcp_server.tools.flow.tools import FLOW_TOOLS_TAG
+from keboola_mcp_server.tools.jobs import JOB_TOOLS_TAG
+from keboola_mcp_server.tools.oauth import OAUTH_TOOLS_TAG
+from keboola_mcp_server.tools.project import PROJECT_TOOLS_TAG
+from keboola_mcp_server.tools.search import SEARCH_TOOLS_TAG
+from keboola_mcp_server.tools.sql import SQL_TOOLS_TAG
+from keboola_mcp_server.tools.storage import STORAGE_TOOLS_TAG
 from keboola_mcp_server.workspace import WorkspaceManager
 
 
@@ -235,13 +244,14 @@ async def test_keboola_injection_and_lifespan(
 
 
 @pytest.mark.asyncio
-async def test_tool_annotations():
+async def test_tool_annotations_and_tags():
     """
     Test that the tool annotations are properly set.
     """
     server = create_server(Config())
     tools = await server.get_tools()
     for tool in tools.values():
+        assert tool.tags is not None, f'{tool.name} has no tags'
         assert tool.annotations is not None, f'{tool.name} has no annotations'
         assert tool.annotations.readOnlyHint is not None, f'{tool.name} has no readOnlyHint'
         assert tool.annotations.destructiveHint is not None, f'{tool.name} has no destructiveHint'
@@ -253,52 +263,52 @@ async def test_tool_annotations():
 @pytest.mark.parametrize(
     'tool_info',
     [
-        # (tool_name, expected_readonly, expected_destructive, expected_idempotent)
+        # (tool_name, expected_readonly, expected_destructive, expected_idempotent, tags)
         (
             # components
-            ('get_component', True, False, False),
-            ('get_config', True, False, False),
-            ('list_configs', True, False, False),
-            ('get_config_examples', True, False, False),
-            ('create_config', False, False, False),
-            ('update_config', False, True, True),
-            ('add_config_row', False, False, False),
-            ('update_config_row', False, True, True),
-            ('list_transformations', True, False, False),
-            ('create_sql_transformation', False, False, False),
-            ('update_sql_transformation', False, True, True),
+            ('get_component', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('get_config', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('list_configs', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('get_config_examples', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('create_config', False, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('update_config', False, True, True, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('add_config_row', False, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('update_config_row', False, True, True, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('list_transformations', True, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('create_sql_transformation', False, False, False, {f'{COMPONENT_TOOLS_TAG}'}),
+            ('update_sql_transformation', False, True, True, {f'{COMPONENT_TOOLS_TAG}'}),
             # storage
-            ('get_bucket', True, False, False),
-            ('list_buckets', True, False, False),
-            ('get_table', True, False, False),
-            ('list_tables', True, False, False),
-            ('update_description', False, True, True),
+            ('get_bucket', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
+            ('list_buckets', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
+            ('get_table', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
+            ('list_tables', True, False, False, {f'{STORAGE_TOOLS_TAG}'}),
+            ('update_description', False, True, True, {f'{STORAGE_TOOLS_TAG}'}),
             # flows
-            ('create_flow', False, False, False),
-            ('create_conditional_flow', False, False, False),
-            ('list_flows', True, False, False),
-            ('update_flow', False, True, True),
-            ('get_flow', True, False, False),
-            ('get_flow_examples', True, False, False),
-            ('get_flow_schema', True, False, False),
+            ('create_flow', False, False, False, {f'{FLOW_TOOLS_TAG}'}),
+            ('create_conditional_flow', False, False, False, {f'{FLOW_TOOLS_TAG}'}),
+            ('list_flows', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
+            ('update_flow', False, True, True, {f'{FLOW_TOOLS_TAG}'}),
+            ('get_flow', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
+            ('get_flow_examples', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
+            ('get_flow_schema', True, False, False, {f'{FLOW_TOOLS_TAG}'}),
             # sql
-            ('query_data', True, False, False),
-            ('get_sql_dialect', True, False, False),
+            ('query_data', True, False, False, {f'{SQL_TOOLS_TAG}'}),
+            ('get_sql_dialect', True, False, False, {f'{SQL_TOOLS_TAG}'}),
             # jobs
-            ('get_job', True, False, False),
-            ('list_jobs', True, False, False),
-            ('run_job', False, False, False),
+            ('get_job', True, False, False, {f'{JOB_TOOLS_TAG}'}),
+            ('list_jobs', True, False, False, {f'{JOB_TOOLS_TAG}'}),
+            ('run_job', False, False, False, {f'{JOB_TOOLS_TAG}'}),
             # project/doc/search
-            ('get_project_info', True, False, False),
-            ('docs_query', True, False, False),
-            ('search', True, False, False),
-            ('find_component_id', True, False, False),
+            ('get_project_info', True, False, False, {f'{PROJECT_TOOLS_TAG}'}),
+            ('docs_query', True, False, False, {f'{DOC_TOOLS_TAG}'}),
+            ('search', True, False, False, {f'{SEARCH_TOOLS_TAG}'}),
+            ('find_component_id', True, False, False, {f'{SEARCH_TOOLS_TAG}'}),
             # oauth
-            ('create_oauth_url', False, False, False),
+            ('create_oauth_url', False, False, False, {f'{OAUTH_TOOLS_TAG}'}),
         ),
     ],
 )
-async def test_tool_annotations_values(tool_info: list[tuple[str, bool, bool, bool]]) -> None:
+async def test_tool_annotations_tags_values(tool_info: list[tuple[str, bool, bool, bool, set[str]]]) -> None:
     """
     Test that the tool annotations are having the expected values.
     """
@@ -308,7 +318,7 @@ async def test_tool_annotations_values(tool_info: list[tuple[str, bool, bool, bo
     def normalize(value: Any) -> bool:
         return False if value is None else bool(value)
 
-    for tool_name, expected_readonly, expected_destructive, expected_idempotent in tool_info:
+    for tool_name, expected_readonly, expected_destructive, expected_idempotent, tags in tool_info:
         assert tool_name in tools, f'Missing tool registered: {tool_name}'
         tool = tools[tool_name]
         assert tool.annotations is not None, f'{tool_name} has no annotations'
@@ -317,3 +327,5 @@ async def test_tool_annotations_values(tool_info: list[tuple[str, bool, bool, bo
             normalize(tool.annotations.destructiveHint) is expected_destructive
         ), f'{tool_name}.destructiveHint mismatch'
         assert normalize(tool.annotations.idempotentHint) is expected_idempotent, f'{tool_name}.idempotentHint mismatch'
+
+        assert tool.tags == tags, f'{tool_name} tags mismatch'


### PR DESCRIPTION
We annotate tools with flags `readonly`, `idempotent` and `destructive` regarding mcp annotations
Additionally, we tag tools with corresponding group, e.g. `components` tag is assigned to the tools accessing components, `jobs` to tools with jobs,.... We may think about additional tags to support client side filtering for certain tool groups.

- All tools were annotated and tagged.
- Tests have been added to check the expected tags and annotations
- `generate_tools_doc.py` has been modified to reflect current changes in the tools.md file

**Annotations:**
```
    readOnlyHint: bool | None = None
    """
    If true, the tool does not modify its environment.
    Default: false
    """

    destructiveHint: bool | None = None
    """
    If true, the tool may perform destructive updates to its environment.
    If false, the tool performs only additive updates.
    (This property is meaningful only when `readOnlyHint == false`)
    Default: true
    """

    idempotentHint: bool | None = None
    """
    If true, calling the tool repeatedly with the same arguments
    will have no additional effect on the its environment.
    (This property is meaningful only when `readOnlyHint == false`)
    Default: false
    """
 ```
   **Tags for tool groups:**
- jobs
- components
- flows
- storage
- project
- search
- docs
- oauth