### PR TITLE
AI-1772: Release MCP Server 1.26.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.26.0"
+version = "1.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
# Release Notes

Version `1.26.1` of the Keboola MCP Server delivers multiple enhancements and bug fixes. This release upgrades the `mcp` and `fastmcp` library dependencies to versions `1.17.0` and `2.12.4`, respectively. It adds conversation ID tracking to Storage API events emitted for tool calls, improving observability and debugging capabilities. The `list_transformations` tool has been consolidated into the `list_configs` tool, simplifying the API surface. A new release step has been added to the GitHub CI workflow to automatically register released versions with Anthropic's registry. Additionally, this release fixes an issue with Keboola stack URL extraction from environment variables.

# Plans for Customer Communication

None.

# Impact Analysis

This release should have no impact on existing workflows or integrations. The consolidation of `list_transformations` into `list_configs` maintains backward compatibility, as transformation filtering remains available through the `component_types` parameter of `list_configs`.

# Change Type

Bug-fix release.

# Justification

This release addresses a critical bug in the Keboola stack URL extraction logic that could prevent proper server initialization. The dependency upgrades ensure compatibility with the latest `mcp` and `fastmcp` libraries, while the addition of conversation ID tracking enhances operational visibility. The consolidation of `list_transformations` into `list_configs` improves API consistency and maintainability by reducing code duplication while preserving all existing functionality through parameter-based filtering. The automated registry registration streamlines the release process and ensures timely availability of new versions to users.

# Deployment Plan

Merge and release to PyPI, then deploy to stacks.

# Rollback Plan

Revert to the release version (`1.22.3`) if critical issues arise.

# Post-Release Support Plan

Monitor for issues and provide support via GitHub Issues.