### PR TITLE
AI-2662: fix config-based search match scopes broken by jsonpath_ng 1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.45.0"
+version = "1.45.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -15,7 +15,7 @@ dependencies = [
     "mcp == 1.24.0",
     "httpx ~= 0.28",
     "httpx-retries~=0.4",
-    "jsonpath-ng ~= 1.7",
+    "jsonpath-ng ~= 1.8",
     "jsonschema ~= 4.25",
     "pyjwt ~= 2.10",
     "json-log-formatter ~= 1.1",

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -279,7 +279,7 @@ class SearchSpec(BaseModel):
             if matched := self.match_patterns(value):
                 matches.append(
                     PatternMatch(
-                        scope=re.sub(r'\.\[', '[', str(jpath_match.full_path)),
+                        scope=_clean_jsonpath_path_str(str(jpath_match.full_path)),
                         patterns=matched,
                     )
                 )
@@ -337,6 +337,20 @@ class SearchSpec(BaseModel):
                 if not self.return_all_matched_patterns:
                     break
         return matches
+
+
+def _clean_jsonpath_path_str(path_str: str) -> str:
+    """Normalize a jsonpath_ng full_path string across library versions.
+
+    jsonpath_ng >= 1.8.0 wraps Child nodes in parentheses and single-quotes field names
+    with special characters, e.g. "(authorization.'#apiKey')" instead of "authorization.#apiKey".
+    """
+    # Strip parentheses added by jsonpath_ng >= 1.8.0
+    result = path_str.replace('(', '').replace(')', '')
+    # Remove surrounding quotes from field name segments, e.g. "'#apiKey'" -> "#apiKey"
+    result = re.sub(r"['\"]([^'\"]+)['\"]", r'\1', result)
+    # Normalize .[N] -> [N]
+    return re.sub(r'\.\[', '[', result)
 
 
 def _get_field_value(item: JsonDict, fields: Sequence[str]) -> Any | None:

--- a/uv.lock
+++ b/uv.lock
@@ -1150,15 +1150,9 @@ sdist = { url = "https://files.pythonhosted.org/packages/e8/ef/324f4a28ed0152a32
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ply" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
 
 [[package]]
 name = "jsonschema"
@@ -1223,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.45.0"
+version = "1.45.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1288,7 +1282,7 @@ requires-dist = [
     { name = "httpx-retries", specifier = "~=0.4" },
     { name = "isort", marker = "extra == 'codestyle'", specifier = "~=7.0" },
     { name = "json-log-formatter", specifier = "~=1.1" },
-    { name = "jsonpath-ng", specifier = "~=1.7" },
+    { name = "jsonpath-ng", specifier = "~=1.8" },
     { name = "jsonschema", specifier = "~=4.25" },
     { name = "kbcstorage", marker = "extra == 'integtests'", specifier = "~=0.9" },
     { name = "mcp", specifier = "==1.24.0" },
@@ -1563,15 +1557,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]
@@ -2489,8 +2474,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
## Description

**Linear**: [AI-2662](https://linear.app/keboola/issue/AI-2662/mcp-config-based-search-returns-wrong-match-scopes-due-to-jsonpath-ng)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`jsonpath_ng` 1.8.0 (released 2026-02-24) changed `Child.__str__()` to wrap path segments in parentheses and single-quote field names with special characters. This broke `search(search_type="config-based")` which relies on the string representation of `jpath_match.full_path` to populate `match_scopes` in search results.

**Before (1.7.x):** `parameters.query`, `storage.input[0].source`, `authorization.#apiKey`
**After (1.8.0):** `(parameters.query)`, `(((storage.input).[0]).source)`, `(authorization.'#apiKey')`

The fix adds a `_clean_jsonpath_path_str()` helper that strips these additions, restoring clean dot-bracket notation regardless of library version. The dependency constraint is bumped from `~=1.7` to `~=1.8`.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`SSE` and `Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)