### PR TITLE
feat(data-apps): add create_git_data_app tool for git-backed JS/TypeScript data apps [AI-3153]

### DIFF
--- a/.claude/skills/data-app-workflow/SKILL.md
+++ b/.claude/skills/data-app-workflow/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: data-app-workflow
+version: 1.0.0
+description: >
+  Use when the user says "create me a dashboard", "build a data app showing X",
+  "deploy a new data app from my extractor", "I want a JS/TypeScript dashboard for my data",
+  "create me a data app", or similar requests. Orchestrates the full lifecycle: gather
+  requirements → explore available data → choose framework sub-skill → set up GitHub
+  repo → create Keboola data app (git-backed) → deploy.
+---
+
+## Overview
+
+This skill is an **orchestrator**. It gathers what the user wants, explores the data, delegates
+code generation to a framework-specific sub-skill (Express, Vite, HONO, etc.), sets up the
+GitHub repository, then creates and deploys the Keboola data app using the `create_git_data_app`
+MCP tool.
+
+```
+Step 1: Requirements
+Step 2: Data exploration
+Step 3: Git repo decision (new vs existing, public vs private)
+Step 4: Code generation → framework sub-skill  [new repo path only]
+Step 5: GitHub repo setup + push               [new repo path only]
+Step 6: create_git_data_app  (MCP tool — handles credential encryption)
+Step 7: deploy_data_app
+```
+
+---
+
+## Step 1 — Gather requirements
+
+If the user's message is not specific enough, ask in **one combined prompt**:
+
+- What should the dashboard display? (metric names, KPIs, charts, tables, filters)
+- Which connector, extractor, or table is the data source? (bucket/table name, or describe it)
+- What name should the app have?
+
+If the user already provided all of this in their request, skip to Step 2.
+
+---
+
+## Step 2 — Explore available data
+
+Use MCP tools to understand the data before any code is written:
+
+```
+search(item_types=["table", "bucket"], query=<user's connector/table name>)
+get_tables(...)      → inspect schema, column names, types
+query_data(...)      → SELECT * FROM <table> LIMIT 10 — confirm columns & sample values
+```
+
+Summarise what you found to the user (table name, key columns, row count) and confirm
+it matches what they want to display before proceeding.
+
+---
+
+## Step 3 — Git repository decision
+
+Ask the user two questions (combine into one prompt):
+
+**3A — New or existing repo?**
+- **Existing**: Ask for the repo URL and branch. Skip to Step 6.
+- **New**: Proceed to Step 3B.
+
+**3B — For a new repo:**
+
+- GitHub organisation name and desired repo name
+- Public or private?
+- If **private**: username **and** one of:
+  - GitHub Personal Access Token (PAT, starts with `ghp_`)  
+  - SSH private key (paste the full PEM block)
+
+Collect all details in one prompt. Store credentials in memory only for this
+session — never log or echo them.
+
+---
+
+## Step 4 — Code generation via framework sub-skill (new repo path only)
+
+The skill is **framework-agnostic**. Use the table below to pick a sub-skill, then
+invoke it with the Skill tool (or `/sub-skill-name`). Pass the data schema, table
+names, and dashboard requirements so the sub-skill generates appropriate code.
+
+| Sub-skill | When to use |
+|---|---|
+| `express-data-app` | Node.js Express server + JSON API endpoints |
+| `vite-data-app` | React/TypeScript SPA (Vite build, served by nginx) |
+| `hono-data-app` | Hono (lightweight edge-ready Node.js) |
+| _(none matched)_ | Generate code directly based on requirements |
+
+If no sub-skill matches the user's preference, generate the JS/TypeScript code
+directly. Aim for the simplest structure that meets the requirements:
+- Minimal dependencies (CDN preferred over npm install for libraries)
+- A working `setup.sh` and a clear entry point
+- nginx or Node.js to serve the app on the Keboola platform port
+
+---
+
+## Step 5 — GitHub repo setup and code push (new repo path only)
+
+```bash
+# Create the repo in the user's org
+gh repo create <org>/<repo-name> --public/--private --clone --description "<description>"
+
+# cd into the cloned repo, copy generated files
+cd <repo-name>
+# ... write all generated files ...
+
+# Stage, commit, push
+git add .
+git commit -m "Initial dashboard scaffold"
+git push origin main
+```
+
+### Credential safety rules
+
+- **Never** pass PATs or SSH keys as plain shell arguments (no `echo "ghp_..."` or `git clone https://user:token@...`).
+- For HTTPS push with a PAT, configure via `gh auth` or a one-time `.netrc` entry before pushing.
+- For SSH push, use `ssh-agent` or write the key to a temp file with restricted permissions,
+  add to agent, then delete the file after the push.
+- After the push is done, **discard** the credential — do not store or log it anywhere.
+
+---
+
+## Step 6 — Create the Keboola data app
+
+Call `create_git_data_app` from the MCP server. This tool handles credential encryption
+automatically — pass credentials as **plaintext**:
+
+```
+create_git_data_app(
+  name=<app name>,
+  description=<description>,
+  git_repo=<HTTPS or SSH URL>,
+  git_branch=<branch, default "main">,
+  # For public repos: omit git_username, git_pat, git_ssh_key
+  # For HTTPS private repos:
+  git_username=<username>,
+  git_pat=<plaintext PAT>,
+  # For SSH private repos:
+  git_ssh_key=<plaintext SSH private key>,
+  authentication_type="basic-auth",   # or "no-auth" if user explicitly wants public access
+)
+```
+
+Save the returned `configuration_id` — it is needed for the deploy step and for
+any future updates.
+
+---
+
+## Step 7 — Deploy
+
+```
+deploy_data_app(action="deploy", configuration_id=<from step 6>)
+```
+
+Report to the user:
+- The deployment URL (from `deployment_url` in the response)
+- The simpleAuth password if `authentication_type="basic-auth"` was used
+  (the user will need this to log in)
+- A reminder that the app may take 1-3 minutes to cold-start on first access
+
+---
+
+## Updating an existing app
+
+When the user says "update my data app", "change the dashboard", "point the app to a
+different branch", etc.:
+
+1. Find the existing app: `get_data_apps(configuration_ids=[<id>])` or `search(...)`
+2. Call `create_git_data_app` with the same `configuration_id` and the changed params
+3. Call `deploy_data_app(action="deploy", configuration_id=...)` to apply changes
+
+---
+
+## CRITICAL RULES
+
+1. **Always call `deploy_data_app` after `create_git_data_app`** — without it the app
+   will not start (or the updated config won't take effect for running apps).
+
+2. **Never handle encryption yourself.** The `create_git_data_app` MCP tool encrypts
+   all credentials via the project's KMS. Pass plaintext values; the tool does the rest.
+
+3. **Credentials are session-only.** Do not write PATs or SSH keys to disk, memory files,
+   or any persistent location. Use them only for the git push in Step 5, then discard.
+
+4. **SSH URL format**: `git@github.com:org/repo.git` — not HTTPS.
+   HTTPS URL format: `https://github.com/org/repo` — not SSH.
+
+5. **Explore before generating.** Always run Step 2 (data exploration) before writing
+   any code. Generating code without knowing the actual column names leads to bugs.
+
+6. **One prompt for credentials.** Collect username, PAT/SSH key, org, and repo name
+   in a single prompt — do not ask for them one at a time.
+
+---
+
+## Example conversation flow
+
+```
+User: "Create me a dashboard showing monthly revenue and top 10 customers from
+       my Snowflake extractor"
+
+Skill Step 1: Requirements already provided — name TBD, ask for it
+Skill Step 2: search("snowflake") → find output tables → query_data(LIMIT 10)
+              → confirm schema with user
+Skill Step 3: "New or existing repo? Public or private?"
+              → User: "New, private, org=acme, name=revenue-dashboard, PAT=ghp_..."
+Skill Step 4: invoke vite-data-app sub-skill (or generate directly) with schema context
+Skill Step 5: gh repo create acme/revenue-dashboard --private --clone
+              → push generated code
+Skill Step 6: create_git_data_app(name="Revenue Dashboard",
+                                   git_repo="https://github.com/acme/revenue-dashboard",
+                                   git_username="acme-bot", git_pat="ghp_...")
+Skill Step 7: deploy_data_app(action="deploy", configuration_id="cfg-abc123")
+              → report URL + password to user
+```

--- a/.claude/skills/data-app-workflow/SKILL.md
+++ b/.claude/skills/data-app-workflow/SKILL.md
@@ -89,34 +89,135 @@ names, and dashboard requirements so the sub-skill generates appropriate code.
 | `hono-data-app` | Hono (lightweight edge-ready Node.js) |
 | _(none matched)_ | Generate code directly based on requirements |
 
-If no sub-skill matches the user's preference, generate the JS/TypeScript code
-directly. Aim for the simplest structure that meets the requirements:
-- Minimal dependencies (CDN preferred over npm install for libraries)
-- A working `setup.sh` and a clear entry point
-- nginx or Node.js to serve the app on the Keboola platform port
+If no sub-skill matches the user's preference, generate the JS/TypeScript code directly.
+
+### Required repo structure for Keboola `python-js` data apps
+
+Reference: https://help.keboola.com/data-apps/python-js/#step-3---create-the-keboola-config-folder
+
+```
+repo/
+├── keboola-config/
+│   ├── setup.sh                          ← install (+ build for static apps)
+│   ├── nginx/
+│   │   └── sites/
+│   │       └── default.conf             ← reverse proxy to 127.0.0.1:<app-port>
+│   └── supervisord/
+│       └── services/
+│           └── app.conf                 ← long-running app process
+├── package.json                         ← include "serve" in dependencies for static apps
+└── src/
+```
+
+**`keboola-config/setup.sh`** — runs once at container start, before the app launches.
+Install deps here; also run the build step for static Vite/React apps.
+Always `cd /app` first (default working dir is `/home/app`).
+Use `set -Eeuo pipefail` (stricter than `set -e`):
+
+```bash
+# Node.js app (install only)
+#!/bin/bash
+set -Eeuo pipefail
+cd /app && npm install
+
+# Vite/React static app (install + build)
+#!/bin/bash
+set -Eeuo pipefail
+cd /app && npm install && npm run build
+```
+
+**`keboola-config/supervisord/services/app.conf`** — defines the long-running process
+that supervisord keeps alive. For a static Vite app served via `serve`:
+
+```ini
+[program:app]
+command=node /app/node_modules/.bin/serve -s /app/dist -l 5000
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+```
+
+For a Node.js server (`server.js` listening on port 5000):
+
+```ini
+[program:app]
+command=node /app/server.js
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+```
+
+**`keboola-config/nginx/sites/default.conf`** — nginx runs as non-root and acts as a
+**reverse proxy** to the app on localhost. Port must be >= 1024; use **8888**:
+
+```nginx
+server {
+    listen 8888;
+    server_name _;
+
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+For apps with WebSockets (Dash, live-updating content), add inside the `location /` block:
+
+```nginx
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+```
 
 ---
 
 ## Step 5 — GitHub repo setup and code push (new repo path only)
 
 ```bash
-# Create the repo in the user's org
-gh repo create <org>/<repo-name> --public/--private --clone --description "<description>"
+# 1. Create the remote repo (no --clone; we init locally instead)
+gh repo create <org>/<repo-name> --public/--private --description "<description>"
 
-# cd into the cloned repo, copy generated files
-cd <repo-name>
-# ... write all generated files ...
+# 2. Write all generated files into a temp directory
+mkdir -p /tmp/<repo-name>
+# ... write all files (Write tool) ...
 
-# Stage, commit, push
+# 3. Init, stage, and commit locally
+cd /tmp/<repo-name>
+git init
 git add .
 git commit -m "Initial dashboard scaffold"
-git push origin main
+
+# 4. Push — use a temporary .netrc for HTTPS PAT auth (never pass token in URL)
+printf 'machine github.com login %s password %s\n' "<username>" "<pat>" \
+  > /tmp/.ghcreds && chmod 600 /tmp/.ghcreds
+GIT_CONFIG_COUNT=1 \
+  GIT_CONFIG_KEY_0=credential.helper \
+  GIT_CONFIG_VALUE_0="store --file /tmp/.ghcreds" \
+  git remote add origin https://github.com/<org>/<repo-name>.git
+git push -u origin main
+rm -f /tmp/.ghcreds   # discard immediately after push
 ```
+
+For SSH push, write the key to a temp file (`chmod 600`), add to `ssh-agent`, push, then
+remove the file.
 
 ### Credential safety rules
 
 - **Never** pass PATs or SSH keys as plain shell arguments (no `echo "ghp_..."` or `git clone https://user:token@...`).
-- For HTTPS push with a PAT, configure via `gh auth` or a one-time `.netrc` entry before pushing.
+- For HTTPS push with a PAT, use a temporary `.netrc` / `credential.helper store` file as shown above — delete it right after pushing.
 - For SSH push, use `ssh-agent` or write the key to a temp file with restricted permissions,
   add to agent, then delete the file after the push.
 - After the push is done, **discard** the credential — do not store or log it anywhere.
@@ -172,6 +273,16 @@ different branch", etc.:
 2. Call `create_git_data_app` with the same `configuration_id` and the changed params
 3. Call `deploy_data_app(action="deploy", configuration_id=...)` to apply changes
 
+## Redeploying after a git push
+
+When new code is pushed to the repo (bug fix, UI change, etc.) **without** changing the
+Keboola configuration, skip `create_git_data_app` and call `deploy_data_app` directly —
+the platform re-clones the repo and rebuilds on every deploy:
+
+```
+deploy_data_app(action="deploy", configuration_id=<existing id>)
+```
+
 ---
 
 ## CRITICAL RULES
@@ -179,20 +290,28 @@ different branch", etc.:
 1. **Always call `deploy_data_app` after `create_git_data_app`** — without it the app
    will not start (or the updated config won't take effect for running apps).
 
-2. **Never handle encryption yourself.** The `create_git_data_app` MCP tool encrypts
+2. **Always call `deploy_data_app` after a `git push`** — pushing code does not
+   automatically restart the app. The platform re-clones and rebuilds only on deploy.
+
+3. **Never handle encryption yourself.** The `create_git_data_app` MCP tool encrypts
    all credentials via the project's KMS. Pass plaintext values; the tool does the rest.
 
-3. **Credentials are session-only.** Do not write PATs or SSH keys to disk, memory files,
+4. **Credentials are session-only.** Do not write PATs or SSH keys to disk, memory files,
    or any persistent location. Use them only for the git push in Step 5, then discard.
 
-4. **SSH URL format**: `git@github.com:org/repo.git` — not HTTPS.
+5. **SSH URL format**: `git@github.com:org/repo.git` — not HTTPS.
    HTTPS URL format: `https://github.com/org/repo` — not SSH.
 
-5. **Explore before generating.** Always run Step 2 (data exploration) before writing
+6. **Explore before generating.** Always run Step 2 (data exploration) before writing
    any code. Generating code without knowing the actual column names leads to bugs.
 
-6. **One prompt for credentials.** Collect username, PAT/SSH key, org, and repo name
+7. **One prompt for credentials.** Collect username, PAT/SSH key, org, and repo name
    in a single prompt — do not ask for them one at a time.
+
+8. **`setup.sh` is for install/build only** — it lives in `keboola-config/setup.sh`, not
+   the repo root. Never start a server there. The long-running process goes in
+   `keboola-config/supervisord/services/app.conf`. nginx (port 8888) reverse-proxies to it.
+   Always `cd /app` first — npm's default working dir is `/home/app`.
 
 ---
 
@@ -208,8 +327,8 @@ Skill Step 2: search("snowflake") → find output tables → query_data(LIMIT 10
 Skill Step 3: "New or existing repo? Public or private?"
               → User: "New, private, org=acme, name=revenue-dashboard, PAT=ghp_..."
 Skill Step 4: invoke vite-data-app sub-skill (or generate directly) with schema context
-Skill Step 5: gh repo create acme/revenue-dashboard --private --clone
-              → push generated code
+Skill Step 5: gh repo create acme/revenue-dashboard --private
+              → write files to /tmp/revenue-dashboard, git init, push via temp .netrc
 Skill Step 6: create_git_data_app(name="Revenue Dashboard",
                                    git_repo="https://github.com/acme/revenue-dashboard",
                                    git_username="acme-bot", git_pat="ghp_...")

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -38,6 +38,7 @@ name or description.
 - [create_oauth_url](#create_oauth_url): Generates an OAuth authorization URL for a Keboola component configuration.
 
 ### Other Tools
+- [create_git_data_app](#create_git_data_app): Creates or updates a git-backed JS/TypeScript data app deployed from a git repository.
 - [deploy_data_app](#deploy_data_app): Deploys/redeploys a data app or stops running data app in the Keboola environment asynchronously given the action
 and the configuration ID.
 - [get_data_apps](#get_data_apps): Lists summaries of data apps in the project given the limit and offset or gets details of a data apps by
@@ -1705,6 +1706,132 @@ Example 4 - Update storage mappings:
 ---
 
 # Other Tools
+<a name="create_git_data_app"></a>
+## create_git_data_app
+**Annotations**: 
+
+**Tags**: `config-diff-preview, data-apps`
+
+**Description**:
+
+Creates or updates a git-backed JS/TypeScript data app deployed from a git repository.
+
+Use this tool when the data app source code lives in a git repository (JS/TypeScript, Node.js,
+React, etc.) rather than being provided as inline Python/Streamlit code.
+
+Considerations:
+- After creating or updating, ALWAYS call `deploy_data_app(action="deploy", configuration_id=...)`
+  to start or restart the app so changes take effect.
+- For public repositories, omit git_username, git_pat, and git_ssh_key.
+- For HTTPS private repositories, provide git_username and git_pat (plaintext — encrypted automatically).
+- For SSH private repositories, use an SSH git_repo URL and provide git_ssh_key (plaintext — encrypted
+  automatically). Do not provide git_username or git_pat in this case.
+- git_pat and git_ssh_key are mutually exclusive.
+- New apps use HTTP basic authentication by default for security; set authentication_type to "default"
+  when updating to preserve the existing authentication configuration.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "description": "Name of the data app (max ~50 chars to fit DNS label limit).",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the data app.",
+      "type": "string"
+    },
+    "git_repo": {
+      "description": "Full URL of the git repository containing the data app source code. Use HTTPS URL (e.g. https://github.com/org/repo) for username/PAT auth, or SSH URL (e.g. git@github.com:org/repo.git) for SSH key auth.",
+      "type": "string"
+    },
+    "git_branch": {
+      "default": "main",
+      "description": "Git branch to deploy (default: \"main\").",
+      "type": "string"
+    },
+    "git_username": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Git username for HTTPS private repositories. Required when git_pat is provided. Leave empty for public repos or SSH auth."
+    },
+    "git_pat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Plaintext GitHub Personal Access Token for HTTPS private repositories. The tool encrypts it automatically before storing \u2014 never pass a pre-encrypted value. Leave empty for public repos or SSH auth."
+    },
+    "git_ssh_key": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Plaintext SSH private key for private repositories accessed via SSH URL. The tool encrypts it automatically before storing \u2014 never pass a pre-encrypted value. Leave empty for public repos or HTTPS auth."
+    },
+    "authentication_type": {
+      "default": "basic-auth",
+      "description": "Authentication type for the data app UI: \"no-auth\" removes authentication completely, \"basic-auth\" secures the app with HTTP basic authentication, \"default\" keeps the existing authentication type when updating.",
+      "enum": [
+        "no-auth",
+        "basic-auth",
+        "default"
+      ],
+      "type": "string"
+    },
+    "configuration_id": {
+      "default": "",
+      "description": "The ID of an existing data app configuration when updating, otherwise empty string.",
+      "type": "string"
+    },
+    "change_description": {
+      "default": "",
+      "description": "Description of the change when updating (e.g. \"Update git branch\"), otherwise empty.",
+      "type": "string"
+    },
+    "folder": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Folder name to organize this data app in the Keboola UI. Pass an empty string to remove an existing folder assignment. Existing folder names are returned in the response change_summary when no folder is provided and there are 20 or more data apps in the project. If there are 20 or more data apps, you should assign one of the existing folders or create a new one that clearly reflects the data app purpose."
+    }
+  },
+  "required": [
+    "name",
+    "description",
+    "git_repo"
+  ],
+  "type": "object"
+}
+```
+
+---
 <a name="deploy_data_app"></a>
 ## deploy_data_app
 **Annotations**: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.60.0"
+version = "1.61.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -196,20 +196,47 @@ class DataScienceClient(KeboolaServiceClient):
         name: str,
         description: str,
         configuration: DataAppConfig,
+        app_type: str = 'streamlit',
     ) -> DataAppResponse:
         """
         Create a data app from a simplified config used in the MCP server.
         :param name: The name of the data app
         :param description: The description of the data app
         :param configuration: The simplified configuration of the data app
+        :param app_type: The type of the data app (e.g. 'streamlit', 'python-js')
         :return: The data app
         """
         data = {
             'branchId': self._branch_id,
             'name': name,
-            'type': 'streamlit',
+            'type': app_type,
             'description': description,
             'config': configuration.model_dump(exclude_none=True, by_alias=True),
+        }
+        response = await self.post(endpoint='apps', data=data)
+        return DataAppResponse.model_validate(response)
+
+    async def create_data_app_from_config(
+        self,
+        name: str,
+        description: str,
+        config: dict[str, Any],
+        app_type: str,
+    ) -> DataAppResponse:
+        """
+        Create a data app from a raw config dict (used for git-backed apps).
+        :param name: The name of the data app
+        :param description: The description of the data app
+        :param config: The raw configuration dict (already encrypted)
+        :param app_type: The type of the data app (e.g. 'python-js')
+        :return: The data app
+        """
+        data: dict[str, Any] = {
+            'branchId': self._branch_id,
+            'name': name,
+            'type': app_type,
+            'description': description,
+            'config': config,
         }
         response = await self.post(endpoint='apps', data=data)
         return DataAppResponse.model_validate(response)

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -872,7 +872,9 @@ async def update_sql_transformation(
         folder_stripped = folder.strip()
         if folder_stripped:
             try:
-                await set_configuration_folder_metadata(client, sql_transformation_id, configuration_id, folder_stripped)
+                await set_configuration_folder_metadata(
+                    client, sql_transformation_id, configuration_id, folder_stripped
+                )
             except Exception as exc:
                 LOG.warning(
                     'Unable to set folder metadata for component "%s", configuration "%s".',

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -57,6 +57,13 @@ def add_data_app_tools(mcp: FastMCP) -> None:
             annotations=ToolAnnotations(destructiveHint=False),
         )
     )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            create_git_data_app,
+            tags={DATA_APP_TOOLS_TAG, CONFIG_DIFF_PREVIEW_TAG},
+            annotations=ToolAnnotations(destructiveHint=False),
+        )
+    )
     LOG.info('Data app tools initialized.')
 
 
@@ -66,7 +73,7 @@ State = Literal['created', 'running', 'stopped', 'starting', 'stopping', 'restar
 # LLM agent can still understand the state of the data app even if it is different from the known states
 SafeState = Union[State, str]
 # Type of the data app
-Type = Literal['streamlit']
+Type = Literal['streamlit', 'python-js']
 # Accepts known types or any string preventing from validation errors when receiving unknown types from the API
 # LLM agent can still understand the type of the data app even if it is different from the known types
 SafeType = Union[Type, str]
@@ -570,6 +577,228 @@ async def deploy_data_app(
         return DeploymentDataAppOutput(state=data_app.state, links=links, deployment_info=None)
     else:
         raise ValueError(f'Invalid action: {action}')
+
+
+GIT_DATA_APP_TYPE = 'python-js'
+
+
+class CreateGitDataAppOutput(BaseModel):
+    """Output of the create_git_data_app tool."""
+
+    response: str = Field(description='The response of the action performed with potential additional information.')
+    change_summary: Optional[str] = Field(default=None, description='Additional notes or hints about the operation.')
+    data_app: DataAppSummary = Field(description='The data app.')
+    links: list[Link] = Field(description='Navigation links for the web interface.')
+
+
+@tool_errors()
+async def create_git_data_app(
+    ctx: Context,
+    name: Annotated[str, Field(description='Name of the data app (max ~50 chars to fit DNS label limit).')],
+    description: Annotated[str, Field(description='Description of the data app.')],
+    git_repo: Annotated[
+        str,
+        Field(
+            description=(
+                'Full URL of the git repository containing the data app source code. '
+                'Use HTTPS URL (e.g. https://github.com/org/repo) for username/PAT auth, '
+                'or SSH URL (e.g. git@github.com:org/repo.git) for SSH key auth.'
+            )
+        ),
+    ],
+    git_branch: Annotated[str, Field(description='Git branch to deploy (default: "main").')] = 'main',
+    git_username: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                'Git username for HTTPS private repositories. '
+                'Required when git_pat is provided. Leave empty for public repos or SSH auth.'
+            )
+        ),
+    ] = None,
+    git_pat: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                'Plaintext GitHub Personal Access Token for HTTPS private repositories. '
+                'The tool encrypts it automatically before storing — never pass a pre-encrypted value. '
+                'Leave empty for public repos or SSH auth.'
+            )
+        ),
+    ] = None,
+    git_ssh_key: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                'Plaintext SSH private key for private repositories accessed via SSH URL. '
+                'The tool encrypts it automatically before storing — never pass a pre-encrypted value. '
+                'Leave empty for public repos or HTTPS auth.'
+            )
+        ),
+    ] = None,
+    authentication_type: Annotated[
+        AuthenticationType,
+        Field(
+            description=(
+                'Authentication type for the data app UI: "no-auth" removes authentication completely, '
+                '"basic-auth" secures the app with HTTP basic authentication, '
+                '"default" keeps the existing authentication type when updating.'
+            )
+        ),
+    ] = 'basic-auth',
+    configuration_id: Annotated[
+        str, Field(description='The ID of an existing data app configuration when updating, otherwise empty string.')
+    ] = '',
+    change_description: Annotated[
+        str,
+        Field(description='Description of the change when updating (e.g. "Update git branch"), otherwise empty.'),
+    ] = '',
+    folder: Annotated[
+        Optional[str],
+        Field(description=folder_field_description('data app', 'data apps')),
+    ] = None,
+) -> CreateGitDataAppOutput:
+    """Creates or updates a git-backed JS/TypeScript data app deployed from a git repository.
+
+    Use this tool when the data app source code lives in a git repository (JS/TypeScript, Node.js,
+    React, etc.) rather than being provided as inline Python/Streamlit code.
+
+    Considerations:
+    - After creating or updating, ALWAYS call `deploy_data_app(action="deploy", configuration_id=...)`
+      to start or restart the app so changes take effect.
+    - For public repositories, omit git_username, git_pat, and git_ssh_key.
+    - For HTTPS private repositories, provide git_username and git_pat (plaintext — encrypted automatically).
+    - For SSH private repositories, use an SSH git_repo URL and provide git_ssh_key (plaintext — encrypted
+      automatically). Do not provide git_username or git_pat in this case.
+    - git_pat and git_ssh_key are mutually exclusive.
+    - New apps use HTTP basic authentication by default for security; set authentication_type to "default"
+      when updating to preserve the existing authentication configuration.
+    """
+    client = KeboolaClient.from_state(ctx.session.state)
+    links_manager = await ProjectLinksManager.from_client(client)
+    project_id = await client.storage_client.project_id()
+
+    config = _build_git_data_app_config(
+        name=name,
+        git_repo=git_repo,
+        git_branch=git_branch,
+        git_username=git_username,
+        git_pat=git_pat,
+        git_ssh_key=git_ssh_key,
+        authentication_type=authentication_type,
+    )
+    config = cast(
+        dict[str, Any],
+        await client.encryption_client.encrypt(config, component_id=DATA_APP_COMPONENT_ID, project_id=project_id),
+    )
+
+    if configuration_id:
+        await client.storage_client.configuration_update(
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=configuration_id,
+            configuration=config,
+            change_description=change_description or 'Update git data app',
+            updated_name=name,
+            updated_description=description,
+        )
+        data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
+        await set_cfg_update_metadata(
+            client=client,
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=configuration_id,
+            configuration_version=int(data_app.config_version),
+        )
+        folder_hint = await apply_folder_metadata(
+            client, DATA_APP_COMPONENT_ID, configuration_id, folder, 'data apps', 'create_git_data_app'
+        )
+        links = links_manager.get_data_app_links(
+            configuration_id=data_app.configuration_id,
+            configuration_name=name,
+            deployment_link=data_app.deployment_url,
+            uses_basic_authentication=_uses_basic_authentication(data_app.configuration.get('authorization') or {}),
+        )
+        response = (
+            'updated (redeploy required to apply changes in the running app)'
+            if data_app.state in ('running', 'starting')
+            else 'updated'
+        )
+        return CreateGitDataAppOutput(
+            response=response,
+            change_summary=folder_hint,
+            data_app=DataAppSummary.model_validate(data_app.model_dump()),
+            links=links,
+        )
+    else:
+        data_app_resp = await client.data_science_client.create_data_app_from_config(
+            name=name,
+            description=description,
+            config=config,
+            app_type=GIT_DATA_APP_TYPE,
+        )
+        await set_cfg_creation_metadata(
+            client=client,
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=data_app_resp.config_id,
+        )
+        folder_hint = await apply_folder_metadata(
+            client,
+            DATA_APP_COMPONENT_ID,
+            data_app_resp.config_id,
+            folder,
+            'data apps',
+            'create_git_data_app',
+            is_new=True,
+        )
+        uses_basic_auth = authentication_type == 'basic-auth'
+        links = links_manager.get_data_app_links(
+            configuration_id=data_app_resp.config_id,
+            configuration_name=name,
+            deployment_link=data_app_resp.url,
+            uses_basic_authentication=uses_basic_auth,
+        )
+        return CreateGitDataAppOutput(
+            response='created',
+            change_summary=folder_hint,
+            data_app=DataAppSummary.from_api_response(data_app_resp),
+            links=links,
+        )
+
+
+def _build_git_data_app_config(
+    name: str,
+    git_repo: str,
+    git_branch: str,
+    git_username: Optional[str],
+    git_pat: Optional[str],
+    git_ssh_key: Optional[str],
+    authentication_type: AuthenticationType,
+) -> dict[str, Any]:
+    """Build the Storage config dict for a git-backed data app.
+
+    Keys prefixed with '#' are encrypted by the caller via the Encryption API.
+    """
+    slug = _get_data_app_slug(name) or 'data-app'
+    git_block: dict[str, Any] = {
+        'repository': git_repo,
+        'branch': git_branch,
+    }
+    if git_username:
+        git_block['username'] = git_username
+    if git_pat:
+        git_block['#password'] = git_pat
+    if git_ssh_key:
+        git_block['#sshPrivateKey'] = git_ssh_key
+
+    parameters: dict[str, Any] = {
+        'size': 'tiny',
+        'autoSuspendAfterSeconds': 900,
+        'dataApp': {
+            'slug': slug,
+            'git': git_block,
+        },
+    }
+    authorization = _get_authorization(authentication_type == 'basic-auth')
+    return {'parameters': parameters, 'authorization': authorization}
 
 
 def _build_data_app_config(

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -782,6 +782,8 @@ def _build_git_data_app_config(
         'repository': git_repo,
         'branch': git_branch,
     }
+    if git_pat or git_ssh_key:
+        git_block['private'] = True
     if git_username:
         git_block['username'] = git_username
     if git_pat:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,7 @@ class TestServer:
             'create_conditional_flow',
             'create_config',
             'create_flow',
+            'create_git_data_app',
             'create_oauth_url',
             'create_sql_transformation',
             'deploy_data_app',
@@ -392,6 +393,7 @@ async def test_tool_annotations_and_tags():
         ('modify_data_app', None, True, None, {DATA_APP_TOOLS_TAG, CONFIG_DIFF_PREVIEW_TAG}),
         ('get_data_apps', True, None, None, {DATA_APP_TOOLS_TAG}),
         ('deploy_data_app', None, False, None, {DATA_APP_TOOLS_TAG}),
+        ('create_git_data_app', None, False, None, {DATA_APP_TOOLS_TAG, CONFIG_DIFF_PREVIEW_TAG}),
     ],
 )
 async def test_tool_annotations_tags_values(

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -785,8 +785,8 @@ async def test_modify_data_app_folder(
     ('git_username', 'git_pat', 'git_ssh_key', 'expected_keys'),
     [
         pytest.param(None, None, None, [], id='public_repo'),
-        pytest.param('alice', 'ghp_tok', None, ['username', '#password'], id='https_private_pat'),
-        pytest.param(None, None, '-----BEGIN...', ['#sshPrivateKey'], id='ssh_private_key'),
+        pytest.param('alice', 'ghp_tok', None, ['private', 'username', '#password'], id='https_private_pat'),
+        pytest.param(None, None, '-----BEGIN...', ['private', '#sshPrivateKey'], id='ssh_private_key'),
     ],
 )
 def test_build_git_data_app_config(
@@ -918,12 +918,13 @@ async def test_create_git_data_app_create_path(
     assert len(received_configs) == 1
     sent_config = received_configs[0]
 
+    git_block = sent_config['parameters']['dataApp']['git']
     if plaintext_secret_key:
         # The plaintext credential must appear in the pre-encryption config
-        assert sent_config['parameters']['dataApp']['git'][plaintext_secret_key] in (
-            git_pat,
-            git_ssh_key,
-        )
+        assert git_block[plaintext_secret_key] in (git_pat, git_ssh_key)
+        assert git_block.get('private') is True
+    else:
+        assert 'private' not in git_block
 
     # DS API must be called with the python-js type
     keboola_client.data_science_client.create_data_app_from_config.assert_called_once()

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -13,12 +13,15 @@ from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.data_apps import (
     _QUERY_SERVICE_QUERY_DATA_FUNCTION_CODE,
     _STORAGE_QUERY_DATA_FUNCTION_CODE,
+    GIT_DATA_APP_TYPE,
     MAX_DNS_LABEL_LENGTH,
+    CreateGitDataAppOutput,
     DataApp,
     DataAppSlugTooLongError,
     DataAppSummary,
     ModifiedDataAppOutput,
     _build_data_app_config,
+    _build_git_data_app_config,
     _fetch_data_app,
     _get_authorization,
     _get_data_app_slug,
@@ -27,6 +30,7 @@ from keboola_mcp_server.tools.data_apps import (
     _inject_query_to_source_code,
     _update_existing_data_app_config,
     _uses_basic_authentication,
+    create_git_data_app,
     deploy_data_app,
     get_data_apps,
     modify_data_app,
@@ -770,3 +774,224 @@ async def test_modify_data_app_folder(
         assert str(app_count) in result.change_summary
     else:
         assert result.change_summary is None
+
+
+# ---------------------------------------------------------------------------
+# _build_git_data_app_config unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('git_username', 'git_pat', 'git_ssh_key', 'expected_keys'),
+    [
+        pytest.param(None, None, None, [], id='public_repo'),
+        pytest.param('alice', 'ghp_tok', None, ['username', '#password'], id='https_private_pat'),
+        pytest.param(None, None, '-----BEGIN...', ['#sshPrivateKey'], id='ssh_private_key'),
+    ],
+)
+def test_build_git_data_app_config(
+    git_username: str | None,
+    git_pat: str | None,
+    git_ssh_key: str | None,
+    expected_keys: list[str],
+) -> None:
+    config = _build_git_data_app_config(
+        name='My Dashboard',
+        git_repo='https://github.com/org/repo',
+        git_branch='main',
+        git_username=git_username,
+        git_pat=git_pat,
+        git_ssh_key=git_ssh_key,
+        authentication_type='basic-auth',
+    )
+    git_block = config['parameters']['dataApp']['git']
+    assert git_block['repository'] == 'https://github.com/org/repo'
+    assert git_block['branch'] == 'main'
+    for key in expected_keys:
+        assert key in git_block
+    # Only the expected keys (plus repository + branch) should be present
+    extra_keys = set(git_block.keys()) - {'repository', 'branch'} - set(expected_keys)
+    assert not extra_keys, f'Unexpected keys in git block: {extra_keys}'
+
+
+def test_build_git_data_app_config_auth_basic() -> None:
+    config = _build_git_data_app_config(
+        name='App',
+        git_repo='https://github.com/org/repo',
+        git_branch='main',
+        git_username=None,
+        git_pat=None,
+        git_ssh_key=None,
+        authentication_type='basic-auth',
+    )
+    assert _uses_basic_authentication(config['authorization']) is True
+
+
+def test_build_git_data_app_config_auth_no_auth() -> None:
+    config = _build_git_data_app_config(
+        name='App',
+        git_repo='https://github.com/org/repo',
+        git_branch='main',
+        git_username=None,
+        git_pat=None,
+        git_ssh_key=None,
+        authentication_type='no-auth',
+    )
+    assert _uses_basic_authentication(config['authorization']) is False
+
+
+# ---------------------------------------------------------------------------
+# create_git_data_app integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_encrypted_git_config() -> dict:
+    return {
+        'parameters': {
+            'dataApp': {'slug': 'my-dashboard', 'git': {'repository': 'https://github.com/org/repo', 'branch': 'main'}},
+            'size': 'tiny',
+            'autoSuspendAfterSeconds': 900,
+        },
+        'authorization': {'app_proxy': {'auth_providers': [], 'auth_rules': []}},
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('git_username', 'git_pat', 'git_ssh_key', 'plaintext_secret_key'),
+    [
+        pytest.param(None, None, None, None, id='public_repo'),
+        pytest.param('alice', 'ghp_tok', None, '#password', id='https_private'),
+        pytest.param(None, None, '-----BEGIN RSA PRIVATE KEY-----', '#sshPrivateKey', id='ssh_private'),
+    ],
+)
+async def test_create_git_data_app_create_path(
+    mocker,
+    mcp_context_client: Context,
+    git_username: str | None,
+    git_pat: str | None,
+    git_ssh_key: str | None,
+    plaintext_secret_key: str | None,
+) -> None:
+    """create_git_data_app create path: encryption called with plaintext secrets, DS API called with python-js type."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+
+    keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
+
+    encrypted_config = _make_encrypted_git_config()
+
+    # Track what the encryption client receives
+    received_configs: list[dict] = []
+
+    async def capture_encrypt(value, **_kwargs):
+        received_configs.append(value)
+        return encrypted_config
+
+    keboola_client.encryption_client = mocker.AsyncMock()
+    keboola_client.encryption_client.encrypt = capture_encrypt
+
+    data_app_response = _make_data_app_response(config_id='new-cfg-1')
+    keboola_client.data_science_client = mocker.AsyncMock()
+    keboola_client.data_science_client.create_data_app_from_config = mocker.AsyncMock(return_value=data_app_response)
+
+    mocker.patch(
+        'keboola_mcp_server.tools.components.utils.get_config_folders',
+        mocker.AsyncMock(return_value=(0, [], False)),
+    )
+
+    result = await create_git_data_app(
+        ctx=mcp_context_client,
+        name='My Dashboard',
+        description='desc',
+        git_repo='https://github.com/org/repo',
+        git_branch='main',
+        git_username=git_username,
+        git_pat=git_pat,
+        git_ssh_key=git_ssh_key,
+        authentication_type='basic-auth',
+    )
+
+    assert isinstance(result, CreateGitDataAppOutput)
+    assert result.response == 'created'
+
+    # Encryption must have been called exactly once
+    assert len(received_configs) == 1
+    sent_config = received_configs[0]
+
+    if plaintext_secret_key:
+        # The plaintext credential must appear in the pre-encryption config
+        assert sent_config['parameters']['dataApp']['git'][plaintext_secret_key] in (
+            git_pat,
+            git_ssh_key,
+        )
+
+    # DS API must be called with the python-js type
+    keboola_client.data_science_client.create_data_app_from_config.assert_called_once()
+    call_kwargs = keboola_client.data_science_client.create_data_app_from_config.call_args.kwargs
+    assert call_kwargs['app_type'] == GIT_DATA_APP_TYPE
+
+
+@pytest.mark.asyncio
+async def test_create_git_data_app_update_path(
+    mocker,
+    mcp_context_client: Context,
+    data_app: DataApp,
+) -> None:
+    """create_git_data_app update path: storage config_update called, DS API create_data_app_from_config not called."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+
+    keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
+    keboola_client.storage_client.configuration_update = mocker.AsyncMock(return_value={})
+
+    encrypted_config = _make_encrypted_git_config()
+    keboola_client.encryption_client = mocker.AsyncMock()
+    keboola_client.encryption_client.encrypt = mocker.AsyncMock(return_value=encrypted_config)
+
+    data_app.configuration_id = 'cfg-existing'
+    data_app.config_version = '3'
+    data_app.state = 'stopped'
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', return_value=data_app)
+
+    keboola_client.data_science_client = mocker.AsyncMock()
+
+    mocker.patch(
+        'keboola_mcp_server.tools.components.utils.get_config_folders',
+        mocker.AsyncMock(return_value=(0, [], False)),
+    )
+
+    result = await create_git_data_app(
+        ctx=mcp_context_client,
+        name='My Dashboard',
+        description='desc',
+        git_repo='https://github.com/org/repo',
+        git_branch='main',
+        authentication_type='default',
+        configuration_id='cfg-existing',
+        change_description='Update branch',
+    )
+
+    assert isinstance(result, CreateGitDataAppOutput)
+    assert result.response == 'updated'
+    keboola_client.storage_client.configuration_update.assert_called_once()
+    keboola_client.data_science_client.create_data_app_from_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_git_data_app_slug_too_long(
+    mocker,
+    mcp_context_client: Context,
+) -> None:
+    """create_git_data_app raises DataAppSlugTooLongError for names that exceed the DNS label limit."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
+    keboola_client.encryption_client = mocker.AsyncMock()
+    keboola_client.encryption_client.encrypt = mocker.AsyncMock(return_value={})
+
+    with pytest.raises(DataAppSlugTooLongError):
+        await create_git_data_app(
+            ctx=mcp_context_client,
+            name='a' * (MAX_DNS_LABEL_LENGTH + 1),
+            description='desc',
+            git_repo='https://github.com/org/repo',
+            authentication_type='no-auth',
+        )

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -63,13 +63,57 @@ _DEV_BRANCH = {'id': 456, 'name': 'feature-x', 'isDefault': False}
     ),
     [
         # developer role on default branch
-        ('developer', 'developer', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
+        (
+            'developer',
+            'developer',
+            ['cannot set their schedules'],
+            False,
+            'Snowflake',
+            '"DATABASE"."SCHEMA"."TABLE"',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # guest role on default branch
-        ('guest', 'guest', ['cannot set their schedules'], False, 'BigQuery', '`project`.`dataset`.`table`', None, 123, 'Main', False),
+        (
+            'guest',
+            'guest',
+            ['cannot set their schedules'],
+            False,
+            'BigQuery',
+            '`project`.`dataset`.`table`',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # no role on default branch
-        (None, 'unknown', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
+        (
+            None,
+            'unknown',
+            ['cannot set their schedules'],
+            False,
+            'Snowflake',
+            '"DATABASE"."SCHEMA"."TABLE"',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # readonly role on default branch
-        ('readonly', 'readonly', ['read-only'], False, 'BigQuery', '`project`.`dataset`.`table`', None, 123, 'Main', False),
+        (
+            'readonly',
+            'readonly',
+            ['read-only'],
+            False,
+            'BigQuery',
+            '`project`.`dataset`.`table`',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # admin role on default branch
         ('admin', 'admin', [], True, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
         # admin role on a dev branch — exercises the dev-branch resolution path

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.60.0"
+version = "1.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3153](https://linear.app/keboola/issue/AI-3153/add-git-backed-jstypescript-data-app-support-to-mcp-server-data-app)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Adds a new `create_git_data_app` MCP tool that creates and updates git-backed JS/TypeScript data apps deployed from a GitHub repository, as an alternative to the existing inline Python/Streamlit `modify_data_app` tool.

**Why:** Users want to create JS/TypeScript dashboards (React, Express, HONO, Vite, etc.) stored in git and referenced by the Keboola platform — not just inline Streamlit code. The new tool is the server-side counterpart to the `data-app-workflow` Claude Code skill, which orchestrates the full lifecycle (requirements → data exploration → code generation → GitHub repo setup → deploy).

**Key design decisions:**
- Credentials (GitHub PAT or SSH private key) are passed as **plaintext** to the tool; the tool encrypts them via the project's KMS Encryption API using the `#`-prefix convention before writing to Storage. Callers never handle ciphertext.
- `app_type='python-js'` is used for the Data Science API (was hardcoded `'streamlit'` in the existing path).
- Fully backward-compatible: `modify_data_app` and `DataScienceClient.create_data_app` are unchanged for existing callers.

**Changes:**

`src/keboola_mcp_server/clients/data_science.py`
- Parameterised `app_type` in `create_data_app` (default `'streamlit'`)
- Added `create_data_app_from_config` for raw dict configs (used by git-backed apps where the config structure differs from `DataAppConfig`)

`src/keboola_mcp_server/tools/data_apps.py`
- Extended `Type` literal to include `'python-js'`
- New `CreateGitDataAppOutput` Pydantic model
- New `create_git_data_app` tool with full create + update paths, folder metadata, encryption, link generation
- New `_build_git_data_app_config` builder (sets `#password` / `#sshPrivateKey` for KMS encryption)
- Registered in `add_data_app_tools`

`tests/` — 10 new parametrised tests (public repo, HTTPS private, SSH private, update path, slug-too-long guard, auth config)

`TOOLS.md` — regenerated with new tool entry

Version bump: `1.60.0 → 1.61.0`

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (if applicable)
- [x] Documentation updated (if applicable)