### PR TITLE
fix(tests): replace fixed sleep in test_json_logging with readiness poll loop

### DIFF
--- a/tests/docker/ci.sh
+++ b/tests/docker/ci.sh
@@ -38,7 +38,7 @@ main() {
            -H "Content-Type: application/json" \
            -H "Accept: application/json, text/event-stream" \
            -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "ci-docker-test", "version": "1.0.0"}}}' \
-           "http://localhost:8080/mcp" 2>/dev/null)
+           "http://localhost:8080/mcp" 2>/dev/null) || true
 
         http_code=$(echo "$response" | tail -n1)
         body=$(echo "$response" | sed '$d')
@@ -50,7 +50,7 @@ main() {
                -H "Content-Type: application/json" \
                -H "Accept: application/json, text/event-stream" \
                -d '{"jsonrpc": "2.0", "method": "notifications/initialized"}' \
-               "http://localhost:8080/mcp" 2>/dev/null)
+               "http://localhost:8080/mcp" 2>/dev/null) || true
 
             http_code=$(echo "$response" | tail -n1)
             body=$(echo "$response" | sed '$d')
@@ -62,7 +62,7 @@ main() {
                    -H "Content-Type: application/json" \
                    -H "Accept: application/json, text/event-stream" \
                    -d '{"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "get_project_info", "arguments": {}}}' \
-                   "http://localhost:8080/mcp" 2>/dev/null)
+                   "http://localhost:8080/mcp" 2>/dev/null) || true
 
                 http_code=$(echo "$response" | tail -n1)
                 body=$(echo "$response" | sed '$d')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import subprocess
 import tempfile
+
+import httpx
 from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated, Any
@@ -470,10 +472,21 @@ async def test_json_logging():
         stderr_task = asyncio.create_task(read_stream(p.stderr, stderr_lines))
 
         try:
-            # give the server time to fully start
-            await asyncio.sleep(5)
+            # Poll until the server is ready (up to 30s) instead of a fixed sleep.
+            # A fixed sleep is fragile: slow CI runners may need more than 5s to start.
+            for attempt in range(60):
+                await asyncio.sleep(0.5)
+                if p.poll() is not None:
+                    raise RuntimeError(f'MCP server process exited early (rc={p.returncode})')
+                try:
+                    async with httpx.AsyncClient() as hc:
+                        await hc.get('http://localhost:8000/mcp', timeout=1.0)
+                    break
+                except (httpx.ConnectError, httpx.TimeoutException):
+                    if attempt == 59:
+                        raise RuntimeError('MCP server did not become ready within 30s')
 
-            # connect to the server and list prompts to force 'fastmcp' looger to get used
+            # connect to the server and list prompts to force 'fastmcp' logger to get used
             # the listing of the prompts does not require SAPI connection
             async with Client(StreamableHttpTransport('http://localhost:8000/mcp')) as client:
                 prompts = await client.list_prompts()


### PR DESCRIPTION
## Description

**Linear**: N/A

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`test_json_logging` starts the MCP server as a subprocess then waits a fixed 5 seconds before connecting. On slow CI runners or branches with older dependencies (fastmcp 2.x), the server can take longer than 5s to become ready, causing a spurious `ConnectError`.

This PR replaces the hard-coded `await asyncio.sleep(5)` with a poll loop that:
- Probes `http://localhost:8000/mcp` every 0.5s for up to 30s
- Fails fast with a clear message if the subprocess exits early
- Breaks as soon as the server responds, so fast runners are not penalised

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)