### PR TITLE
fix: forward runtime.image_tag to sync actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.60.1"
+version = "1.60.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -872,7 +872,9 @@ async def update_sql_transformation(
         folder_stripped = folder.strip()
         if folder_stripped:
             try:
-                await set_configuration_folder_metadata(client, sql_transformation_id, configuration_id, folder_stripped)
+                await set_configuration_folder_metadata(
+                    client, sql_transformation_id, configuration_id, folder_stripped
+                )
             except Exception as exc:
                 LOG.warning(
                     'Unable to set folder metadata for component "%s", configuration "%s".',
@@ -1884,6 +1886,10 @@ async def run_sync_action(
     root_configuration = config_response.configuration
     parameters = root_configuration.get('parameters') or {}
     storage = root_configuration.get('storage') or {}
+    # `runtime` (which carries `image_tag`, backend hints, etc.) lives only on the root configuration
+    # in the docker-runner's contract — rows do not override it. Forward it so the sync-actions
+    # service honors `runtime.image_tag` from the saved configuration.
+    runtime = root_configuration.get('runtime') or {}
 
     if configuration_row_id:
         row_detail = await client.storage_client.configuration_row_detail(
@@ -1899,6 +1905,8 @@ async def run_sync_action(
         'parameters': parameters,
         'storage': storage,
     }
+    if runtime:
+        config_data['runtime'] = runtime
 
     result = await client.sync_actions_client.execute_action(
         component_id=component_id,

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -1764,7 +1764,16 @@ async def test_update_config_row(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('root_params', 'root_storage', 'row_params', 'row_storage', 'expected_params', 'expected_storage'),
+    (
+        'root_params',
+        'root_storage',
+        'root_runtime',
+        'row_params',
+        'row_storage',
+        'expected_params',
+        'expected_storage',
+        'expected_runtime',
+    ),
     [
         # No row - uses root config only
         (
@@ -1772,38 +1781,74 @@ async def test_update_config_row(
             {'input': {'tables': []}},
             None,
             None,
+            None,
             {'host': 'db.example.com', 'port': 3306},
             {'input': {'tables': []}},
+            None,
         ),
         # With row - row params override root params (shallow merge)
         (
             {'host': 'db.example.com', 'port': 3306, 'database': 'prod'},
             {'input': {'tables': [{'source': 't1'}]}},
+            None,
             {'database': 'staging', 'schema': 'public'},
             {'input': {'tables': [{'source': 't2'}]}},
             {'host': 'db.example.com', 'port': 3306, 'database': 'staging', 'schema': 'public'},
             {'input': {'tables': [{'source': 't2'}]}},
+            None,
         ),
         # With row - empty root, row provides all
         (
             {},
             {},
+            None,
             {'key': 'value'},
             {'output': {'tables': []}},
             {'key': 'value'},
             {'output': {'tables': []}},
+            None,
+        ),
+        # Root has runtime.image_tag - must be forwarded so the runner picks up the pinned tag
+        (
+            {'host': 'db.example.com'},
+            {'input': {'tables': []}},
+            {'image_tag': '1.2.3'},
+            None,
+            None,
+            {'host': 'db.example.com'},
+            {'input': {'tables': []}},
+            {'image_tag': '1.2.3'},
+        ),
+        # Root runtime is preserved alongside row overrides for parameters/storage
+        (
+            {'host': 'db.example.com'},
+            {'input': {'tables': []}},
+            {'image_tag': '4.5.6', 'safe': True},
+            {'database': 'staging'},
+            {'input': {'tables': [{'source': 't2'}]}},
+            {'host': 'db.example.com', 'database': 'staging'},
+            {'input': {'tables': [{'source': 't2'}]}},
+            {'image_tag': '4.5.6', 'safe': True},
         ),
     ],
-    ids=['no-row', 'row-overrides-root', 'empty-root-with-row'],
+    ids=[
+        'no-row',
+        'row-overrides-root',
+        'empty-root-with-row',
+        'root-runtime-image-tag',
+        'root-runtime-with-row',
+    ],
 )
 async def test_run_sync_action(
     mcp_context_components_configs: Context,
     root_params: dict,
     root_storage: dict,
+    root_runtime: dict | None,
     row_params: dict | None,
     row_storage: dict | None,
     expected_params: dict,
     expected_storage: dict,
+    expected_runtime: dict | None,
 ):
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
@@ -1813,6 +1858,13 @@ async def test_run_sync_action(
     action_name = 'testConnection'
     expected_response = {'status': 'ok'}
 
+    root_configuration: dict[str, Any] = {
+        'parameters': root_params,
+        'storage': root_storage,
+    }
+    if root_runtime is not None:
+        root_configuration['runtime'] = root_runtime
+
     keboola_client.storage_client.configuration_detail.return_value = {
         'id': configuration_id,
         'componentId': component_id,
@@ -1820,10 +1872,7 @@ async def test_run_sync_action(
         'version': 1,
         'isDisabled': False,
         'isDeleted': False,
-        'configuration': {
-            'parameters': root_params,
-            'storage': root_storage,
-        },
+        'configuration': root_configuration,
         'rows': [],
     }
 
@@ -1851,14 +1900,18 @@ async def test_run_sync_action(
 
     assert result == expected_response
 
+    expected_config_data: dict[str, Any] = {
+        'parameters': expected_params,
+        'storage': expected_storage,
+    }
+    if expected_runtime is not None:
+        expected_config_data['runtime'] = expected_runtime
+
     keboola_client.storage_client.configuration_detail.assert_called_once_with(component_id, configuration_id)
     keboola_client.sync_actions_client.execute_action.assert_called_once_with(
         component_id=component_id,
         action=action_name,
-        config_data={
-            'parameters': expected_params,
-            'storage': expected_storage,
-        },
+        config_data=expected_config_data,
     )
 
     if row_id:

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.60.1"
+version = "1.60.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`run_sync_action` was flattening the saved configuration to just `parameters` + `storage` when constructing the sync-actions payload, dropping the `runtime` block entirely. The sync-actions docker-runner reads `configData.runtime.image_tag` to pin the component image; without it the runner silently falls back to the default tag, so any `runtime.image_tag` pinned on the saved configuration was being ignored when the sync action was invoked through MCP.

The fix forwards the root configuration's `runtime` block in `configData` so `runtime.image_tag` (and any other runtime fields such as backend hints) from the saved configuration are respected by default — no new tool parameter needed, no caller change required.

Notes:
- `run_job` is unaffected by design: the Job Queue / docker-runner pipeline fetches the saved configuration server-side and applies `runtime.image_tag` on its own — confirmed against the `keboola/docker-bundle` `ImageCreator` / `Container` configuration schema.
- Rows do not override `runtime` in the docker-runner's contract, so only the root configuration's `runtime` is forwarded.
- `processors` is intentionally not forwarded — sync actions don't execute processors in the platform either.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)