### PR TITLE
Add workspace/SQL editor update support

### DIFF
--- a/integtests/project_lock.py
+++ b/integtests/project_lock.py
@@ -301,7 +301,7 @@ class ProjectLock:
             self._delete(f'/v2/storage/buckets/{bucket_id}', force='true')
 
         # Delete all component configurations
-        components = self._get('/v2/storage/branch/default/components', include='configurations')
+        components = self._get('/v2/storage/components', include='configurations')
         for component in components:
             comp_id = component['id']
             for cfg in component.get('configurations', []):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.49.0"
+version = "1.50.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -60,6 +60,22 @@ get_configs(component_ids=["keboola.sandboxes"])
 update_config(component_id="keboola.sandboxes", configuration_id="<id>", ...)
 ```
 
+**CRITICAL — `script` must always be an array of strings, never a plain string.**
+The workspace configuration stores SQL in `parameters.script` as a list of individual
+SQL statements. Setting it as a string will corrupt the configuration and crash the UI.
+
+Correct:
+```json
+{"parameters": {"script": ["SELECT 1;", "SELECT 2;"]}}
+```
+Wrong (causes UI crash):
+```json
+{"parameters": {"script": "SELECT 1;\nSELECT 2;"}}
+```
+
+When reading an existing workspace config via `get_configs`, `parameters.script` will already
+be an array — preserve that structure when writing back.
+
 **Creating new workspaces is NOT supported via the API** — use the Keboola UI to create workspaces.
 
 #### Disambiguation — SQL Transformation vs SQL Editor

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -60,22 +60,6 @@ get_configs(component_ids=["keboola.sandboxes"])
 update_config(component_id="keboola.sandboxes", configuration_id="<id>", ...)
 ```
 
-**CRITICAL — `script` must always be an array of strings, never a plain string.**
-The workspace configuration stores SQL in `parameters.script` as a list of individual
-SQL statements. Setting it as a string will corrupt the configuration and crash the UI.
-
-Correct:
-```json
-{"parameters": {"script": ["SELECT 1;", "SELECT 2;"]}}
-```
-Wrong (causes UI crash):
-```json
-{"parameters": {"script": "SELECT 1;\nSELECT 2;"}}
-```
-
-When reading an existing workspace config via `get_configs`, `parameters.script` will already
-be an array — preserve that structure when writing back.
-
 **Creating new workspaces is NOT supported via the API** — use the Keboola UI to create workspaces.
 
 #### Disambiguation — SQL Transformation vs SQL Editor

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -60,7 +60,7 @@ get_configs(component_ids=["keboola.sandboxes"])
 update_config(component_id="keboola.sandboxes", configuration_id="<id>", ...)
 ```
 
-**Creating new workspaces is NOT supported via the API** — use the Keboola UI to create workspaces.
+**Creating new workspaces is NOT supported via the API** — tell user to create workspaces in Keboola UI.
 
 #### Disambiguation — SQL Transformation vs SQL Editor
 

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -44,6 +44,37 @@ Keboola Storage.
 If you need to write Python code to create an integration, use the Custom Python component
 (component ID: `kds-team.app-custom-python`).
 
+### Workspaces / SQL Editor
+
+**Workspaces** (also called SQL Editor) are interactive SQL environments backed by the
+`keboola.sandboxes` component. Unlike SQL Transformations, workspaces are not pipeline
+components — they are used for ad-hoc exploration and editing SQL queries directly.
+
+**Reading workspace configurations:**
+```
+get_configs(component_ids=["keboola.sandboxes"])
+```
+
+**Updating a workspace SQL query:**
+```
+update_config(component_id="keboola.sandboxes", configuration_id="<id>", ...)
+```
+
+**Creating new workspaces is NOT supported via the API** — use the Keboola UI to create workspaces.
+
+#### Disambiguation — SQL Transformation vs SQL Editor
+
+When a user asks to "write SQL", "update a SQL query", "change SQL code", or similar, and the
+context does not make it clear whether they mean a **SQL Transformation** or the
+**SQL Editor (workspace)**, always ask for clarification before acting:
+
+> "Do you mean a SQL **Transformation** (part of a pipeline, processes data in Storage), or
+> the SQL **Editor** / workspace (interactive SQL environment)?"
+
+- For SQL Transformations → use `create_sql_transformation` / `update_sql_transformation`
+- For SQL Editor workspaces → use `get_configs` / `update_config` with
+  `component_id="keboola.sandboxes"`
+
 ### Creating Custom Integrations
 
 Sometimes users require integrations or complex applications that are not covered by any existing off-the-shelf component.

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -67,6 +67,7 @@ from keboola_mcp_server.tools.components.utils import (
     SNOWFLAKE_TRANSFORMATION_ID,
     add_ids,
     check_suitable,
+    check_suitable_for_create,
     create_transformation_configuration,
     expand_component_types,
     fetch_component,
@@ -938,7 +939,7 @@ async def create_config(
         - set the component_id and configuration parameters accordingly
         - returns the created component configuration if successful.
     """
-    check_suitable('create_config', component_id)
+    check_suitable_for_create('create_config', component_id)
 
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
@@ -1072,7 +1073,7 @@ async def add_config_row(
         - set the component_id, configuration_id and configuration parameters accordingly
         - returns the created component configuration if successful.
     """
-    check_suitable('add_config_row', component_id)
+    check_suitable_for_create('add_config_row', component_id)
 
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -63,6 +63,7 @@ T = TypeVar('T')
 
 SNOWFLAKE_TRANSFORMATION_ID = 'keboola.snowflake-transformation'
 BIGQUERY_TRANSFORMATION_ID = 'keboola.google-bigquery-transformation'
+SANDBOXES_COMPONENT_ID = 'keboola.sandboxes'
 
 
 # ============================================================================
@@ -736,4 +737,32 @@ def check_suitable(tool_name: str, component_id: str) -> None:
     :raises ValueError: If the component needs to be handled by special tools.
     """
     if message := _UNSUITABLE_COMPONENTS_MESSAGES.get(component_id):
+        raise ValueError(f'The "{tool_name}" tool cannot be used with {component_id} component. {message}')
+
+
+# Components that cannot be created via the API (create-only restriction)
+_CREATE_UNSUITABLE_COMPONENTS_MESSAGES: Mapping[str, str] = {
+    SANDBOXES_COMPONENT_ID: (
+        'Creating SQL editor configurations via the API is not supported. ' 'Use the Keboola UI to create workspaces.'
+    ),
+}
+
+
+def check_suitable_for_create(tool_name: str, component_id: str) -> None:
+    """
+    Checks if a component supports creation or row-addition via the API.
+
+    Extends check_suitable with creation-specific blocks. Some components
+    (e.g., keboola.sandboxes) are readable and updatable via the API but cannot
+    be created programmatically — they must be created via the Keboola UI.
+
+    Use this for creation operations (create_config, add_config_row) only.
+    Update operations (update_config, update_config_row) should use check_suitable
+    so that existing configurations of these components remain manageable.
+
+    :raises ValueError: If the component is unsuitable for any operation,
+        or if it specifically cannot be created via the API.
+    """
+    check_suitable(tool_name, component_id)
+    if message := _CREATE_UNSUITABLE_COMPONENTS_MESSAGES.get(component_id):
         raise ValueError(f'The "{tool_name}" tool cannot be used with {component_id} component. {message}')

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from typing import Any, Callable
 
 import pytest
@@ -50,6 +51,7 @@ from keboola_mcp_server.tools.components.tools import (
 )
 from keboola_mcp_server.tools.components.utils import (
     BIGQUERY_TRANSFORMATION_ID,
+    SANDBOXES_COMPONENT_ID,
     SNOWFLAKE_TRANSFORMATION_ID,
     clean_bucket_name,
 )
@@ -1194,6 +1196,12 @@ async def test_update_config(
             'Use the SQL transformation tools.',
         ),
         (
+            create_config,
+            {'name': 'foo', 'description': 'bar', 'parameters': {}},
+            SANDBOXES_COMPONENT_ID,
+            'Creating SQL editor configurations via the API is not supported.',
+        ),
+        (
             add_config_row,
             {'name': 'foo', 'description': 'bar', 'configuration_id': 'baz', 'parameters': {}},
             DATA_APP_COMPONENT_ID,
@@ -1223,6 +1231,12 @@ async def test_update_config(
             SNOWFLAKE_TRANSFORMATION_ID,
             'Use the SQL transformation tools.',
         ),
+        (
+            add_config_row,
+            {'name': 'foo', 'description': 'bar', 'configuration_id': 'baz', 'parameters': {}},
+            SANDBOXES_COMPONENT_ID,
+            'Creating SQL editor configurations via the API is not supported.',
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -1232,8 +1246,8 @@ async def test_generic_tools_reject_specialized_components(
     component_id: str,
     message: str,
     mcp_context_components_configs: Context,
-):
-    m = f'The "{tool_fn.__name__}" tool cannot be used with {component_id} component. {message}'
+) -> None:
+    m = re.escape(f'The "{tool_fn.__name__}" tool cannot be used with {component_id} component. {message}')
     with pytest.raises(ValueError, match=m):
         await tool_fn(
             ctx=mcp_context_components_configs,

--- a/tests/tools/components/test_utils.py
+++ b/tests/tools/components/test_utils.py
@@ -3,6 +3,7 @@ from typing import Any, Sequence
 
 import pytest
 
+from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID
 from keboola_mcp_server.tools.components.model import (
     ALL_COMPONENT_TYPES,
     ComponentType,
@@ -23,8 +24,12 @@ from keboola_mcp_server.tools.components.model import (
     TransformationConfiguration,
 )
 from keboola_mcp_server.tools.components.utils import (
+    BIGQUERY_TRANSFORMATION_ID,
+    SANDBOXES_COMPONENT_ID,
     _apply_param_update,
     _normalize_jsonpath,
+    check_suitable,
+    check_suitable_for_create,
     clean_bucket_name,
     create_transformation_configuration,
     expand_component_types,
@@ -1370,3 +1375,59 @@ def test_update_transformation_parameters(
     else:
         # For simple patterns, check exact match
         assert result_msg == expected_msg
+
+
+# ============================================================================
+# check_suitable / check_suitable_for_create
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ('tool_name', 'component_id'),
+    [
+        ('update_config', SANDBOXES_COMPONENT_ID),
+        ('update_config_row', SANDBOXES_COMPONENT_ID),
+        ('get_configs', SANDBOXES_COMPONENT_ID),
+    ],
+    ids=['update_config_sandboxes', 'update_config_row_sandboxes', 'get_configs_sandboxes'],
+)
+def test_check_suitable_allows_sandboxes(tool_name: str, component_id: str) -> None:
+    """check_suitable must NOT block keboola.sandboxes so that read/update operations work."""
+    check_suitable(tool_name, component_id)  # should not raise
+
+
+@pytest.mark.parametrize(
+    ('tool_name', 'component_id', 'expected_fragment'),
+    [
+        (
+            'create_config',
+            SANDBOXES_COMPONENT_ID,
+            'Creating SQL editor configurations via the API is not supported.',
+        ),
+        (
+            'add_config_row',
+            SANDBOXES_COMPONENT_ID,
+            'Creating SQL editor configurations via the API is not supported.',
+        ),
+        (
+            'create_config',
+            DATA_APP_COMPONENT_ID,
+            'Use the data applications tools.',
+        ),
+        (
+            'create_config',
+            BIGQUERY_TRANSFORMATION_ID,
+            'Use the SQL transformation tools.',
+        ),
+    ],
+    ids=[
+        'create_config_sandboxes',
+        'add_config_row_sandboxes',
+        'create_config_data_app',
+        'create_config_bigquery',
+    ],
+)
+def test_check_suitable_for_create_blocks(tool_name: str, component_id: str, expected_fragment: str) -> None:
+    """check_suitable_for_create blocks both generally-unsuitable and create-only-blocked components."""
+    with pytest.raises(ValueError, match=re.escape(expected_fragment)):
+        check_suitable_for_create(tool_name, component_id)


### PR DESCRIPTION
## Description

**Linear**:  https://linear.app/keboola/issue/AI-2778/add-support-for-editing-sql-queries-within-editor-using

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Allow the MCP server to read and update existing SQL editor (workspace) configurations
(`keboola.sandboxes`) that were previously invisible to the AI.

**Problem:** `get_configs` with default args only enumerates the 4 standard component
types. Passing `component_ids=["keboola.sandboxes"]` uses a separate listing path that
does work, but the AI was never guided to try it. Creating new workspaces requires a
separate editor service and is out of scope.


## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)
- [x]  <img width="1893" height="670" alt="image" src="https://github.com/user-attachments/assets/c4dc0bfc-dd5f-42f7-9a65-d04fcbcde1c7" />


### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`SSE` and `Streamable-HTTP`)
- [x] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [x] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type (if applicable)
- [x] Documentation updated (if applicable)