### PR TITLE
fix: strip empty enum arrays and add full schema recursion in sanitize_schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.56.0"
+version = "1.56.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/validation.py
+++ b/src/keboola_mcp_server/tools/validation.py
@@ -144,13 +144,18 @@ class KeboolaParametersValidator:
     def sanitize_schema(schema: JsonDict) -> JsonDict:
         """Normalize schema by converting required fields to lists and ensuring properties is a dict"""
 
-        def _sanitize_required_and_properties(
+        def _sanitize_node(
             schema: JsonStruct | JsonPrimitive,
         ) -> tuple[JsonStruct | JsonPrimitive, Optional[bool]]:
 
             # default returns the element of a schema if we are at the bottom of the tree (not a dict)
             if not isinstance(schema, dict):
                 return schema, False
+
+            # Strip empty enum arrays - "enum": [] means no value is valid, which is
+            # a side effect of dynamically populated UI schemas with no options available.
+            if 'enum' in schema and isinstance(schema['enum'], list) and len(schema['enum']) == 0:
+                del schema['enum']
 
             is_current_required = None
             required = schema.get('required', [])
@@ -170,7 +175,7 @@ class KeboolaParametersValidator:
 
                 for property_name, subschema in properties.items():
                     # we recursively sanitize the subschemas within the properties
-                    properties[property_name], is_child_required = _sanitize_required_and_properties(subschema)
+                    properties[property_name], is_child_required = _sanitize_node(subschema)
                     # if is_child_required is None, do not propagate - the child has required field correctly set
                     if is_child_required is True and property_name not in required:
                         required.append(property_name)
@@ -183,9 +188,48 @@ class KeboolaParametersValidator:
             else:
                 schema.pop('required', None)
 
+            # Recurse into 'items'
+            if 'items' in schema:
+                items = schema['items']
+                if isinstance(items, dict):
+                    schema['items'], _ = _sanitize_node(items)
+                elif isinstance(items, list):
+                    schema['items'] = [
+                        _sanitize_node(item)[0] if isinstance(item, dict) else item for item in items
+                    ]
+
+            # Recurse into schema-list keywords (allOf, anyOf, oneOf)
+            for keyword in ('allOf', 'anyOf', 'oneOf'):
+                if keyword in schema and isinstance(schema[keyword], list):
+                    schema[keyword] = [
+                        _sanitize_node(s)[0] if isinstance(s, dict) else s for s in schema[keyword]
+                    ]
+
+            # Recurse into single-schema keywords
+            for keyword in ('not', 'if', 'then', 'else'):
+                if keyword in schema and isinstance(schema[keyword], dict):
+                    schema[keyword], _ = _sanitize_node(schema[keyword])
+
+            # Recurse into additionalProperties (when it's a schema, not a boolean)
+            if 'additionalProperties' in schema and isinstance(schema['additionalProperties'], dict):
+                schema['additionalProperties'], _ = _sanitize_node(schema['additionalProperties'])
+
+            # Recurse into patternProperties
+            if 'patternProperties' in schema and isinstance(schema['patternProperties'], dict):
+                for pattern, subschema in schema['patternProperties'].items():
+                    if isinstance(subschema, dict):
+                        schema['patternProperties'][pattern], _ = _sanitize_node(subschema)
+
+            # Recurse into definitions / $defs
+            for keyword in ('definitions', '$defs'):
+                if keyword in schema and isinstance(schema[keyword], dict):
+                    for name, subschema in schema[keyword].items():
+                        if isinstance(subschema, dict):
+                            schema[keyword][name], _ = _sanitize_node(subschema)
+
             return schema, is_current_required
 
-        sanitized_schema = cast(JsonDict, _sanitize_required_and_properties(schema)[0])
+        sanitized_schema = cast(JsonDict, _sanitize_node(schema)[0])
         return sanitized_schema
 
 

--- a/src/keboola_mcp_server/tools/validation.py
+++ b/src/keboola_mcp_server/tools/validation.py
@@ -142,7 +142,20 @@ class KeboolaParametersValidator:
 
     @staticmethod
     def sanitize_schema(schema: JsonDict) -> JsonDict:
-        """Normalize schema by converting required fields to lists and ensuring properties is a dict"""
+        """
+        Normalize a JSON schema in place and return the same schema object.
+
+        The normalization currently:
+        - removes empty ``enum`` arrays, because ``"enum": []`` would otherwise make the
+          schema reject every value;
+        - converts non-list ``required`` values into the standard list form and, for
+          boolean-like required flags, propagates the requirement to the parent schema;
+        - normalizes ``properties`` from an empty list to an empty dict when needed.
+
+        These rules are applied recursively to nested schema nodes, including structures
+        reachable through ``properties`` and other schema-composition/container keywords
+        handled by this sanitizer.
+        """
 
         def _sanitize_node(
             schema: JsonStruct | JsonPrimitive,

--- a/tests/tools/components/test_validation.py
+++ b/tests/tools/components/test_validation.py
@@ -340,11 +340,118 @@ def test_recoverable_validation_error_compact_format(
         ({'type': 'object', 'required': 1}, {'type': 'object'}),
         # Case 11: empty schema should return an empty schema
         ({}, {}),
+        # Case 12: empty enum stripping at top level
+        ({'type': 'string', 'enum': []}, {'type': 'string'}),
+        # Case 13: empty enum stripping inside properties
+        (
+            {'type': 'object', 'properties': {'color': {'type': 'string', 'enum': []}}},
+            {'type': 'object', 'properties': {'color': {'type': 'string'}}},
+        ),
+        # Case 14: empty enum stripping inside items
+        (
+            {'type': 'array', 'items': {'type': 'string', 'enum': []}},
+            {'type': 'array', 'items': {'type': 'string'}},
+        ),
+        # Case 15: empty enum stripping inside anyOf
+        (
+            {'anyOf': [{'type': 'string', 'enum': []}, {'type': 'integer'}]},
+            {'anyOf': [{'type': 'string'}, {'type': 'integer'}]},
+        ),
+        # Case 16: empty enum stripping deeply nested (items -> properties)
+        (
+            {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {'status': {'type': 'string', 'enum': []}},
+                },
+            },
+            {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {'status': {'type': 'string'}},
+                },
+            },
+        ),
+        # Case 17: non-empty enum should NOT be stripped
+        (
+            {'type': 'string', 'enum': ['a', 'b']},
+            {'type': 'string', 'enum': ['a', 'b']},
+        ),
+        # Case 18: recursion into additionalProperties with empty enum and required normalization
+        (
+            {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'object',
+                    'properties': {'x': {'type': 'string', 'enum': [], 'required': True}},
+                },
+            },
+            {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'object',
+                    'required': ['x'],
+                    'properties': {'x': {'type': 'string'}},
+                },
+            },
+        ),
+        # Case 19: recursion into if/then/else and not
+        (
+            {
+                'if': {'properties': {'a': {'type': 'string', 'enum': []}}},
+                'then': {'properties': {'b': {'type': 'string', 'required': True}}},
+                'else': {'properties': {'c': {'type': 'number', 'enum': []}}},
+                'not': {'type': 'object', 'properties': {'d': {'type': 'string', 'enum': []}}},
+            },
+            {
+                'if': {'properties': {'a': {'type': 'string'}}},
+                'then': {'required': ['b'], 'properties': {'b': {'type': 'string'}}},
+                'else': {'properties': {'c': {'type': 'number'}}},
+                'not': {'type': 'object', 'properties': {'d': {'type': 'string'}}},
+            },
+        ),
+        # Case 20: recursion into definitions/$defs
+        (
+            {
+                'definitions': {'color': {'type': 'string', 'enum': []}},
+                '$defs': {'size': {'type': 'integer', 'enum': []}},
+            },
+            {
+                'definitions': {'color': {'type': 'string'}},
+                '$defs': {'size': {'type': 'integer'}},
+            },
+        ),
+        # Case 21: recursion into patternProperties
+        (
+            {
+                'type': 'object',
+                'patternProperties': {'^S_': {'type': 'string', 'enum': []}},
+            },
+            {
+                'type': 'object',
+                'patternProperties': {'^S_': {'type': 'string'}},
+            },
+        ),
     ],
 )
 def test_normalize_schema(input_schema: JsonDict, expected_schema: JsonDict):
     result = validation.KeboolaParametersValidator.sanitize_schema(input_schema)
     assert result == expected_schema
+
+
+def test_validate_with_empty_enum():
+    """Functional test: data validates against a schema containing 'enum': [] after sanitization."""
+    schema = {
+        'type': 'object',
+        'properties': {
+            'color': {'type': 'string', 'enum': []},
+        },
+    }
+    data = {'color': 'red'}
+    # Should NOT raise - empty enum is stripped during sanitization
+    validation.KeboolaParametersValidator.validate(data, schema)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1231,7 +1231,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.55.1"
+version = "1.56.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -1231,7 +1231,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.56.0"
+version = "1.55.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3000](https://linear.app/keboola/issue/AI-3000/ignore-empty-enum-arrays-in-mcp-schema-validation)

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

**A) Strip `"enum": []` from any schema node.**

Inside `sanitize_schema()`, the inner function (renamed from `_sanitize_required_and_properties` to `_sanitize_node`) now removes empty enum arrays from schema nodes. `"enum": []` means no value is valid, which is a side effect of dynamically populated UI schemas with no options available. Stripping it prevents spurious validation failures.

**B) Make recursion traverse ALL schema-bearing keywords, not just `properties`.**

Previously the function only recursed into `schema['properties']` values. It now also recurses into:
- `items` (dict or list of schema dicts)
- `additionalProperties` (when it's a dict/schema, not a boolean)
- `patternProperties` (dict of pattern → schema)
- `allOf`, `anyOf`, `oneOf` (list of schemas)
- `not` (single schema)
- `if`, `then`, `else` (each a single schema)
- `definitions` / `$defs` (dict of name → schema)

The `is_current_required` propagation logic only applies to `properties` children. For all other keywords, we recurse and discard the return value.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)


Link to Devin session: https://app.devin.ai/sessions/6e0abbbc8174482591d5d5bcd47b9e3c
Requested by: @davidesner