### PR TITLE
Report tool events as keboola.mcp-server-tool

### DIFF
--- a/integtests/test_errors.py
+++ b/integtests/test_errors.py
@@ -133,7 +133,7 @@ class TestStorageEvents:
         events = await client.storage_client.get(
             endpoint='events',
             params={
-                'component': 'keboola.mcp-server.tool',
+                'component': 'keboola.mcp-server-tool',
                 'q': f'message:"MCP tool "{tool_name}" call*"',
                 'limit': 10,
             },

--- a/src/keboola_mcp_server/errors.py
+++ b/src/keboola_mcp_server/errors.py
@@ -68,8 +68,8 @@ async def _trigger_event(
         if http_rq := get_http_request_or_none():
             user_agent = http_rq.headers.get('User-Agent')
 
-    # See # https://github.com/keboola/event-schema/blob/main/schema/ext.keboola.mcp-server.tool.json
-    # for the JSON schema describing the 'keboola.mcp-server.tool' component's event params.
+    # See # https://github.com/keboola/event-schema/blob/main/schema/ext.keboola.mcp-server-tool.json
+    # for the JSON schema describing the 'keboola.mcp-server-tool' component's event params.
     event_params: dict[str, Any] = {
         'mcpServerContext': {
             'appEnv': server_state.app_version,
@@ -97,7 +97,7 @@ async def _trigger_event(
     client = KeboolaClient.from_state(ctx.session.state)
     resp = await client.storage_client.trigger_event(
         message=message,
-        component_id='keboola.mcp-server.tool',
+        component_id='keboola.mcp-server-tool',
         event_type=event_type,
         params=event_params,
         duration=execution_time,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -124,7 +124,7 @@ async def test_get_session_id(transport: str, mcp_context_client: Context, mocke
     client = KeboolaClient.from_state(mcp_context_client.session.state)
     client.storage_client.trigger_event.assert_called_once_with(
         message='MCP tool "foo" call succeeded.',
-        component_id='keboola.mcp-server.tool',
+        component_id='keboola.mcp-server-tool',
         event_type='success',
         params={
             'mcpServerContext': {


### PR DESCRIPTION
Changes:

- Report tool events as `keboola.mcp-server-tool`

---

Event schema PR: https://github.com/keboola/event-schema/pull/25

This is draft on purpose, we need to wait until alternative schema is released.