### PR TITLE
Ai 1709 pin pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.23.1"
+version = "1.23.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pyjwt ~= 2.10",
     "json-log-formatter ~= 1.0",
     "cryptography ~= 45.0",
+    "pydantic >=2.0,<2.12",
 ]
 [project.optional-dependencies]
 codestyle = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -988,6 +988,7 @@ dependencies = [
     { name = "jsonpath-ng" },
     { name = "jsonschema" },
     { name = "mcp" },
+    { name = "pydantic" },
     { name = "pyjwt" },
 ]
 
@@ -1042,6 +1043,7 @@ requires-dist = [
     { name = "kbcstorage", marker = "extra == 'integtests'", specifier = "~=0.9" },
     { name = "mcp", specifier = "==1.12.3" },
     { name = "pep8-naming", marker = "extra == 'codestyle'", specifier = "~=0.14" },
+    { name = "pydantic", specifier = ">=2.0,<2.12" },
     { name = "pyjwt", specifier = "~=2.10" },
     { name = "pytest", marker = "extra == 'tests'", specifier = "~=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = "~=0.25" },


### PR DESCRIPTION
This PR pins a specific version of pydantic to avoid dependency issues. Specifically, pydantic 2.12 is incompatible with the version of fastmcp.