### PR TITLE
Ai 1469 fix session state issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.21.0"
+version = "1.20.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.20.1"
+version = "1.21.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -161,7 +161,9 @@ class SessionStateMiddleware(fmw.Middleware):
         try:
             return await call_next(context)
         finally:
-            ctx.session.state = {}
+            # NOTE: This line is commented following a bug related to session state clearance in Claude client
+            # ctx.session.state = {}
+            pass
 
     @staticmethod
     def _create_session_state(config: Config) -> dict[str, Any]:


### PR DESCRIPTION
This PR implements a bug fix related to session state clearance issues. The session state clearing step is removed from the Session state middleware in order to mitigate the issues. This is a temporary fix and should be revised in the future. 

# Release Notes of v1.20.2
- This release fixes intermittent errors in Claude–MCP communication caused by clearing the shared session state after each tool call.  
- We removed the session state clearing step to ensure each tool call retains its state during execution, preventing concurrency issues when multiple calls are made in parallel.

# Plans for Customer Communication
- No customer communication is required unless users encounter related issues.
- If needed, a short Slack/Changelog message will be prepared to inform affected customers (Claude users) about the fix.

# Impact Analysis
- **Worst case:** If the fix introduces new issues, tool calls might retain unused session data longer than expected.
- **Known limitations:** None identified. All other MCP clients (Cursor, etc.) already work without issues.

# Change Type
BugFix

# Justification
This fix is necessary because the current session state handling causes intermittent `KeyError: 'sapi_client'` errors for Claude users when multiple parallel tool calls occur.

# Deployment Plan
- Merge PR
- Tag main branch
- Deploy to production environment

# Rollback Plan
- Revert to `v1.20.1`

# Post Release Support Plan
- Monitor Datadog logs for any recurrence of `KeyError: 'sapi_client'` errors
- Validate fix in production by running tool calls in parallel through Claude
- Be ready for a quick rollback if new issues appear
