### PR TITLE
Ai 1458 optimize change description

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -69,7 +69,7 @@ potentially narrowed down by item type, limited and paginated.
 - [get_table](#get_table): Gets detailed information about a specific table including its DB identifier and column information.
 - [list_buckets](#list_buckets): Retrieves information about all buckets in the project.
 - [list_tables](#list_tables): Retrieves all tables in a specific bucket with their basic information.
-- [update_description](#update_description): Updates the description for a Keboola storage item.
+- [update_descriptions](#update_descriptions): Updates descriptions for Keboola storage items (buckets, tables, columns).
 
 ---
 
@@ -2018,74 +2018,32 @@ Retrieves all tables in a specific bucket with their basic information.
 ```
 
 ---
-<a name="update_description"></a>
-## update_description
+<a name="update_descriptions"></a>
+## update_descriptions
 **Annotations**: `destructive`
 
 **Tags**: `storage`
 
 **Description**:
 
-Updates the description for a Keboola storage item.
-
-The tool supports three item types and validates the required identifiers based on the selected type:
-
-- item_type = "bucket": requires bucket_id
-- item_type = "table": requires table_id
-- item_type = "column": requires table_id and column_name
-
-Usage examples:
-- Update a bucket: item_type="bucket", bucket_id="in.c-my-bucket",
-  description="New bucket description"
-- Update a table: item_type="table", table_id="in.c-my-bucket.my-table",
-  description="New table description"
-- Update a column: item_type="column", table_id="in.c-my-bucket.my-table",
-  column_name="my_column", description="New column description"
-
-:return: The update result containing the stored description, timestamp, success flag, and optional links.
+Updates descriptions for Keboola storage items (buckets, tables, columns).
 
 
 **Input JSON Schema**:
 ```json
 {
   "properties": {
-    "item_type": {
-      "description": "Type of the item to update. One of: bucket, table, column.",
-      "enum": [
-        "bucket",
-        "table",
-        "column"
-      ],
-      "title": "Item Type",
-      "type": "string"
-    },
-    "description": {
-      "description": "The new description to set for the specified item.",
-      "title": "Description",
-      "type": "string"
-    },
-    "bucket_id": {
-      "default": "",
-      "description": "Bucket ID. Required when item_type is \"bucket\".",
-      "title": "Bucket Id",
-      "type": "string"
-    },
-    "table_id": {
-      "default": "",
-      "description": "Table ID. Required when item_type is \"table\" or \"column\".",
-      "title": "Table Id",
-      "type": "string"
-    },
-    "column_name": {
-      "default": "",
-      "description": "Column name. Required when item_type is \"column\".",
-      "title": "Column Name",
-      "type": "string"
+    "updates": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Dictionary mapping paths to descriptions. Paths: \"bucket_id\", \"bucket_id.table_id\", \"bucket_id.table_id.column_name\"",
+      "title": "Updates",
+      "type": "object"
     }
   },
   "required": [
-    "item_type",
-    "description"
+    "updates"
   ],
   "type": "object"
 }

--- a/integtests/tools/test_storage.py
+++ b/integtests/tools/test_storage.py
@@ -12,12 +12,12 @@ from keboola_mcp_server.tools.storage import (
     ListBucketsOutput,
     ListTablesOutput,
     TableDetail,
-    UpdateDescriptionOutput,
+    UpdateDescriptionsOutput,
     get_bucket,
     get_table,
     list_buckets,
     list_tables,
-    update_description,
+    update_descriptions,
 )
 
 LOG = logging.getLogger(__name__)
@@ -89,21 +89,30 @@ async def test_list_tables(mcp_context: Context, tables: list[TableDef], buckets
 
 
 @pytest.mark.asyncio
-async def test_update_bucket_description(mcp_context: Context, buckets: list[BucketDef]):
-    """Tests that `update_bucket_description` updates the description of a bucket."""
+async def test_update_descriptions_bucket(mcp_context: Context, buckets: list[BucketDef]):
+    """Tests that `update_descriptions` updates bucket descriptions correctly."""
     bucket = buckets[0]
     md_id: str | None = None
     client = KeboolaClient.from_state(mcp_context.session.state)
     try:
-        result = await update_description(
+        result = await update_descriptions(
             ctx=mcp_context,
-            item_type='bucket',
-            description='New Description',
-            bucket_id=bucket.bucket_id,
+            updates={bucket.bucket_id: 'New Description'},
         )
-        assert isinstance(result, UpdateDescriptionOutput)
-        assert result.description == 'New Description'
 
+        assert isinstance(result, UpdateDescriptionsOutput)
+        assert result.total_processed == 1
+        assert result.successful == 1
+        assert result.failed == 0
+        assert len(result.results) == 1
+
+        bucket_result = result.results[0]
+        assert bucket_result.path == bucket.bucket_id
+        assert bucket_result.success is True
+        assert bucket_result.error is None
+        assert bucket_result.timestamp is not None
+
+        # Verify the description was actually updated
         metadata = await client.storage_client.bucket_metadata_get(bucket.bucket_id)
         metadata_entry = next((entry for entry in metadata if entry.get('key') == MetadataField.DESCRIPTION), None)
         assert metadata_entry is not None, f'Metadata entry for bucket {bucket.bucket_id} description not found'
@@ -115,25 +124,34 @@ async def test_update_bucket_description(mcp_context: Context, buckets: list[Buc
 
 
 @pytest.mark.asyncio
-async def test_update_table_description(mcp_context: Context, tables: list[TableDef]):
-    """Tests that `update_table_description` updates the description of a table."""
+async def test_update_descriptions_table(mcp_context: Context, tables: list[TableDef]):
+    """Tests that `update_descriptions` updates table descriptions correctly."""
     table = tables[0]
     md_id: str | None = None
     client = KeboolaClient.from_state(mcp_context.session.state)
     try:
-        result = await update_description(
+        result = await update_descriptions(
             ctx=mcp_context,
-            item_type='table',
-            description='New Description',
-            table_id=table.table_id,
+            updates={table.table_id: 'New Table Description'},
         )
-        assert isinstance(result, UpdateDescriptionOutput)
-        assert result.description == 'New Description'
 
+        assert isinstance(result, UpdateDescriptionsOutput)
+        assert result.total_processed == 1
+        assert result.successful == 1
+        assert result.failed == 0
+        assert len(result.results) == 1
+
+        table_result = result.results[0]
+        assert table_result.path == table.table_id
+        assert table_result.success is True
+        assert table_result.error is None
+        assert table_result.timestamp is not None
+
+        # Verify the description was actually updated
         metadata = await client.storage_client.table_metadata_get(table.table_id)
         metadata_entry = next((entry for entry in metadata if entry.get('key') == MetadataField.DESCRIPTION), None)
         assert metadata_entry is not None, f'Metadata entry for table {table.table_id} description not found'
-        assert metadata_entry['value'] == 'New Description'
+        assert metadata_entry['value'] == 'New Table Description'
         md_id = str(metadata_entry['id'])
     finally:
         if md_id is not None:
@@ -141,30 +159,81 @@ async def test_update_table_description(mcp_context: Context, tables: list[Table
 
 
 @pytest.mark.asyncio
-async def test_update_column_description(mcp_context: Context, tables: list[TableDef]):
-    """Tests that `update_column_description` updates the description of a column."""
+async def test_update_descriptions_mixed_types(mcp_context: Context, buckets: list[BucketDef], tables: list[TableDef]):
+    """Tests that `update_descriptions` can handle mixed types in a single call."""
+    bucket = buckets[0]
     table = tables[0]
 
     # Get the first column name from the table CSV file
     with table.file_path.open('r', encoding='utf-8') as f:
         reader = csv.reader(f)
         columns = next(reader)
+    column_name = columns[0]
 
-    column_name = columns[0]  # Use the first column
-    test_description = 'New Column Description'
+    md_ids: list[str] = []
+    client = KeboolaClient.from_state(mcp_context.session.state)
+    try:
+        result = await update_descriptions(
+            ctx=mcp_context,
+            updates={
+                bucket.bucket_id: 'Mixed Bucket Description',
+                table.table_id: 'Mixed Table Description',
+                f'{table.table_id}.{column_name}': 'Mixed Column Description',
+            },
+        )
 
-    # Test the update_column_description function
-    result = await update_description(
+        assert isinstance(result, UpdateDescriptionsOutput)
+        assert result.total_processed == 3
+        assert result.successful == 3
+        assert result.failed == 0
+        assert len(result.results) == 3
+
+        # Verify all results are successful
+        for item_result in result.results:
+            assert item_result.success is True
+            assert item_result.error is None
+            assert item_result.timestamp is not None
+
+        # Verify bucket description was updated
+        bucket_metadata = await client.storage_client.bucket_metadata_get(bucket.bucket_id)
+        bucket_entry = next((entry for entry in bucket_metadata if entry.get('key') == MetadataField.DESCRIPTION), None)
+        if bucket_entry:
+            assert bucket_entry['value'] == 'Mixed Bucket Description'
+            md_ids.append(('bucket', bucket.bucket_id, str(bucket_entry['id'])))
+
+        # Verify table description was updated
+        table_metadata = await client.storage_client.table_metadata_get(table.table_id)
+        table_entry = next((entry for entry in table_metadata if entry.get('key') == MetadataField.DESCRIPTION), None)
+        if table_entry:
+            assert table_entry['value'] == 'Mixed Table Description'
+            md_ids.append(('table', table.table_id, str(table_entry['id'])))
+
+    finally:
+        # Clean up metadata
+        for md_type, item_id, md_id in md_ids:
+            if md_type == 'bucket':
+                await client.storage_client.bucket_metadata_delete(bucket_id=item_id, metadata_id=md_id)
+            elif md_type == 'table':
+                await client.storage_client.table_metadata_delete(table_id=item_id, metadata_id=md_id)
+
+
+@pytest.mark.asyncio
+async def test_update_descriptions_invalid_path(mcp_context: Context):
+    """Tests that `update_descriptions` handles invalid paths gracefully."""
+    result = await update_descriptions(
         ctx=mcp_context,
-        item_type='column',
-        description=test_description,
-        table_id=table.table_id,
-        column_name=column_name,
+        updates={'invalid-path': 'This should fail'},
     )
-    LOG.error(result)
 
-    # Verify the function returns expected result
-    assert isinstance(result, UpdateDescriptionOutput)
-    assert result.description == test_description
-    assert result.success is True
-    assert result.timestamp is not None
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 1
+    assert result.successful == 0
+    assert result.failed == 1
+    assert len(result.results) == 1
+
+    error_result = result.results[0]
+    assert error_result.path == 'invalid-path'
+    assert error_result.success is False
+    assert error_result.error is not None
+    assert 'Invalid path format' in error_result.error
+    assert error_result.timestamp is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.20.4"
+version = "1.21.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -65,7 +65,7 @@ class TestServer:
             'search',
             'update_config',
             'update_config_row',
-            'update_description',
+            'update_descriptions',
             'update_flow',
             'update_sql_transformation',
         ]
@@ -291,7 +291,7 @@ async def test_tool_annotations_and_tags():
         ('list_buckets', True, None, None, {STORAGE_TOOLS_TAG}),
         ('get_table', True, None, None, {STORAGE_TOOLS_TAG}),
         ('list_tables', True, None, None, {STORAGE_TOOLS_TAG}),
-        ('update_description', None, True, None, {STORAGE_TOOLS_TAG}),
+        ('update_descriptions', None, True, None, {STORAGE_TOOLS_TAG}),
         # flows
         ('create_flow', None, False, None, {FLOW_TOOLS_TAG}),
         ('create_conditional_flow', None, False, None, {FLOW_TOOLS_TAG}),

--- a/tests/tools/test_storage.py
+++ b/tests/tools/test_storage.py
@@ -17,12 +17,13 @@ from keboola_mcp_server.tools.storage import (
     ListTablesOutput,
     TableColumnInfo,
     TableDetail,
-    UpdateDescriptionOutput,
+    UpdateDescriptionsOutput,
+    UpdateItemResult,
     get_bucket,
     get_table,
     list_buckets,
     list_tables,
-    update_description,
+    update_descriptions,
 )
 from keboola_mcp_server.workspace import TableFqn, WorkspaceManager
 
@@ -426,7 +427,7 @@ def mock_update_column_description_response() -> Mapping[str, Any]:
             }
         ],
         'columnsMetadata': {
-            'text': [
+            'column_name': [
                 {
                     'id': '1725066342',
                     'key': 'KBC.description',
@@ -983,56 +984,65 @@ async def test_list_tables(
 
 
 @pytest.mark.asyncio
-async def test_update_bucket_description_success(
+async def test_update_descriptions_bucket_success(
     mocker: MockerFixture, mcp_context_client, mock_update_bucket_description_response
 ) -> None:
-    """Test successful update of bucket description."""
-
+    """Test successful update of bucket description using update_descriptions."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.storage_client.bucket_metadata_update = mocker.AsyncMock(
         return_value=mock_update_bucket_description_response,
     )
 
-    result = await update_description(
+    result = await update_descriptions(
         ctx=mcp_context_client,
-        item_type='bucket',
-        description='Updated bucket description',
-        bucket_id='in.c-test.bucket-id',
+        updates={'in.c-test-bucket': 'Updated bucket description'},
     )
 
-    assert isinstance(result, UpdateDescriptionOutput)
-    assert result.success is True
-    assert result.description == 'Updated bucket description'
-    assert result.timestamp == parse_iso_timestamp('2024-01-01T00:00:00Z')
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 1
+    assert result.successful == 1
+    assert result.failed == 0
+    assert len(result.results) == 1
+
+    bucket_result = result.results[0]
+    assert bucket_result.path == 'in.c-test-bucket'
+    assert bucket_result.success is True
+    assert bucket_result.error is None
+    assert bucket_result.timestamp == parse_iso_timestamp('2024-01-01T00:00:00Z')
+
     keboola_client.storage_client.bucket_metadata_update.assert_called_once_with(
-        bucket_id='in.c-test.bucket-id',
+        bucket_id='in.c-test-bucket',
         metadata={MetadataField.DESCRIPTION: 'Updated bucket description'},
     )
 
 
 @pytest.mark.asyncio
-async def test_update_table_description_success(
+async def test_update_descriptions_table_success(
     mocker: MockerFixture, mcp_context_client, mock_update_table_description_response
 ) -> None:
-    """Test successful update of table description."""
-
-    # Mock the Keboola client post method
+    """Test successful update of table description using update_descriptions."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.storage_client.table_metadata_update = mocker.AsyncMock(
         return_value=mock_update_table_description_response,
     )
 
-    result = await update_description(
+    result = await update_descriptions(
         ctx=mcp_context_client,
-        item_type='table',
-        description='Updated table description',
-        table_id='in.c-test.test-table',
+        updates={'in.c-test.test-table': 'Updated table description'},
     )
 
-    assert isinstance(result, UpdateDescriptionOutput)
-    assert result.success is True
-    assert result.description == 'Updated table description'
-    assert result.timestamp == parse_iso_timestamp('2024-01-01T00:00:00Z')
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 1
+    assert result.successful == 1
+    assert result.failed == 0
+    assert len(result.results) == 1
+
+    table_result = result.results[0]
+    assert table_result.path == 'in.c-test.test-table'
+    assert table_result.success is True
+    assert table_result.error is None
+    assert table_result.timestamp == parse_iso_timestamp('2024-01-01T00:00:00Z')
+
     keboola_client.storage_client.table_metadata_update.assert_called_once_with(
         table_id='in.c-test.test-table',
         metadata={MetadataField.DESCRIPTION: 'Updated table description'},
@@ -1041,31 +1051,153 @@ async def test_update_table_description_success(
 
 
 @pytest.mark.asyncio
-async def test_update_column_description_success(
+async def test_update_descriptions_column_success(
     mocker: MockerFixture, mcp_context_client, mock_update_column_description_response
 ) -> None:
-    """Test successful update of column description."""
-
+    """Test successful update of column description using update_descriptions."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.storage_client.table_metadata_update = mocker.AsyncMock(
         return_value=mock_update_column_description_response,
     )
 
-    result = await update_description(
+    result = await update_descriptions(
         ctx=mcp_context_client,
-        item_type='column',
-        description='Updated column description',
-        table_id='in.c-test.test-table',
-        column_name='text',
+        updates={'in.c-test.test-table.column_name': 'Updated column description'},
     )
 
-    assert isinstance(result, UpdateDescriptionOutput)
-    assert result.success is True
-    assert result.description == 'Updated column description'
-    assert result.timestamp == parse_iso_timestamp('2024-01-01T00:00:00Z')
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 1
+    assert result.successful == 1
+    assert result.failed == 0
+    assert len(result.results) == 1
+
+    column_result = result.results[0]
+    assert column_result.path == 'in.c-test.test-table.column_name'
+    assert column_result.success is True
+    assert column_result.error is None
+    assert column_result.timestamp == parse_iso_timestamp('2024-01-01T00:00:00Z')
+
     keboola_client.storage_client.table_metadata_update.assert_called_once_with(
         table_id='in.c-test.test-table',
         columns_metadata={
-            'text': [{'key': MetadataField.DESCRIPTION, 'value': 'Updated column description', 'columnName': 'text'}]
+            'column_name': [
+                {'key': MetadataField.DESCRIPTION, 'value': 'Updated column description', 'columnName': 'column_name'}
+            ]
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_update_descriptions_mixed_types_success(
+    mocker: MockerFixture,
+    mcp_context_client,
+    mock_update_bucket_description_response,
+    mock_update_table_description_response,
+) -> None:
+    """Test successful update of mixed types using update_descriptions."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.storage_client.bucket_metadata_update = mocker.AsyncMock(
+        return_value=mock_update_bucket_description_response,
+    )
+    keboola_client.storage_client.table_metadata_update = mocker.AsyncMock(
+        return_value=mock_update_table_description_response,
+    )
+
+    result = await update_descriptions(
+        ctx=mcp_context_client,
+        updates={
+            'in.c-test-bucket': 'Updated bucket description',
+            'in.c-test.test-table': 'Updated table description',
+        },
+    )
+
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 2
+    assert result.successful == 2
+    assert result.failed == 0
+    assert len(result.results) == 2
+
+    # Check bucket result
+    bucket_result = next(r for r in result.results if r.path == 'in.c-test-bucket')
+    assert bucket_result.success is True
+    assert bucket_result.error is None
+
+    # Check table result
+    table_result = next(r for r in result.results if r.path == 'in.c-test.test-table')
+    assert table_result.success is True
+    assert table_result.error is None
+
+    # Verify API calls
+    keboola_client.storage_client.bucket_metadata_update.assert_called_once_with(
+        bucket_id='in.c-test-bucket',
+        metadata={MetadataField.DESCRIPTION: 'Updated bucket description'},
+    )
+    keboola_client.storage_client.table_metadata_update.assert_called_once_with(
+        table_id='in.c-test.test-table',
+        metadata={MetadataField.DESCRIPTION: 'Updated table description'},
+        columns_metadata={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_descriptions_invalid_path_error(mcp_context_client) -> None:
+    """Test that invalid paths are handled gracefully."""
+    result = await update_descriptions(
+        ctx=mcp_context_client,
+        updates={'invalid-path': 'This should fail'},
+    )
+
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 1
+    assert result.successful == 0
+    assert result.failed == 1
+    assert len(result.results) == 1
+
+    error_result = result.results[0]
+    assert error_result.path == 'invalid-path'
+    assert error_result.success is False
+    assert error_result.error is not None
+    assert 'Invalid path format' in error_result.error
+    assert error_result.timestamp is None
+
+
+@pytest.mark.asyncio
+async def test_update_descriptions_api_error_handling(mocker: MockerFixture, mcp_context_client) -> None:
+    """Test that API errors are handled gracefully."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.storage_client.bucket_metadata_update = mocker.AsyncMock()
+    keboola_client.storage_client.bucket_metadata_update.side_effect = httpx.HTTPStatusError(
+        message='API Error', request=AsyncMock(), response=httpx.Response(status_code=500)
+    )
+
+    result = await update_descriptions(
+        ctx=mcp_context_client,
+        updates={'in.c-test-bucket': 'This will fail'},
+    )
+
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 1
+    assert result.successful == 0
+    assert result.failed == 1
+    assert len(result.results) == 1
+
+    error_result = result.results[0]
+    assert error_result.path == 'in.c-test-bucket'
+    assert error_result.success is False
+    assert error_result.error is not None
+    assert error_result.timestamp is None
+
+
+@pytest.mark.asyncio
+async def test_update_descriptions_empty_updates(mcp_context_client) -> None:
+    """Test that empty updates dictionary is handled."""
+    result = await update_descriptions(
+        ctx=mcp_context_client,
+        updates={},
+    )
+
+    assert isinstance(result, UpdateDescriptionsOutput)
+    assert result.total_processed == 0
+    assert result.successful == 0
+    assert result.failed == 0
+    assert len(result.results) == 0


### PR DESCRIPTION
This PR changes the `update_description` tool to handle batch updates in a single tool call in an efficient manner.

Update of bucket, table and column in a single call example:
<img width="995" height="321" alt="image" src="https://github.com/user-attachments/assets/53b9ff77-0da3-408a-90ea-a3bcd0d28463" />

Invalid path handling:
<img width="1007" height="384" alt="image" src="https://github.com/user-attachments/assets/97c22587-f26e-42db-a2b2-78877fdba483" />

Large batch update of many columns:
<img width="1007" height="654" alt="image" src="https://github.com/user-attachments/assets/4d65cdbc-adda-4a04-870d-f83c71bcebe0" />
