### PR TITLE
AI-1322: disarm 'FastMCP' logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.17.1"
+version = "1.17.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -72,7 +72,11 @@ async def run_server(args: Optional[list[str]] = None) -> None:
         log_config = None
 
     if log_config:
-        logging.config.fileConfig(log_config, disable_existing_loggers=False)
+        logging.config.fileConfig(log_config, disable_existing_loggers=True)
+        # disarm the 'FastMCP' logger; there is no legitimate way to configure this in fastmcp
+        fastmcp_logger = logging.getLogger('FastMCP')
+        fastmcp_logger.handlers.clear()
+        fastmcp_logger.propagate = True
     else:
         logging.basicConfig(
             format='%(asctime)s %(name)s %(levelname)s: %(message)s',


### PR DESCRIPTION
Another try to tame the loggers in the MCP server. The change disarms the `FastMCP` logger that's set up by the `fastmcp` library. It's static and initialized from the library's code without any way to customize it. The change keeps the logger, but removes its handlers and set's it to forward messages up to the its parent logger.