### PR TITLE
feat: Add release for MCP server agent using separate tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           tags: |
             type=sha,format=long
             type=raw,value=production-${{ github.sha }},enable=${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/agent-v')) && !contains(github.ref, '-dev.') }}
-            type=raw,value=latest,enable=${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/agent-v')) && !contains(github.ref, '-dev.') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
             type=raw,value=canary-orion-${{ github.sha }},enable=${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/agent-v')) && contains(github.ref, '-dev.') }}
 
       - name: Docker login


### PR DESCRIPTION
* Update CI/CD setup to create new tags `agent-v-XXX` to release only MCP server agent
* Trigger update for different helm chart
* Fixing Issue AI-1798