### PR TITLE
fix(AI-3028): add mandatory schema pre-flight guidance to create_config / add_config_row

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -86,11 +86,12 @@ column definitions, lineage references (created/updated by) and links.
 Creates a component configuration row in the specified configuration_id, using the specified name,
 component ID, configuration JSON, and description.
 
-CONSIDERATIONS:
-- The configuration JSON object must follow the row_configuration_schema of the specified component.
-- Make sure the configuration parameters always adhere to the row_configuration_schema,
-  which is available via the get_components tool.
-- The configuration JSON object should adhere to the component's configuration examples if found.
+BEFORE CALLING - REQUIRED STEPS:
+1. Call `get_components([component_id])` to retrieve the component's `configuration_row_schema`.
+2. Read `configuration_row_schema.required` to find ALL mandatory top-level fields.
+3. Call `get_config_examples(component_id)` to see real-world row parameter examples.
+4. Populate `parameters` with every required field before calling this tool.
+Skipping these steps will cause a schema validation error.
 
 USAGE:
 - Use when you want to create a new row configuration for a specific component configuration.
@@ -179,11 +180,12 @@ EXAMPLES:
 
 Creates a root component configuration using the specified name, component ID, configuration JSON, and description.
 
-CONSIDERATIONS:
-- The configuration JSON object must follow the root_configuration_schema of the specified component.
-- Make sure the configuration parameters always adhere to the root_configuration_schema,
-  which is available via the get_components tool.
-- The configuration JSON object should adhere to the component's configuration examples if found.
+BEFORE CALLING - REQUIRED STEPS:
+1. Call `get_components([component_id])` to retrieve the component's `configuration_schema`.
+2. Read `configuration_schema.required` to find ALL mandatory top-level fields.
+3. Call `get_config_examples(component_id)` to see real-world parameter examples.
+4. Populate `parameters` with every required field before calling this tool.
+Skipping these steps will cause a schema validation error.
 
 USAGE:
 - Use when you want to create a new root configuration for a specific component.
@@ -423,6 +425,7 @@ EXAMPLES:
 Retrieves sample configuration examples for a specific component.
 
 USAGE:
+- Use before calling `create_config` or `add_config_row` to understand the expected parameters structure.
 - Use when you want to see example configurations for a specific component.
 
 EXAMPLES:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -130,7 +130,7 @@ EXAMPLES:
     },
     "parameters": {
       "additionalProperties": true,
-      "description": "The component row configuration parameters, adhering to the row_configuration_schema",
+      "description": "The component row configuration parameters, adhering to the configuration_row_schema",
       "type": "object"
     },
     "storage": {
@@ -220,7 +220,7 @@ EXAMPLES:
     },
     "parameters": {
       "additionalProperties": true,
-      "description": "The component configuration parameters, adhering to the root_configuration_schema",
+      "description": "The component configuration parameters, adhering to the configuration_schema",
       "type": "object"
     },
     "storage": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.57.0"
+version = "1.57.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -1010,11 +1010,12 @@ async def create_config(
     """
     Creates a root component configuration using the specified name, component ID, configuration JSON, and description.
 
-    CONSIDERATIONS:
-    - The configuration JSON object must follow the root_configuration_schema of the specified component.
-    - Make sure the configuration parameters always adhere to the root_configuration_schema,
-      which is available via the get_components tool.
-    - The configuration JSON object should adhere to the component's configuration examples if found.
+    BEFORE CALLING - REQUIRED STEPS:
+    1. Call `get_components([component_id])` to retrieve the component's `configuration_schema`.
+    2. Read `configuration_schema.required` to find ALL mandatory top-level fields.
+    3. Call `get_config_examples(component_id)` to see real-world parameter examples.
+    4. Populate `parameters` with every required field before calling this tool.
+    Skipping these steps will cause a schema validation error.
 
     USAGE:
     - Use when you want to create a new root configuration for a specific component.
@@ -1149,11 +1150,12 @@ async def add_config_row(
     Creates a component configuration row in the specified configuration_id, using the specified name,
     component ID, configuration JSON, and description.
 
-    CONSIDERATIONS:
-    - The configuration JSON object must follow the row_configuration_schema of the specified component.
-    - Make sure the configuration parameters always adhere to the row_configuration_schema,
-      which is available via the get_components tool.
-    - The configuration JSON object should adhere to the component's configuration examples if found.
+    BEFORE CALLING - REQUIRED STEPS:
+    1. Call `get_components([component_id])` to retrieve the component's `configuration_row_schema`.
+    2. Read `configuration_row_schema.required` to find ALL mandatory top-level fields.
+    3. Call `get_config_examples(component_id)` to see real-world row parameter examples.
+    4. Populate `parameters` with every required field before calling this tool.
+    Skipping these steps will cause a schema validation error.
 
     USAGE:
     - Use when you want to create a new row configuration for a specific component configuration.
@@ -1757,6 +1759,7 @@ async def get_config_examples(
     Retrieves sample configuration examples for a specific component.
 
     USAGE:
+    - Use before calling `create_config` or `add_config_row` to understand the expected parameters structure.
     - Use when you want to see example configurations for a specific component.
 
     EXAMPLES:

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -987,7 +987,7 @@ async def create_config(
     component_id: Annotated[str, Field(description='The ID of the component for which to create the configuration.')],
     parameters: Annotated[
         dict[str, Any],
-        Field(description='The component configuration parameters, adhering to the root_configuration_schema'),
+        Field(description='The component configuration parameters, adhering to the configuration_schema'),
     ],
     storage: Annotated[
         dict[str, Any],
@@ -1126,7 +1126,7 @@ async def add_config_row(
     ],
     parameters: Annotated[
         dict[str, Any],
-        Field(description='The component row configuration parameters, adhering to the row_configuration_schema'),
+        Field(description='The component row configuration parameters, adhering to the configuration_row_schema'),
     ],
     storage: Annotated[
         dict[str, Any],

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -96,9 +96,7 @@ async def update_project_description(
     ctx: Context,
     description: Annotated[
         str,
-        Field(
-            description='The new project description text.'
-        ),
+        Field(description='The new project description text.'),
     ],
 ) -> None:
     """Updates the description of the current Keboola project."""

--- a/src/keboola_mcp_server/tools/validation.py
+++ b/src/keboola_mcp_server/tools/validation.py
@@ -101,9 +101,15 @@ class RecoverableValidationError(jsonschema.ValidationError):
             str_repr += f'{self.initial_message}\n'
         if self.validation_context:
             str_repr += f'Validation component context: {str(self.validation_context)}\n'
-        # When a required-field violation occurs, surface ALL required fields so the agent
-        # can populate every missing field in a single retry instead of fixing one at a time.
-        if self.validator == 'required' and isinstance(self.validator_value, list):
+        # When a required-field violation occurs in parameters scope, surface ALL required fields so
+        # the agent can populate every missing field in a single retry instead of fixing one at a time.
+        # Only emitted for parameters scope — for storage/flow the hint wording does not apply.
+        if (
+            self.validator == 'required'
+            and isinstance(self.validator_value, list)
+            and self.validation_context is not None
+            and self.validation_context.scope == 'parameters'
+        ):
             required_fields = ', '.join(f'`{f}`' for f in self.validator_value)
             str_repr += (
                 f'HINT: Ensure ALL of the following required fields are present in `parameters`: {required_fields}. '

--- a/src/keboola_mcp_server/tools/validation.py
+++ b/src/keboola_mcp_server/tools/validation.py
@@ -101,6 +101,15 @@ class RecoverableValidationError(jsonschema.ValidationError):
             str_repr += f'{self.initial_message}\n'
         if self.validation_context:
             str_repr += f'Validation component context: {str(self.validation_context)}\n'
+        # When a required-field violation occurs, surface ALL required fields so the agent
+        # can populate every missing field in a single retry instead of fixing one at a time.
+        if self.validator == 'required' and isinstance(self.validator_value, list):
+            required_fields = ', '.join(f'`{f}`' for f in self.validator_value)
+            str_repr += (
+                f'HINT: Ensure ALL of the following required fields are present in `parameters`: {required_fields}. '
+                f'Call `get_components` to retrieve the full schema and `get_config_examples` for real-world examples.'
+                f'\n'
+            )
         return str_repr.rstrip()
 
 
@@ -207,16 +216,12 @@ class KeboolaParametersValidator:
                 if isinstance(items, dict):
                     schema['items'], _ = _sanitize_node(items)
                 elif isinstance(items, list):
-                    schema['items'] = [
-                        _sanitize_node(item)[0] if isinstance(item, dict) else item for item in items
-                    ]
+                    schema['items'] = [_sanitize_node(item)[0] if isinstance(item, dict) else item for item in items]
 
             # Recurse into schema-list keywords (allOf, anyOf, oneOf)
             for keyword in ('allOf', 'anyOf', 'oneOf'):
                 if keyword in schema and isinstance(schema[keyword], list):
-                    schema[keyword] = [
-                        _sanitize_node(s)[0] if isinstance(s, dict) else s for s in schema[keyword]
-                    ]
+                    schema[keyword] = [_sanitize_node(s)[0] if isinstance(s, dict) else s for s in schema[keyword]]
 
             # Recurse into single-schema keywords
             for keyword in ('not', 'if', 'then', 'else'):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,12 +2,11 @@ import asyncio
 import json
 import subprocess
 import tempfile
-
-import httpx
 from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated, Any
 
+import httpx
 import pytest
 from fastmcp import Client, Context, FastMCP
 from fastmcp.client import StreamableHttpTransport

--- a/tests/tools/components/test_validation.py
+++ b/tests/tools/components/test_validation.py
@@ -194,6 +194,7 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
     [
         # Case 1: missing required property at root level
         # Only the violated 'required' list should appear, not the full schema object
+        # The HINT must list ALL required fields so the agent can fix everything in one retry
         (
             ROOT_SCHEMA_PATH,
             {'qdrant_settings': {'url': 'http://localhost:6333', '#api_key': 'key'}},
@@ -201,6 +202,9 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
                 "'embedding_settings' is a required property",
                 "Failed validating 'required' in schema",
                 '"embedding_settings"',  # the required list value is shown
+                'HINT: Ensure ALL of the following required fields are present in `parameters`',
+                '`embedding_settings`',  # required field listed in the hint
+                'get_components',  # hint directs agent to look up the schema
             ],
             ['azure_settings', 'huggingface_settings', 'google_vertex_settings'],  # full schema not dumped
         ),
@@ -235,7 +239,7 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
             ['enable_chunking', 'chunking_settings', '"title"'],  # full subschema not dumped
         ),
         # Case 4: minimum constraint violation - batch_size below minimum of 1
-        # Only the 'minimum' constraint value should appear
+        # Only the 'minimum' constraint value should appear; HINT must NOT appear for non-required errors
         (
             ROW_SCHEMA_PATH,
             {'text_column': 'notes', 'advanced_options': {'batch_size': 0}},
@@ -246,7 +250,7 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
                 "On instance['advanced_options']['batch_size']",
                 '"minimum": 1',  # the minimum value is shown
             ],
-            ['enable_chunking', 'chunking_settings', '"title"'],  # full subschema not dumped
+            ['enable_chunking', 'chunking_settings', '"title"', 'HINT:'],  # full subschema not dumped; no hint
         ),
     ],
 )

--- a/tests/tools/components/test_validation.py
+++ b/tests/tools/components/test_validation.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 from typing import Optional
@@ -307,7 +308,7 @@ def test_recoverable_validation_error_compact_format(
         with open(schema_or_path) as f:
             schema = json.load(f)
     else:
-        schema = schema_or_path
+        schema = copy.deepcopy(schema_or_path)
 
     with pytest.raises(validation.RecoverableValidationError) as exc_info:
         validation._validate_parameters_configuration_against_schema(

--- a/tests/tools/components/test_validation.py
+++ b/tests/tools/components/test_validation.py
@@ -189,12 +189,24 @@ ROOT_SCHEMA_PATH = 'tests/resources/parameters/root_parameters_schema.json'
 ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
 
 
+_MULTI_REQUIRED_SCHEMA: JsonDict = {
+    'type': 'object',
+    'required': ['api_key', 'endpoint', 'timeout'],
+    'properties': {
+        'api_key': {'type': 'string'},
+        'endpoint': {'type': 'string'},
+        'timeout': {'type': 'integer'},
+    },
+}
+
+
 @pytest.mark.parametrize(
-    ('schema_path', 'invalid_data', 'expected_in_str', 'not_expected_in_str'),
+    ('schema_or_path', 'invalid_data', 'expected_in_str', 'not_expected_in_str', 'validation_context'),
     [
         # Case 1: missing required property at root level
         # Only the violated 'required' list should appear, not the full schema object
         # The HINT must list ALL required fields so the agent can fix everything in one retry
+        # validation_context with scope='parameters' is required for the HINT to appear
         (
             ROOT_SCHEMA_PATH,
             {'qdrant_settings': {'url': 'http://localhost:6333', '#api_key': 'key'}},
@@ -207,6 +219,7 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
                 'get_components',  # hint directs agent to look up the schema
             ],
             ['azure_settings', 'huggingface_settings', 'google_vertex_settings'],  # full schema not dumped
+            validation.ValidationContext(component_id='keboola.ex-test', scope='parameters'),
         ),
         # Case 2: invalid enum value for provider_type
         # Only the 'enum' list should appear at the precise schema path, not the full provider_type subschema
@@ -222,6 +235,7 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
                 '"gpt-9000"',  # the bad value is shown
             ],
             ['azure_settings', 'huggingface_settings', '"title"'],  # full subschema properties not dumped
+            None,
         ),
         # Case 3: wrong type - batch_size must be integer, not string
         # Only the 'type' constraint should appear at the precise schema path
@@ -237,6 +251,7 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
                 '"not-a-number"',  # the bad value is shown
             ],
             ['enable_chunking', 'chunking_settings', '"title"'],  # full subschema not dumped
+            None,
         ),
         # Case 4: minimum constraint violation - batch_size below minimum of 1
         # Only the 'minimum' constraint value should appear; HINT must NOT appear for non-required errors
@@ -251,22 +266,53 @@ ROW_SCHEMA_PATH = 'tests/resources/parameters/row_parameters_schema.json'
                 '"minimum": 1',  # the minimum value is shown
             ],
             ['enable_chunking', 'chunking_settings', '"title"', 'HINT:'],  # full subschema not dumped; no hint
+            None,
+        ),
+        # Case 5: multiple required fields missing — HINT must list ALL of them
+        # Verifies the hint format when validator_value contains more than one field name
+        (
+            _MULTI_REQUIRED_SCHEMA,
+            {},  # all three required fields missing
+            [
+                'HINT: Ensure ALL of the following required fields are present in `parameters`',
+                '`api_key`',
+                '`endpoint`',
+                '`timeout`',
+                'get_components',
+            ],
+            [],
+            validation.ValidationContext(component_id='keboola.ex-test', scope='parameters'),
+        ),
+        # Case 6: required violation without parameters scope — HINT must NOT appear
+        # Verifies that hint is suppressed when scope != 'parameters' (e.g. storage or no context)
+        (
+            _MULTI_REQUIRED_SCHEMA,
+            {},
+            ['is a required property'],
+            ['HINT:'],
+            None,  # no validation_context → no scope → hint suppressed
         ),
     ],
 )
 def test_recoverable_validation_error_compact_format(
-    schema_path: str,
+    schema_or_path: str | JsonDict,
     invalid_data: JsonDict,
     expected_in_str: list,
     not_expected_in_str: list,
+    validation_context: validation.ValidationContext | None,
 ):
     """Verify that RecoverableValidationError.__str__ shows only the violated schema constraint,
-    not the entire schema object."""
-    with open(schema_path) as f:
-        schema = json.load(f)
+    not the entire schema object, and that the required-field HINT only appears for parameters scope."""
+    if isinstance(schema_or_path, str):
+        with open(schema_or_path) as f:
+            schema = json.load(f)
+    else:
+        schema = schema_or_path
 
     with pytest.raises(validation.RecoverableValidationError) as exc_info:
-        validation._validate_parameters_configuration_against_schema(invalid_data, schema)
+        validation._validate_parameters_configuration_against_schema(
+            invalid_data, schema, validation_context=validation_context
+        )
 
     err_str = str(exc_info.value)
     for fragment in expected_in_str:

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.57.0"
+version = "1.57.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3028](https://linear.app/keboola/issue/AI-3028/agent-constructs-invalid-parameters-for-create-config-schema)

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Addresses Datadog errors where the agent called `create_config` / `add_config_row` with missing required parameters, causing schema validation failures (9 errors across 3 components on 2026-04-15/16).

**Root cause:** The agent was constructing `parameters` without first looking up the component's `configuration_schema`, so required fields like `packages`, `blocks`, `user_properties` were omitted.

**Two-pronged fix:**

1. **Mandatory pre-flight checklist in tool docstrings** — Replaces the weak "make sure to adhere to the schema" note in `create_config` and `add_config_row` with a numbered `BEFORE CALLING - REQUIRED STEPS` block that explicitly instructs the agent to:
   1. Call `get_components([component_id])` to retrieve the schema
   2. Read `configuration_schema.required` to identify ALL mandatory fields
   3. Call `get_config_examples(component_id)` for real-world examples
   4. Populate every required field before calling the tool

   This mirrors the approach from PR #459 that fixed tool-selection errors by adding `WHEN NOT TO USE` guidance.

2. **Improved validation error for single-shot recovery** — When a `required` violation occurs, `RecoverableValidationError.__str__()` now appends:
   ```
   HINT: Ensure ALL of the following required fields are present in `parameters`: `blocks`, `packages`.
   Call `get_components` to retrieve the full schema and `get_config_examples` for real-world examples.
   ```
   Previously the error showed the required list but not as an actionable fix-all hint, so the agent fixed one field at a time.

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type (if applicable)
- [x] Documentation updated (if applicable)