### PR TITLE
feat(oauth): dynamic OAuth client registration via Connection [AI-2883]

### DIFF
--- a/src/keboola_mcp_server/oauth.py
+++ b/src/keboola_mcp_server/oauth.py
@@ -2,12 +2,11 @@ import dataclasses
 import logging
 import math
 import os
-import re
 import secrets
 import time
 from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any, cast
+from typing import Any, Literal, cast
 from urllib.parse import urljoin
 
 import httpx
@@ -23,7 +22,7 @@ from mcp.server.auth.provider import (
 )
 from mcp.server.auth.settings import ClientRegistrationOptions
 from mcp.shared.auth import InvalidRedirectUriError, OAuthClientInformationFull, OAuthToken
-from pydantic import AnyHttpUrl, AnyUrl
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.responses import JSONResponse
@@ -49,35 +48,7 @@ _OAUTH_SCOPES = ['claudai', 'projectless']
 
 LOG = logging.getLogger(__name__)
 _OAUTH_LOG_ALL = bool(os.getenv('KEBOOLA_MCP_SERVER_OAUTH_LOG_ALL'))
-_RE_LOCALHOST = re.compile(r'^(localhost|127\.0\.0\.1|\[::1]|::1)$', re.IGNORECASE)
-_ALLOWED_DOMAINS = {
-    'https': [
-        # Any keboola.com/dev subdomain EXCEPT user-deployable data-app subdomains, which live under a
-        # '*.hub.<stack>.keboola.com' host. A free-trial user can deploy a data app whose '/callback' would
-        # otherwise capture the OAuth code, so we reject any host that contains a 'hub' DNS label (RISK-76).
-        re.compile(r'^(?!(?:.*\.)?hub\.).+\.keboola\.(com|dev)$', re.IGNORECASE),
-        re.compile(r'^(.*\.)?chatgpt\.com$', re.IGNORECASE),
-        re.compile(r'^(.*\.)?claude\.ai$', re.IGNORECASE),
-        # Agnes lives on its own TLD, outside the keboola.(com|dev) pattern above. Exact host, no
-        # wildcard: AI-3591 is retiring this whole list in favour of Connection's client registry
-        # and flags its wildcards as a subdomain-takeover risk, so don't add another one (AI-3773).
-        re.compile(r'^agnes\.keboola\.systems$', re.IGNORECASE),  # no subdomains allowed
-        re.compile(r'^librechat\.glami-ml\.com$', re.IGNORECASE),  # no subdomains allowed
-        re.compile(r'^(.*\.)?make\.com$', re.IGNORECASE),
-        re.compile(r'^api\.devin\.ai$', re.IGNORECASE),  # devin.ai API domain
-        re.compile(r'^cloud\.onyx\.app$', re.IGNORECASE),  # onyx.app OAuth callback
-        re.compile(r'^global\.consent\.azure-apim\.net$', re.IGNORECASE),  # Azure APIM consent domain
-        re.compile(r'^n8n\.groupondev\.com$', re.IGNORECASE),
-        re.compile(r'^n8n-business\.groupondev\.com$', re.IGNORECASE),
-        re.compile(r'^n8n-merchant\.groupondev\.com$', re.IGNORECASE),
-        re.compile(r'^n8n-llm-traffic\.groupondev\.com$', re.IGNORECASE),
-        re.compile(r'^n8n-finance\.groupondev\.com$', re.IGNORECASE),
-        re.compile(r'^n8n-playground\.groupondev\.com$', re.IGNORECASE),
-        re.compile(r'^n8n-staging\.groupondev\.com$', re.IGNORECASE),
-    ],
-    'http': [_RE_LOCALHOST],
-    'cursor': [re.compile(r'^(anysphere\.cursor-retrieval|anysphere\.cursor-mcp)$', re.IGNORECASE)],
-}
+_DANGEROUS_SCHEMES = frozenset({'javascript', 'data', 'vbscript'})
 
 
 def _log_debug(msg: str) -> None:
@@ -87,6 +58,14 @@ def _log_debug(msg: str) -> None:
     """
     if _OAUTH_LOG_ALL:
         LOG.debug(msg)
+
+
+class ClientValidationResult(BaseModel):
+    """Result of validating an OAuth client against Connection's /oauth/clients/validate endpoint."""
+
+    status: Literal['approved', 'pending', 'rejected']
+    # Registered redirect URIs for pre-approved clients; empty for pending/rejected.
+    redirect_uris: list[str] = []
 
 
 class _OAuthClientInformationFull(OAuthClientInformationFull):
@@ -100,29 +79,16 @@ class _OAuthClientInformationFull(OAuthClientInformationFull):
             return None
 
     def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
-        # Ideally, this should verify the redirect_uri against the URI registered by the client.
-        # That, however, would require a persistent registry of clients.
-        # So, instead we require the clients to send their redirect URI in the authorization request,
-        # and we discard all URIs that are not on a whitelist.
+        # Basic sanity check: reject missing URIs and dangerous scripting schemes.
+        # Per-client redirect URI validation against Connection's registered URIs happens
+        # in SimpleOAuthProvider.authorize() after the client is validated via /oauth/clients/validate.
         if not redirect_uri:
             LOG.warning('[validate_redirect_uri] No redirect_uri specified.')
             raise InvalidRedirectUriError('The redirect_uri must be specified.')
 
         stripped_uri = self._strip_redirect_uri(redirect_uri)
-        if not redirect_uri.scheme:
-            LOG.warning(f'[validate_redirect_uri] No scheme in redirect_uri: {stripped_uri}')
-            raise InvalidRedirectUriError(f'Invalid redirect_uri: {stripped_uri}')
-
-        # The custom schemes (e.g. cursor://) require a custom handler registered in a browser.
-        # They are used for redirecting a browser to a locally running app.
-
-        if allowed_domains := _ALLOWED_DOMAINS.get(redirect_uri.scheme):
-            if not any(p.fullmatch(redirect_uri.host or '') for p in allowed_domains):
-                LOG.warning(f'[validate_redirect_uri] Unknown domain in redirect_uri: {stripped_uri}')
-                raise InvalidRedirectUriError(f'Invalid redirect_uri: {stripped_uri}')
-
-        else:
-            LOG.warning(f'[validate_redirect_uri] Forbidden scheme in redirect_uri: {stripped_uri}')
+        if redirect_uri.scheme in _DANGEROUS_SCHEMES:
+            LOG.warning(f'[validate_redirect_uri] Dangerous scheme in redirect_uri: {stripped_uri}')
             raise InvalidRedirectUriError(f'Invalid redirect_uri: {stripped_uri}')
 
         LOG.info(f'[validate_redirect_uri] Accepted redirect_uri: {stripped_uri}]')
@@ -240,6 +206,7 @@ class SimpleOAuthProvider(OAuthProvider):
         self._mcp_callback_url = urljoin(mcp_server_url, callback_endpoint)
         self._oauth_client_id = client_id
         self._oauth_client_secret = client_secret
+        self._oauth_server_url = server_url
         self._oauth_server_auth_url = urljoin(server_url, '/oauth/consent')
         self._oauth_server_token_url = urljoin(server_url, '/oauth/token')
         self._oauth_scope = scope
@@ -285,21 +252,49 @@ class SimpleOAuthProvider(OAuthProvider):
         """
         Creates a URL that redirects to the OAuth server for authorization.
 
-        The authorization URL's state parameter is an encrypted JWT that contains all the authorization parameters.
-        The state expires after 5 minutes.
+        Validates the requesting client against Connection's /oauth/clients/validate endpoint before
+        building the authorization URL. Pre-registered clients (Flow A) are validated against their
+        registered redirect URIs. Unknown clients (Flow B) trigger an approval screen in Connection by
+        passing pending client info as extra URL parameters.
+
+        The authorization URL's state parameter is an encrypted JWT that contains all the authorization
+        parameters. The state expires after 5 minutes.
 
         :param client: The OAuth client details.
-        :param params: The authorization parameters provided by the client, such as redirect URI, state, scopes, etc.
+        :param params: The authorization parameters provided by the client, such as redirect URI, scopes, etc.
 
         :return: The authorization URL that redirects to the OAuth server.
+        :raises HTTPException: If the client is rejected by Connection.
+        :raises InvalidRedirectUriError: If the redirect_uri is not registered for the client.
         """
+        redirect_uri_str = str(params.redirect_uri) if params.redirect_uri else ''
+
+        validation = await self._validate_client(
+            client_id=client.client_id,
+            redirect_uri=redirect_uri_str,
+            client_name=getattr(client, 'client_name', None),
+            client_uri=str(getattr(client, 'client_uri', '') or ''),
+        )
+
+        if validation.status == 'rejected':
+            LOG.warning(f'[authorize] Rejected client: client_id={client.client_id}')
+            raise HTTPException(403, f"OAuth client '{client.client_id}' is not authorized.")
+
+        # Flow A: for pre-registered clients, validate the redirect_uri against Connection's registered list.
+        if validation.redirect_uris and redirect_uri_str not in validation.redirect_uris:
+            LOG.warning(
+                f'[authorize] redirect_uri not registered for client: '
+                f'client_id={client.client_id}, redirect_uri={redirect_uri_str}'
+            )
+            raise InvalidRedirectUriError(f'Invalid redirect_uri: {redirect_uri_str}')
+
         # Create and encode the authorization state.
         # We don't store the authentication states that we create here to avoid having to persist them.
         # Instead, we encode them to JWT and pass them back to the client.
         # The states expire after 5 minutes.
         scopes = cast(list[str], params.scopes or [])
         state = {
-            'redirect_uri': str(params.redirect_uri),
+            'redirect_uri': redirect_uri_str,
             'redirect_uri_provided_explicitly': str(params.redirect_uri_provided_explicitly),
             # the scopes sent by the MCP server's OAuth client (e.g. claude.ai)
             'scopes': scopes,
@@ -313,7 +308,7 @@ class SimpleOAuthProvider(OAuthProvider):
         LOG.debug(f'[authorize] client_id={client.client_id}, params={params}, state={state}')
 
         # create the authorization URL
-        url_params = {
+        url_params: dict[str, str] = {
             'client_id': self._oauth_client_id,
             'response_type': 'code',
             'redirect_uri': self._mcp_callback_url,
@@ -323,10 +318,73 @@ class SimpleOAuthProvider(OAuthProvider):
             'scope': 'claudai projectless',
         }
 
+        # Flow B: pass pending client info to Connection so it can show an approval screen.
+        if validation.status == 'pending':
+            url_params['pending_client_id'] = client.client_id
+            url_params['pending_redirect_uri'] = redirect_uri_str
+            if client_name := getattr(client, 'client_name', None):
+                url_params['pending_client_name'] = client_name
+
         auth_url = construct_redirect_uri(self._oauth_server_auth_url, **url_params)
         LOG.debug(f'[authorize] client_id={client.client_id}, params={params}, {auth_url}')
 
         return auth_url
+
+    async def _validate_client(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        client_name: str | None = None,
+        client_uri: str | None = None,
+    ) -> ClientValidationResult:
+        """
+        Validates an OAuth client against Connection's /oauth/clients/validate endpoint.
+
+        :param client_id: The OAuth client identifier.
+        :param redirect_uri: The redirect URI requested by the client.
+        :param client_name: Optional human-readable name of the client (used on the approval screen).
+        :param client_uri: Optional URL of the client's homepage.
+
+        :return: ClientValidationResult with status:
+          - 'approved': client is pre-registered; redirect_uris contains the registered URIs
+          - 'pending': client is unknown; Connection will show an approval screen
+          - 'rejected': client is explicitly denied; the authorization should be refused
+        """
+        payload: dict[str, Any] = {'client_id': client_id, 'redirect_uri': redirect_uri}
+        if client_name:
+            payload['client_name'] = client_name
+        if client_uri:
+            payload['client_uri'] = client_uri
+
+        try:
+            async with self._create_http_client() as http_client:
+                response = await http_client.post(
+                    urljoin(self._oauth_server_url, '/oauth/clients/validate'),
+                    json=payload,
+                )
+        except Exception:
+            # Fail closed: if Connection can't be reached (timeout, connection error, etc.), reject the
+            # client rather than defaulting to 'approved' -- an unreachable Connection must never widen
+            # what redirect_uris get accepted (see AI-3792 / mariankrotil's review on this PR).
+            LOG.warning(
+                '[_validate_client] Failed to reach Connection; rejecting client (fail-closed)',
+                exc_info=True,
+            )
+            return ClientValidationResult(status='rejected')
+
+        if response.status_code == 200:
+            return ClientValidationResult.model_validate(response.json())
+        elif response.status_code in (401, 403):
+            LOG.warning(f'[_validate_client] Connection rejected client: client_id={client_id}')
+            return ClientValidationResult(status='rejected')
+        else:
+            # Fail closed: an unexpected status code from Connection is treated as a rejection, not an
+            # approval -- same reasoning as the exception handler above.
+            LOG.warning(
+                f'[_validate_client] Unexpected response from Connection (fail-closed): '
+                f'client_id={client_id}, status={response.status_code}, text={response.text}'
+            )
+            return ClientValidationResult(status='rejected')
 
     async def handle_oauth_callback(self, code: str, state: str) -> str:
         """

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -14,10 +14,12 @@ import pytest
 from mcp.server.auth.provider import AccessToken, AuthorizationParams, RefreshToken, TokenError
 from mcp.shared.auth import InvalidRedirectUriError, OAuthClientInformationFull
 from pydantic import AnyHttpUrl, AnyUrl
+from starlette.exceptions import HTTPException
 
 from keboola_mcp_server.auth_login import Introspection, ProjectAccess, ScopedToken
 from keboola_mcp_server.clients.auth_bridge import OAuthTokenExchangeError
 from keboola_mcp_server.oauth import (
+    ClientValidationResult,
     DatabaseUnavailableMiddleware,
     ProxyRefreshToken,
     SimpleOAuthProvider,
@@ -280,112 +282,22 @@ class TestSimpleOAuthProvider:
     @pytest.mark.parametrize(
         ('uri', 'valid'),
         [
-            # === HTTP scheme - localhost only ===
-            (AnyUrl('http://localhost:8080/foo'), True),
-            (AnyUrl('http://localhost:20388/oauth/callback'), True),
-            (AnyUrl('http://localhost/callback'), True),
-            (AnyUrl('http://127.0.0.1:1234/bar'), True),
-            (AnyUrl('http://127.0.0.1:54750/auth/callback'), True),
-            (AnyUrl('http://127.0.0.1/callback'), True),
-            # IPv6 localhost
-            (AnyUrl('http://[::1]:8080/callback'), True),
-            (AnyUrl('http://[::1]/callback'), True),
-            # HTTP to non-localhost should be rejected
-            (AnyUrl('http://example.com/callback'), False),
-            (AnyUrl('http://keboola.com/callback'), False),
-            (AnyUrl('http://192.168.1.1/callback'), False),
-            # === HTTPS scheme - whitelisted domains ===
-            # Keboola domains (requires subdomain)
-            (AnyUrl('https://foo.keboola.com/bar/baz'), True),
-            (AnyUrl('https://bar.keboola.dev/baz'), True),
-            (AnyUrl('https://connection.keboola.com/oauth/callback'), True),
-            (AnyUrl('https://keboola.com/callback'), False),  # requires subdomain
-            (AnyUrl('https://keboola.dev/callback'), False),  # requires subdomain
-            # Data-app 'hub' subdomains are user-deployable and must be rejected (RISK-76)
-            (AnyUrl('https://my-app.hub.keboola.com/callback'), False),
-            (AnyUrl('https://my-app.hub.north-europe.azure.keboola.com/callback'), False),
-            (AnyUrl('https://my-app.hub.keboola.dev/callback'), False),
-            (AnyUrl('https://hub.keboola.com/callback'), False),  # the hub root itself
-            (AnyUrl('https://my-app.hub.us-east4.gcp.keboola.com/callback'), False),
-            # ChatGPT (subdomain optional)
-            (AnyUrl('https://chatgpt.com'), True),
-            (AnyUrl('https://foo.chatgpt.com/bar'), True),
-            (AnyUrl('https://chatgpt.com/connector_platform_oauth_redirect'), True),
-            # Claude (subdomain optional)
-            (AnyUrl('https://claude.ai'), True),
-            (AnyUrl('https://foo.claude.ai/bar'), True),
+            # Any http/https/custom scheme is accepted — per-client redirect URI validation
+            # against Connection-registered URIs happens in SimpleOAuthProvider.authorize().
+            (AnyUrl('http://localhost:8080/callback'), True),
+            (AnyUrl('http://example.com/callback'), True),  # domain check moved to Connection
             (AnyUrl('https://claude.ai/api/mcp/auth_callback'), True),
-            # Agnes (exact host only -- its own TLD, outside the keboola.(com|dev) pattern) [AI-3773]
-            (AnyUrl('https://agnes.keboola.systems'), True),
-            (AnyUrl('https://agnes.keboola.systems/api/mcp/oauth-client/callback'), True),
-            (AnyUrl('https://foo.agnes.keboola.systems/bar'), False),  # no subdomains allowed
-            (AnyUrl('https://keboola.systems/callback'), False),  # must be agnes.keboola.systems
-            (AnyUrl('https://evil.keboola.systems/callback'), False),  # no sibling hosts
-            # LibreChat (no subdomains allowed)
-            (AnyUrl('https://librechat.glami-ml.com'), True),
-            (AnyUrl('https://librechat.glami-ml.com/api/mcp/keboola/oauth/callback'), True),
-            (AnyUrl('https://foo.librechat.glami-ml.com/bar'), False),  # no subdomains allowed
-            # Make.com (subdomain optional)
-            (AnyUrl('https://make.com'), True),
-            (AnyUrl('https://foo.make.com/bar'), True),
-            (AnyUrl('https://www.make.com/oauth/cb/mcp'), True),
-            # Devin (exact domain only)
-            (AnyUrl('https://api.devin.ai/callback'), True),
-            (AnyUrl('https://api.devin.ai'), True),
-            (AnyUrl('https://devin.ai/callback'), False),  # must be api.devin.ai
-            (AnyUrl('https://foo.api.devin.ai/callback'), False),  # no subdomains
-            # Onyx (no subdomains allowed)
-            (AnyUrl('https://cloud.onyx.app'), True),
-            (AnyUrl('https://cloud.onyx.app/mcp/oauth/callback'), True),
-            (AnyUrl('https://foo.cloud.onyx.app/bar'), False),  # no subdomains allowed
-            (AnyUrl('https://onyx.app/callback'), False),  # must be cloud.onyx.app
-            # Azure APIM (no subdomains allowed)
-            (AnyUrl('https://global.consent.azure-apim.net'), True),
-            (AnyUrl('https://global.consent.azure-apim.net/oauth/callback'), True),
-            (AnyUrl('https://foo.global.consent.azure-apim.net/bar'), False),  # no subdomains allowed
-            # n8n at Groupon (no subdomains allowed)
-            (AnyUrl('https://n8n.groupondev.com'), True),
-            (AnyUrl('https://n8n.groupondev.com/rest/oauth2-credential/callback'), True),
-            (AnyUrl('https://n8n-business.groupondev.com'), True),
-            (AnyUrl('https://n8n-business.groupondev.com/rest/oauth2-credential/callback'), True),
-            (AnyUrl('https://n8n-merchant.groupondev.com'), True),
-            (AnyUrl('https://n8n-merchant.groupondev.com/rest/oauth2-credential/callback'), True),
-            (AnyUrl('https://n8n-llm-traffic.groupondev.com'), True),
-            (AnyUrl('https://n8n-llm-traffic.groupondev.com/rest/oauth2-credential/callback'), True),
-            (AnyUrl('https://n8n-finance.groupondev.com'), True),
-            (AnyUrl('https://n8n-finance.groupondev.com/rest/oauth2-credential/callback'), True),
-            (AnyUrl('https://n8n-playground.groupondev.com'), True),
-            (AnyUrl('https://n8n-playground.groupondev.com/rest/oauth2-credential/callback'), True),
-            (AnyUrl('https://n8n-staging.groupondev.com'), True),
-            (AnyUrl('https://n8n-staging.groupondev.com/rest/oauth2-credential/callback'), True),
-            (AnyUrl('https://foo.n8n-playground.groupondev.com/bar'), False),  # no subdomains allowed
-            (AnyUrl('https://n8n-unknown.groupondev.com'), False),  # not whitelisted
-            # Unknown HTTPS domains should be rejected
-            (AnyUrl('https://foo.bar.com/callback'), False),
-            (AnyUrl('https://evil.com/callback'), False),
-            (AnyUrl('https://fakechatgpt.com/callback'), False),
-            (AnyUrl('https://evilclaude.ai/callback'), False),
-            # === Cursor scheme - specific hosts only ===
+            (AnyUrl('https://foo.bar.com/callback'), True),  # domain check moved to Connection
             (AnyUrl('cursor://anysphere.cursor-retrieval/oauth/user-keboola-Data_warehouse/callback'), True),
             (AnyUrl('cursor://anysphere.cursor-mcp/oauth/callback'), True),
-            (AnyUrl('cursor://anysphere.cursor-mcp/some/path'), True),
-            # Cursor with unknown hosts should be rejected
-            (AnyUrl('cursor://evil.com/callback'), False),
-            (AnyUrl('cursor://localhost/callback'), False),
-            (AnyUrl('cursor://anysphere.cursor-other/callback'), False),
-            # === Unknown/forbidden schemes should be rejected ===
-            (AnyUrl('ftp://foo.bar.com'), False),
-            (AnyUrl('file:///etc/passwd'), False),
+            (AnyUrl('vscode://callback'), True),  # custom IDE schemes now allowed
+            (AnyUrl('ftp://foo.bar.com'), True),  # non-dangerous scheme allowed
+            # Dangerous scripting schemes are still rejected.
             (AnyUrl('javascript://alert(1)'), False),
             (AnyUrl('data://text/html,<script>alert(1)</script>'), False),
-            # Custom schemes that are NOT whitelisted should be rejected
-            (AnyUrl('vscode://localhost/callback'), False),
-            (AnyUrl('jetbrains://localhost/callback'), False),
-            (AnyUrl('zed://localhost/callback'), False),
-            (AnyUrl('myapp://localhost/callback'), False),
-            (AnyUrl('evil://localhost/callback'), False),
-            # === Edge cases ===
-            (None, False),  # no redirect_uri
+            (AnyUrl('vbscript://foo'), False),
+            # Missing redirect_uri is rejected.
+            (None, False),
         ],
     )
     def test_validate_redirect_uri(self, uri: AnyUrl | None, valid: bool):
@@ -399,8 +311,13 @@ class TestSimpleOAuthProvider:
 
     @pytest.mark.asyncio
     async def test_authorize_redirects_to_consent_with_claudai_projectless_scope(
-        self, oauth_provider: SimpleOAuthProvider
+        self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch
     ):
+        monkeypatch.setattr(
+            oauth_provider,
+            '_validate_client',
+            mock.AsyncMock(return_value=ClientValidationResult(status='approved', redirect_uris=[])),
+        )
         client = _OAuthClientInformationFull(redirect_uris=[AnyHttpUrl('http://foo')], client_id='foo-client-id')
         params = AuthorizationParams(
             redirect_uri=AnyUrl('http://foo/callback'),
@@ -800,3 +717,166 @@ class TestSimpleOAuthProvider:
     @pytest.mark.asyncio
     async def test_revoke_token_unknown_token_is_a_noop(self, oauth_provider: SimpleOAuthProvider) -> None:
         await oauth_provider.revoke_token('never-issued')  # must not raise
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('status_code', 'response_body', 'expected_status', 'expected_redirect_uris'),
+        [
+            # Connection returns approved with registered URIs
+            (
+                200,
+                {'status': 'approved', 'redirect_uris': ['https://claude.ai/cb']},
+                'approved',
+                ['https://claude.ai/cb'],
+            ),
+            # Connection returns pending (unknown client)
+            (200, {'status': 'pending'}, 'pending', []),
+            # Connection rejects the client (401)
+            (401, {}, 'rejected', []),
+            # Connection rejects the client (403)
+            (403, {}, 'rejected', []),
+            # Unexpected status code — fail closed, not open (AI-3792 / mariankrotil's review comment)
+            (500, {}, 'rejected', []),
+        ],
+    )
+    async def test__validate_client(
+        self,
+        status_code: int,
+        response_body: dict,
+        expected_status: str,
+        expected_redirect_uris: list[str],
+        oauth_provider: SimpleOAuthProvider,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        mock_response = mock.MagicMock()
+        mock_response.status_code = status_code
+        mock_response.json.return_value = response_body
+        mock_response.text = str(response_body)
+
+        mock_http = mock.AsyncMock()
+        mock_http.post = mock.AsyncMock(return_value=mock_response)
+        mock_http.__aenter__ = mock.AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = mock.AsyncMock(return_value=False)
+
+        monkeypatch.setattr(oauth_provider, '_create_http_client', lambda: mock_http)
+        result = await oauth_provider._validate_client(
+            client_id='test-client',
+            redirect_uri='https://example.com/cb',
+        )
+
+        assert result.status == expected_status
+        assert result.redirect_uris == expected_redirect_uris
+
+    @pytest.mark.asyncio
+    async def test__validate_client_connection_error(
+        self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Connection unreachable (timeout/connection error/etc.) → fail closed (rejected), never approved."""
+        mock_http = mock.AsyncMock()
+        mock_http.post = mock.AsyncMock(side_effect=httpx.ConnectError('connection refused'))
+        mock_http.__aenter__ = mock.AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = mock.AsyncMock(return_value=False)
+
+        monkeypatch.setattr(oauth_provider, '_create_http_client', lambda: mock_http)
+        result = await oauth_provider._validate_client(client_id='x', redirect_uri='https://x.com/cb')
+
+        assert result.status == 'rejected'
+        assert result.redirect_uris == []
+
+    def _make_auth_params(self, redirect_uri: str = 'https://claude.ai/cb') -> AuthorizationParams:
+        return AuthorizationParams(
+            state='state-xyz',
+            scopes=['email'],
+            redirect_uri=AnyUrl(redirect_uri),
+            redirect_uri_provided_explicitly=True,
+            code_challenge='challenge',
+            code_challenge_method='S256',
+            resource=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_authorize_approved_client(
+        self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Flow A: pre-registered client — redirect_uri validated against Connection's list."""
+        monkeypatch.setattr(
+            oauth_provider,
+            '_validate_client',
+            mock.AsyncMock(
+                return_value=ClientValidationResult(status='approved', redirect_uris=['https://claude.ai/cb'])
+            ),
+        )
+        client = OAuthClientInformationFull(client_id='claude.ai', redirect_uris=[AnyHttpUrl('http://foo')])
+        url = await oauth_provider.authorize(client, self._make_auth_params())
+
+        assert 'pending_client_id' not in url
+        assert 'state=' in url
+
+    @pytest.mark.asyncio
+    async def test_authorize_approved_client_wrong_redirect_uri(
+        self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Flow A: redirect_uri not in Connection's registered list → InvalidRedirectUriError."""
+        monkeypatch.setattr(
+            oauth_provider,
+            '_validate_client',
+            mock.AsyncMock(
+                return_value=ClientValidationResult(status='approved', redirect_uris=['https://other.example.com/cb'])
+            ),
+        )
+        client = OAuthClientInformationFull(client_id='claude.ai', redirect_uris=[AnyHttpUrl('http://foo')])
+        with pytest.raises(InvalidRedirectUriError):
+            await oauth_provider.authorize(client, self._make_auth_params('https://claude.ai/cb'))
+
+    @pytest.mark.asyncio
+    async def test_authorize_pending_client(self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch):
+        """Flow B: unknown client — pending_client_* params appended to Connection auth URL."""
+        monkeypatch.setattr(
+            oauth_provider,
+            '_validate_client',
+            mock.AsyncMock(return_value=ClientValidationResult(status='pending')),
+        )
+        client = OAuthClientInformationFull(
+            client_id='my-new-app',
+            redirect_uris=[AnyHttpUrl('http://foo')],
+            client_name='My New App',
+        )
+        url = await oauth_provider.authorize(client, self._make_auth_params('https://my-app.example.com/cb'))
+
+        assert 'pending_client_id=my-new-app' in url
+        assert 'pending_redirect_uri=' in url
+        assert 'pending_client_name=My+New+App' in url
+
+    @pytest.mark.asyncio
+    async def test_authorize_rejected_client(
+        self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Rejected client → HTTPException 403."""
+        monkeypatch.setattr(
+            oauth_provider,
+            '_validate_client',
+            mock.AsyncMock(return_value=ClientValidationResult(status='rejected')),
+        )
+        client = OAuthClientInformationFull(client_id='evil-app', redirect_uris=[AnyHttpUrl('http://foo')])
+        with pytest.raises(HTTPException) as exc_info:
+            await oauth_provider.authorize(client, self._make_auth_params())
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_authorize_rejects_when_connection_unreachable(
+        self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Fail-closed end-to-end: a Connection outage during authorize() must reject, not silently
+        accept an unvalidated redirect_uri (AI-3792 / mariankrotil's review comment on this PR)."""
+        mock_http = mock.AsyncMock()
+        mock_http.post = mock.AsyncMock(side_effect=httpx.ConnectError('connection refused'))
+        mock_http.__aenter__ = mock.AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = mock.AsyncMock(return_value=False)
+        monkeypatch.setattr(oauth_provider, '_create_http_client', lambda: mock_http)
+
+        client = OAuthClientInformationFull(
+            client_id='attacker-client', redirect_uris=[AnyHttpUrl('https://attacker.evil-test.example/cb')]
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await oauth_provider.authorize(client, self._make_auth_params('https://attacker.evil-test.example/cb'))
+        assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Description

**Linear**: [AI-2883](https://linear.app/keboola/issue/AI-2883/mcp-server-implement-dynamic-oauth-client-registration-via-connection) | Relates to: [RISK-76](https://linear.app/keboola/issue/RISK-76)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Addresses the security issue RISK-76 where the MCP server bypassed Connection's OAuth client registry entirely — accepting any `client_id` without validation and using a hardcoded domain whitelist for redirect URI validation.

**What changed:**

- Removed the hardcoded `_ALLOWED_DOMAINS` / `_RE_LOCALHOST` whitelist constants
- Added `_validate_client()` method that calls Connection's `POST /oauth/clients/validate` endpoint before authorizing any client
- `authorize()` now enforces two flows:
  - **Flow A — Pre-registered clients** (Claude.ai, ChatGPT, Make.com, Cursor, n8n, etc.): redirect URI is validated against Connection's registered URI list for that specific client
  - **Flow B — Dynamic registration**: unknown clients receive `pending` status; their `client_id`, `redirect_uri`, and `client_name` are forwarded as URL params to Connection, which shows an approval screen during the OAuth login flow
- `validate_redirect_uri()` is now minimal — only rejects dangerous scripting schemes (`javascript`, `data`, `vbscript`); per-client domain validation is fully delegated to Connection
- Fails open (treats as `approved`) when Connection is unreachable, to avoid breaking existing clients during migration rollout

**Connection side (prerequisite — must be deployed first):**
- `POST /oauth/clients/validate` endpoint
- Client approval screen in OAuth login flow
- Pre-registered known clients via `php bin/console league:oauth2-server:create-client`

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`SSE` and `Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)