### PR TITLE
AI-3048: fix BigQuery SQL dialect guidance in modify_data_app

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1804,14 +1804,35 @@ appropriately based on the parameter type.
 updating, set `authentication_type` to `default` to keep the existing authentication type configuration
 (including OIDC setups) unless explicitly specified otherwise.
 
-SQL & DATA TYPE RULES:
+WORKSPACE & TABLE ACCESS:
+- The data app workspace is ISOLATED and EMPTY by default. Storage tables are NOT automatically
+  available inside it. To access a table, either:
+  (a) Use its `fullyQualifiedName` from `get_tables` — the workspace service account has
+      read access to the underlying backend datasets directly (e.g. BigQuery project datasets).
+  (b) Configure input mapping (not yet supported via MCP — use the Keboola UI for this).
+- Do NOT assume a table is queryable by its Storage ID (e.g. `out.c-bucket.table`).
+  Always retrieve the `fullyQualifiedName` via `get_tables` and use that in queries.
+
+SQL DIALECT RULES:
+- Always check `get_project_info` for the `sql_dialect` field before writing any SQL.
+- Snowflake: use double quotes for identifiers: `"column"`, `"DATABASE"."SCHEMA"."TABLE"`
+- BigQuery: use backticks for identifiers: `` `column` ``, `` `project`.`dataset`.`table` ``
+- Never mix quoting styles.
 - SNOWFLAKE COLUMN ALIASES are auto-uppercased unless quoted. Quote aliases to preserve case:
 `CAST("downloads" AS INTEGER) as "downloads"`. Match exact case in Python code.
+
+DATA TYPE RULES:
 - `query_data` RETURNS ALL COLUMNS AS STRINGS regardless of SQL CAST. Always convert types in Python after loading:
 `df["col"] = pd.to_numeric(df["col"], errors="coerce").fillna(0)` and
 `df["date"] = pd.to_datetime(df["date"], errors="coerce")`.
-- Pattern:
+
+PATTERN (Snowflake):
 `df = query_data('SELECT "model_id", "downloads", "created_at" FROM "DB"."SCHEMA"."TABLE"')`
+`df["downloads"] = pd.to_numeric(df["downloads"], errors="coerce").fillna(0)`
+`df["created_at"] = pd.to_datetime(df["created_at"], errors="coerce")`
+
+PATTERN (BigQuery):
+`df = query_data('SELECT `model_id`, `downloads`, `created_at` FROM `project`.`dataset`.`table`')`
 `df["downloads"] = pd.to_numeric(df["downloads"], errors="coerce").fillna(0)`
 `df["created_at"] = pd.to_datetime(df["created_at"], errors="coerce")`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.57.1"
+version = "1.57.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -331,10 +331,12 @@ async def modify_data_app(
     PATTERN (Snowflake):
     `df = query_data('SELECT "model_id", "downloads", "created_at" FROM "DB"."SCHEMA"."TABLE"')`
     `df["downloads"] = pd.to_numeric(df["downloads"], errors="coerce").fillna(0)`
+    `df["created_at"] = pd.to_datetime(df["created_at"], errors="coerce")`
 
     PATTERN (BigQuery):
     `df = query_data('SELECT `model_id`, `downloads`, `created_at` FROM `project`.`dataset`.`table`')`
     `df["downloads"] = pd.to_numeric(df["downloads"], errors="coerce").fillna(0)`
+    `df["created_at"] = pd.to_datetime(df["created_at"], errors="coerce")`
     """
     client = KeboolaClient.from_state(ctx.session.state)
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -306,16 +306,35 @@ async def modify_data_app(
     updating, set `authentication_type` to `default` to keep the existing authentication type configuration
     (including OIDC setups) unless explicitly specified otherwise.
 
-    SQL & DATA TYPE RULES:
+    WORKSPACE & TABLE ACCESS:
+    - The data app workspace is ISOLATED and EMPTY by default. Storage tables are NOT automatically
+      available inside it. To access a table, either:
+      (a) Use its `fullyQualifiedName` from `get_tables` — the workspace service account has
+          read access to the underlying backend datasets directly (e.g. BigQuery project datasets).
+      (b) Configure input mapping (not yet supported via MCP — use the Keboola UI for this).
+    - Do NOT assume a table is queryable by its Storage ID (e.g. `out.c-bucket.table`).
+      Always retrieve the `fullyQualifiedName` via `get_tables` and use that in queries.
+
+    SQL DIALECT RULES:
+    - Always check `get_project_info` for the `sql_dialect` field before writing any SQL.
+    - Snowflake: use double quotes for identifiers: `"column"`, `"DATABASE"."SCHEMA"."TABLE"`
+    - BigQuery: use backticks for identifiers: `` `column` ``, `` `project`.`dataset`.`table` ``
+    - Never mix quoting styles.
     - SNOWFLAKE COLUMN ALIASES are auto-uppercased unless quoted. Quote aliases to preserve case:
     `CAST("downloads" AS INTEGER) as "downloads"`. Match exact case in Python code.
+
+    DATA TYPE RULES:
     - `query_data` RETURNS ALL COLUMNS AS STRINGS regardless of SQL CAST. Always convert types in Python after loading:
     `df["col"] = pd.to_numeric(df["col"], errors="coerce").fillna(0)` and
     `df["date"] = pd.to_datetime(df["date"], errors="coerce")`.
-    - Pattern:
+
+    PATTERN (Snowflake):
     `df = query_data('SELECT "model_id", "downloads", "created_at" FROM "DB"."SCHEMA"."TABLE"')`
     `df["downloads"] = pd.to_numeric(df["downloads"], errors="coerce").fillna(0)`
-    `df["created_at"] = pd.to_datetime(df["created_at"], errors="coerce")`
+
+    PATTERN (BigQuery):
+    `df = query_data('SELECT `model_id`, `downloads`, `created_at` FROM `project`.`dataset`.`table`')`
+    `df["downloads"] = pd.to_numeric(df["downloads"], errors="coerce").fillna(0)`
     """
     client = KeboolaClient.from_state(ctx.session.state)
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.57.1"
+version = "1.57.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3048](https://linear.app/keboola/issue/AI-3048/fix-bigquery-sql-dialect-guidance-in-deploy-data-app-modify-data-app)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

The `modify_data_app` tool docstring contained only Snowflake-style SQL
examples (double-quoted identifiers). On BigQuery projects the LLM read these examples and
generated Snowflake syntax, which BigQuery rejects — double quotes are string literals in BQ,
not identifier quotes.

Two problems fixed in the docstring:

1. **Wrong SQL quoting on BigQuery** — added explicit BigQuery backtick syntax rules mirroring
   what `query_data` already documents (both dialects, both identifier formats).

2. **Undocumented workspace isolation** — added a clear note that the data app workspace is
   isolated and empty by default. Tables must be accessed via their `fullyQualifiedName` from
   `get_tables`, or loaded via input mapping (UI only for now).

3. **Missing type-conversion examples** — restored `pd.to_datetime()` line to both PATTERN
   (Snowflake) and PATTERN (BigQuery) examples, consistent with the DATA TYPE RULES section.

No code logic changes — docstring-only fix.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [ ] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)