### PR TITLE
feat: add update_project_description tool

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2766,17 +2766,6 @@ to establish the project context before using other tools.
 
 Updates the description of the current Keboola project.
 
-USAGE:
-- Use when the user wants to set or change the project description.
-
-EXAMPLES:
-- user_input: `Set the project description to "Sales data pipeline project"`
-    - set the description parameter to "Sales data pipeline project"
-    - returns the updated project description.
-- user_input: `Clear the project description`
-    - set the description parameter to ""
-    - returns the updated (empty) project description.
-
 
 **Input JSON Schema**:
 ```json

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -48,6 +48,7 @@ providing their configuration IDs.
 - [get_project_info](#get_project_info): Retrieves structured information about the current project,
 including essential context and base instructions for working with it
 (e.
+- [update_project_description](#update_project_description): Updates the description of the current Keboola project.
 
 ### SQL Tools
 - [query_data](#query_data): Executes an SQL SELECT query to get the data from the underlying database.
@@ -2750,6 +2751,45 @@ to establish the project context before using other tools.
 ```json
 {
   "properties": {},
+  "type": "object"
+}
+```
+
+---
+<a name="update_project_description"></a>
+## update_project_description
+**Annotations**: `destructive`
+
+**Tags**: `project`
+
+**Description**:
+
+Updates the description of the current Keboola project.
+
+USAGE:
+- Use when the user wants to set or change the project description.
+
+EXAMPLES:
+- user_input: `Set the project description to "Sales data pipeline project"`
+    - set the description parameter to "Sales data pipeline project"
+    - returns the updated project description.
+- user_input: `Clear the project description`
+    - set the description parameter to ""
+    - returns the updated (empty) project description.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "description": {
+      "description": "The new project description text.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "description"
+  ],
   "type": "object"
 }
 ```

--- a/integtests/test_mcp_server.py
+++ b/integtests/test_mcp_server.py
@@ -194,6 +194,7 @@ async def _assert_basic_setup(client: Client):
         'update_config_row',
         'update_descriptions',
         'update_flow',
+        'update_project_description',
         'update_sql_transformation',
     }
     expected_tools = expected_tools - exclude

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.55.0"
+version = "1.56.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -91,12 +91,6 @@ class ProjectInfo(BaseModel):
     )
 
 
-class UpdateProjectDescriptionOutput(BaseModel):
-    project_description: str = Field(
-        description='The updated project description.',
-    )
-
-
 @tool_errors()
 async def update_project_description(
     ctx: Context,
@@ -106,27 +100,14 @@ async def update_project_description(
             description='The new project description text.'
         ),
     ],
-) -> UpdateProjectDescriptionOutput:
-    """Updates the description of the current Keboola project.
-
-    USAGE:
-    - Use when the user wants to set or change the project description.
-
-    EXAMPLES:
-    - user_input: `Set the project description to "Sales data pipeline project"`
-        - set the description parameter to "Sales data pipeline project"
-        - returns the updated project description.
-    - user_input: `Clear the project description`
-        - set the description parameter to ""
-        - returns the updated (empty) project description.
-    """
+) -> None:
+    """Updates the description of the current Keboola project."""
     client = KeboolaClient.from_state(ctx.session.state)
     storage = client.storage_client
 
     await storage.branch_metadata_update({MetadataField.PROJECT_DESCRIPTION: description})
 
     LOG.info('Project description updated successfully.')
-    return UpdateProjectDescriptionOutput(project_description=description)
 
 
 @tool_errors()

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -35,7 +35,7 @@ def add_project_tools(mcp: FastMCP) -> None:
     mcp.add_tool(
         FunctionTool.from_function(
             update_project_description,
-            annotations=ToolAnnotations(destructiveHint=False),
+            annotations=ToolAnnotations(destructiveHint=True),
             tags={PROJECT_TOOLS_TAG},
         )
     )

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -1,5 +1,5 @@
 import logging
-from typing import cast
+from typing import Annotated, cast
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
@@ -27,6 +27,15 @@ def add_project_tools(mcp: FastMCP) -> None:
         FunctionTool.from_function(
             get_project_info,
             annotations=ToolAnnotations(readOnlyHint=True),
+            tags={PROJECT_TOOLS_TAG},
+        )
+    )
+
+    LOG.info(f'Adding tool {update_project_description.__name__} to the MCP server.')
+    mcp.add_tool(
+        FunctionTool.from_function(
+            update_project_description,
+            annotations=ToolAnnotations(destructiveHint=False),
             tags={PROJECT_TOOLS_TAG},
         )
     )
@@ -80,6 +89,44 @@ class ProjectInfo(BaseModel):
             'Do not change them. Remember to include them in all subsequent instructions.'
         )
     )
+
+
+class UpdateProjectDescriptionOutput(BaseModel):
+    project_description: str = Field(
+        description='The updated project description.',
+    )
+
+
+@tool_errors()
+async def update_project_description(
+    ctx: Context,
+    description: Annotated[
+        str,
+        Field(
+            description='The new project description text.'
+        ),
+    ],
+) -> UpdateProjectDescriptionOutput:
+    """Updates the description of the current Keboola project.
+
+    USAGE:
+    - Use when the user wants to set or change the project description.
+
+    EXAMPLES:
+    - user_input: `Set the project description to "Sales data pipeline project"`
+        - set the description parameter to "Sales data pipeline project"
+        - returns the updated project description.
+    - user_input: `Clear the project description`
+        - set the description parameter to ""
+        - returns the updated (empty) project description.
+    """
+    client = KeboolaClient.from_state(ctx.session.state)
+    storage = client.storage_client
+
+    await storage.branch_metadata_update({MetadataField.PROJECT_DESCRIPTION: description})
+
+    LOG.info('Project description updated successfully.')
+    return UpdateProjectDescriptionOutput(project_description=description)
 
 
 @tool_errors()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,6 +72,7 @@ class TestServer:
             'update_config_row',
             'update_descriptions',
             'update_flow',
+            'update_project_description',
             'update_sql_transformation',
             'validate_semantic_query',
         ]
@@ -376,6 +377,7 @@ async def test_tool_annotations_and_tags():
         ('run_job', None, True, None, {JOB_TOOLS_TAG}),
         # project/doc/search
         ('get_project_info', True, None, None, {PROJECT_TOOLS_TAG}),
+        ('update_project_description', None, False, None, {PROJECT_TOOLS_TAG}),
         ('docs_query', True, None, None, {DOC_TOOLS_TAG}),
         ('find_component_id', True, None, None, {SEARCH_TOOLS_TAG}),
         # semantic

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -377,7 +377,7 @@ async def test_tool_annotations_and_tags():
         ('run_job', None, True, None, {JOB_TOOLS_TAG}),
         # project/doc/search
         ('get_project_info', True, None, None, {PROJECT_TOOLS_TAG}),
-        ('update_project_description', None, False, None, {PROJECT_TOOLS_TAG}),
+        ('update_project_description', None, True, None, {PROJECT_TOOLS_TAG}),
         ('docs_query', True, None, None, {DOC_TOOLS_TAG}),
         ('find_component_id', True, None, None, {SEARCH_TOOLS_TAG}),
         # semantic

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -8,7 +8,6 @@ from keboola_mcp_server.links import Link
 from keboola_mcp_server.resources.prompts import get_project_system_prompt
 from keboola_mcp_server.tools.project import (
     ProjectInfo,
-    UpdateProjectDescriptionOutput,
     _get_toolset_restrictions,
     get_project_info,
     update_project_description,
@@ -127,8 +126,7 @@ async def test_update_project_description(
 
     result = await update_project_description(mcp_context_client, description='New description')
 
-    assert isinstance(result, UpdateProjectDescriptionOutput)
-    assert result.project_description == 'New description'
+    assert result is None
     keboola_client.storage_client.branch_metadata_update.assert_called_once_with(
         {MetadataField.PROJECT_DESCRIPTION: 'New description'}
     )
@@ -146,8 +144,7 @@ async def test_update_project_description_empty(
 
     result = await update_project_description(mcp_context_client, description='')
 
-    assert isinstance(result, UpdateProjectDescriptionOutput)
-    assert result.project_description == ''
+    assert result is None
     keboola_client.storage_client.branch_metadata_update.assert_called_once_with(
         {MetadataField.PROJECT_DESCRIPTION: ''}
     )

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -6,7 +6,13 @@ from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
 from keboola_mcp_server.resources.prompts import get_project_system_prompt
-from keboola_mcp_server.tools.project import ProjectInfo, _get_toolset_restrictions, get_project_info
+from keboola_mcp_server.tools.project import (
+    ProjectInfo,
+    UpdateProjectDescriptionOutput,
+    _get_toolset_restrictions,
+    get_project_info,
+    update_project_description,
+)
 from keboola_mcp_server.workspace import WorkspaceManager
 
 
@@ -107,3 +113,41 @@ async def test_get_project_info(
         assert result.toolset_restrictions is not None
         for substring in expected_restriction_substrings:
             assert substring in result.toolset_restrictions
+
+
+@pytest.mark.asyncio
+async def test_update_project_description(
+    mocker: MockerFixture,
+    mcp_context_client: Context,
+) -> None:
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.storage_client.branch_metadata_update = mocker.AsyncMock(
+        return_value=[{'key': 'KBC.projectDescription', 'value': 'New description'}]
+    )
+
+    result = await update_project_description(mcp_context_client, description='New description')
+
+    assert isinstance(result, UpdateProjectDescriptionOutput)
+    assert result.project_description == 'New description'
+    keboola_client.storage_client.branch_metadata_update.assert_called_once_with(
+        {MetadataField.PROJECT_DESCRIPTION: 'New description'}
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_project_description_empty(
+    mocker: MockerFixture,
+    mcp_context_client: Context,
+) -> None:
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.storage_client.branch_metadata_update = mocker.AsyncMock(
+        return_value=[{'key': 'KBC.projectDescription', 'value': ''}]
+    )
+
+    result = await update_project_description(mcp_context_client, description='')
+
+    assert isinstance(result, UpdateProjectDescriptionOutput)
+    assert result.project_description == ''
+    keboola_client.storage_client.branch_metadata_update.assert_called_once_with(
+        {MetadataField.PROJECT_DESCRIPTION: ''}
+    )

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -114,37 +114,27 @@ async def test_get_project_info(
             assert substring in result.toolset_restrictions
 
 
+@pytest.mark.parametrize(
+    'description',
+    [
+        'New description',
+        '',
+    ],
+)
 @pytest.mark.asyncio
 async def test_update_project_description(
     mocker: MockerFixture,
     mcp_context_client: Context,
+    description: str,
 ) -> None:
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.storage_client.branch_metadata_update = mocker.AsyncMock(
-        return_value=[{'key': 'KBC.projectDescription', 'value': 'New description'}]
+        return_value=[{'key': 'KBC.projectDescription', 'value': description}]
     )
 
-    result = await update_project_description(mcp_context_client, description='New description')
+    result = await update_project_description(mcp_context_client, description=description)
 
     assert result is None
     keboola_client.storage_client.branch_metadata_update.assert_called_once_with(
-        {MetadataField.PROJECT_DESCRIPTION: 'New description'}
-    )
-
-
-@pytest.mark.asyncio
-async def test_update_project_description_empty(
-    mocker: MockerFixture,
-    mcp_context_client: Context,
-) -> None:
-    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.storage_client.branch_metadata_update = mocker.AsyncMock(
-        return_value=[{'key': 'KBC.projectDescription', 'value': ''}]
-    )
-
-    result = await update_project_description(mcp_context_client, description='')
-
-    assert result is None
-    keboola_client.storage_client.branch_metadata_update.assert_called_once_with(
-        {MetadataField.PROJECT_DESCRIPTION: ''}
+        {MetadataField.PROJECT_DESCRIPTION: description}
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1231,7 +1231,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.55.0"
+version = "1.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Adds a new `update_project_description` MCP tool that allows users to set or change the project description. Previously, the project description was only readable via `get_project_info`; there was no tool to update it.

The tool writes to branch metadata using the existing `KBC.projectDescription` metadata key (via `branch_metadata_update`), matching how `get_project_info` reads it. It returns `None` on success (errors are raised via `@tool_errors()`).

**Key review points:**
- The tool is annotated with `destructiveHint=True`, consistent with other update tools (e.g., `update_descriptions`).
- Implemented as a separate tool rather than merged into `update_descriptions`, since project description writes to branch metadata while `update_descriptions` operates on storage items (buckets/tables/columns) via `DescriptionUpdate` objects. [Approved by @mariankrotil](https://github.com/keboola/mcp-server/pull/462#issuecomment-4089248857).

### Updates since last revision
- Rebased on latest `main` (picks up `fakeredis == 2.34.1` pin and `PYDANTIC_DOCS_VERSION` fix that were causing previous CI failures).
- Bumped version `1.55.0` → `1.56.0` and synced `uv.lock`.
- Combined `test_update_project_description` and `test_update_project_description_empty` into a single `@pytest.mark.parametrize`-decorated test per CLAUDE.md conventions.

### Human review checklist
- [x] ~~Confirm separate tool is preferred over merging into `update_descriptions`~~ — approved by @mariankrotil
- [ ] Verify `branch_metadata_update` is the correct API for writing project descriptions (it mirrors how `get_project_info` reads via `branch_metadata_get`)

## Testing

- [x] E2E tested locally via JSON-RPC (`http-compat` transport) against real Keboola project
- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`SSE` and `Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [x] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [x] Documentation updated (if applicable)

Link to Devin session: https://app.devin.ai/sessions/338903d82d3b477daa3152a6ca437f2f
Requested by: @cjayyy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/mcp-server/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
