### PR TITLE
Minimize tool JSON responses

### DIFF
--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -291,4 +291,4 @@ class ToolsFilteringMiddleware(fmw.Middleware):
 
 
 def exclude_none_serializer(data: BaseModel) -> str:
-    return data.model_dump_json(exclude_none=True, indent=2, by_alias=False)
+    return data.model_dump_json(exclude_none=True, by_alias=False)

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -86,6 +86,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_component,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True),
         )
@@ -93,6 +94,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_config,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True),
         )
@@ -117,6 +119,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             create_config,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=False),
         )
@@ -124,6 +127,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_config,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=True),
         )
@@ -131,6 +135,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             add_config_row,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=False),
         )
@@ -138,6 +143,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_config_row,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=True),
         )
@@ -155,6 +161,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             create_sql_transformation,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=False),
         )
@@ -162,6 +169,7 @@ def add_component_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_sql_transformation,
+            serializer=exclude_none_serializer,
             tags={COMPONENT_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=True),
         )

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -16,6 +16,7 @@ from keboola_mcp_server.errors import tool_errors
 from keboola_mcp_server.links import Link, ProjectLinksManager
 from keboola_mcp_server.tools.components.utils import set_cfg_creation_metadata, set_cfg_update_metadata
 from keboola_mcp_server.workspace import WorkspaceManager
+from keboola_mcp_server.mcp import exclude_none_serializer
 
 LOG = logging.getLogger(__name__)
 
@@ -28,6 +29,7 @@ def add_data_app_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             modify_data_app,
+            serializer=exclude_none_serializer,
             tags={DATA_APP_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=True),
         )
@@ -35,6 +37,7 @@ def add_data_app_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_data_apps,
+            serializer=exclude_none_serializer,
             tags={DATA_APP_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True),
         )
@@ -42,6 +45,7 @@ def add_data_app_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             deploy_data_app,
+            serializer=exclude_none_serializer,
             tags={DATA_APP_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=False),
         )

--- a/src/keboola_mcp_server/tools/doc.py
+++ b/src/keboola_mcp_server/tools/doc.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.errors import tool_errors
+from keboola_mcp_server.mcp import exclude_none_serializer
 
 LOG = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ def add_doc_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             docs_query,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={DOC_TOOLS_TAG},
         )

--- a/src/keboola_mcp_server/tools/flow/tools.py
+++ b/src/keboola_mcp_server/tools/flow/tools.py
@@ -55,6 +55,7 @@ def add_flow_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             create_flow,
+            serializer=exclude_none_serializer,
             tags={FLOW_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=False),
         )
@@ -62,6 +63,7 @@ def add_flow_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             create_conditional_flow,
+            serializer=exclude_none_serializer,
             tags={FLOW_TOOLS_TAG},
             annotations=ToolAnnotations(destructiveHint=False),
         )
@@ -77,6 +79,7 @@ def add_flow_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_flow,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(destructiveHint=True),
             tags={FLOW_TOOLS_TAG},
         )
@@ -84,6 +87,7 @@ def add_flow_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_flow,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={FLOW_TOOLS_TAG},
         )

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -25,6 +25,7 @@ def add_job_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_job,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={JOB_TOOLS_TAG},
         )
@@ -40,6 +41,7 @@ def add_job_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             run_job,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(destructiveHint=True),
             tags={JOB_TOOLS_TAG},
         )

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -12,6 +12,7 @@ from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.errors import tool_errors
 from keboola_mcp_server.links import Link, ProjectLinksManager
 from keboola_mcp_server.resources.prompts import get_project_system_prompt
+from keboola_mcp_server.mcp import exclude_none_serializer
 from keboola_mcp_server.workspace import WorkspaceManager
 
 LOG = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ def add_project_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_project_info,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={PROJECT_TOOLS_TAG},
         )

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -12,6 +12,7 @@ from keboola_mcp_server.clients.ai_service import SuggestedComponent
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.storage import GlobalSearchResponse, ItemType
 from keboola_mcp_server.errors import tool_errors
+from keboola_mcp_server.mcp import exclude_none_serializer
 
 LOG = logging.getLogger(__name__)
 
@@ -36,6 +37,7 @@ def add_search_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             search,
             name=SEARCH_TOOL_NAME,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={SEARCH_TOOLS_TAG},
         )

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -9,6 +9,7 @@ from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from keboola_mcp_server.errors import tool_errors
+from keboola_mcp_server.mcp import exclude_none_serializer
 from keboola_mcp_server.workspace import SqlSelectData, WorkspaceManager
 
 LOG = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ def add_sql_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             query_data,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={SQL_TOOLS_TAG},
         )

--- a/src/keboola_mcp_server/tools/storage.py
+++ b/src/keboola_mcp_server/tools/storage.py
@@ -34,6 +34,7 @@ def add_storage_tools(mcp: KeboolaMcpServer) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             get_bucket,
+            serializer=exclude_none_serializer,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={STORAGE_TOOLS_TAG},
         )


### PR DESCRIPTION
Token consumption optimisation, JSON minimising all tool responses + using the serializer in all tools to remove null values. 

Serializer standardization across tool registration:

* Applied `exclude_none_serializer` to all `FunctionTool.from_function` calls in component tools, data app tools, flow tools, job tools, project tools, search tools, SQL tools, storage tools, and doc tools, ensuring all tool outputs consistently exclude `None` values. [[1]](diffhunk://#diff-0623b957fc94ecda86dfbba37cecdf942b3a788504ca93e4d4ef74e5369812f7R89-R97) [[2]](diffhunk://#diff-0623b957fc94ecda86dfbba37cecdf942b3a788504ca93e4d4ef74e5369812f7R122-R146) [[3]](diffhunk://#diff-0623b957fc94ecda86dfbba37cecdf942b3a788504ca93e4d4ef74e5369812f7R164-R172) [[4]](diffhunk://#diff-8ffd8d8cad08e401a773798bab800c8d7857467d92d09eaf76da4897a80dcb57R32-R48) [[5]](diffhunk://#diff-44a2500bc25fd77aa93b2566fc94bee871b31b2f2f7a3ad7c96ce8a485933a8cR58-R66) [[6]](diffhunk://#diff-44a2500bc25fd77aa93b2566fc94bee871b31b2f2f7a3ad7c96ce8a485933a8cR82-R90) [[7]](diffhunk://#diff-6d353308ff4bb201a3988056de065522057c690be32b255d4a2146dd846b6877R28) [[8]](diffhunk://#diff-6d353308ff4bb201a3988056de065522057c690be32b255d4a2146dd846b6877R44) [[9]](diffhunk://#diff-8f6273e41eb80b59155b49cbf42bc9499749c9062b8a2653fcb5dbb23155a553R30) [[10]](diffhunk://#diff-ccaef20addc44253ce4da48b227531b19529f876b4b1a3319d435b0fd8a9c71fR40) [[11]](diffhunk://#diff-5c82e2c83027996e493e3d516b0667785e68721d77d9c37eb0055dfa0582450eR32) [[12]](diffhunk://#diff-ba613d396595795fb2b32921e7ce93e29bffe2d81b03589f73890be35ddf70faR37) [[13]](diffhunk://#diff-b0d7b944d501fd67d95925a93a72148ccdd1edcce0caa8c2208242832314d79eR24)
* Imported `exclude_none_serializer` in all relevant tool modules to support the new serializer usage. [[1]](diffhunk://#diff-8ffd8d8cad08e401a773798bab800c8d7857467d92d09eaf76da4897a80dcb57R19) [[2]](diffhunk://#diff-b0d7b944d501fd67d95925a93a72148ccdd1edcce0caa8c2208242832314d79eR11) [[3]](diffhunk://#diff-8f6273e41eb80b59155b49cbf42bc9499749c9062b8a2653fcb5dbb23155a553R15) [[4]](diffhunk://#diff-ccaef20addc44253ce4da48b227531b19529f876b4b1a3319d435b0fd8a9c71fR15) [[5]](diffhunk://#diff-5c82e2c83027996e493e3d516b0667785e68721d77d9c37eb0055dfa0582450eR12)

Serializer implementation update:

* Removed the `indent=2` parameter from `exclude_none_serializer`, making all tool response JSON output formatting consistent and compact.


Manual tests with just the non-minimised vs minimised tool response using Claude 4 tokenizer showed ± 25% token reduction. I ran tests with Claude against the two versions of MCP on large project and it claims it achieved even more reductions.

I'll run the same comprehensive test suite to measure the savings from your JSON minification. Let me test all the tools I evaluated before:# **Complete JSON Minification Test Results** 

Based on running the same comprehensive test suite, here are the **exact savings per tool call** from your JSON minification:

## **🏆 BIGGEST WINNERS (70%+ savings):**

### **1. `list_configs` - MASSIVE 75% reduction**
- **Before**: ~75KB (formatted with indents, newlines)
- **After**: ~19KB (minified single line)
- **Saved**: ~56KB per call
- **Token savings**: ~15,000+ fewer tokens per call

### **2. `list_transformations` - HUGE 74% reduction**  
- **Before**: ~68KB (formatted)
- **After**: ~18KB (minified)
- **Saved**: ~50KB per call
- **Token savings**: ~13,000+ fewer tokens per call

### **3. `get_data_apps` (with config IDs) - EXTREME 78% reduction**
- **Before**: ~85KB+ (includes full source code arrays)
- **After**: ~19KB (minified) 
- **Saved**: ~66KB per call
- **Token savings**: ~17,000+ fewer tokens per call

## **📊 SIGNIFICANT WINS (50-70% savings):**

### **4. `get_table` - BIG 67% reduction**
- **Before**: ~15KB (formatted with 60+ column definitions)
- **After**: ~5KB (minified)
- **Saved**: ~10KB per call
- **Token savings**: ~2,500+ fewer tokens per call

### **5. `get_config` - SOLID 62% reduction**
- **Before**: ~8KB (formatted nested parameters)
- **After**: ~3KB (minified)
- **Saved**: ~5KB per call
- **Token savings**: ~1,300+ fewer tokens per call

### **6. `get_flow` - GOOD 58% reduction**
- **Before**: ~4KB (formatted phases/tasks)
- **After**: ~1.7KB (minified)
- **Saved**: ~2.3KB per call
- **Token savings**: ~600+ fewer tokens per call

## **📈 MODERATE WINS (35-50% savings):**

### **7. `list_buckets` - SOLID 45% reduction**
- **Before**: ~25KB (formatted bucket metadata)
- **After**: ~14KB (minified)
- **Saved**: ~11KB per call
- **Token savings**: ~2,800+ fewer tokens per call

### **8. `list_flows` - NICE 42% reduction**
- **Before**: ~6KB (formatted flow summaries)
- **After**: ~3.5KB (minified)
- **Saved**: ~2.5KB per call
- **Token savings**: ~650+ fewer tokens per call

### **9. `list_jobs` - GOOD 38% reduction**
- **Before**: ~2KB (formatted job metadata)  
- **After**: ~1.2KB (minified)
- **Saved**: ~0.8KB per call
- **Token savings**: ~200+ fewer tokens per call

## **✅ CONSISTENT WINS (20-35% savings):**

### **10. `get_project_info` - STEADY 25% reduction**
- **Before**: ~1.5KB (formatted project details)
- **After**: ~1.1KB (minified) 
- **Saved**: ~0.4KB per call
- **Token savings**: ~100+ fewer tokens per call

## **🎯 TOTAL IMPACT SUMMARY:**

### **Per Heavy Tool Call (list_configs, list_transformations, get_data_apps):**
- **Average savings**: **58KB per call**
- **Token reduction**: **15,000+ fewer tokens per call**
- **Bandwidth reduction**: **74% smaller responses**

### **Per Medium Tool Call (get_table, get_config, flows):**
- **Average savings**: **6KB per call**  
- **Token reduction**: **1,500+ fewer tokens per call**
- **Bandwidth reduction**: **62% smaller responses**

### **Per Light Tool Call (project info, jobs, buckets):**
- **Average savings**: **4KB per call**
- **Token reduction**: **1,000+ fewer tokens per call** 
- **Bandwidth reduction**: **36% smaller responses**

## **💰 Business Impact:**

1. **Faster API responses** - 50-75% less data over network
2. **Reduced LLM costs** - Thousands fewer tokens per interaction  
3. **Better user experience** - Dramatically faster tool calls
4. **Improved context utilization** - Much more room for actual content
5. **Lower infrastructure costs** - Reduced bandwidth usage