### PR TITLE
AI-1941: add Onyx redirect URI to OAuth whitelist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.28.1"
+version = "1.29.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/oauth.py
+++ b/src/keboola_mcp_server/oauth.py
@@ -33,6 +33,7 @@ _WELL_KNOWN_DOMAINS = [
     re.compile(r'^librechat\.glami-ml\.com$', re.IGNORECASE),  # no subdomains allowed
     re.compile(r'^.*make\.com$', re.IGNORECASE),
     re.compile(r'^api\.devin\.ai$', re.IGNORECASE),  # devin.ai API domain
+    re.compile(r'^cloud\.onyx\.app$', re.IGNORECASE),  # onyx.app OAuth callback
 ]
 _FORBIDDEN_SCHEMES = [
     # # Web/HTTP

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -125,6 +125,9 @@ class TestSimpleOAuthProvider:
             (AnyUrl('https://make.com'), True),
             (AnyUrl('https://foo.make.com/bar'), True),
             (AnyUrl('https://www.make.com/oauth/cb/mcp'), True),
+            (AnyUrl('https://cloud.onyx.app'), True),
+            (AnyUrl('https://cloud.onyx.app/mcp/oauth/callback'), True),
+            (AnyUrl('https://foo.cloud.onyx.app/bar'), False),  # no subdomains allowed
             (AnyUrl('cursor://anysphere.cursor-retrieval/oauth/user-keboola-Data_warehouse/callback'), True),
             (None, False),
             (AnyUrl('https://foo.bar.com/callback'), False),

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.28.1"
+version = "1.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1526,6 +1526,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
     { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },


### PR DESCRIPTION
Added cloud.onyx.app to the allowed OAuth redirect URIs for MCP server authentication. Incremented version to 1.29.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)