### PR TITLE
AI-2391: surface branch context in get_project_info

### DIFF
--- a/feature_spec/project_info_branch_context/RFC.md
+++ b/feature_spec/project_info_branch_context/RFC.md
@@ -1,0 +1,119 @@
+# RFC: Branch context in `get_project_info`
+
+Linear: [AI-2391](https://linear.app/keboola/issue/AI-2391/kai-uses-dev-branch-bucket-names-when-generating-sql)
+
+## Problem
+
+The `project_system_prompt.md` returned by `get_project_info` contains guidance specific
+to **development branches**:
+
+- FQN of branched tables differs from production paths.
+- Transformations should prefer input mapping over direct FQN references in branches.
+- Data App tools are not supported in dev branches.
+
+For agents (e.g. Kai) to apply that guidance correctly they must know whether the
+current MCP call is operating on a dev branch. The server already resolves a per-request
+branch from the `X-Branch-Id` HTTP header (or `KBC_BRANCH_ID` env var, see
+`src/keboola_mcp_server/config.py:91-93` and `src/keboola_mcp_server/mcp.py:218-220`),
+but `get_project_info` does not surface this. Today an agent has no reliable way to tell.
+
+The visible symptom in AI-2391 is that Kai used dev-branch bucket names when generating
+SQL — i.e. it could not distinguish branch vs production context.
+
+## Required Behavior
+
+`get_project_info` must return enough context for the agent to determine its branch
+mode. Concretely, three new fields on `ProjectInfo`:
+
+| Field                    | Type        | Meaning                                                              |
+|--------------------------|-------------|----------------------------------------------------------------------|
+| `branch_id`              | `str \| int` | Resolved branch ID, always populated (even on default).              |
+| `branch_name`            | `str`       | Human-readable branch name (e.g. `"Main"` or the dev branch name).   |
+| `is_development_branch`  | `bool`      | `True` iff this is **not** the default/production branch.            |
+
+The fields must reflect the **per-request** branch resolution — i.e. two simultaneous
+clients passing different `X-Branch-Id` headers must each see their own branch.
+
+## Resolution Strategy
+
+Use the existing `AsyncStorageClient.branches_list()`
+(`src/keboola_mcp_server/clients/storage.py:327`):
+
+- If `KeboolaClient.branch_id is None` → pick the entry with `isDefault is True`
+  (default/production branch).
+- Else → pick the entry where `id` matches `client.branch_id` (compare as strings to be
+  safe across `int`/`str`).
+- Populate `branch_id`, `branch_name` (`name`), `is_development_branch = not isDefault`.
+
+`branches_list` is preferred over `dev_branch_detail` because the default branch's
+numeric ID is unknown when `client.branch_id is None`, and the `dev-branches/{id}`
+endpoint is not verified to accept the `'default'` shorthand (only
+`branch/{id}/metadata` does).
+
+## Compatibility with Kai (Keboola UI)
+
+Verified against `/Users/esner/Documents/Prace/KBC/AI-TESTING/ui` — the consumer of this
+tool. Adding the three fields is **non-breaking**:
+
+- **Backend** (`apps/kai-assistant-backend/lib/ai/mcp.ts:148-155`, schema
+  `GetProjectInfoResponseSchema` lines 265-276): Zod `.optional()` shape; unknown fields
+  are silently dropped during validation. No break.
+- **Agent** (`apps/kai-agent/src/services/mcp-client.ts:248-263`): TypeScript interface
+  `ProjectInfo` (lines 31-40); `JSON.parse(...) as ProjectInfo` tolerates extra
+  properties. No break.
+- **Branch transport already wired**: Both Kai entry points already inject
+  `X-Branch-Id` on MCP requests when `config.branchId` is present
+  (`mcp.ts:314`, `mcp-client.ts:82`). The per-request branch resolution this RFC depends
+  on is therefore live in the Kai integration today.
+- **`llm_instruction` injection**: Both Kai paths concatenate `llm_instruction` verbatim
+  under a `## Platform-Wide Instructions` section in the agent system prompt
+  (`prompts.ts:25-27`, `prompt-builder.ts:56-59`). Existing dev-branch guidance in
+  `project_system_prompt.md` is therefore already reaching the agent — what's missing is
+  the data the agent needs to act on it.
+- **Current Kai branch awareness**: Kai does **not** today read any branch field from
+  `ProjectInfo`; it only passes the header through. So the symptom in AI-2391 (Kai
+  using dev-branch bucket names in SQL) is consistent with the agent having no
+  in-context signal about branch mode.
+
+### Follow-up on the Kai side (separate PR, not in this scope)
+
+To make the new fields useful end-to-end, Kai will need a small change:
+
+1. Add the three fields as optional to both the Zod schema and the TS interface:
+   - `apps/kai-assistant-backend/lib/ai/mcp.ts` `GetProjectInfoResponseSchema`
+   - `apps/kai-agent/src/services/mcp-client.ts` `ProjectInfo`
+2. Inject them (or a derived hint) into the system prompt builders alongside
+   `llm_instruction`, e.g. a one-line "You are operating on development branch
+   '<name>' (id: <id>). Apply branch-specific guidance." when
+   `is_development_branch` is true.
+
+This MCP server change is forward-compatible: until Kai is updated, the new fields are
+simply ignored.
+
+## Scope
+
+In scope:
+
+- Add the three fields to `ProjectInfo` (`src/keboola_mcp_server/tools/project.py`).
+- Resolve them from `branches_list` inside `get_project_info`.
+- Extend the existing parametrized unit test (`tests/tools/test_project.py`) with a
+  branch-mode axis (default vs dev).
+- Add type/sanity assertions to the integtest (`integtests/tools/test_project.py`).
+- Bump version `1.58.1` → `1.59.0` (new field on a tool response = feature → minor
+  bump per CLAUDE.md) and refresh `uv.lock`.
+- Regenerate `TOOLS.md` via `tox -e check-tools-docs`.
+
+Out of scope:
+
+- Edits to `project_system_prompt.md`. Existing in-flight edits to that file already
+  cover dev branch guidance; once the fields exist agents can key off them. A follow-up
+  may add an explicit reference to `is_development_branch` if needed.
+
+## Verification
+
+1. `tox` — pytest, black, flake8, check-tools-docs all exit 0.
+2. Manual end-to-end via local MCP (`.mcp.json` per CLAUDE.md):
+   - Without `KBC_BRANCH_ID`: `is_development_branch=False`, branch_name = production
+     branch name.
+   - With `KBC_BRANCH_ID=<dev branch>`: `is_development_branch=True`, matching name/ID.
+3. Optional: integtests against a real project.

--- a/integtests/tools/test_project.py
+++ b/integtests/tools/test_project.py
@@ -23,3 +23,9 @@ async def test_get_project_info(mcp_context: Context, keboola_project) -> None:
         assert link.type in {'ui-detail', 'ui-dashboard', 'docs'}
         assert isinstance(link.title, str)
         assert isinstance(link.url, str)
+
+    assert isinstance(result.branch_id, (str, int))
+    assert isinstance(result.branch_name, str)
+    assert result.branch_name
+    # The pool fixture runs on the default branch — see integtests/conftest.py.
+    assert result.is_development_branch is False

--- a/integtests/tools/test_storage_branches.py
+++ b/integtests/tools/test_storage_branches.py
@@ -18,6 +18,7 @@ from mcp.types import ClientCapabilities, InitializeRequestParams
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config
 from keboola_mcp_server.mcp import ServerRuntimeInfo, ServerState
+from keboola_mcp_server.tools.project import get_project_info
 from keboola_mcp_server.tools.storage.tools import get_buckets, get_tables
 from keboola_mcp_server.workspace import WorkspaceManager
 
@@ -380,18 +381,20 @@ def branch_project(request, branch_test_projects: list[BranchTestProject]) -> Br
     pytest.skip(f'No project matching {request.param}')
 
 
-@pytest_asyncio.fixture
-async def branch_context(
+async def _build_context(
     mocker,
     branch_project: BranchTestProject,
+    *,
+    branch_id: str | None,
 ) -> Context:
-    """MCP context bound to Branch A of the current parametrized project."""
+    """Build an MCP context bound to a specific branch (or the default branch when None)."""
     keboola_client = KeboolaClient(
         storage_api_url=branch_project.storage_api_url,
         storage_api_token=branch_project.storage_api_token,
         headers={'User-Agent': 'KeboolaMCPServer/integtest'},
     )
-    keboola_client = await keboola_client.with_branch_id(branch_project.branch_a_id)
+    if branch_id is not None:
+        keboola_client = await keboola_client.with_branch_id(branch_id)
     workspace_manager = await WorkspaceManager.create(keboola_client)
 
     mcp_config = Config(
@@ -414,6 +417,24 @@ async def branch_context(
     ctx.request_context = mocker.MagicMock()
     ctx.request_context.lifespan_context = ServerState(mcp_config, ServerRuntimeInfo(transport='stdio'))
     return ctx
+
+
+@pytest_asyncio.fixture
+async def branch_context(
+    mocker,
+    branch_project: BranchTestProject,
+) -> Context:
+    """MCP context bound to Branch A of the current parametrized project."""
+    return await _build_context(mocker, branch_project, branch_id=branch_project.branch_a_id)
+
+
+@pytest_asyncio.fixture
+async def default_branch_context(
+    mocker,
+    branch_project: BranchTestProject,
+) -> Context:
+    """MCP context bound to the default/production branch of the current parametrized project."""
+    return await _build_context(mocker, branch_project, branch_id=None)
 
 
 # --- Tests ---
@@ -460,3 +481,34 @@ async def test_deference_branched_table(
 
     table = next(t for t in result.tables if t.id == 'in.c-test_bucket_01.test_table_01')
     assert table.branch_id is None
+
+
+@pytest.mark.asyncio
+async def test_get_project_info_reports_dev_branch(
+    branch_context: Context,
+    branch_project: BranchTestProject,
+) -> None:
+    """get_project_info from a dev-branch context should populate branch fields and is_development_branch=True."""
+    result = await get_project_info(branch_context)
+
+    assert str(result.branch_id) == str(branch_project.branch_a_id)
+    assert isinstance(result.branch_name, str)
+    assert result.branch_name
+    assert result.is_development_branch is True
+
+
+@pytest.mark.asyncio
+async def test_get_project_info_reports_default_branch(
+    default_branch_context: Context,
+    branch_project: BranchTestProject,
+) -> None:
+    """get_project_info from a default-branch context should populate branch fields and is_development_branch=False."""
+    result = await get_project_info(default_branch_context)
+
+    assert isinstance(result.branch_id, (str, int))
+    assert isinstance(result.branch_name, str)
+    assert result.branch_name
+    assert result.is_development_branch is False
+    # Sanity: the default branch must not be the dev branch we created for this session.
+    assert str(result.branch_id) != str(branch_project.branch_a_id)
+    assert str(result.branch_id) != str(branch_project.branch_b_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.59.1"
+version = "1.60.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -44,6 +44,35 @@ Keboola Storage.
 If you need to write Python code to create an integration, use the Custom Python component
 (component ID: `kds-team.app-custom-python`).
 
+#### Input mapping vs RO Storage
+Transformations can read from Storage in two ways:
+1. Input mapping: the transformation configuration specifies which Storage tables should be made available as inputs. Such tables are then loaded into the transformation workspace under user specified name. e.g. `SELECT * FROM in_my_table`.
+2. RO Storage: the transformation can access any table in Storage using it's FQN directly. e.g. `SELECT * FROM "KEBOOLA_123"."in.c-main"."my-table"`.
+
+IMPORTANT: When working in branches the FQNs of the tables in RO Storage will be different than in the main branch - if
+the table was edited or created in the branch. FQN of the branched table/bucket will not be accessible after merging to production.
+See the (development-branches)[#development-branches] section for more details.
+
+**Rules to follow**
+- NEVER use branch specific FQNs in transformation code if working in branches.
+- Prefer input mapping over RO Storage when working in branches. If the users tries to edit a transformation that uses
+  direct FQN references in a branch, explain the caveats and suggest switching to input mapping for better branch
+  compatibility.
+    - If the user prefers using FQNs, be sure not to use branch specific paths in the code. If the transformation works
+      with a new table created in the branch, or if you need to run the transformation to test changes in other tables.
+      Branch specific FQN may be used, but only temporarily. It needs to be switched back to the production path before
+      merging.
+
+### Development Branches
+
+When working in development branches the storage objects (tables, buckets) created or edited in the branch will have different FQNs than in production. 
+Listing tables and buckets in the branch will return a mix of production and branch specific objects (depending of which ones were edited or created in the branch).
+This deference is being handled on the tool level. Branched version objects have a branch id prefix in the FQN e.g. `"KEBOOLA_123"."BRANCH_ID_in.c-main"."my-table"` or `"KEBOOLA_123"."in.c-BRANCH_ID-main"."my-table"`
+
+If you run a new process in a branch that creates a new table, this table will only exist in the branch (branched FQN) until the process is merged and executed in the production.
+
+Be aware of these differences especially when working with transformations. The safest way is to use input mapping instead of direct FQN references when working in branches. See the (Transformations)[#transformations] section for more details.
+
 ### Creating Custom Integrations
 
 Sometimes users require integrations or complex applications that are not covered by any existing off-the-shelf component.

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -51,7 +51,7 @@ Transformations can read from Storage in two ways:
 
 IMPORTANT: When working in branches the FQNs of the tables in RO Storage will be different than in the main branch - if
 the table was edited or created in the branch. FQN of the branched table/bucket will not be accessible after merging to production.
-See the (development-branches)[#development-branches] section for more details.
+See the [Development Branches](#development-branches) section for more details.
 
 **Rules to follow**
 - NEVER use branch specific FQNs in transformation code if working in branches.
@@ -71,7 +71,7 @@ This deference is being handled on the tool level. Branched version objects have
 
 If you run a new process in a branch that creates a new table, this table will only exist in the branch (branched FQN) until the process is merged and executed in the production.
 
-Be aware of these differences especially when working with transformations. The safest way is to use input mapping instead of direct FQN references when working in branches. See the (Transformations)[#transformations] section for more details.
+Be aware of these differences especially when working with transformations. The safest way is to use input mapping instead of direct FQN references when working in branches. See the [Transformations](#transformations) section for more details.
 
 ### Creating Custom Integrations
 

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -46,28 +46,28 @@ If you need to write Python code to create an integration, use the Custom Python
 
 #### Input mapping vs RO Storage
 Transformations can read from Storage in two ways:
-1. Input mapping: the transformation configuration specifies which Storage tables should be made available as inputs. Such tables are then loaded into the transformation workspace under user specified name. e.g. `SELECT * FROM in_my_table`.
-2. RO Storage: the transformation can access any table in Storage using it's FQN directly. e.g. `SELECT * FROM "KEBOOLA_123"."in.c-main"."my-table"`.
+1. Input mapping: the transformation configuration specifies which Storage tables should be made available as inputs. Such tables are then loaded into the transformation workspace under a user-specified name. e.g. `SELECT * FROM in_my_table`.
+2. RO Storage: the transformation can access any table in Storage using its FQN directly. e.g. `SELECT * FROM "KEBOOLA_123"."in.c-main"."my-table"`.
 
 IMPORTANT: When working in branches the FQNs of the tables in RO Storage will be different than in the main branch - if
 the table was edited or created in the branch. FQN of the branched table/bucket will not be accessible after merging to production.
 See the [Development Branches](#development-branches) section for more details.
 
 **Rules to follow**
-- NEVER use branch specific FQNs in transformation code if working in branches.
-- Prefer input mapping over RO Storage when working in branches. If the users tries to edit a transformation that uses
+- NEVER use branch-specific FQNs in transformation code when working in branches.
+- Prefer input mapping over RO Storage when working in branches. If the user tries to edit a transformation that uses
   direct FQN references in a branch, explain the caveats and suggest switching to input mapping for better branch
   compatibility.
-    - If the user prefers using FQNs, be sure not to use branch specific paths in the code. If the transformation works
-      with a new table created in the branch, or if you need to run the transformation to test changes in other tables.
-      Branch specific FQN may be used, but only temporarily. It needs to be switched back to the production path before
-      merging.
+    - If the user prefers using FQNs, do not use branch-specific paths in the code unless they are temporarily required.
+      If the transformation works with a new table created in the branch, or if you need to run the transformation to
+      test changes in other tables, a branch-specific FQN may be used temporarily, but it must be switched back to the
+      production path before merging.
 
 ### Development Branches
 
 When working in development branches the storage objects (tables, buckets) created or edited in the branch will have different FQNs than in production. 
-Listing tables and buckets in the branch will return a mix of production and branch specific objects (depending of which ones were edited or created in the branch).
-This deference is being handled on the tool level. Branched version objects have a branch id prefix in the FQN e.g. `"KEBOOLA_123"."BRANCH_ID_in.c-main"."my-table"` or `"KEBOOLA_123"."in.c-BRANCH_ID-main"."my-table"`
+Listing tables and buckets in the branch will return a mix of production and branch-specific objects (depending on which ones were edited or created in the branch).
+This difference is being handled on the tool level. Branched version objects have a branch ID prefix in the FQN e.g. `"KEBOOLA_123"."BRANCH_ID_in.c-main"."my-table"` or `"KEBOOLA_123"."in.c-BRANCH_ID-main"."my-table"`
 
 If you run a new process in a branch that creates a new table, this table will only exist in the branch (branched FQN) until the process is merged and executed in the production.
 

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -71,7 +71,7 @@ async def _resolve_branch_context(client: KeboolaClient) -> tuple[str | int, str
         return fallback_id, 'unknown', target_branch_id is not None
 
     branch_id = cast(
-        'str | int',
+        str | int,
         selected.get('id', target_branch_id if target_branch_id is not None else 'default'),
     )
     branch_name = cast(str, selected.get('name', 'unknown'))

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -67,9 +67,13 @@ async def _resolve_branch_context(client: KeboolaClient) -> tuple[str | int, str
 
     if selected is None:
         # Should not happen in a healthy project, but stay defensive.
-        return target_branch_id or 'default', 'unknown', target_branch_id is not None
+        fallback_id: str | int = target_branch_id if target_branch_id is not None else 'default'
+        return fallback_id, 'unknown', target_branch_id is not None
 
-    branch_id = cast('str | int', selected.get('id', target_branch_id or 'default'))
+    branch_id = cast(
+        'str | int',
+        selected.get('id', target_branch_id if target_branch_id is not None else 'default'),
+    )
     branch_name = cast(str, selected.get('name', 'unknown'))
     is_development_branch = selected.get('isDefault') is not True
     return branch_id, branch_name, is_development_branch

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -43,6 +43,38 @@ def add_project_tools(mcp: FastMCP) -> None:
     LOG.info('Project tools initialized.')
 
 
+async def _resolve_branch_context(client: KeboolaClient) -> tuple[str | int, str, bool]:
+    """
+    Resolves the current branch's id, name, and dev-branch flag from the storage API.
+
+    `client.branch_id` is None on the default/production branch (normalized by
+    `KeboolaClient.with_branch_id`), so we look up the branches list and pick either
+    the entry matching the client's branch_id or the one with `isDefault=True`.
+    """
+    target_branch_id = client.branch_id
+    branches = await client.storage_client.branches_list()
+
+    selected: JsonDict | None = None
+    for branch in branches:
+        if target_branch_id is None:
+            if branch.get('isDefault') is True:
+                selected = branch
+                break
+        else:
+            if str(branch.get('id')) == str(target_branch_id):
+                selected = branch
+                break
+
+    if selected is None:
+        # Should not happen in a healthy project, but stay defensive.
+        return target_branch_id or 'default', 'unknown', target_branch_id is not None
+
+    branch_id = cast('str | int', selected.get('id', target_branch_id or 'default'))
+    branch_name = cast(str, selected.get('name', 'unknown'))
+    is_development_branch = selected.get('isDefault') is not True
+    return branch_id, branch_name, is_development_branch
+
+
 def _get_toolset_restrictions(role: str) -> str | None:
     """
     Returns a human-readable description of toolset restrictions for the given user role,
@@ -72,6 +104,17 @@ class ProjectInfo(BaseModel):
     sql_dialect: str = Field(description='The sql dialect used in the project.')
     conditional_flows: bool = Field(description='Whether the project supports conditional flows.')
     links: list[Link] = Field(description='The links relevant to the project.')
+    branch_id: str | int = Field(
+        description='The ID of the branch this call is operating on (default/production or a development branch).'
+    )
+    branch_name: str = Field(description='The name of the branch this call is operating on.')
+    is_development_branch: bool = Field(
+        description=(
+            'True if this call is operating on a development branch, False if on the default/production branch. '
+            'Use this to apply branch-specific guidance (e.g., FQN handling in transformations, '
+            'unsupported tools in development branches).'
+        )
+    )
     user_role: str = Field(
         description='The Keboola role of the current user (e.g. "admin", "developer", "guest", "readonly").',
     )
@@ -144,6 +187,8 @@ async def get_project_info(
     conditional_flows = 'hide-conditional-flows' not in project_features
     links = links_manager.get_project_links()
 
+    branch_id, branch_name, is_development_branch = await _resolve_branch_context(client)
+
     project_info = ProjectInfo(
         project_id=project_id,
         project_name=project_name,
@@ -152,6 +197,9 @@ async def get_project_info(
         sql_dialect=sql_dialect,
         conditional_flows=conditional_flows,
         links=links,
+        branch_id=branch_id,
+        branch_name=branch_name,
+        is_development_branch=is_development_branch,
         user_role=user_role,
         toolset_restrictions=_get_toolset_restrictions(user_role),
         llm_instruction=get_project_system_prompt(sql_dialect),

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -8,6 +8,7 @@ from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.project import (
     ProjectInfo,
     _get_toolset_restrictions,
+    _resolve_branch_context,
     get_project_info,
     update_project_description,
 )
@@ -43,6 +44,10 @@ def test_get_toolset_restrictions(role: str, expected_substring: str | None, exp
             assert 'unknown' in result
 
 
+_DEFAULT_BRANCH = {'id': 123, 'name': 'Main', 'isDefault': True}
+_DEV_BRANCH = {'id': 456, 'name': 'feature-x', 'isDefault': False}
+
+
 @pytest.mark.parametrize(
     (
         'token_role',
@@ -51,18 +56,24 @@ def test_get_toolset_restrictions(role: str, expected_substring: str | None, exp
         'restriction_is_none',
         'sql_dialect',
         'expected_fqn_example',
+        'client_branch_id',
+        'expected_branch_id',
+        'expected_branch_name',
+        'expected_is_dev',
     ),
     [
-        # developer role: schedules not available
-        ('developer', 'developer', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"'),
-        # guest role: schedules not available
-        ('guest', 'guest', ['cannot set their schedules'], False, 'BigQuery', '`project`.`dataset`.`table`'),
-        # no role: schedules not available
-        (None, 'unknown', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"'),
-        # readonly role: only read-only tools
-        ('readonly', 'readonly', ['read-only'], False, 'BigQuery', '`project`.`dataset`.`table`'),
-        # admin role: no restrictions
-        ('admin', 'admin', [], True, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"'),
+        # developer role on default branch
+        ('developer', 'developer', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
+        # guest role on default branch
+        ('guest', 'guest', ['cannot set their schedules'], False, 'BigQuery', '`project`.`dataset`.`table`', None, 123, 'Main', False),
+        # no role on default branch
+        (None, 'unknown', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
+        # readonly role on default branch
+        ('readonly', 'readonly', ['read-only'], False, 'BigQuery', '`project`.`dataset`.`table`', None, 123, 'Main', False),
+        # admin role on default branch
+        ('admin', 'admin', [], True, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
+        # admin role on a dev branch — exercises the dev-branch resolution path
+        ('admin', 'admin', [], True, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', '456', 456, 'feature-x', True),
     ],
 )
 @pytest.mark.asyncio
@@ -75,6 +86,10 @@ async def test_get_project_info(
     restriction_is_none: bool,
     sql_dialect: str,
     expected_fqn_example: str,
+    client_branch_id: str | None,
+    expected_branch_id: int,
+    expected_branch_name: str,
+    expected_is_dev: bool,
 ) -> None:
     admin_data = {'role': token_role} if token_role is not None else {}
     token_data = {
@@ -87,8 +102,10 @@ async def test_get_project_info(
         {'key': 'other', 'value': 'ignore'},
     ]
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.branch_id = client_branch_id
     keboola_client.storage_client.verify_token = mocker.AsyncMock(return_value=token_data)
     keboola_client.storage_client.branch_metadata_get = mocker.AsyncMock(return_value=metadata)
+    keboola_client.storage_client.branches_list = mocker.AsyncMock(return_value=[_DEFAULT_BRANCH, _DEV_BRANCH])
     workspace_manager = WorkspaceManager.from_state(mcp_context_client.session.state)
     workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
 
@@ -113,6 +130,9 @@ async def test_get_project_info(
     assert result.links == links
     assert result.user_role == expected_user_role
     assert expected_fqn_example in result.llm_instruction
+    assert result.branch_id == expected_branch_id
+    assert result.branch_name == expected_branch_name
+    assert result.is_development_branch is expected_is_dev
 
     if restriction_is_none:
         assert result.toolset_restrictions is None
@@ -120,6 +140,40 @@ async def test_get_project_info(
         assert result.toolset_restrictions is not None
         for substring in expected_restriction_substrings:
             assert substring in result.toolset_restrictions
+
+
+@pytest.mark.parametrize(
+    ('client_branch_id', 'branches', 'expected_id', 'expected_name', 'expected_is_dev'),
+    [
+        # default branch resolution
+        (None, [_DEFAULT_BRANCH, _DEV_BRANCH], 123, 'Main', False),
+        # dev branch resolution by id (string vs int safe)
+        ('456', [_DEFAULT_BRANCH, _DEV_BRANCH], 456, 'feature-x', True),
+        (456, [_DEFAULT_BRANCH, _DEV_BRANCH], 456, 'feature-x', True),
+        # defensive: branch id present but not in list (should not happen, but covered)
+        ('999', [_DEFAULT_BRANCH], '999', 'unknown', True),
+        # defensive: empty list when on default
+        (None, [], 'default', 'unknown', False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_resolve_branch_context(
+    mocker: MockerFixture,
+    client_branch_id: str | int | None,
+    branches: list[dict],
+    expected_id: str | int,
+    expected_name: str,
+    expected_is_dev: bool,
+) -> None:
+    client = mocker.Mock()
+    client.branch_id = client_branch_id
+    client.storage_client.branches_list = mocker.AsyncMock(return_value=branches)
+
+    branch_id, branch_name, is_dev = await _resolve_branch_context(client)
+
+    assert branch_id == expected_id
+    assert branch_name == expected_name
+    assert is_dev is expected_is_dev
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.59.1"
+version = "1.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-2391](https://linear.app/keboola/issue/AI-2391/kai-uses-dev-branch-bucket-names-when-generating-sql)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Two coordinated changes that together fix AI-2391 (Kai using dev-branch bucket names in generated SQL):

**1. New branch fields on `ProjectInfo`**

Adds `branch_id`, `branch_name`, and `is_development_branch` to the `get_project_info` response so MCP agents can detect dev-branch mode from the tool result. Today the `X-Branch-Id` header is plumbed end-to-end and resolved per request, but `get_project_info` did not surface the resolved branch, so the LLM had no in-context signal.

Resolution uses one `branches_list()` call: pick the entry with `isDefault=True` when `client.branch_id is None`, otherwise the entry whose id matches.

**2. New branch-related guidance in `project_system_prompt.md`**

Two new sections on the platform-wide instructions returned via `llm_instruction`:

- **Input mapping vs RO Storage** (under Transformations) — explicit rules: never use branch-specific FQNs in transformation code; prefer input mapping in branches; only allow branch FQNs as a temporary device that must be reverted before merge.
- **Development Branches** (top-level) — explains how branched objects appear with different FQN patterns (`BRANCH_ID_in.c-…` for `storage-branches` projects, `in.c-BRANCH_ID-…` for legacy) and that the tool layer hides this except for FQN building.

Together, the new fields tell the agent **whether** it's on a branch, and the prompt updates tell it **what to do** about it.

Forward-compatible — Kai's Zod schema and TS interface tolerate the new fields without changes; the companion Kai PR (read both fields and surface them in the agent system prompt) is tracked as [AI-3114](https://linear.app/keboola/issue/AI-3114/kai-surface-mcp-branch-context-in-agent-system-prompt) (https://github.com/keboola/ui/pull/5368). Full design in `feature_spec/project_info_branch_context/RFC.md`.

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports) — N/A (server-side only, validated via integtests below)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Verified end-to-end via `integtests/tools/test_storage_branches.py::test_get_project_info_reports_default_branch` and `::test_get_project_info_reports_dev_branch` against both `storage-branches` and `old-branches` projects (4 cases, all pass).

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (parametrized in `tests/tools/test_project.py`, plus a new `test_resolve_branch_context`)
- [x] Integration tests added/updated (default + dev branch in `integtests/tools/test_storage_branches.py`, type assertions in `integtests/tools/test_project.py`)
- [x] Project version bumped (1.58.1 -> 1.59.0)
- [x] Documentation updated (RFC under `feature_spec/project_info_branch_context/`)
