### PR TITLE
fix(ci): fix flaky test_json_logging and e2e Docker test startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.56.2"
+version = "1.56.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.56.2"
+version = "1.56.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: N/A (CI reliability fixes)

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Two CI reliability fixes:

1. **`test_json_logging` flaky test** — replaced a fixed `sleep(0.5)` with a readiness poll loop (up to 2s) that checks whether the log file has been written before asserting on its contents. The sleep was too short in slow CI environments causing intermittent failures.

2. **`tests/docker/ci.sh` e2e test exits immediately** — under `set -Eeuo pipefail`, a `response=$(curl ...)` command substitution exits the entire script if curl returns non-zero (exit code 7 = connection refused). Added `|| true` to all three curl assignments so a connection-refused error sets `response=""`, the `if [ "$http_code" = "200" ]` check fails silently, and the retry loop continues sleeping 1s until the server is ready (up to 30 retries).

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [x] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)