### PR TITLE
Release 1.20.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For detailed setup instructions and region-specific URLs, see our [Remote Server
 - **Components**: Create, List and inspect extractors, writers, data apps, and transformation configurations
 - **SQL**: Create SQL transformations with natural language
 - **Jobs**: Run components and transformations, and retrieve job execution details
+- **Data Apps**: Create, deploy and manage Keboola Streamlit Data Apps displaying your queries over storage data.
 - **Metadata**: Search, read, and update project documentation and object metadata using natural language
 
 ## Preparations
@@ -353,6 +354,9 @@ What buckets and tables are in my Keboola project?
 | **Jobs** | `get_job` | Retrieves detailed information about a specific job |
 | | `list_jobs` | Lists jobs with optional filtering, sorting, and pagination |
 | | `run_job` | Starts a job for a component or transformation |
+| **Data Apps** | `get_data_apps` | Retrieves detailed information about a specific Data Apps or List Data Apps in the project. |
+| | `modify_data_app` | Creates or updates Data Apps |
+| | `deploy_data_app` | Deploys or supsends Streamlit Data Apps in the Keboola environment. |
 | **Documentation** | `docs_query` | Answers questions using Keboola documentation as the source |
 | **Other** | `create_oauth_url` | Generates an OAuth authorization URL for a component configuration |
 | | `search` | Searches for items in the project by name prefixes |


### PR DESCRIPTION
### Release notes  between v18.2 and 1.20.1
- New tools: modify_data_app, get_data_apps, deploy_data_app for Streamlit data apps, incl. code injection for query_data, logs tailing, and UI links.
- Client refactor: split into modular clients (storage, jobs queue, AI, data science, encryption); branch-aware `KeboolaClient`.
- Branch support: optional branch_id in config; links and global search now branch-aware; list_buckets overlays dev buckets over prod.
- Security: encryption client integrated; secrets for data apps encrypted (Fernet + Encryption Service).
- SQL: removed get_sql_dialect tool (breaking); use project info/WorkspaceManager internally.
- Server/UX: server name set to “Keboola MCP Server”; OAuth URL generation fixed to use storage_api_url.
- Docs updated (TOOLS/README); added cryptography dependency; extensive unit/integ tests for new features.

### plans for customer communication
- Announce new Data Apps tools and required permissions/DSAPI availability.
- Call out breaking removal of get_sql_dialect; advise to obtain dialect via Project Info or SDK WorkspaceManager.
- Note branch-aware behavior and changed bucket listing in dev branches.
- Mention new cryptography dependency (ensure environments install it).

### impact analysys
- Breaking: external consumers of get_sql_dialect will fail until migrated.
- Data Apps deployment is asynchronous; redeploy briefly stops apps; DSAPI listing quirks may show temporary limits.
- Secrets misconfiguration could block app startup; missing DSAPI/permissions cause tool failures.
- Branch-aware list_buckets may change visible bucket set in dev branches.
- New dependency may fail install in restricted environments.

### change type
Feature

### justification
- Enable end-to-end Data Apps lifecycle from MCP.
- Improve security (secrets encryption) and branch-awareness.
- Cleanup and correctness (OAuth URL, server naming, client layering).

### deployment plan
- Merge PRs; tag main as v1.20.1; publish package.
- a4fd520 Merge pull request #246 from keboola/ujovlado-app-user  
- 85ce01d Merge pull request #239 from keboola/AI-1349-branch-id-http-header  
- 1f9963f Merge pull request #242 from keboola/AI-1406-release  
- 9d3b87e Merge pull request #236 from keboola/AI-1343-mcp-add-support-for-data-apps-tool  
- 9265dbe Merge pull request #240 from keboola/AI-1352-remove-get-sql-dialect-tool  
- 180fe22 Merge pull request #241 from keboola/server-name-cleanup  
- 960648f Merge pull request #235 from keboola/AI-1343-mcp-add-support-for-data-apps

### rollback plan
- Revert merge/retag to previous stable (v1.18.2).
- If needed, reintroduce compatibility alias for get_sql_dialect temporarily.

### post release support plan
- Monitor logs for encryption/DSAPI errors and global search flakiness.
- Provide migration guidance for get_sql_dialect users and assist with setup for Data Apps.