### PR TITLE
docs: expand SSE transport deprecation notice with 2026-Mar-31 deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ With the AI Agent and MCP Server, you can:
 ## 🚀 Quick Start: Remote MCP Server (Easiest Way)
 
 <div class="alert alert-warning" role="alert">
-<strong>⚠️ SSE Transport Deprecation:</strong> The SSE transport will be deprecated on 2026-04-01. Please migrate to Streamable HTTP transport using <code>/mcp</code> endpoints instead of <code>/sse</code>. Streamable HTTP provides bidirectional streaming for improved performance and reliability.
+<strong>⚠️ SSE Transport Decommissioning:</strong> The SSE transport is deprecated and will be removed from the Keboola MCP Server on 2026-Mar-31. Please migrate to the Streamable HTTP transport and use the <code>/mcp</code> endpoints instead of <code>/sse</code>.
 </div>
 
 The easiest way to use Keboola MCP Server is through our **Remote MCP Server**. This hosted solution eliminates the need for local setup, configuration, or installation.
@@ -133,7 +133,7 @@ Run the MCP server on your own machine for full control and easy development. Ch
 The server supports multiple **transport** options, which can be selected by providing the `--transport <transport>` argument when starting the server:
 - `stdio` - Default when `--transport` is not specified. Standard input/output, typically used for local deployment with a single client.
 - `streamable-http` - Runs the server remotely over HTTP with a bidirectional streaming channel, allowing the client and server to continuously exchange messages. Connect via <url>/mcp (e.g., http://localhost:8000/mcp).
-- `sse` - **Deprecated (will be removed on 2026-04-01)**, use `streamable-http` instead. Runs the server remotely using Server-Sent Events (SSE) for one-way event streaming from server to client. Connect via <url>/sse (e.g., http://localhost:8000/sse).
+- `sse` - **Deprecated (will be removed on 2026-Mar-31)**, use `streamable-http` instead. Runs the server remotely using Server-Sent Events (SSE) for one-way event streaming from server to client. Connect via <url>/sse (e.g., http://localhost:8000/sse).
 - `http-compat` - A custom transport supporting both `SSE` and `streamable-http`. It is currently used on Keboola remote servers but will be replaced by `streamable-http` only when SSE is removed.
 
 For client–server communication, Keboola credentials must be provided to enable working with your project in your Keboola Region. The following are required: `KBC_STORAGE_TOKEN`, `KBC_STORAGE_API_URL`, `KBC_WORKSPACE_SCHEMA` and optionally `KBC_BRANCH_ID`. You can provide these in two ways:


### PR DESCRIPTION
## Description

**Linear**: AI-2342

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

This PR adds comprehensive SSE transport deprecation warnings to the README documentation as part of a coordinated update across three repositories (connection-docs, developers-docs, mcp-server).

**Changes:**
- Added prominent deprecation warning box in Quick Start section with explicit 2026-Mar-31 deadline
- Updated remote server description to recommend Streamable HTTP over SSE
- Changed URL examples from `/sse` to `/mcp` endpoints throughout
- Updated Cursor deeplink to use `/mcp` endpoint
- Expanded deprecation notice for `sse` transport option with explicit removal date
- Updated CLI and Docker examples to use `streamable-http` transport instead of `sse`

### Updates since last revision
- Changed deprecation timeline from "3 months" to specific date "01.04.2026" per reviewer feedback
- Updated date format from "01.04.2026" to ISO 8601 format "2026-04-01" per Copilot suggestion to avoid locale ambiguity
- Updated wording per vita-stejskal's review: changed "SSE Transport Deprecation" to "SSE Transport Decommissioning", date to "2026-Mar-31", and clarified that SSE "is deprecated and will be removed"

**Human Review Checklist:**
- [ ] Verify the Cursor deeplink base64 config decodes correctly to `{"url":"https://mcp.us-east4.gcp.keboola.com/mcp"}`
- [ ] Check if the HTML alert div renders appropriately in GitHub markdown (note: GitHub doesn't support `alert-warning` class styling)
- [ ] Verify the date format (2026-Mar-31) is clear and unambiguous

## Testing

- [x] N/A - Documentation only change

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`SSE` and `Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type (if applicable)
- [x] Documentation updated (if applicable)

---

Link to Devin run: https://app.devin.ai/sessions/3ddcad4977384d26b3e88e94e3e3778b
Requested by: Martin Vasko (@Matovidlo)