### PR TITLE
fix: Change user agent to kai-assistant from in-platform-chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.44.3"
+version = "1.44.4"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/errors.py
+++ b/src/keboola_mcp_server/errors.py
@@ -24,7 +24,7 @@ F = TypeVar('F', bound=Callable[..., Any])
 
 _USER_AGENT_TO_COMPONENT_ID: Mapping[str, str] = {
     'read-only-chat': 'keboola.ai-chat',
-    'in-platform-chat': 'keboola.kai-assistant',
+    'kai-assistant': 'keboola.kai-assistant',
 }
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -115,7 +115,7 @@ async def test_logging_on_tool_exception(caplog, function_with_value_error, mcp_
     [
         ('http', None, 'keboola.mcp-server-tool'),
         ('stdio', Implementation(name='read-only-chat', version='1.2.3'), 'keboola.ai-chat'),
-        ('stdio', Implementation(name='in-platform-chat', version='x.y.z'), 'keboola.kai-assistant'),
+        ('stdio', Implementation(name='kai-assistant', version='x.y.z'), 'keboola.kai-assistant'),
     ],
 )
 async def test_get_session_id(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1200,7 +1200,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.44.3"
+version = "1.44.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-2519](https://linear.app/keboola/issue/AI-2519/storage-events-from-rokai-chats-show-as-mcp-server-tool-calls)

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Describe what has changed and why.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`SSE` and `Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [x] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [x] Documentation updated (if applicable)
