### PR TITLE
AI-3064: restore SQL formatting for readable diff previews

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.57.1"
+version = "1.57.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/sql_utils.py
+++ b/src/keboola_mcp_server/tools/components/sql_utils.py
@@ -129,7 +129,8 @@ def format_sql(sql: str, dialect: str) -> str:
     """
     try:
         # transpile returns a list - one item per statement/comment
-        formatted_items = sqlglot.transpile(sql, read=dialect.lower(), pretty=True)
+        # write=dialect preserves dialect-specific functions/operators (TO_VARCHAR, !=, etc.)
+        formatted_items = sqlglot.transpile(sql, read=dialect.lower(), write=dialect.lower(), pretty=True)
 
         if not formatted_items:
             return sql

--- a/src/keboola_mcp_server/tools/components/tf_update.py
+++ b/src/keboola_mcp_server/tools/components/tf_update.py
@@ -18,6 +18,11 @@ from keboola_mcp_server.tools.components.model import (
     TfSetCode,
     TfStrReplace,
 )
+from keboola_mcp_server.tools.components.sql_utils import (
+    format_simplified_tf_block,
+    format_simplified_tf_code,
+    format_sql,
+)
 
 # Operations that change the structure of the transformation
 STRUCTURAL_OPS = frozenset[str]({'add_block', 'add_code', 'remove_block', 'remove_code'})
@@ -39,7 +44,8 @@ def add_block(params: dict, op: TfAddBlock, sql_dialect: str) -> tuple[dict, str
     if not op.block.name.strip():
         raise ValueError('Invalid operation: block name cannot be empty')
 
-    new_block_dict = op.block.model_dump()
+    new_block, _ = format_simplified_tf_block(block=op.block, dialect=sql_dialect)
+    new_block_dict = new_block.model_dump()
 
     if op.position == 'start':
         params['blocks'].insert(0, new_block_dict)
@@ -111,7 +117,8 @@ def add_code(params: dict, op: TfAddCode, sql_dialect: str) -> tuple[dict, str]:
 
     codes = matches[0].value
 
-    new_code_dict = op.code.model_dump()
+    new_code, _ = format_simplified_tf_code(code=op.code, dialect=sql_dialect)
+    new_code_dict = new_code.model_dump()
 
     if op.position == 'start':
         codes.insert(0, new_code_dict)
@@ -175,6 +182,8 @@ def set_code(params: dict, op: TfSetCode, sql_dialect: str) -> tuple[dict, str]:
     if not op.script.strip():
         raise ValueError('Invalid operation: script cannot be empty')
 
+    formatted_script = format_sql(sql=op.script, dialect=sql_dialect)
+
     # Target the specific code's script field directly
     expr = parse_jsonpath(f"$.blocks[?(@.id = '{op.block_id}')].codes[?(@.id = '{op.code_id}')].script")
     matches = expr.find(params)
@@ -184,7 +193,7 @@ def set_code(params: dict, op: TfSetCode, sql_dialect: str) -> tuple[dict, str]:
 
     # Update the script field
     message = f"Changed code with id '{op.code_id}' in block '{op.block_id}'"
-    return expr.update(params, op.script), message
+    return expr.update(params, formatted_script), message
 
 
 def add_script(params: dict, op: TfAddScript, sql_dialect: str) -> tuple[dict, str]:
@@ -210,9 +219,9 @@ def add_script(params: dict, op: TfAddScript, sql_dialect: str) -> tuple[dict, s
 
     # Compute new script based on position
     if op.position == 'start':
-        new_script = f'{op.script} {current_script}' if current_script else op.script
+        new_script = f'{op.script}\n{current_script}' if current_script else op.script
     else:  # 'end'
-        new_script = f'{current_script} {op.script}' if current_script else op.script
+        new_script = f'{current_script}\n{op.script}' if current_script else op.script
 
     # Update the script field
     message = f"Added script to code with id '{op.code_id}' in block '{op.block_id}'"

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -52,6 +52,7 @@ from keboola_mcp_server.tools.components.model import (
     TfParamUpdate,
     TransformationConfiguration,
 )
+from keboola_mcp_server.tools.components.sql_utils import format_simplified_tf_block
 
 LOG = logging.getLogger(__name__)
 T = TypeVar('T')
@@ -338,6 +339,7 @@ async def create_transformation_configuration(
         name='Blocks',
         codes=list(codes),
     )
+    block, _ = format_simplified_tf_block(block=block, dialect=sql_dialect)
     parameters = SimplifiedTfBlocks(blocks=[block])
     raw_parameters = await parameters.to_raw_parameters()
 

--- a/tests/tools/components/test_tf_update.py
+++ b/tests/tools/components/test_tf_update.py
@@ -148,18 +148,18 @@ def empty_params():
                             {
                                 'name': 'Code 1',
                                 'script': (
-                                    'SELECT u.id, u.name, COUNT(o.id) as order_count '
-                                    'FROM users u LEFT JOIN orders o ON u.id = o.user_id '
-                                    "WHERE u.created_at > '2024-01-01' "
-                                    'GROUP BY u.id, u.name HAVING COUNT(o.id) > 5'
+                                    'SELECT\n  u.id,\n  u.name,\n  COUNT(o.id) AS order_count\n'
+                                    'FROM users AS u\nLEFT JOIN orders AS o\n  ON u.id = o.user_id\n'
+                                    "WHERE\n  u.created_at > '2024-01-01'\n"
+                                    'GROUP BY\n  u.id,\n  u.name\nHAVING\n  COUNT(o.id) > 5;'
                                 ),
                             },
                             {
                                 'name': 'Code 2',
                                 'script': (
-                                    'SELECT p.product_name, SUM(oi.quantity * oi.price) as revenue '
-                                    'FROM products p INNER JOIN order_items oi ON p.id = oi.product_id '
-                                    'GROUP BY p.product_name ORDER BY revenue DESC LIMIT 10'
+                                    'SELECT\n  p.product_name,\n  SUM(oi.quantity * oi.price) AS revenue\n'
+                                    'FROM products AS p\nINNER JOIN order_items AS oi\n  ON p.id = oi.product_id\n'
+                                    'GROUP BY\n  p.product_name\nORDER BY\n  revenue DESC\nLIMIT 10;'
                                 ),
                             },
                         ],
@@ -442,7 +442,7 @@ def test_rename_block_error(sample_params, block_id, block_name, error_match):
                         'codes': [
                             {'id': 'b0.c0', 'name': 'Code X', 'script': 'SELECT * FROM table1'},
                             {'id': 'b0.c1', 'name': 'Code Y', 'script': 'SELECT * FROM table2'},
-                            {'name': 'New Code at End', 'script': 'SELECT col1 FROM table1;'},
+                            {'name': 'New Code at End', 'script': 'SELECT\n  col1\nFROM table1;'},
                         ],
                     },
                 ]
@@ -483,8 +483,9 @@ def test_rename_block_error(sample_params, block_id, block_name, error_match):
                             {
                                 'name': 'New Code at Start',
                                 'script': (
-                                    'SELECT DISTINCT category, AVG(price) OVER (PARTITION BY category) as avg_price '
-                                    'FROM products WHERE in_stock = true ORDER BY category'
+                                    'SELECT DISTINCT\n  category,\n'
+                                    '  AVG(price) OVER (PARTITION BY category) AS avg_price\n'
+                                    'FROM products\nWHERE\n  in_stock = TRUE\nORDER BY\n  category;'
                                 ),
                             },
                             {'id': 'b0.c0', 'name': 'Code X', 'script': 'SELECT * FROM table1'},
@@ -758,7 +759,7 @@ def test_rename_code_error(sample_params, block_id, code_id, code_name, error_ma
                         'id': 'b0',
                         'name': 'Block A',
                         'codes': [
-                            {'id': 'b0.c0', 'name': 'Code X', 'script': 'SELECT * FROM new_table'},
+                            {'id': 'b0.c0', 'name': 'Code X', 'script': 'SELECT\n  *\nFROM new_table;'},
                         ],
                     },
                 ]
@@ -785,7 +786,7 @@ def test_rename_code_error(sample_params, block_id, code_id, code_name, error_ma
                         'id': 'b0',
                         'name': 'Block A',
                         'codes': [
-                            {'id': 'b0.c0', 'name': 'Code X', 'script': 'SELECT *\nFROM table1\nWHERE col = 1'},
+                            {'id': 'b0.c0', 'name': 'Code X', 'script': 'SELECT\n  *\nFROM table1\nWHERE\n  col = 1;'},
                         ],
                     },
                 ]
@@ -851,7 +852,7 @@ def test_set_code_error(sample_params, block_id, code_id, script, error_match):
                             {
                                 'id': 'b0.c0',
                                 'name': 'Code X',
-                                'script': 'SELECT * FROM table1 WHERE col = 1',
+                                'script': 'SELECT * FROM table1\nWHERE col = 1',
                             },
                         ],
                     },
@@ -884,7 +885,7 @@ def test_set_code_error(sample_params, block_id, code_id, script, error_match):
                             {
                                 'id': 'b0.c0',
                                 'name': 'Code X',
-                                'script': 'SELECT * FROM table0; SELECT * FROM table1',
+                                'script': 'SELECT * FROM table0;\nSELECT * FROM table1',
                             },
                         ],
                     },
@@ -917,7 +918,7 @@ def test_set_code_error(sample_params, block_id, code_id, script, error_match):
                             {
                                 'id': 'b0.c0',
                                 'name': 'Code X',
-                                'script': 'SELECT * FROM table0 SELECT * FROM table1',
+                                'script': 'SELECT * FROM table0\nSELECT * FROM table1',
                             },
                         ],
                     },

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -37,6 +37,7 @@ from keboola_mcp_server.tools.components.model import (
     TfSetCode,
     TfStrReplace,
 )
+from keboola_mcp_server.tools.components.sql_utils import format_simplified_tf_code
 from keboola_mcp_server.tools.components.tools import (
     add_config_row,
     create_config,
@@ -590,7 +591,8 @@ async def test_create_sql_transformation(
     assert new_transformation_configuration.description == mock_configuration['description']
     assert new_transformation_configuration.version == mock_configuration['version']
 
-    raw_code_blocks = await asyncio.gather(*[b.to_raw_code() for b in code_blocks])
+    formatted_codes = [format_simplified_tf_code(b, sql_dialect.lower())[0] for b in code_blocks]
+    raw_code_blocks = await asyncio.gather(*[b.to_raw_code() for b in formatted_codes])
     keboola_client.storage_client.configuration_create.assert_called_once_with(
         component_id=expected_component_id,
         name=transformation_name,
@@ -809,7 +811,9 @@ async def test_update_sql_transformation_folder(
                     'blocks': [
                         {
                             'name': 'Updated Blocks',
-                            'codes': [{'name': 'Existing Code', 'script': ['SELECT 1;', 'SELECT * FROM new_table;']}],
+                            'codes': [
+                                {'name': 'Existing Code', 'script': ['SELECT\n  1;', 'SELECT\n  *\nFROM new_table;']}
+                            ],
                         }
                     ]
                 },

--- a/tests/tools/components/test_utils.py
+++ b/tests/tools/components/test_utils.py
@@ -73,7 +73,7 @@ def test_expand_component_types(
                             codes=[
                                 TransformationConfiguration.Parameters.Block.Code(
                                     name='Code 0',
-                                    script=['SELECT * FROM test;', 'SELECT * FROM test2;'],
+                                    script=['SELECT\n  *\nFROM test;', 'SELECT\n  *\nFROM test2;'],
                                 )
                             ],
                         )
@@ -109,9 +109,11 @@ def test_expand_component_types(
                                 TransformationConfiguration.Parameters.Block.Code(
                                     name='Code 0',
                                     script=[
-                                        'CREATE OR REPLACE TABLE "test_table_1" AS SELECT * FROM "test";',
-                                        '-- comment\n'
-                                        'CREATE OR REPLACE TABLE "test_table_2" AS SELECT * FROM "test";',
+                                        'CREATE OR REPLACE TABLE "test_table_1" AS\nSELECT\n  *\nFROM "test";',
+                                        (
+                                            '/* comment */\nCREATE OR REPLACE TABLE "test_table_2"'
+                                            ' AS\nSELECT\n  *\nFROM "test";'
+                                        ),
                                     ],
                                 )
                             ],
@@ -153,7 +155,7 @@ def test_expand_component_types(
                             codes=[
                                 TransformationConfiguration.Parameters.Block.Code(
                                     name='Code 0',
-                                    script=['CREATE OR REPLACE TABLE "test_table_1" AS SELECT * FROM "test";'],
+                                    script=['CREATE OR REPLACE TABLE "test_table_1" AS\nSELECT\n  *\nFROM "test";'],
                                 )
                             ],
                         )
@@ -1109,7 +1111,7 @@ def test_structure_summary(parameters: dict[str, Any], expected_markdown: str):
                     SimplifiedTfBlocks.Block(
                         name='Block A',
                         codes=[
-                            SimplifiedTfBlocks.Block.Code(name='Code X', script='SELECT * FROM new_table'),
+                            SimplifiedTfBlocks.Block.Code(name='Code X', script='SELECT\n  *\nFROM new_table;'),
                         ],
                     ),
                 ]
@@ -1137,7 +1139,7 @@ def test_structure_summary(parameters: dict[str, Any], expected_markdown: str):
                     SimplifiedTfBlocks.Block(
                         name='Renamed Block',
                         codes=[
-                            SimplifiedTfBlocks.Block.Code(name='Code X', script='SELECT * FROM new_table'),
+                            SimplifiedTfBlocks.Block.Code(name='Code X', script='SELECT\n  *\nFROM new_table;'),
                         ],
                     ),
                 ]
@@ -1178,7 +1180,7 @@ def test_structure_summary(parameters: dict[str, Any], expected_markdown: str):
                     SimplifiedTfBlocks.Block(
                         name='New Block',
                         codes=[
-                            SimplifiedTfBlocks.Block.Code(name='New Code', script='SELECT * IN table2'),
+                            SimplifiedTfBlocks.Block.Code(name='New Code', script='SELECT\n  *\nIN table2;'),
                         ],
                     ),
                 ]
@@ -1252,7 +1254,7 @@ def test_structure_summary(parameters: dict[str, Any], expected_markdown: str):
                         name='Block A',
                         codes=[
                             SimplifiedTfBlocks.Block.Code(name='Code X', script='SELECT * IN table1'),
-                            SimplifiedTfBlocks.Block.Code(name='New Code', script='SELECT * IN table2'),
+                            SimplifiedTfBlocks.Block.Code(name='New Code', script='SELECT\n  *\nIN table2;'),
                         ],
                     ),
                 ]
@@ -1319,7 +1321,7 @@ def test_structure_summary(parameters: dict[str, Any], expected_markdown: str):
                         name='Block A',
                         codes=[
                             SimplifiedTfBlocks.Block.Code(name='Code X', script='SELECT * FROM table1'),
-                            SimplifiedTfBlocks.Block.Code(name='New Code', script='SELECT 1'),
+                            SimplifiedTfBlocks.Block.Code(name='New Code', script='SELECT\n  1;'),
                         ],
                     ),
                     SimplifiedTfBlocks.Block(name='New Block', codes=[]),

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.57.1"
+version = "1.57.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3064](https://linear.app/keboola/issue/AI-3064/updating-a-transformation-does-not-show-diff-preview)

### Change Type

- [x] Patch (bug fixes, small improvements, no new features)

### Summary

**Root cause**: PR #433 (AI-2773) removed all SQL formatting from transformation write operations to fix a semantic mutation bug where `sqlglot.transpile` was changing `MM→mm`, `!=→<>`, and `TO_VARCHAR→TO_CHAR`. After that removal, LLM-generated SQL was stored as a single long line, making the `POST /preview/config-diff` platform diff preview unreadable.

**Fix**: The semantic issue was caused by `sqlglot.transpile` using `read=dialect` but no `write=dialect`, causing output in sqlglot's generic SQL dialect. Adding `write=dialect.lower()` makes it output back into the same input dialect, preserving all Snowflake/BigQuery-specific syntax.

Changes:
- `sql_utils.py`: Added `write=dialect.lower()` to `sqlglot.transpile` in `format_sql` — this is the key fix preventing semantic drift
- `tf_update.py`: Restored `format_simplified_tf_block`, `format_simplified_tf_code`, and `format_sql` calls in `add_block`, `add_code`, `set_code` operations; also fixed `add_script` to use `\n` separator instead of space
- `utils.py`: Restored `format_simplified_tf_block` call in `create_transformation_configuration`
- Tests updated to reflect the now-formatted SQL in expected values
- Version bumped `1.57.1 → 1.57.2`

## Testing

- [x] Unit tests added/updated (if applicable)

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)