### PR TITLE
feat: include config creator info in get_configs response

### DIFF
--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -248,6 +248,11 @@ class ConfigurationAPIResponse(BaseModel):
         description='Configuration metadata',
         validation_alias=AliasChoices('metadata', 'configuration_metadata', 'configurationMetadata'),
     )
+    creator_token: Optional[dict[str, Any]] = Field(
+        default=None,
+        description='Metadata about the token that created the configuration',
+        validation_alias=AliasChoices('creatorToken', 'creator_token', 'creator-token'),
+    )
 
 
 class CreateConfigurationAPIResponse(BaseModel):

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -234,6 +234,9 @@ class ConfigurationRoot(BaseModel):
     configuration_metadata: list[dict[str, Any]] = Field(
         default_factory=list, description='Configuration metadata including MCP tracking'
     )
+    created_by: Optional[str] = Field(
+        default=None, description='Description of the token that created this configuration'
+    )
 
     @classmethod
     def from_api_response(cls, api_config: 'ConfigurationAPIResponse') -> 'ConfigurationRoot':
@@ -246,6 +249,7 @@ class ConfigurationRoot(BaseModel):
         :param api_config: Validated API configuration response
         :return: Complete configuration root domain model
         """
+        created_by = (api_config.creator_token or {}).get('description') if api_config.creator_token else None
         return cls.model_construct(
             component_id=api_config.component_id,
             configuration_id=api_config.configuration_id,
@@ -258,6 +262,7 @@ class ConfigurationRoot(BaseModel):
             storage=api_config.configuration.get('storage'),
             processors=api_config.configuration.get('processors'),
             configuration_metadata=api_config.metadata,
+            created_by=created_by,
         )
 
 
@@ -332,10 +337,14 @@ class ConfigurationRootSummary(BaseModel):
     description: Optional[str] = Field(default=None, description='The description of the configuration')
     is_disabled: bool = Field(default=False, description='Whether the configuration is disabled')
     is_deleted: bool = Field(default=False, description='Whether the configuration is deleted')
+    created_by: Optional[str] = Field(
+        default=None, description='Description of the token that created this configuration'
+    )
 
     @classmethod
     def from_api_response(cls, api_config: 'ConfigurationAPIResponse') -> 'ConfigurationRootSummary':
         """Create lightweight configuration root summary from API response."""
+        created_by = (api_config.creator_token or {}).get('description') if api_config.creator_token else None
         return cls.model_construct(
             component_id=api_config.component_id,
             configuration_id=api_config.configuration_id,
@@ -343,6 +352,7 @@ class ConfigurationRootSummary(BaseModel):
             description=api_config.description,
             is_disabled=api_config.is_disabled,
             is_deleted=api_config.is_deleted,
+            created_by=created_by,
         )
 
 

--- a/tests/tools/components/conftest.py
+++ b/tests/tools/components/conftest.py
@@ -55,6 +55,7 @@ def mock_configurations() -> list[dict[str, Any]]:
             'isDeleted': False,
             'version': 1,
             'configuration': {},
+            'creatorToken': {'id': 100, 'description': 'john.doe@example.com'},
         },
         {
             'id': '456',
@@ -65,6 +66,7 @@ def mock_configurations() -> list[dict[str, Any]]:
             'isDeleted': True,
             'version': 2,
             'configuration': {},
+            'creatorToken': {'id': 200, 'description': 'jane.smith@example.com'},
         },
     ]
 
@@ -132,6 +134,7 @@ def mock_configuration() -> dict[str, Any]:
         'version': 1,
         'configuration': {},
         'rows': [{'id': '1', 'name': 'Row 1', 'version': 1}, {'id': '2', 'name': 'Row 2', 'version': 1}],
+        'creatorToken': {'id': 100, 'description': 'john.doe@example.com'},
     }
 
 
@@ -146,6 +149,7 @@ def mock_tf_configuration() -> dict[str, Any]:
         'isDisabled': False,
         'isDeleted': False,
         'version': 1,
+        'creatorToken': {'id': 100, 'description': 'john.doe@example.com'},
         'configuration': {
             'parameters': {
                 'blocks': [


### PR DESCRIPTION
## Description

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

The `get_configs` tool was not returning information about who created each configuration, even though the Storage API includes `creatorToken` in its response. This PR surfaces the creator info as a `created_by` field on both list and detail mode outputs.

**Changes:**
- Added `creator_token` field to `ConfigurationAPIResponse` to capture `creatorToken` from the Storage API
- Added `created_by: Optional[str]` field to both `ConfigurationRoot` (detail mode) and `ConfigurationRootSummary` (list mode)
- The `created_by` value is extracted from `creatorToken.description` (the human-readable token description, typically a user email)
- Updated test fixtures to include `creatorToken` data

**Reviewer notes:**
- Only the `description` field from `creatorToken` is exposed (not the token `id`). Verify this is sufficient for downstream consumers.
- No new test assertions explicitly verify the `created_by` value flows through — existing tests pass because the field defaults to `None`. Consider whether dedicated assertions are needed.
- The extraction logic `(api_config.creator_token or {}).get('description') if api_config.creator_token else None` has a redundant `or {}` guard since the truthiness check already handles `None`.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)

## Release Notes
**Justification, description**

The `get_configs` MCP tool now includes `created_by` in its response, surfacing the creator token description from the Storage API for both list and detail modes.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Backward compatible — `created_by` defaults to `None` when `creatorToken` is absent from the API response.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/3d15df221b864a069b3f1eb5eb3b48b9
Requested by: @cjayyy