### PR TITLE
Update MCP Server installation link for Cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ Our remote server is hosted on every multi-tenant Keboola stack and supports OAu
 ### Supported Clients
 
 - **[Cursor](https://cursor.com)**: Use the "Install In Cursor" button in your project's MCP Server settings or click
-  this button
-  [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=keboola&config=eyJ1cmwiOiJodHRwczovL21jcC51cy1lYXN0NC5nY3Aua2Vib29sYS5jb20vc3NlIn0%3D)
-- **[Claude Desktop](https://claude.ai)**: Add the integration via Settings → Integrations
+  this button [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=keboola&config=eyJ1cmwiOiJodHRwczovL21jcC51cy1lYXN0NC5nY3Aua2Vib29sYS5jb20vbWNwIn0=)
 - **[Windsurf](https://windsurf.ai)**: Configure with the remote server URL
 - **[Make](https://make.com)**: Configure with the remote server URL
 - **Other MCP clients**: Configure with the remote server URL


### PR DESCRIPTION
 cursor deeplinks as generated by https://cursor.com/docs/context/mcp/install-links#generate-install-link do not work anymore. Replaced by the `cursor://anysphere.cursor-deeplink` url that works and we use it in the platform as well.

**NOTE** There is an issue with displaying these links in github so they don't work. We need to either wait for cursor to fix it and scratch this or remove the link  https://keboolaglobal.slack.com/archives/C090RAKJ6BC/p1758650632698259?thread_ts=1758641291.965279&cid=C090RAKJ6BC