### PR TITLE
fix(security): add HSTS middleware for Strict-Transport-Security header [PAT-1312]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.58.0"
+version = "1.58.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -19,7 +19,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
-from keboola_mcp_server.mcp import ForwardSlashMiddleware
+from keboola_mcp_server.mcp import ForwardSlashMiddleware, HSTSMiddleware
 from keboola_mcp_server.server import CustomRoutes, create_server
 
 LOG = logging.getLogger(__name__)
@@ -176,7 +176,7 @@ async def run_server(args: Optional[list[str]] = None) -> None:
                     yield
 
             app = Starlette(
-                middleware=[Middleware(ForwardSlashMiddleware)],
+                middleware=[Middleware(HSTSMiddleware), Middleware(ForwardSlashMiddleware)],
                 lifespan=lifespan,
                 exception_handlers=_exception_handlers,
             )

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -100,6 +100,34 @@ class ForwardSlashMiddleware:
         await self._app(scope, receive, send)
 
 
+class HSTSMiddleware:
+    """Injects Strict-Transport-Security on HTTPS responses (detected via X-Forwarded-Proto)."""
+
+    _HSTS_HEADER = b'strict-transport-security'
+    _HSTS_VALUE = b'max-age=31536000; includeSubDomains'
+
+    def __init__(self, app: ASGIApp):
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope['type'] != 'http':
+            await self._app(scope, receive, send)
+            return
+
+        headers = dict(scope.get('headers', []))
+        if headers.get(b'x-forwarded-proto', b'') != b'https':
+            await self._app(scope, receive, send)
+            return
+
+        async def _send(message):
+            if message['type'] == 'http.response.start':
+                message = dict(message)
+                message['headers'] = list(message.get('headers', [])) + [(self._HSTS_HEADER, self._HSTS_VALUE)]
+            await send(message)
+
+        await self._app(scope, receive, _send)
+
+
 class KeboolaMcpServer(FastMCP):
     def add_tool(self, tool: Tool) -> None:
         """Applies `textwrap.dedent()` function to the tool's docstring, if no explicit description is provided."""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -12,6 +12,7 @@ from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
 from keboola_mcp_server.mcp import (
     AggregateError,
+    HSTSMiddleware,
     ServerState,
     SessionStateMiddleware,
     ToolsFilteringMiddleware,
@@ -707,3 +708,59 @@ class TestSessionStateMiddleware:
         assert result is expected_result
         assert len(captured_configs) == 1
         assert captured_configs[0].branch_id == expected_branch_id
+
+
+# ── HSTSMiddleware tests ──────────────────────────────────────────────────────
+
+
+async def _run_hsts_middleware(forwarded_proto: str | None) -> dict:
+    """Helper: run HSTSMiddleware with a minimal HTTP scope and return the response.start message."""
+    headers = []
+    if forwarded_proto is not None:
+        headers.append((b'x-forwarded-proto', forwarded_proto.encode()))
+
+    scope = {'type': 'http', 'headers': headers}
+    received_start: dict = {}
+
+    async def app(s, r, send):
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b''})
+
+    async def capture_send(message):
+        if message['type'] == 'http.response.start':
+            received_start.update(message)
+
+    middleware = HSTSMiddleware(app)
+    await middleware(scope, None, capture_send)
+    return received_start
+
+
+@pytest.mark.parametrize(
+    ('forwarded_proto', 'expect_hsts'),
+    [
+        ('https', True),
+        ('http', False),
+        (None, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_hsts_middleware_http(forwarded_proto, expect_hsts):
+    msg = await _run_hsts_middleware(forwarded_proto)
+    response_headers = dict(msg.get('headers', []))
+    hsts_present = b'strict-transport-security' in response_headers
+    assert hsts_present == expect_hsts
+    if expect_hsts:
+        assert response_headers[b'strict-transport-security'] == b'max-age=31536000; includeSubDomains'
+
+
+@pytest.mark.asyncio
+async def test_hsts_middleware_non_http_scope():
+    """Non-HTTP scopes (lifespan, websocket) pass through unchanged."""
+    called = []
+
+    async def app(scope, receive, send):
+        called.append(scope['type'])
+
+    middleware = HSTSMiddleware(app)
+    await middleware({'type': 'lifespan'}, None, None)
+    assert called == ['lifespan']

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.58.0"
+version = "1.58.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: PAT-1312

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Pen test finding ID009 (CVSS 3.1 Low): `mcp.us-east4.gcp.keboola.com` was missing the `Strict-Transport-Security` header despite serving exclusively over HTTPS, leaving it open to SSL-stripping MITM downgrade attacks.

This PR adds a `HSTSMiddleware` ASGI class (Starlette) that injects `Strict-Transport-Security: max-age=31536000; includeSubDomains` on every HTTP response **only when** the incoming request contains `X-Forwarded-Proto: https`. This header is set by the k8s nginx ingress when it terminates TLS and forwards the request to the app.

The guard on `X-Forwarded-Proto` means:
- **Production (HTTPS via ingress)**: header is injected ✅
- **Local dev / stdio transport / plain HTTP**: header is omitted — no impact on local OAuth flows or MCP clients ✅
- **MCP SDK clients** (`mcp`, `fastmcp`, Claude Desktop): ignore unknown HTTP headers — fully safe ✅

`HSTSMiddleware` is registered as the outermost Starlette middleware so it wraps all responses including those from exception handlers.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Manual smoke test:
```bash
# Header present when behind HTTPS proxy
curl -si -H "X-Forwarded-Proto: https" http://localhost:8000/mcp/ | grep -i strict-transport
# → strict-transport-security: max-age=31536000; includeSubDomains

# Header absent for plain HTTP (local dev)
curl -si http://localhost:8000/mcp/ | grep -i strict-transport
# → (empty)
```

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)