### PR TITLE
AI-1839: use the latest version of mcp-publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,7 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          PUBLISHER=1.2.3
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v${PUBLISHER}/mcp-publisher_${PUBLISHER}_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/
 
       - name: Create private key file


### PR DESCRIPTION
The fix was tested in https://github.com/keboola/mcp-server/pull/311 which got messy and I abandoned it in the end.

The MCP Server versions registered with Anthropic can be seen here -- https://registry.modelcontextprotocol.io/v0/servers?search=com.keboola/mcp