### PR TITLE
chore: release v1.55.0

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: release-notes
+description: Prepares release notes and a draft PR for a new Keboola MCP Server version. Use when the user asks to prepare a release, create release notes, or tag a new version.
+disable-model-invocation: true
+---
+
+**Before doing anything**, ask the user two questions in a single prompt:
+
+1. **What version are we releasing?** (e.g. `1.55.0`)
+2. **MCP only or also agent?** — MCP only (`v1.55.0`) or both MCP and agent (`v1.55.0` + `agent-v1.55.0`)
+
+Then follow these steps:
+
+**1. Find the base tag**
+```bash
+BASE_TAG=$(git tag --list 'v*' | grep -v '\-dev\.' | grep -v 'agent-v' | sort -V | tail -1)
+```
+
+**2. Collect merged PRs since that tag**
+```bash
+BASE_TIMESTAMP=$(git log -1 --format=%cI $BASE_TAG)
+gh api --paginate "repos/keboola/mcp-server/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
+  --jq ".[] | select(.merged_at != null and .merged_at > \"${BASE_TIMESTAMP}\") | {number, title, user: .user.login, merged_at}"
+```
+
+**3. Categorise** — include: breaking changes, new features, enhancements, bug fixes. Skip: CI/internal, docs-only, dependency bumps, integtest changes.
+
+**4. Create branch and draft PR** from `main`:
+
+> Release branches use `release/vX.Y.Z` naming — this is an explicit exception to the
+> normal Linear-ID-prefix convention documented in `CLAUDE.md`.
+
+```bash
+git checkout -b release/vX.Y.Z
+git push -u origin release/vX.Y.Z
+gh pr create --draft --title "chore: release vX.Y.Z" --body "..."
+```
+
+The PR body uses the project PR template. Fill the Summary section with the release notes — **plain prose only, no PR numbers or links**:
+
+```markdown
+## Description
+
+**Linear**: N/A
+
+### Change Type
+- [ ] Major / [x] Minor / [ ] Patch
+
+### Summary
+
+Release vX.Y.Z. Changes since vA.B.C:
+
+#### ⚠️ Breaking Changes
+- **Title**: What changed and what users must do to migrate.
+
+#### New Features
+- **Title**: What it does and what problem it solves.
+
+#### Enhancements
+- **Title**: What improved and the observable effect.
+
+#### Bug Fixes
+- **Title**: What was broken and what is now correct.
+
+## Testing
+- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)
+- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
+- [ ] Tested with In Platform Agent on `canary-orion`
+- [ ] Tested with RO chat on `canary-orion`
+- [ ] KaiBench run locally against the canary image
+
+## Checklist
+- [ ] Self-review completed
+- [x] Project version bumped according to the change type (if applicable)
+```
+
+**5. After PR is approved and tested**, merge via GitHub UI then tag:
+```bash
+git checkout main && git pull
+git tag vX.Y.Z && git push origin vX.Y.Z
+# if agent release confirmed in step 0:
+git tag agent-vX.Y.Z && git push origin agent-vX.Y.Z
+```
+
+Pushed tags trigger `release.yml` CI which builds and publishes the Docker image. KaiBench runs automatically — only on production tags, not dev tags.

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ wheels/
 *.egg-info
 
 # IDE related files
-.claude/
+.claude/settings.json
+.claude/settings.local.json
+.claude/worktrees/
 .cursor/
 .idea/
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Git Workflow
 - **Always create a branch first** before committing changes
 - Branch names must start with the Linear issue ID and be short (e.g., `AI-2480-whitelist-n8n-domains`)
+  - **Exception:** release branches use `release/vX.Y.Z` (e.g., `release/v1.55.0`) — these have no Linear issue
 - Commit messages must **start** with the Linear issue ID (e.g., `AI-2480: description`)
 - When working on a Linear task, **check the current branch first** (`git branch`). If not already on the correct task branch, create one before making any changes: `git checkout -b AI-XXXX-short-description`
 - When creating PRs, use the template at `.github/pull_request_template.md`


### PR DESCRIPTION
## Description

**Linear**: N/A

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Release v1.55.0. Changes since v1.49.1:

---

#### ⚠️ Breaking Changes

- **SSE transport removed** ([#446](https://github.com/keboola/mcp-server/pull/446)): The `sse` transport has been removed. All clients must connect via `streamable-http`. Update any client configuration that uses `--transport sse` or `transport=sse`.

#### New Features

- **Semantic layer MCP tools** ([#416](https://github.com/keboola/mcp-server/pull/416), [#450](https://github.com/keboola/mcp-server/pull/450), [#415](https://github.com/keboola/mcp-server/pull/415)): Full suite of tools for querying and managing semantic layer objects via the Keboola Metastore API — tables, attributes, metrics, filters, and datasets (list, get, create, update, delete, schema validation, SQL dimension generation).

- **Folder parameter for transformations, apps and flows** ([#438](https://github.com/keboola/mcp-server/pull/438)): `create_sql_transformation`, `update_sql_transformation`, data app create/update, and flow tools now accept an optional `folder` parameter to organise components into named workspace folders.

- **`configuration_row_ids` for `run_job`** ([#454](https://github.com/keboola/mcp-server/pull/454)): The `run_job` tool now accepts an optional `configuration_row_ids` list to target specific configuration rows instead of running all of them.

#### Bug Fixes / Improvements

- **`WHEN NOT TO USE` guidance in generic component tool docstrings** ([#459](https://github.com/keboola/mcp-server/pull/459)): `get_components`, `get_configs`, `create_config`, `update_config` now include explicit guidance to prefer specialised tools (e.g. `create_sql_transformation`), reducing hallucination.

- **Clarify `parameter_updates` path is relative to `parameters`** ([#469](https://github.com/keboola/mcp-server/pull/469)): Docstring for `update_config` now explicitly states that keys in `parameter_updates` are relative to the `parameters` object, not the root configuration.

---

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [x] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [x] Tested with In Platform Agent on `canary-orion`
- [x] Tested with RO chat on `canary-orion`
- [x] KaiBench run locally against canary image

## Checklist

- [ ] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)