### PR TITLE
AI-1954 Update argument description for update_config

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -700,7 +700,7 @@ WORKFLOW:
     },
     "parameter_updates": {
       "default": null,
-      "description": "List of granular parameter update operations to apply. Each operation (set, str_replace, remove, list_append) modifies a specific value using JSONPath notation. Only provide if updating parameters - do not use for changing description, storage or processors. Prefer simple dot-delimited JSONPaths and make the smallest possible updates - only change what needs changing. In case you need to replace the whole parameters section, you can use the `set` operation with `$` as path.",
+      "description": "List of granular parameter update operations to apply. Each operation (set, str_replace, remove, list_append) modifies a specific value using JSONPath notation. Only provide if updating parameters - do not use for changing description, storage or processors. Prefer simple JSONPaths (e.g., \"array_param[1]\", \"object_param.key\") and make the smallest possible updates - only change what needs changing. In case you need to replace the whole parameters section, you can use the `set` operation with `$` as path.",
       "items": {
         "discriminator": {
           "mapping": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.32.5"
+version = "1.32.6"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -1140,7 +1140,7 @@ async def update_config(
                 'Each operation (set, str_replace, remove, list_append) modifies a specific '
                 'value using JSONPath notation. Only provide if updating parameters -'
                 ' do not use for changing description, storage or processors. '
-                'Prefer simple dot-delimited JSONPaths '
+                'Prefer simple JSONPaths (e.g., "array_param[1]", "object_param.key") '
                 'and make the smallest possible updates - only change what needs changing. '
                 'In case you need to replace the whole parameters section, you can use the `set` operation '
                 'with `$` as path.'

--- a/uv.lock
+++ b/uv.lock
@@ -1110,7 +1110,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.32.5"
+version = "1.32.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This seems to fix the issue when KAI produced invalid paths like `blocks.0.codes.0.script.0` instead of correct `blocks[0]codes[0]script[0]` in Python transformations. More long-term solution would be treating python transformations in a similar way as SQL with specialised structure-aware edit operations.