### PR TITLE
AI-2975: clarify parameter_updates path is relative to parameters

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -750,7 +750,7 @@ WORKFLOW:
     },
     "parameter_updates": {
       "default": null,
-      "description": "List of granular parameter update operations to apply. Each operation (set, str_replace, remove, list_append) modifies a specific value using JSONPath notation. Only provide if updating parameters - do not use for changing description, storage or processors. Prefer simple JSONPaths (e.g., \"array_param[1]\", \"object_param.key\") and make the smallest possible updates - only change what needs changing. In case you need to replace the whole parameters section, you can use the `set` operation with `$` as path.",
+      "description": "List of granular parameter update operations to apply. Each operation (set, str_replace, remove, list_append) modifies a specific value using JSONPath notation. Only provide if updating parameters - do not use for changing description, storage or processors. Paths are relative to the `parameters` object, not the configuration root (e.g. use `tables`, not `parameters.tables`). Prefer simple JSONPaths (e.g., \"array_param[1]\", \"object_param.key\") and make the smallest possible updates - only change what needs changing. In case you need to replace the whole parameters section, you can use the `set` operation with `$` as path.",
       "items": {
         "discriminator": {
           "mapping": {
@@ -986,7 +986,7 @@ WORKFLOW:
     },
     "parameter_updates": {
       "default": null,
-      "description": "List of granular parameter update operations to apply to this row. Each operation (set, str_replace, remove, list_append) modifies a specific parameter using JSONPath notation. Only provide if updating parameters - do not use for changing description or storage. Prefer simple dot-delimited JSONPaths and make the smallest possible updates - only change what needs changing. In case you need to replace the whole parameters, you can use the `set` operation with `$` as path.",
+      "description": "List of granular parameter update operations to apply to this row. Each operation (set, str_replace, remove, list_append) modifies a specific parameter using JSONPath notation. Only provide if updating parameters - do not use for changing description or storage. Paths are relative to the row's `parameters` object, not the row root (e.g. use `tables`, not `parameters.tables`). Prefer simple dot-delimited JSONPaths and make the smallest possible updates - only change what needs changing. In case you need to replace the whole parameters, you can use the `set` operation with `$` as path.",
       "items": {
         "discriminator": {
           "mapping": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.53.0"
+version = "1.53.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -1206,6 +1206,8 @@ async def update_config(
                 'Each operation (set, str_replace, remove, list_append) modifies a specific '
                 'value using JSONPath notation. Only provide if updating parameters -'
                 ' do not use for changing description, storage or processors. '
+                'Paths are relative to the `parameters` object, not the configuration root '
+                '(e.g. use `tables`, not `parameters.tables`). '
                 'Prefer simple JSONPaths (e.g., "array_param[1]", "object_param.key") '
                 'and make the smallest possible updates - only change what needs changing. '
                 'In case you need to replace the whole parameters section, you can use the `set` operation '
@@ -1437,6 +1439,8 @@ async def update_config_row(
                 'Each operation (set, str_replace, remove, list_append) modifies a specific '
                 'parameter using JSONPath notation. Only provide if updating parameters - '
                 'do not use for changing description or storage. '
+                "Paths are relative to the row's `parameters` object, not the row root "
+                '(e.g. use `tables`, not `parameters.tables`). '
                 'Prefer simple dot-delimited JSONPaths '
                 'and make the smallest possible updates - only change what needs changing. '
                 'In case you need to replace the whole parameters, you can use the `set` operation '

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1231,7 +1231,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.53.0"
+version = "1.53.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-2975](https://linear.app/keboola/issue/AI-2975/clarify-config-diff-path-is-relative-to-parameters)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Adds one sentence to the `parameter_updates` field description on `update_config` and `update_config_row` to make it explicit that the JSONPath is relative to the `parameters` object, not the configuration/row root.

Why: in #468 a user reported that calling `update_config` with `path: "parameters.tables"` "lost all sibling keys under `parameters`". Investigation (see issue thread) showed the underlying `_apply_param_update` is correct — `jsonpath_ng`'s `Child.update()` does not replace the parent — and existing tests cover the sibling-preservation case. The real cause is that paths are silently relative to `parameters`, so `parameters.tables` actually creates a nested `parameters.parameters.tables` key, which then fails schema validation or looks like data loss. Clarifying the description in the tool argument prevents agents/users from making that mistake.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable) — existing `test_apply_param_update` already covers the sibling-preservation behavior; no new tests needed
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable) — 1.53.0 → 1.53.1 (patch)
- [x] Documentation updated (if applicable) — TOOLS.md regenerated