### PR TITLE
fix(ci): remove invalid properties from reusable workflow call [AI-2588]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,5 @@ jobs:
     name: KaiBench Evaluation
     needs: build-and-push
     if: needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.')
-    continue-on-error: true
-    permissions:
-      contents: read
-      actions: read
-      packages: read
     uses: ./.github/workflows/kaibench.yml
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: read
+  actions: read
+  packages: read
 
 env:
   SERVICE_IMAGE_NAME: "keboola/mcp-server"


### PR DESCRIPTION
## Description

**Linear**: AI-2588

### Change Type  

- [x] Patch (bug fixes, small improvements, no new features)

### Summary

The `kaibench` job in `release.yml` was failing GitHub Actions YAML validation with:

```
(Line: 118, Col: 5): Unexpected value 'uses'
(Line: 119, Col: 5): Unexpected value 'secrets'
(Line: 110, Col: 5): Required property is missing: runs-on
```

**Root cause:** `continue-on-error` and `permissions` are not valid keys for jobs that call a reusable workflow via `uses:`. Their presence caused GitHub's schema validator to treat the `kaibench` job as a regular job, then flag `uses` and `secrets` as unexpected values and require the missing `runs-on`.

**Fix:** Remove both properties from the caller job — they are redundant:
- `permissions` are already declared at the workflow level inside `kaibench.yml`
- `continue-on-error` is already handled inside `kaibench.yml` via `continue-on-error: ${{ github.event_name == 'workflow_call' }}` on the `evaluate` job, which prevents a KaiBench failure from failing the release workflow

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)