### PR TITLE
AI-3005: add modify_code_data_app tool for python-js data apps

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -42,6 +42,7 @@ name or description.
 and the configuration ID.
 - [get_data_apps](#get_data_apps): Lists summaries of data apps in the project given the limit and offset or gets details of a data apps by
 providing their configuration IDs.
+- [modify_code_data_app](#modify_code_data_app): Creates, updates, or finalizes a "python-js" data app that continuously pulls code from a git repo.
 - [modify_data_app](#modify_data_app): Creates or updates a Streamlit data app.
 
 ### Project Tools
@@ -1758,6 +1759,84 @@ data app logs to investigate in-app errors. The logs may be updated after openin
       "type": "integer"
     }
   },
+  "type": "object"
+}
+```
+
+---
+<a name="modify_code_data_app"></a>
+## modify_code_data_app
+**Annotations**: `destructive`
+
+**Tags**: `data-apps`
+
+**Description**:
+
+Creates, updates, or finalizes a "python-js" data app that continuously pulls code from a git repo.
+
+The app runs a base image that auto-pulls application code from `watched_repo_url` on the given
+branch. Any commits pushed to that repo are picked up automatically — no separate deploy step is
+needed (do NOT call `deploy_data_app` for python-js apps). The response includes the app's
+`deployment_url` which can be used as a preview URL (e.g. embedded in an iframe).
+
+Workflow:
+1. Call with `watched_repo_url`/`watched_repo_branch` (no `configuration_id`) to CREATE the app.
+   Push commits to the watched repo; the running container auto-pulls and restarts the app.
+2. Call with same args + `configuration_id` to UPDATE the watched repo pointer (e.g. change branch).
+3. Call with `finalize=True` + `configuration_id` to switch the app to deploy statically from
+   `watched_repo_url` (removes the continuous-pull mechanism).
+
+Limitations: public git repos only (no credentials), pull period hardcoded to 1 second,
+authentication is always no-auth.
+
+
+**Input JSON Schema**:
+```json
+{
+  "properties": {
+    "name": {
+      "description": "Name of the data app (max ~50 chars to fit DNS label limit).",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the data app.",
+      "type": "string"
+    },
+    "watched_repo_url": {
+      "description": "Public git URL of the repository whose contents the running app will continuously pull. When `finalize` is true, this URL replaces the base image repo as the static source.",
+      "type": "string"
+    },
+    "watched_repo_branch": {
+      "description": "Branch of the watched repository to pull from.",
+      "type": "string"
+    },
+    "finalize": {
+      "default": false,
+      "description": "When true, removes the watchedRepo block and sets the app source to `watched_repo_url` directly. The app stops live-pulling and deploys statically from the repo. Requires configuration_id of an existing app.",
+      "type": "boolean"
+    },
+    "configuration_id": {
+      "default": "",
+      "description": "The ID of existing data app configuration when updating, otherwise empty string.",
+      "type": "string"
+    },
+    "change_description": {
+      "default": "",
+      "description": "The description of the change when updating, otherwise empty string.",
+      "type": "string"
+    },
+    "folder": {
+      "default": "",
+      "description": "Folder name to organize this data app in the Keboola UI. Existing folder names are returned in the response change_summary when no folder is provided and there are 20 or more data apps in the project. If there are 20 or more data apps, you should assign one of the existing folders or create a new one that clearly reflects the data app purpose.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "description",
+    "watched_repo_url",
+    "watched_repo_branch"
+  ],
   "type": "object"
 }
 ```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1775,9 +1775,9 @@ data app logs to investigate in-app errors. The logs may be updated after openin
 Creates, updates, or finalizes a "python-js" data app that continuously pulls code from a git repo.
 
 The app runs a base image that auto-pulls application code from `watched_repo_url` on the given
-branch. Any commits pushed to that repo are picked up automatically — no separate deploy step is
-needed (do NOT call `deploy_data_app` for python-js apps). The response includes the app's
-`deployment_url` which can be used as a preview URL (e.g. embedded in an iframe).
+branch. Any commits pushed to that repo are picked up automatically. The tool handles deployment
+internally — do NOT call `deploy_data_app` separately for python-js apps. The response includes
+the app's `deployment_url` which can be used as a preview URL (e.g. embedded in an iframe).
 
 Workflow:
 1. Call with `watched_repo_url`/`watched_repo_branch` (no `configuration_id`) to CREATE the app.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.55.0"
+version = "1.56.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -105,6 +105,7 @@ class CodeDataAppConfig(BaseModel):
         class DataApp(BaseModel):
             class Git(BaseModel):
                 repository: str = Field(description='Git repository URL of the base image or final app source')
+                branch: str | None = Field(description='Git branch to use', default=None)
 
             class WatchedRepo(BaseModel):
                 pull_period: int = Field(
@@ -123,6 +124,7 @@ class CodeDataAppConfig(BaseModel):
             slug: str = Field(description='The slug of the data app')
             type: Literal['python-js'] = Field(description='The data app sub-type')
             git: Git = Field(description='Git source of the base image or final app source')
+            secrets: dict[str, str] | None = Field(description='The secrets of the data app', default=None)
             watched_repo: WatchedRepo | None = Field(
                 default=None,
                 validation_alias=AliasChoices('watchedRepo', 'watched_repo'),

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from pydantic import AliasChoices, BaseModel, Field
 
@@ -93,6 +93,64 @@ class DataAppConfig(BaseModel):
     parameters: Parameters = Field(description='The parameters of the data app')
     authorization: Authorization = Field(description='The authorization of the data app')
     storage: dict[str, Any] = Field(description='The storage of the data app', default_factory=dict)
+
+
+class CodeDataAppConfig(BaseModel):
+    """
+    Simplified config model for "python-js" data apps that run a fixed base image and continuously
+    pull application code from a watched git repository.
+    """
+
+    class Parameters(BaseModel):
+        class DataApp(BaseModel):
+            class Git(BaseModel):
+                repository: str = Field(description='Git repository URL of the base image or final app source')
+
+            class WatchedRepo(BaseModel):
+                pull_period: int = Field(
+                    validation_alias=AliasChoices('pullPeriod', 'pull_period'),
+                    serialization_alias='pullPeriod',
+                    description='Git pull period in seconds',
+                )
+                url: str = Field(description='Git URL of the watched repository')
+                branch: str = Field(description='Branch of the watched repository to pull from')
+                auto_re_setup: bool = Field(
+                    validation_alias=AliasChoices('autoReSetup', 'auto_re_setup'),
+                    serialization_alias='autoReSetup',
+                    description='Automatically re-setup the app when watched repo changes',
+                )
+
+            slug: str = Field(description='The slug of the data app')
+            type: Literal['python-js'] = Field(description='The data app sub-type')
+            git: Git = Field(description='Git source of the base image or final app source')
+            watched_repo: WatchedRepo | None = Field(
+                default=None,
+                validation_alias=AliasChoices('watchedRepo', 'watched_repo'),
+                serialization_alias='watchedRepo',
+                description='The repository the running container continuously pulls from',
+            )
+
+        auto_suspend_after_seconds: int = Field(
+            validation_alias=AliasChoices('autoSuspendAfterSeconds', 'auto_suspend_after_seconds'),
+            serialization_alias='autoSuspendAfterSeconds',
+            description='The auto suspend after seconds',
+        )
+        data_app: DataApp = Field(
+            description='The data app sub config',
+            serialization_alias='dataApp',
+            validation_alias=AliasChoices('dataApp', 'data_app'),
+        )
+        id: str | None = Field(description='The id of the data app', default=None)
+
+    class Runtime(BaseModel):
+        class Backend(BaseModel):
+            size: str = Field(description='The size of the backend (e.g. "tiny")')
+
+        backend: Backend = Field(description='The backend configuration')
+
+    parameters: Parameters = Field(description='The parameters of the data app')
+    authorization: DataAppConfig.Authorization = Field(description='The authorization of the data app')
+    runtime: Runtime = Field(description='The runtime configuration of the data app')
 
 
 class DataScienceClient(KeboolaServiceClient):
@@ -195,19 +253,22 @@ class DataScienceClient(KeboolaServiceClient):
         self,
         name: str,
         description: str,
-        configuration: DataAppConfig,
+        configuration: DataAppConfig | CodeDataAppConfig,
+        *,
+        type: Literal['streamlit', 'python-js'] = 'streamlit',
     ) -> DataAppResponse:
         """
         Create a data app from a simplified config used in the MCP server.
         :param name: The name of the data app
         :param description: The description of the data app
         :param configuration: The simplified configuration of the data app
+        :param type: The DSAPI data app type (defaults to 'streamlit' for backwards compatibility)
         :return: The data app
         """
         data = {
             'branchId': self._branch_id,
             'name': name,
-            'type': 'streamlit',
+            'type': type,
             'description': description,
             'config': configuration.model_dump(exclude_none=True, by_alias=True),
         }

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -1071,7 +1071,7 @@ def _build_code_data_app_config(
             'dataApp': {
                 'slug': slug,
                 'type': 'python-js',
-                'git': {'repository': _CONTINUOUS_PULL_BASE_REPO},
+                'git': {'repository': _CONTINUOUS_PULL_BASE_REPO, 'branch': 'feat/user-nginx-and-multi-process'},
                 'watchedRepo': {
                     'pullPeriod': _DEFAULT_PULL_PERIOD_SECONDS,
                     'url': watched_repo_url,

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID, KeboolaClient
-from keboola_mcp_server.clients.data_science import DataAppConfig, DataAppResponse
+from keboola_mcp_server.clients.data_science import CodeDataAppConfig, DataAppConfig, DataAppResponse
 from keboola_mcp_server.clients.storage import ConfigurationAPIResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.errors import tool_errors
@@ -46,6 +46,13 @@ def add_data_app_tools(mcp: FastMCP) -> None:
     )
     mcp.add_tool(
         FunctionTool.from_function(
+            modify_code_data_app,
+            tags={DATA_APP_TOOLS_TAG},
+            annotations=ToolAnnotations(destructiveHint=True),
+        )
+    )
+    mcp.add_tool(
+        FunctionTool.from_function(
             get_data_apps,
             tags={DATA_APP_TOOLS_TAG},
             annotations=ToolAnnotations(readOnlyHint=True),
@@ -68,10 +75,19 @@ State = Literal['created', 'running', 'stopped', 'starting', 'stopping', 'restar
 # LLM agent can still understand the state of the data app even if it is different from the known states
 SafeState = Union[State, str]
 # Type of the data app
-Type = Literal['streamlit']
+Type = Literal['streamlit', 'python-js']
 # Accepts known types or any string preventing from validation errors when receiving unknown types from the API
 # LLM agent can still understand the type of the data app even if it is different from the known types
 SafeType = Union[Type, str]
+
+# Base image repo used by python-js data apps during the continuous-pull (watching) phase.
+_CONTINUOUS_PULL_BASE_REPO = 'https://github.com/pepamartinec/data-app-continuous-pull'
+# Git pull interval (seconds) hardcoded for the POC.
+_DEFAULT_PULL_PERIOD_SECONDS = 1
+# Default backend size for python-js apps.
+_DEFAULT_CODE_APP_SIZE = 'tiny'
+# Default auto-suspend timeout (seconds) for python-js apps.
+_DEFAULT_CODE_APP_AUTO_SUSPEND_SECONDS = 900
 
 _DATA_APP_RESOURCES = resources.files('keboola_mcp_server.resources.data_app')
 _QUERY_SERVICE_QUERY_DATA_FUNCTION_CODE = _DATA_APP_RESOURCES.joinpath('qsapi_query_data_code.py').read_text(
@@ -109,11 +125,13 @@ class DataAppSummary(BaseModel):
     state: SafeState = Field(description='The state of the data app.')
     type: SafeType = Field(
         description=(
-            'The type of the data app. Currently, only "streamlit" is supported in the MCP. However, Keboola DSAPI '
-            'supports additional types, which can be retrieved from the API.'
+            'The type of the data app ("streamlit" for inline-code Streamlit apps, '
+            '"python-js" for git-backed continuous-pull apps).'
         )
     )
-    deployment_url: Optional[str] = Field(description='The URL of the running data app.', default=None)
+    deployment_url: Optional[str] = Field(
+        description='The URL of the running data app, usable as a preview/embed URL.', default=None
+    )
     auto_suspend_after_seconds: Optional[int] = Field(
         description='The number of seconds after which the running data app is automatically suspended.',
         default=None,
@@ -166,11 +184,13 @@ class DataApp(BaseModel):
     state: SafeState = Field(description='The state of the data app.')
     type: SafeType = Field(
         description=(
-            'The type of the data app. Currently, only "streamlit" is supported in the MCP. However, Keboola DSAPI '
-            'supports additional types, which can be retrieved from the API.'
+            'The type of the data app ("streamlit" for inline-code Streamlit apps, '
+            '"python-js" for git-backed continuous-pull apps).'
         )
     )
-    deployment_url: Optional[str] = Field(description='The URL of the running data app.', default=None)
+    deployment_url: Optional[str] = Field(
+        description='The URL of the running data app, usable as a preview/embed URL.', default=None
+    )
     auto_suspend_after_seconds: Optional[int] = Field(
         description='The number of seconds after which the running data app is automatically suspended.',
         default=None,
@@ -403,6 +423,158 @@ async def modify_data_app(
             response='created',
             change_summary=folder_hint,
             data_app=DataAppSummary.from_api_response(data_app_resp),
+            links=links,
+        )
+
+
+@tool_errors()
+async def modify_code_data_app(
+    ctx: Context,
+    name: Annotated[str, Field(description='Name of the data app (max ~50 chars to fit DNS label limit).')],
+    description: Annotated[str, Field(description='Description of the data app.')],
+    watched_repo_url: Annotated[
+        str,
+        Field(
+            description=(
+                'Public git URL of the repository whose contents the running app will continuously pull. '
+                'When `finalize` is true, this URL replaces the base image repo as the static source.'
+            )
+        ),
+    ],
+    watched_repo_branch: Annotated[
+        str,
+        Field(description='Branch of the watched repository to pull from.'),
+    ],
+    finalize: Annotated[
+        bool,
+        Field(
+            description=(
+                'When true, removes the watchedRepo block and sets the app source to `watched_repo_url` '
+                'directly. The app stops live-pulling and deploys statically from the repo. '
+                'Requires configuration_id of an existing app.'
+            )
+        ),
+    ] = False,
+    configuration_id: Annotated[
+        str, Field(description='The ID of existing data app configuration when updating, otherwise empty string.')
+    ] = '',
+    change_description: Annotated[
+        str,
+        Field(description='The description of the change when updating, otherwise empty string.'),
+    ] = '',
+    folder: Annotated[
+        str,
+        Field(description=folder_field_description('data app', 'data apps')),
+    ] = '',
+) -> ModifiedDataAppOutput:
+    """Creates, updates, or finalizes a "python-js" data app that continuously pulls code from a git repo.
+
+    The app runs a base image that auto-pulls application code from `watched_repo_url` on the given
+    branch. Any commits pushed to that repo are picked up automatically. The tool handles deployment
+    internally — do NOT call `deploy_data_app` separately for python-js apps. The response includes
+    the app's `deployment_url` which can be used as a preview URL (e.g. embedded in an iframe).
+
+    Workflow:
+    1. Call with `watched_repo_url`/`watched_repo_branch` (no `configuration_id`) to CREATE the app.
+       Push commits to the watched repo; the running container auto-pulls and restarts the app.
+    2. Call with same args + `configuration_id` to UPDATE the watched repo pointer (e.g. change branch).
+    3. Call with `finalize=True` + `configuration_id` to switch the app to deploy statically from
+       `watched_repo_url` (removes the continuous-pull mechanism).
+
+    Limitations: public git repos only (no credentials), pull period hardcoded to 1 second,
+    authentication is always no-auth.
+    """
+    client = KeboolaClient.from_state(ctx.session.state)
+    links_manager = await ProjectLinksManager.from_client(client)
+
+    project_id = await client.storage_client.project_id()
+
+    if finalize and not configuration_id:
+        raise ValueError('`finalize=True` requires `configuration_id` of an existing data app.')
+
+    if configuration_id:
+        # Update existing python-js data app (watched-repo pointer change or finalize)
+        data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
+        updated_config = _update_existing_code_data_app_config(
+            data_app.configuration,
+            name=name,
+            watched_repo_url=watched_repo_url,
+            watched_repo_branch=watched_repo_branch,
+            finalize=finalize,
+        )
+        updated_config = cast(
+            JsonDict,
+            await client.encryption_client.encrypt(
+                updated_config, component_id=DATA_APP_COMPONENT_ID, project_id=project_id
+            ),
+        )
+        await client.storage_client.configuration_update(
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=configuration_id,
+            configuration=updated_config,
+            change_description=change_description or ('Finalize Data App' if finalize else 'Change Data App'),
+            updated_name=name or data_app.name,
+            updated_description=description or data_app.description,
+        )
+        # Deploy so the updated config takes effect and the URL is assigned.
+        config_version = await client.storage_client.configuration_version_latest(
+            DATA_APP_COMPONENT_ID, configuration_id
+        )
+        await client.data_science_client.deploy_data_app(data_app.data_app_id, str(config_version))
+        data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
+        await set_cfg_update_metadata(
+            client=client,
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=configuration_id,
+            configuration_version=int(data_app.config_version),
+        )
+        folder_hint = await _apply_folder(client, DATA_APP_COMPONENT_ID, configuration_id, folder)
+        links = links_manager.get_data_app_links(
+            configuration_id=data_app.configuration_id,
+            configuration_name=name or data_app.name,
+            deployment_link=data_app.deployment_url,
+            uses_basic_authentication=_uses_basic_authentication(data_app.configuration.get('authorization') or {}),
+        )
+        response = 'finalized' if finalize else 'updated'
+        return ModifiedDataAppOutput(
+            response=response,
+            change_summary=folder_hint,
+            data_app=DataAppSummary.model_validate(data_app.model_dump()),
+            links=links,
+        )
+    else:
+        # Create new python-js data app in watching mode
+        config = _build_code_data_app_config(name, watched_repo_url, watched_repo_branch)
+        config = await client.encryption_client.encrypt(
+            config, component_id=DATA_APP_COMPONENT_ID, project_id=project_id
+        )
+        validated_config = CodeDataAppConfig.model_validate(config)
+        data_app_resp = await client.data_science_client.create_data_app(
+            name, description, configuration=validated_config, type='python-js'
+        )
+        # Deploy the newly created app so the container starts and a URL is assigned.
+        config_version = await client.storage_client.configuration_version_latest(
+            DATA_APP_COMPONENT_ID, data_app_resp.config_id
+        )
+        await client.data_science_client.deploy_data_app(data_app_resp.id, str(config_version))
+        await set_cfg_creation_metadata(
+            client=client,
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=data_app_resp.config_id,
+        )
+        # Re-fetch to pick up the deployment URL.
+        data_app = await _fetch_data_app(client, configuration_id=data_app_resp.config_id, data_app_id=None)
+        folder_hint = await _apply_folder(client, DATA_APP_COMPONENT_ID, data_app_resp.config_id, folder)
+        links = links_manager.get_data_app_links(
+            configuration_id=data_app.configuration_id,
+            configuration_name=name,
+            deployment_link=data_app.deployment_url,
+            uses_basic_authentication=_uses_basic_authentication(validated_config.authorization),
+        )
+        return ModifiedDataAppOutput(
+            response='created',
+            change_summary=folder_hint,
+            data_app=DataAppSummary.model_validate(data_app.model_dump()),
             links=links,
         )
 
@@ -873,3 +1045,66 @@ def _get_secrets(workspace_id: str, branch_id: str) -> dict[str, Any]:
         SECRET_BRANCH_ID: branch_id,
     }
     return secrets
+
+
+def _build_code_data_app_config(
+    name: str,
+    watched_repo_url: str,
+    watched_repo_branch: str,
+) -> dict[str, Any]:
+    """
+    Builds a python-js data app config in watching mode. The running container pulls code continuously
+    from `watched_repo_url`; the base image comes from `_CONTINUOUS_PULL_BASE_REPO`. POC uses no-auth
+    and public git repos only.
+    """
+    slug = _get_data_app_slug(name) or 'Data-App'
+    return {
+        'parameters': {
+            'autoSuspendAfterSeconds': _DEFAULT_CODE_APP_AUTO_SUSPEND_SECONDS,
+            'dataApp': {
+                'slug': slug,
+                'type': 'python-js',
+                'git': {'repository': _CONTINUOUS_PULL_BASE_REPO},
+                'watchedRepo': {
+                    'pullPeriod': _DEFAULT_PULL_PERIOD_SECONDS,
+                    'url': watched_repo_url,
+                    'branch': watched_repo_branch,
+                    'autoReSetup': True,
+                },
+            },
+        },
+        'authorization': _get_authorization(auth_with_password=False),
+        'runtime': {'backend': {'size': _DEFAULT_CODE_APP_SIZE}},
+    }
+
+
+def _update_existing_code_data_app_config(
+    existing_config: Mapping[str, Any],
+    *,
+    name: str,
+    watched_repo_url: str,
+    watched_repo_branch: str,
+    finalize: bool,
+) -> dict[str, Any]:
+    """
+    Updates an existing python-js data app config.
+
+    - When `finalize` is False: refreshes the watchedRepo.url / branch pointers.
+    - When `finalize` is True: replaces parameters.dataApp.git.repository with `watched_repo_url` and
+      drops the watchedRepo block so the app deploys statically from the user's repo.
+    """
+    new_config = cast(dict[str, Any], copy.deepcopy(existing_config))
+    data_app = new_config['parameters']['dataApp']
+    if name:
+        data_app['slug'] = _get_data_app_slug(name) or data_app.get('slug', 'Data-App')
+    if finalize:
+        data_app['git'] = {'repository': watched_repo_url}
+        data_app.pop('watchedRepo', None)
+    else:
+        data_app['watchedRepo'] = {
+            'pullPeriod': _DEFAULT_PULL_PERIOD_SECONDS,
+            'url': watched_repo_url,
+            'branch': watched_repo_branch,
+            'autoReSetup': True,
+        }
+    return new_config

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -485,9 +485,14 @@ async def modify_code_data_app(
     authentication is always no-auth.
     """
     client = KeboolaClient.from_state(ctx.session.state)
+    workspace_manager = WorkspaceManager.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
 
     project_id = await client.storage_client.project_id()
+    secrets = _get_secrets(
+        workspace_id=str(await workspace_manager.get_workspace_id()),
+        branch_id=str(await workspace_manager.get_branch_id()),
+    )
 
     if finalize and not configuration_id:
         raise ValueError('`finalize=True` requires `configuration_id` of an existing data app.')
@@ -501,6 +506,7 @@ async def modify_code_data_app(
             watched_repo_url=watched_repo_url,
             watched_repo_branch=watched_repo_branch,
             finalize=finalize,
+            secrets=secrets,
         )
         updated_config = cast(
             JsonDict,
@@ -544,7 +550,7 @@ async def modify_code_data_app(
         )
     else:
         # Create new python-js data app in watching mode
-        config = _build_code_data_app_config(name, watched_repo_url, watched_repo_branch)
+        config = _build_code_data_app_config(name, watched_repo_url, watched_repo_branch, secrets)
         config = await client.encryption_client.encrypt(
             config, component_id=DATA_APP_COMPONENT_ID, project_id=project_id
         )
@@ -1051,6 +1057,7 @@ def _build_code_data_app_config(
     name: str,
     watched_repo_url: str,
     watched_repo_branch: str,
+    secrets: dict[str, Any],
 ) -> dict[str, Any]:
     """
     Builds a python-js data app config in watching mode. The running container pulls code continuously
@@ -1071,6 +1078,7 @@ def _build_code_data_app_config(
                     'branch': watched_repo_branch,
                     'autoReSetup': True,
                 },
+                'secrets': secrets,
             },
         },
         'authorization': _get_authorization(auth_with_password=False),
@@ -1085,6 +1093,7 @@ def _update_existing_code_data_app_config(
     watched_repo_url: str,
     watched_repo_branch: str,
     finalize: bool,
+    secrets: dict[str, Any],
 ) -> dict[str, Any]:
     """
     Updates an existing python-js data app config.
@@ -1107,4 +1116,11 @@ def _update_existing_code_data_app_config(
             'branch': watched_repo_branch,
             'autoReSetup': True,
         }
+
+    updated_secrets = existing_config['parameters']['dataApp'].get('secrets', {}).copy()
+    for key in secrets:
+        if key not in updated_secrets:
+            updated_secrets[key] = secrets[key]
+    data_app['secrets'] = updated_secrets
+
     return new_config

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -61,6 +61,7 @@ class TestServer:
             'get_semantic_context',
             'get_semantic_schema',
             'get_tables',
+            'modify_code_data_app',
             'modify_data_app',
             'modify_flow',
             'query_data',
@@ -387,6 +388,7 @@ async def test_tool_annotations_and_tags():
         ('create_oauth_url', None, True, None, {OAUTH_TOOLS_TAG}),
         # data apps
         ('modify_data_app', None, True, None, {DATA_APP_TOOLS_TAG, CONFIG_DIFF_PREVIEW_TAG}),
+        ('modify_code_data_app', None, True, None, {DATA_APP_TOOLS_TAG}),
         ('get_data_apps', True, None, None, {DATA_APP_TOOLS_TAG}),
         ('deploy_data_app', None, False, None, {DATA_APP_TOOLS_TAG}),
     ],

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -779,7 +779,10 @@ class TestBuildCodeDataAppConfig:
         data_app = params['dataApp']
         assert data_app['slug'] == 'my-code-app'
         assert data_app['type'] == 'python-js'
-        assert data_app['git'] == {'repository': _CONTINUOUS_PULL_BASE_REPO}
+        assert data_app['git'] == {
+            'repository': _CONTINUOUS_PULL_BASE_REPO,
+            'branch': 'feat/user-nginx-and-multi-process',
+        }
         assert data_app['watchedRepo'] == {
             'pullPeriod': _DEFAULT_PULL_PERIOD_SECONDS,
             'url': 'https://github.com/user/repo.git',

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -765,10 +765,12 @@ class TestBuildCodeDataAppConfig:
     """Tests for _build_code_data_app_config helper."""
 
     def test_builds_watching_mode_config(self):
+        secrets = {'WORKSPACE_ID': '123', 'BRANCH_ID': 'default'}
         config = _build_code_data_app_config(
             name='My Code App',
             watched_repo_url='https://github.com/user/repo.git',
             watched_repo_branch='main',
+            secrets=secrets,
         )
 
         params = config['parameters']
@@ -784,8 +786,9 @@ class TestBuildCodeDataAppConfig:
             'branch': 'main',
             'autoReSetup': True,
         }
+        assert data_app['secrets'] == secrets
 
-        # No script, no packages, no secrets (streamlit-only)
+        # No script, no packages
         assert 'script' not in params
         assert 'packages' not in params
 
@@ -800,6 +803,7 @@ class TestBuildCodeDataAppConfig:
             name='!!!',
             watched_repo_url='https://github.com/user/repo.git',
             watched_repo_branch='dev',
+            secrets={'WORKSPACE_ID': '1', 'BRANCH_ID': 'default'},
         )
         assert config['parameters']['dataApp']['slug'] == 'Data-App'
 
@@ -829,12 +833,14 @@ class TestUpdateExistingCodeDataAppConfig:
         }
 
     def test_update_watched_repo(self, existing_code_config):
+        secrets = {'WORKSPACE_ID': '123', 'BRANCH_ID': 'default'}
         updated = _update_existing_code_data_app_config(
             existing_code_config,
             name='New Name',
             watched_repo_url='https://github.com/user/new-repo.git',
             watched_repo_branch='feature',
             finalize=False,
+            secrets=secrets,
         )
 
         data_app = updated['parameters']['dataApp']
@@ -847,17 +853,20 @@ class TestUpdateExistingCodeDataAppConfig:
             'branch': 'feature',
             'autoReSetup': True,
         }
+        assert data_app['secrets'] == secrets
         # rest of config untouched
         assert updated['authorization'] == existing_code_config['authorization']
         assert updated['runtime'] == existing_code_config['runtime']
 
     def test_finalize_replaces_git_and_removes_watched_repo(self, existing_code_config):
+        secrets = {'WORKSPACE_ID': '456', 'BRANCH_ID': 'main'}
         updated = _update_existing_code_data_app_config(
             existing_code_config,
             name='',
             watched_repo_url='https://github.com/user/final-repo.git',
             watched_repo_branch='main',
             finalize=True,
+            secrets=secrets,
         )
 
         data_app = updated['parameters']['dataApp']
@@ -867,6 +876,7 @@ class TestUpdateExistingCodeDataAppConfig:
         assert 'watchedRepo' not in data_app
         # slug preserved when name is empty
         assert data_app['slug'] == 'old-slug'
+        assert data_app['secrets'] == secrets
 
     def test_does_not_mutate_original(self, existing_code_config):
         import copy
@@ -878,6 +888,7 @@ class TestUpdateExistingCodeDataAppConfig:
             watched_repo_url='https://github.com/user/x.git',
             watched_repo_branch='y',
             finalize=True,
+            secrets={'WORKSPACE_ID': '1', 'BRANCH_ID': 'default'},
         )
         assert existing_code_config == original
 

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -11,6 +11,10 @@ from keboola_mcp_server.clients.data_science import DataAppResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.data_apps import (
+    _CONTINUOUS_PULL_BASE_REPO,
+    _DEFAULT_CODE_APP_AUTO_SUSPEND_SECONDS,
+    _DEFAULT_CODE_APP_SIZE,
+    _DEFAULT_PULL_PERIOD_SECONDS,
     _QUERY_SERVICE_QUERY_DATA_FUNCTION_CODE,
     _STORAGE_QUERY_DATA_FUNCTION_CODE,
     MAX_DNS_LABEL_LENGTH,
@@ -18,6 +22,7 @@ from keboola_mcp_server.tools.data_apps import (
     DataAppSlugTooLongError,
     DataAppSummary,
     ModifiedDataAppOutput,
+    _build_code_data_app_config,
     _build_data_app_config,
     _fetch_data_app,
     _get_authorization,
@@ -25,10 +30,12 @@ from keboola_mcp_server.tools.data_apps import (
     _get_query_function_code,
     _get_secrets,
     _inject_query_to_source_code,
+    _update_existing_code_data_app_config,
     _update_existing_data_app_config,
     _uses_basic_authentication,
     deploy_data_app,
     get_data_apps,
+    modify_code_data_app,
     modify_data_app,
 )
 
@@ -747,3 +754,306 @@ async def test_modify_data_app_folder(
         assert str(app_count) in result.change_summary
     else:
         assert result.change_summary is None
+
+
+# =============================================================================
+# PYTHON-JS (CODE DATA APP) TESTS
+# =============================================================================
+
+
+class TestBuildCodeDataAppConfig:
+    """Tests for _build_code_data_app_config helper."""
+
+    def test_builds_watching_mode_config(self):
+        config = _build_code_data_app_config(
+            name='My Code App',
+            watched_repo_url='https://github.com/user/repo.git',
+            watched_repo_branch='main',
+        )
+
+        params = config['parameters']
+        assert params['autoSuspendAfterSeconds'] == _DEFAULT_CODE_APP_AUTO_SUSPEND_SECONDS
+
+        data_app = params['dataApp']
+        assert data_app['slug'] == 'my-code-app'
+        assert data_app['type'] == 'python-js'
+        assert data_app['git'] == {'repository': _CONTINUOUS_PULL_BASE_REPO}
+        assert data_app['watchedRepo'] == {
+            'pullPeriod': _DEFAULT_PULL_PERIOD_SECONDS,
+            'url': 'https://github.com/user/repo.git',
+            'branch': 'main',
+            'autoReSetup': True,
+        }
+
+        # No script, no packages, no secrets (streamlit-only)
+        assert 'script' not in params
+        assert 'packages' not in params
+
+        # Authorization: no-auth
+        assert config['authorization'] == _get_authorization(False)
+
+        # Runtime backend size
+        assert config['runtime'] == {'backend': {'size': _DEFAULT_CODE_APP_SIZE}}
+
+    def test_uses_default_slug_when_name_produces_empty(self):
+        config = _build_code_data_app_config(
+            name='!!!',
+            watched_repo_url='https://github.com/user/repo.git',
+            watched_repo_branch='dev',
+        )
+        assert config['parameters']['dataApp']['slug'] == 'Data-App'
+
+
+class TestUpdateExistingCodeDataAppConfig:
+    """Tests for _update_existing_code_data_app_config helper."""
+
+    @pytest.fixture
+    def existing_code_config(self) -> dict:
+        return {
+            'parameters': {
+                'autoSuspendAfterSeconds': 900,
+                'dataApp': {
+                    'slug': 'old-slug',
+                    'type': 'python-js',
+                    'git': {'repository': _CONTINUOUS_PULL_BASE_REPO},
+                    'watchedRepo': {
+                        'pullPeriod': 1,
+                        'url': 'https://github.com/user/old-repo.git',
+                        'branch': 'old-branch',
+                        'autoReSetup': True,
+                    },
+                },
+            },
+            'authorization': _get_authorization(False),
+            'runtime': {'backend': {'size': 'tiny'}},
+        }
+
+    def test_update_watched_repo(self, existing_code_config):
+        updated = _update_existing_code_data_app_config(
+            existing_code_config,
+            name='New Name',
+            watched_repo_url='https://github.com/user/new-repo.git',
+            watched_repo_branch='feature',
+            finalize=False,
+        )
+
+        data_app = updated['parameters']['dataApp']
+        assert data_app['slug'] == 'new-name'
+        # git.repository unchanged — still points at base image
+        assert data_app['git'] == {'repository': _CONTINUOUS_PULL_BASE_REPO}
+        assert data_app['watchedRepo'] == {
+            'pullPeriod': _DEFAULT_PULL_PERIOD_SECONDS,
+            'url': 'https://github.com/user/new-repo.git',
+            'branch': 'feature',
+            'autoReSetup': True,
+        }
+        # rest of config untouched
+        assert updated['authorization'] == existing_code_config['authorization']
+        assert updated['runtime'] == existing_code_config['runtime']
+
+    def test_finalize_replaces_git_and_removes_watched_repo(self, existing_code_config):
+        updated = _update_existing_code_data_app_config(
+            existing_code_config,
+            name='',
+            watched_repo_url='https://github.com/user/final-repo.git',
+            watched_repo_branch='main',
+            finalize=True,
+        )
+
+        data_app = updated['parameters']['dataApp']
+        # git.repository now points to user's repo
+        assert data_app['git'] == {'repository': 'https://github.com/user/final-repo.git'}
+        # watchedRepo completely removed
+        assert 'watchedRepo' not in data_app
+        # slug preserved when name is empty
+        assert data_app['slug'] == 'old-slug'
+
+    def test_does_not_mutate_original(self, existing_code_config):
+        import copy
+
+        original = copy.deepcopy(existing_code_config)
+        _update_existing_code_data_app_config(
+            existing_code_config,
+            name='Changed',
+            watched_repo_url='https://github.com/user/x.git',
+            watched_repo_branch='y',
+            finalize=True,
+        )
+        assert existing_code_config == original
+
+
+class TestModifyCodeDataApp:
+    """Tests for the modify_code_data_app MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_python_js_data_app(self, mocker, mcp_context_client: Context) -> None:
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+
+        keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
+        keboola_client.storage_client.configuration_version_latest = mocker.AsyncMock(return_value=1)
+        keboola_client.encryption_client = mocker.AsyncMock()
+        keboola_client.encryption_client.encrypt = mocker.AsyncMock(side_effect=lambda config, **kw: config)
+
+        data_app_response = DataAppResponse(
+            id='app-new',
+            project_id='proj-1',
+            component_id=DATA_APP_COMPONENT_ID,
+            branch_id='default',
+            config_id='cfg-new',
+            config_version='1',
+            type='python-js',
+            state='created',
+            desired_state='created',
+        )
+        deployed_data_app = DataApp(
+            name='Test Code App',
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id='cfg-new',
+            data_app_id='app-new',
+            project_id='proj-1',
+            branch_id='default',
+            config_version='1',
+            type='python-js',
+            state='running',
+            deployment_url='https://test-code-app.app.keboola.com',
+            configuration={},
+        )
+        keboola_client.data_science_client = mocker.AsyncMock()
+        keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=data_app_response)
+        keboola_client.data_science_client.deploy_data_app = mocker.AsyncMock(return_value=data_app_response)
+
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps._fetch_data_app',
+            return_value=deployed_data_app,
+        )
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps.ProjectLinksManager.from_client',
+            return_value=mocker.AsyncMock(
+                get_data_app_links=mocker.MagicMock(return_value=[]),
+            ),
+        )
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps.get_config_folders',
+            mocker.AsyncMock(return_value=(0, [])),
+        )
+
+        result = await modify_code_data_app(
+            ctx=mcp_context_client,
+            name='Test Code App',
+            description='A test python-js app',
+            watched_repo_url='https://github.com/user/repo.git',
+            watched_repo_branch='main',
+        )
+
+        assert isinstance(result, ModifiedDataAppOutput)
+        assert result.response == 'created'
+        assert result.data_app.type == 'python-js'
+        assert result.data_app.deployment_url == 'https://test-code-app.app.keboola.com'
+
+        # Verify create_data_app was called with type='python-js'
+        create_call = keboola_client.data_science_client.create_data_app
+        create_call.assert_awaited_once()
+        call_kwargs = create_call.call_args
+        assert call_kwargs.kwargs.get('type') == 'python-js'
+
+        # Verify deploy was called after creation
+        keboola_client.data_science_client.deploy_data_app.assert_awaited_once_with('app-new', '1')
+
+    @pytest.mark.asyncio
+    async def test_finalize_requires_configuration_id(self, mcp_context_client: Context) -> None:
+        with pytest.raises(ValueError, match='finalize=True.*requires.*configuration_id'):
+            await modify_code_data_app(
+                ctx=mcp_context_client,
+                name='Test',
+                description='desc',
+                watched_repo_url='https://github.com/user/repo.git',
+                watched_repo_branch='main',
+                finalize=True,
+                configuration_id='',
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('finalize', 'app_state', 'expected_response'),
+        [
+            (False, 'stopped', 'updated'),
+            (False, 'running', 'updated'),
+            (True, 'stopped', 'finalized'),
+            (True, 'running', 'finalized'),
+        ],
+    )
+    async def test_update_and_finalize_responses(
+        self,
+        mocker,
+        mcp_context_client: Context,
+        finalize: bool,
+        app_state: str,
+        expected_response: str,
+    ) -> None:
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+
+        keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
+        keboola_client.storage_client.configuration_version_latest = mocker.AsyncMock(return_value=3)
+        keboola_client.encryption_client = mocker.AsyncMock()
+        keboola_client.encryption_client.encrypt = mocker.AsyncMock(side_effect=lambda config, **kw: config)
+        keboola_client.storage_client.configuration_update = mocker.AsyncMock(return_value={})
+        keboola_client.data_science_client = mocker.AsyncMock()
+        keboola_client.data_science_client.deploy_data_app = mocker.AsyncMock()
+
+        existing_data_app = DataApp(
+            name='Existing App',
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id='cfg-1',
+            data_app_id='app-1',
+            project_id='proj-1',
+            branch_id='default',
+            config_version='2',
+            type='python-js',
+            auto_suspend_after_seconds=900,
+            configuration={
+                'parameters': {
+                    'autoSuspendAfterSeconds': 900,
+                    'dataApp': {
+                        'slug': 'existing',
+                        'type': 'python-js',
+                        'git': {'repository': _CONTINUOUS_PULL_BASE_REPO},
+                        'watchedRepo': {
+                            'pullPeriod': 1,
+                            'url': 'https://github.com/user/repo.git',
+                            'branch': 'main',
+                            'autoReSetup': True,
+                        },
+                    },
+                },
+                'authorization': _get_authorization(False),
+                'runtime': {'backend': {'size': 'tiny'}},
+            },
+            state=app_state,
+        )
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps._fetch_data_app',
+            return_value=existing_data_app,
+        )
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps.ProjectLinksManager.from_client',
+            return_value=mocker.AsyncMock(
+                get_data_app_links=mocker.MagicMock(return_value=[]),
+            ),
+        )
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps.get_config_folders',
+            mocker.AsyncMock(return_value=(0, [])),
+        )
+
+        result = await modify_code_data_app(
+            ctx=mcp_context_client,
+            name='Existing App',
+            description='desc',
+            watched_repo_url='https://github.com/user/repo.git',
+            watched_repo_branch='main',
+            finalize=finalize,
+            configuration_id='cfg-1',
+        )
+
+        assert isinstance(result, ModifiedDataAppOutput)
+        assert result.response == expected_response

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1231,7 +1231,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.55.0"
+version = "1.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: AI-3005

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Add new `modify_code_data_app` MCP tool for creating, updating, and finalizing "python-js" data apps that continuously pull code from a git repository.

Key changes:
- New `CodeDataAppConfig` pydantic model for python-js app configuration
- New `modify_code_data_app` tool that handles the full lifecycle (create → deploy → return URL)
- The tool calls `deploy_data_app` internally after create/update so the `deployment_url` is populated in the response
- Streamlit `modify_data_app` remains unchanged (still two-step: modify config, then deploy separately)
- Config builders for watching mode and finalize mode
- Version bump 1.55.0 → 1.56.0

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [x] Documentation updated (if applicable)