### PR TITLE
fix(workspace): extend BigQuery query timeout to 5 minutes, update sql transformation folder error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.59.0"
+version = "1.59.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/base.py
+++ b/src/keboola_mcp_server/clients/base.py
@@ -149,6 +149,7 @@ class RawKeboolaClient:
         data: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
         headers: dict[str, Any] | None = None,
+        timeout: httpx.Timeout | None = None,
     ) -> JsonStruct:
         """
         Makes a POST request to the service API.
@@ -157,13 +158,14 @@ class RawKeboolaClient:
         :param data: Request payload
         :param params: Query parameters for the request
         :param headers: Additional headers for the request
+        :param timeout: Optional per-call timeout override; falls back to the client default when None
         :return: API response as dictionary
         """
         if self.readonly:
             raise RuntimeError(f'Forbidden POST operation on a readonly client: {self.base_api_url}')
 
         headers = self.headers | (headers or {})
-        async with httpx.AsyncClient(timeout=self.timeout, transport=self._create_transport()) as client:
+        async with httpx.AsyncClient(timeout=timeout or self.timeout, transport=self._create_transport()) as client:
             response = await client.post(
                 f'{self.base_api_url}/{endpoint}',
                 params=params,
@@ -314,6 +316,7 @@ class KeboolaServiceClient:
         endpoint: str,
         data: Optional[dict[str, Any]] = None,
         params: Optional[dict[str, Any]] = None,
+        timeout: Optional[httpx.Timeout] = None,
     ) -> JsonStruct:
         """
         Makes a POST request to the service API.
@@ -321,9 +324,10 @@ class KeboolaServiceClient:
         :param endpoint: API endpoint to call
         :param data: Request payload
         :param params: Query parameters for the request
+        :param timeout: Optional per-call timeout override; falls back to the client default when None
         :return: API response as dictionary
         """
-        return await self.raw_client.post(endpoint=endpoint, data=data, params=params)
+        return await self.raw_client.post(endpoint=endpoint, data=data, params=params, timeout=timeout)
 
     async def put(
         self,

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -3,6 +3,7 @@ import math
 from datetime import datetime
 from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, cast
 
+import httpx
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from keboola_mcp_server.clients.base import JsonDict, KeboolaServiceClient, RawKeboolaClient
@@ -988,12 +989,13 @@ class AsyncStorageClient(KeboolaServiceClient):
     #  and replaced by QueryService.
     #  Unfortunately the QueryService supports only Snowflake backends. We use it in _SnowflakeWorkspace implementation,
     #  but not in _BigQueryWorkspace implementation, which still uses this function.
-    async def workspace_query(self, workspace_id: int, query: str) -> JsonDict:
+    async def workspace_query(self, workspace_id: int, query: str, timeout: httpx.Timeout | None = None) -> JsonDict:
         """
         Executes a query in a given workspace.
 
         :param workspace_id: The id of the workspace
         :param query: The query to execute
+        :param timeout: Optional per-call timeout override; falls back to the client default when None
         :return: The SAPI call response - query result or raise an error.
         """
         return cast(
@@ -1001,6 +1003,7 @@ class AsyncStorageClient(KeboolaServiceClient):
             await self.post(
                 endpoint=f'branch/{self._branch_id}/workspaces/{workspace_id}/query',
                 data={'query': query},
+                timeout=timeout,
             ),
         )
 

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -871,9 +871,25 @@ async def update_sql_transformation(
     else:
         folder_stripped = folder.strip()
         if folder_stripped:
-            await set_configuration_folder_metadata(client, sql_transformation_id, configuration_id, folder_stripped)
+            try:
+                await set_configuration_folder_metadata(client, sql_transformation_id, configuration_id, folder_stripped)
+            except Exception as exc:
+                LOG.warning(
+                    'Unable to set folder metadata for component "%s", configuration "%s".',
+                    sql_transformation_id,
+                    configuration_id,
+                    exc_info=exc,
+                )
         else:
-            await clear_configuration_folder_metadata(client, sql_transformation_id, configuration_id)
+            try:
+                await clear_configuration_folder_metadata(client, sql_transformation_id, configuration_id)
+            except Exception as exc:
+                LOG.warning(
+                    'Unable to clear folder metadata for component "%s", configuration "%s".',
+                    sql_transformation_id,
+                    configuration_id,
+                    exc_info=exc,
+                )
 
     change_summary = ' '.join(filter(None, [msg, folder_hint])) or None
 

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any, Literal, Mapping, Sequence, cast
 from urllib.parse import urlunparse
 
+import httpx
 from httpx import HTTPStatusError
 from pydantic import Field, TypeAdapter
 from pydantic.dataclasses import dataclass
@@ -443,7 +444,11 @@ class _BigQueryWorkspace(_Workspace):
         if max_chars is not None and max_chars <= 0:
             raise ValueError('The "max_chars" must be a positive integer or None.')
 
-        resp = await self._client.storage_client.workspace_query(workspace_id=self.id, query=sql_query)
+        resp = await self._client.storage_client.workspace_query(
+            workspace_id=self.id,
+            query=sql_query,
+            timeout=httpx.Timeout(connect=5.0, read=self._QUERY_TIMEOUT, write=10.0, pool=5.0),
+        )
         qr = cast(QueryResult, TypeAdapter(QueryResult).validate_python(resp))
         if qr.data:
             total_query_rows = len(qr.data.rows)

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -830,6 +830,65 @@ async def test_update_sql_transformation_folder(
 
 
 @pytest.mark.parametrize(
+    ('folder', 'patched_fn'),
+    [
+        ('Sales', 'set_configuration_folder_metadata'),
+        ('', 'clear_configuration_folder_metadata'),
+    ],
+    ids=['set_raises', 'clear_raises'],
+)
+@pytest.mark.asyncio
+async def test_update_sql_transformation_folder_metadata_error_is_swallowed(
+    mocker: MockerFixture,
+    mcp_context_components_configs: Context,
+    mock_component: dict[str, Any],
+    mock_configuration: dict[str, Any],
+    folder: str,
+    patched_fn: str,
+) -> None:
+    """Metadata errors in update_sql_transformation are swallowed and logged, not raised."""
+    context = mcp_context_components_configs
+    workspace_manager = WorkspaceManager.from_state(context.session.state)
+    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    keboola_client = KeboolaClient.from_state(context.session.state)
+    mock_component['id'] = 'keboola.snowflake-transformation'
+    configuration_id = 'cfg-error-test'
+    existing = {
+        'id': configuration_id,
+        'name': 'T',
+        'description': 'D',
+        'configuration': {'parameters': {'blocks': []}, 'storage': {}},
+        'version': 1,
+    }
+    keboola_client.storage_client.configuration_detail = mocker.AsyncMock(return_value=existing)
+    keboola_client.storage_client.configuration_update = mocker.AsyncMock(return_value={**existing, 'version': 2})
+    keboola_client.ai_service_client.get_component_detail = mocker.AsyncMock(return_value=mock_component)
+    keboola_client.storage_client.component_detail = mocker.AsyncMock(return_value=mock_component)
+    keboola_client.storage_client.configuration_metadata_get = mocker.AsyncMock(
+        return_value=[{'id': 'meta-1', 'key': MetadataField.CONFIGURATION_FOLDER_NAME, 'value': 'OldFolder'}]
+    )
+    keboola_client.storage_client.configuration_metadata_delete = mocker.AsyncMock()
+    mocker.patch(
+        f'keboola_mcp_server.tools.components.tools.{patched_fn}',
+        mocker.AsyncMock(side_effect=RuntimeError('metadata API unavailable')),
+    )
+    mocker.patch(
+        'keboola_mcp_server.tools.components.tools.get_config_folders',
+        mocker.AsyncMock(return_value=(0, [], False)),
+    )
+
+    result = await update_sql_transformation(
+        context,
+        change_description='test',
+        configuration_id=configuration_id,
+        folder=folder,
+    )
+
+    assert isinstance(result, ConfigToolOutput)
+    assert result.success is True
+
+
+@pytest.mark.parametrize(
     ('sql_dialect', 'expected_component_id', 'parameter_updates', 'storage', 'expected_config'),
     [
         pytest.param(

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -2,6 +2,7 @@ import json
 from typing import Any
 from unittest.mock import call
 
+import httpx
 import pytest
 from mcp.server.fastmcp import Context
 from pydantic import TypeAdapter
@@ -14,6 +15,7 @@ from keboola_mcp_server.workspace import (
     SqlSelectData,
     TableFqn,
     WorkspaceManager,
+    _BigQueryWorkspace,
     _SnowflakeWorkspace,
 )
 
@@ -591,6 +593,11 @@ class TestWorkspaceManagerBigQuery:
         actual = await m.execute_query(query, max_rows=max_rows, max_chars=max_chars)
 
         assert actual == expected
+        keboola_client.storage_client.workspace_query.assert_called_once_with(
+            workspace_id=1234,
+            query=query,
+            timeout=httpx.Timeout(connect=5.0, read=_BigQueryWorkspace._QUERY_TIMEOUT, write=10.0, pool=5.0),
+        )
 
 
 class TestQueryCancellation:
@@ -686,7 +693,7 @@ class TestQueryCancellation:
         result = await qsclient.cancel_job('job-abc-123', reason='Test cancellation')
 
         raw_client.post.assert_called_once_with(
-            endpoint='queries/job-abc-123/cancel', data={'reason': 'Test cancellation'}, params=None
+            endpoint='queries/job-abc-123/cancel', data={'reason': 'Test cancellation'}, params=None, timeout=None
         )
         assert result == {'status': 'canceling'}
 

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.59.0"
+version = "1.59.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: AI-3076

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

BigQuery queries run via `query_data` were timing out after ~60 seconds with "Upstream request timed out, please retry". The root cause: BigQuery workspace execution uses the legacy Storage API (`POST /branch/{id}/workspaces/{id}/query`) as a single synchronous HTTP call, subject to the default 60-second `httpx` read timeout. Snowflake is unaffected — it uses the async Query Service poll loop.

**Fix:** Threads an optional per-call `timeout` override down through three layers so only the BigQuery workspace query gets a 5-minute read timeout; all other storage API calls keep the 60-second default.

Changes:
- `clients/base.py` — `RawKeboolaClient.post()` and `KeboolaServiceClient.post()` both accept an optional `timeout: httpx.Timeout | None` that overrides the client default for that single call; `KeboolaServiceClient.post()` forwards it to `raw_client.post()`
- `clients/storage.py` — `workspace_query()` threads the `timeout` through to `post()`
- `workspace.py` — `_BigQueryWorkspace.execute_query()` passes `httpx.Timeout(connect=5.0, read=_QUERY_TIMEOUT, write=10.0, pool=5.0)` (reusing the existing `_QUERY_TIMEOUT = 300.0` constant)
- `tests/tools/test_sql.py` — asserts `workspace_query` is called with the correct timeout, referencing `_BigQueryWorkspace._QUERY_TIMEOUT` rather than a hard-coded value

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [x] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [ ] Documentation updated (if applicable)