### PR TITLE
fix(components): handle processors=[] from Storage API in ConfigurationRow [AI-3133]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.60.1"
+version = "1.60.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -37,7 +37,7 @@ import asyncio
 from datetime import datetime
 from typing import Annotated, Any, Literal, Optional, Sequence, Union, get_args
 
-from pydantic import AliasChoices, BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 from keboola_mcp_server.clients.client import get_metadata_property
 from keboola_mcp_server.clients.storage import ComponentAPIResponse, ComponentType, ConfigurationAPIResponse
@@ -238,6 +238,14 @@ class ConfigurationRoot(BaseModel):
         default_factory=list, description='Configuration metadata including MCP tracking'
     )
 
+    @field_validator('processors', mode='before')
+    @classmethod
+    def validate_processors(cls, value: Any) -> Any:
+        # Storage API returns [] when no processors are configured instead of None or {}
+        if value == []:
+            return None
+        return value
+
     @classmethod
     def from_api_response(cls, api_config: 'ConfigurationAPIResponse') -> 'ConfigurationRoot':
         """
@@ -249,7 +257,7 @@ class ConfigurationRoot(BaseModel):
         :param api_config: Validated API configuration response
         :return: Complete configuration root domain model
         """
-        return cls.model_construct(
+        return cls(
             component_id=api_config.component_id,
             configuration_id=api_config.configuration_id,
             name=api_config.name,
@@ -292,6 +300,14 @@ class ConfigurationRow(BaseModel):
         default=None, description='The processors that run before or after the configured component row.'
     )
     configuration_metadata: list[dict[str, Any]] = Field(default_factory=list, description='Configuration row metadata')
+
+    @field_validator('processors', mode='before')
+    @classmethod
+    def validate_processors(cls, value: Any) -> Any:
+        # Storage API returns [] when no processors are configured instead of None or {}
+        if value == []:
+            return None
+        return value
 
     @classmethod
     def from_api_row_data(

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -872,7 +872,9 @@ async def update_sql_transformation(
         folder_stripped = folder.strip()
         if folder_stripped:
             try:
-                await set_configuration_folder_metadata(client, sql_transformation_id, configuration_id, folder_stripped)
+                await set_configuration_folder_metadata(
+                    client, sql_transformation_id, configuration_id, folder_stripped
+                )
             except Exception as exc:
                 LOG.warning(
                     'Unable to set folder metadata for component "%s", configuration "%s".',

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -3,6 +3,7 @@ from typing import Any, Callable
 
 import pytest
 from mcp.server.fastmcp import Context
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from keboola_mcp_server.clients.client import (
@@ -27,7 +28,9 @@ from keboola_mcp_server.tools.components.model import (
     ConfigSummary,
     ConfigToolOutput,
     Configuration,
+    ConfigurationRoot,
     ConfigurationRootSummary,
+    ConfigurationRow,
     FullConfigId,
     GetComponentsOutput,
     GetConfigsDetailOutput,
@@ -431,6 +434,134 @@ async def test_get_configs_detail_ignores_other_params(
     keboola_client.storage_client.configuration_detail.assert_called_once_with(
         component_id=mock_component['id'], configuration_id=mock_configuration['id']
     )
+
+
+@pytest.mark.asyncio
+async def test_get_configs_detail_empty_list_processors(
+    mocker: MockerFixture,
+    mcp_context_components_configs: Context,
+    mock_component: dict[str, Any],
+    mock_metadata: list[dict[str, Any]],
+):
+    """get_configs must not raise when the Storage API returns processors=[] on a row."""
+    context = mcp_context_components_configs
+    keboola_client = KeboolaClient.from_state(context.session.state)
+
+    mock_ai_service = mocker.MagicMock()
+    mock_ai_service.get_component_detail = mocker.AsyncMock(return_value=mock_component)
+    keboola_client.ai_service_client = mock_ai_service
+    keboola_client.storage_client.component_detail = mocker.AsyncMock(return_value=mock_component)
+
+    config_with_empty_processors = {
+        'id': '123',
+        'name': 'My Config',
+        'description': 'Test',
+        'version': 1,
+        'isDisabled': False,
+        'isDeleted': False,
+        'configuration': {'processors': []},
+        'rows': [
+            {
+                'id': 'row-1',
+                'name': 'Row 1',
+                'version': 1,
+                'configuration': {'parameters': {}, 'processors': []},
+            }
+        ],
+    }
+    keboola_client.storage_client.configuration_detail = mocker.AsyncMock(
+        return_value={
+            **config_with_empty_processors,
+            'component': mock_component,
+            'configurationMetadata': mock_metadata,
+        }
+    )
+
+    configs = [FullConfigId(component_id=mock_component['id'], configuration_id='123')]
+    result = await get_configs(ctx=context, configs=configs)
+
+    assert isinstance(result, GetConfigsDetailOutput)
+    assert len(result.configs) == 1
+    config = result.configs[0]
+    config_root = config.configuration_root
+    assert config_root.configuration_id == '123'
+    assert config_root.processors is None
+    assert config.configuration_rows is not None
+    assert len(config.configuration_rows) == 1
+    assert config.configuration_rows[0].processors is None
+
+
+@pytest.mark.parametrize(
+    ('processors_value', 'expected'),
+    [
+        ([], None),
+        (None, None),
+        ('omit', None),
+        ({'after': [{'definition': {'component': 'x'}}]}, {'after': [{'definition': {'component': 'x'}}]}),
+    ],
+    ids=['empty_list_normalized', 'none_passthrough', 'field_omitted', 'dict_passthrough'],
+)
+def test_configuration_root_processors_normalization(processors_value: Any, expected: Any) -> None:
+    """ConfigurationRoot.from_api_response normalizes Storage API processors=[] but preserves dicts."""
+    api_config = ConfigurationAPIResponse.model_validate(
+        {
+            'componentId': 'keboola.ex-aws-s3',
+            'id': '123',
+            'name': 'My Config',
+            'version': 1,
+            'configuration': {'processors': processors_value} if processors_value != 'omit' else {},
+            'metadata': [],
+        }
+    )
+    root = ConfigurationRoot.from_api_response(api_config)
+    assert root.processors == expected
+
+
+@pytest.mark.parametrize(
+    'invalid_processors',
+    [
+        ['unexpected'],
+        [{'after': []}],
+    ],
+    ids=['non_empty_list_of_str', 'non_empty_list_of_dict'],
+)
+def test_configuration_root_rejects_non_empty_list_processors(invalid_processors: list) -> None:
+    """A non-empty list at the root must fail Pydantic validation, not be silently accepted."""
+    api_config = ConfigurationAPIResponse.model_validate(
+        {
+            'componentId': 'keboola.ex-aws-s3',
+            'id': '123',
+            'name': 'My Config',
+            'version': 1,
+            'configuration': {'processors': invalid_processors},
+            'metadata': [],
+        }
+    )
+    with pytest.raises(ValidationError):
+        ConfigurationRoot.from_api_response(api_config)
+
+
+@pytest.mark.parametrize(
+    'invalid_processors',
+    [
+        ['unexpected'],
+        [{'after': []}],
+    ],
+    ids=['non_empty_list_of_str', 'non_empty_list_of_dict'],
+)
+def test_configuration_row_rejects_non_empty_list_processors(invalid_processors: list) -> None:
+    """A non-empty list on a row must fail Pydantic validation, not be silently accepted."""
+    with pytest.raises(ValidationError):
+        ConfigurationRow.from_api_row_data(
+            row_data={
+                'id': 'row-1',
+                'name': 'Row 1',
+                'version': 1,
+                'configuration': {'parameters': {}, 'processors': invalid_processors},
+            },
+            component_id='keboola.ex-aws-s3',
+            configuration_id='123',
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -63,13 +63,57 @@ _DEV_BRANCH = {'id': 456, 'name': 'feature-x', 'isDefault': False}
     ),
     [
         # developer role on default branch
-        ('developer', 'developer', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
+        (
+            'developer',
+            'developer',
+            ['cannot set their schedules'],
+            False,
+            'Snowflake',
+            '"DATABASE"."SCHEMA"."TABLE"',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # guest role on default branch
-        ('guest', 'guest', ['cannot set their schedules'], False, 'BigQuery', '`project`.`dataset`.`table`', None, 123, 'Main', False),
+        (
+            'guest',
+            'guest',
+            ['cannot set their schedules'],
+            False,
+            'BigQuery',
+            '`project`.`dataset`.`table`',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # no role on default branch
-        (None, 'unknown', ['cannot set their schedules'], False, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
+        (
+            None,
+            'unknown',
+            ['cannot set their schedules'],
+            False,
+            'Snowflake',
+            '"DATABASE"."SCHEMA"."TABLE"',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # readonly role on default branch
-        ('readonly', 'readonly', ['read-only'], False, 'BigQuery', '`project`.`dataset`.`table`', None, 123, 'Main', False),
+        (
+            'readonly',
+            'readonly',
+            ['read-only'],
+            False,
+            'BigQuery',
+            '`project`.`dataset`.`table`',
+            None,
+            123,
+            'Main',
+            False,
+        ),
         # admin role on default branch
         ('admin', 'admin', [], True, 'Snowflake', '"DATABASE"."SCHEMA"."TABLE"', None, 123, 'Main', False),
         # admin role on a dev branch — exercises the dev-branch resolution path

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.60.1"
+version = "1.60.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3133](https://linear.app/keboola/issue/AI-3133/find-why-get-configs-fails-on-validation)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

The Keboola Storage API returns `"processors": []` (empty list) for configuration rows when no processors are configured. The `ConfigurationRow` Pydantic model declares `processors: Optional[dict[str, Any]]`, so Pydantic rejects the empty list and raises:

```
ValidationError: 1 validation error for ConfigurationRow
processors
  Input should be a valid dictionary [type=dict_type, input_value=[], input_type=list]
```

This caused `get_configs` to fail entirely with _"Failed to fetch one or more configurations (1 errors)"_ whenever any row in the response had an empty processors list.

**Fix:** Added a `@field_validator('processors', mode='before')` to both `ConfigurationRow` and `ConfigurationRoot` that normalizes only the `[]` sentinel returned by the Storage API to `None`. Non-`[]` list values fall through to Pydantic's declared-type check and raise `ValidationError`, so unexpected processor shapes still fail validation instead of being silently dropped. `ConfigurationRoot.from_api_response` was also switched from `cls.model_construct(...)` to `cls(...)` so the validator actually runs on the root path (per REVIEW.md:28). This follows the same `[]`-sentinel pattern already used in `GlobalSearchResponse` in `clients/storage.py`.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)