### PR TITLE
AI-1984: Remove unnecessary get_config_examples call for Custom Python

### DIFF
--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -58,8 +58,7 @@ Use Custom Python component in cases when:
 - The existing Generic Extractor extraction is too slow and the user complains about its performance.
 - You have already tried Generic Extractor but it's failing. Use Custom Python as a fallback.
 
-When using Custom Python, always look up the documentation using the `get_component` tool and configuration examples
-using the `get_config_examples` tool.
+When using Custom Python, always look up the documentation using the `get_component` tool.
 When creating a Custom Python application, also provide the user with guidance on how to set any user parameters that
 the created application might require.
 Remember to add dependencies into the created configuration!


### PR DESCRIPTION
# AI-1984: Remove unnecessary get_config_examples call for Custom Python

## Summary
This PR removes the instruction to call `get_config_examples` for the Custom Python component (`kds-team.app-custom-python`) from the AI agent's system prompt. This component has no configuration examples defined in the AI Service catalog (`rootConfigurationExamples` and `rowConfigurationExamples` are empty), making the tool call unnecessary overhead that adds latency and token usage without providing value.

The `get_component` tool already provides comprehensive documentation, configuration schemas, and all necessary information for Custom Python components, so removing this instruction eliminates one unnecessary tool call per Custom Python interaction without losing any functionality.

**Changed:**
- Lines 61-62 in `src/keboola_mcp_server/resources/prompts/project_system_prompt.md`
- Removed reference to `get_config_examples` tool while preserving the `get_component` instruction

### Notes
- Linear ticket: AI-1984
- Requested by: Vaclav Nosek (vaclav.nosek@keboola.com) / @cjayyy
- Session: https://app.devin.ai/sessions/e63c1950f4e04386b4fb82da931269b2
- This is a targeted optimization with no functional changes to code - only documentation/prompt modification