### PR TITLE
fix: forward runtime.image_tag to sync actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.61.2"
+version = "1.61.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -1886,10 +1886,12 @@ async def run_sync_action(
     root_configuration = config_response.configuration
     parameters = root_configuration.get('parameters') or {}
     storage = root_configuration.get('storage') or {}
-    # `runtime` (which carries `image_tag`, backend hints, etc.) lives only on the root configuration
-    # in the docker-runner's contract — rows do not override it. Forward it so the sync-actions
-    # service honors `runtime.image_tag` from the saved configuration.
+    # `runtime` and `authorization` live only on the root configuration in the docker-runner's
+    # contract — rows do not override them. `authorization.oauth_api.id` is a broker reference
+    # that the sync-actions service resolves and decrypts before invoking the component; without
+    # it, OAuth/Service-Account components reject the call with "Missing authorization data".
     runtime = root_configuration.get('runtime') or {}
+    authorization = root_configuration.get('authorization') or {}
 
     if configuration_row_id:
         row_detail = await client.storage_client.configuration_row_detail(
@@ -1907,6 +1909,8 @@ async def run_sync_action(
     }
     if runtime:
         config_data['runtime'] = runtime
+    if authorization:
+        config_data['authorization'] = authorization
 
     result = await client.sync_actions_client.execute_action(
         component_id=component_id,

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -1886,6 +1886,10 @@ async def run_sync_action(
     root_configuration = config_response.configuration
     parameters = root_configuration.get('parameters') or {}
     storage = root_configuration.get('storage') or {}
+    # `runtime` (which carries `image_tag`, backend hints, etc.) lives only on the root configuration
+    # in the docker-runner's contract — rows do not override it. Forward it so the sync-actions
+    # service honors `runtime.image_tag` from the saved configuration.
+    runtime = root_configuration.get('runtime') or {}
 
     if configuration_row_id:
         row_detail = await client.storage_client.configuration_row_detail(
@@ -1901,6 +1905,8 @@ async def run_sync_action(
         'parameters': parameters,
         'storage': storage,
     }
+    if runtime:
+        config_data['runtime'] = runtime
 
     result = await client.sync_actions_client.execute_action(
         component_id=component_id,

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -1899,11 +1899,13 @@ async def test_update_config_row(
         'root_params',
         'root_storage',
         'root_runtime',
+        'root_authorization',
         'row_params',
         'row_storage',
         'expected_params',
         'expected_storage',
         'expected_runtime',
+        'expected_authorization',
     ),
     [
         # No row - uses root config only
@@ -1913,8 +1915,10 @@ async def test_update_config_row(
             None,
             None,
             None,
+            None,
             {'host': 'db.example.com', 'port': 3306},
             {'input': {'tables': []}},
+            None,
             None,
         ),
         # With row - row params override root params (shallow merge)
@@ -1922,10 +1926,12 @@ async def test_update_config_row(
             {'host': 'db.example.com', 'port': 3306, 'database': 'prod'},
             {'input': {'tables': [{'source': 't1'}]}},
             None,
+            None,
             {'database': 'staging', 'schema': 'public'},
             {'input': {'tables': [{'source': 't2'}]}},
             {'host': 'db.example.com', 'port': 3306, 'database': 'staging', 'schema': 'public'},
             {'input': {'tables': [{'source': 't2'}]}},
+            None,
             None,
         ),
         # With row - empty root, row provides all
@@ -1933,10 +1939,12 @@ async def test_update_config_row(
             {},
             {},
             None,
+            None,
             {'key': 'value'},
             {'output': {'tables': []}},
             {'key': 'value'},
             {'output': {'tables': []}},
+            None,
             None,
         ),
         # Root has runtime.image_tag - must be forwarded so the runner picks up the pinned tag
@@ -1946,20 +1954,50 @@ async def test_update_config_row(
             {'image_tag': '1.2.3'},
             None,
             None,
+            None,
             {'host': 'db.example.com'},
             {'input': {'tables': []}},
             {'image_tag': '1.2.3'},
+            None,
         ),
         # Root runtime is preserved alongside row overrides for parameters/storage
         (
             {'host': 'db.example.com'},
             {'input': {'tables': []}},
             {'image_tag': '4.5.6', 'safe': True},
+            None,
             {'database': 'staging'},
             {'input': {'tables': [{'source': 't2'}]}},
             {'host': 'db.example.com', 'database': 'staging'},
             {'input': {'tables': [{'source': 't2'}]}},
             {'image_tag': '4.5.6', 'safe': True},
+            None,
+        ),
+        # Root has OAuth authorization - must be forwarded so sync-actions resolves credentials
+        (
+            {'sheets': []},
+            {},
+            None,
+            {'oauth_api': {'id': 'creds-1', 'version': 3}},
+            None,
+            None,
+            {'sheets': []},
+            {},
+            None,
+            {'oauth_api': {'id': 'creds-1', 'version': 3}},
+        ),
+        # Authorization is preserved alongside runtime and row overrides
+        (
+            {'sheets': []},
+            {'input': {'tables': []}},
+            {'image_tag': '1.0.0'},
+            {'oauth_api': {'id': 'creds-2', 'version': 3}},
+            {'sheets': [{'id': 1}]},
+            {'input': {'tables': [{'source': 't1'}]}},
+            {'sheets': [{'id': 1}]},
+            {'input': {'tables': [{'source': 't1'}]}},
+            {'image_tag': '1.0.0'},
+            {'oauth_api': {'id': 'creds-2', 'version': 3}},
         ),
     ],
     ids=[
@@ -1968,6 +2006,8 @@ async def test_update_config_row(
         'empty-root-with-row',
         'root-runtime-image-tag',
         'root-runtime-with-row',
+        'root-authorization-oauth',
+        'root-authorization-with-runtime-and-row',
     ],
 )
 async def test_run_sync_action(
@@ -1975,11 +2015,13 @@ async def test_run_sync_action(
     root_params: dict,
     root_storage: dict,
     root_runtime: dict | None,
+    root_authorization: dict | None,
     row_params: dict | None,
     row_storage: dict | None,
     expected_params: dict,
     expected_storage: dict,
     expected_runtime: dict | None,
+    expected_authorization: dict | None,
 ):
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
@@ -1995,6 +2037,8 @@ async def test_run_sync_action(
     }
     if root_runtime is not None:
         root_configuration['runtime'] = root_runtime
+    if root_authorization is not None:
+        root_configuration['authorization'] = root_authorization
 
     keboola_client.storage_client.configuration_detail.return_value = {
         'id': configuration_id,
@@ -2037,6 +2081,8 @@ async def test_run_sync_action(
     }
     if expected_runtime is not None:
         expected_config_data['runtime'] = expected_runtime
+    if expected_authorization is not None:
+        expected_config_data['authorization'] = expected_authorization
 
     keboola_client.storage_client.configuration_detail.assert_called_once_with(component_id, configuration_id)
     keboola_client.sync_actions_client.execute_action.assert_called_once_with(

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -1895,7 +1895,16 @@ async def test_update_config_row(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('root_params', 'root_storage', 'row_params', 'row_storage', 'expected_params', 'expected_storage'),
+    (
+        'root_params',
+        'root_storage',
+        'root_runtime',
+        'row_params',
+        'row_storage',
+        'expected_params',
+        'expected_storage',
+        'expected_runtime',
+    ),
     [
         # No row - uses root config only
         (
@@ -1903,38 +1912,74 @@ async def test_update_config_row(
             {'input': {'tables': []}},
             None,
             None,
+            None,
             {'host': 'db.example.com', 'port': 3306},
             {'input': {'tables': []}},
+            None,
         ),
         # With row - row params override root params (shallow merge)
         (
             {'host': 'db.example.com', 'port': 3306, 'database': 'prod'},
             {'input': {'tables': [{'source': 't1'}]}},
+            None,
             {'database': 'staging', 'schema': 'public'},
             {'input': {'tables': [{'source': 't2'}]}},
             {'host': 'db.example.com', 'port': 3306, 'database': 'staging', 'schema': 'public'},
             {'input': {'tables': [{'source': 't2'}]}},
+            None,
         ),
         # With row - empty root, row provides all
         (
             {},
             {},
+            None,
             {'key': 'value'},
             {'output': {'tables': []}},
             {'key': 'value'},
             {'output': {'tables': []}},
+            None,
+        ),
+        # Root has runtime.image_tag - must be forwarded so the runner picks up the pinned tag
+        (
+            {'host': 'db.example.com'},
+            {'input': {'tables': []}},
+            {'image_tag': '1.2.3'},
+            None,
+            None,
+            {'host': 'db.example.com'},
+            {'input': {'tables': []}},
+            {'image_tag': '1.2.3'},
+        ),
+        # Root runtime is preserved alongside row overrides for parameters/storage
+        (
+            {'host': 'db.example.com'},
+            {'input': {'tables': []}},
+            {'image_tag': '4.5.6', 'safe': True},
+            {'database': 'staging'},
+            {'input': {'tables': [{'source': 't2'}]}},
+            {'host': 'db.example.com', 'database': 'staging'},
+            {'input': {'tables': [{'source': 't2'}]}},
+            {'image_tag': '4.5.6', 'safe': True},
         ),
     ],
-    ids=['no-row', 'row-overrides-root', 'empty-root-with-row'],
+    ids=[
+        'no-row',
+        'row-overrides-root',
+        'empty-root-with-row',
+        'root-runtime-image-tag',
+        'root-runtime-with-row',
+    ],
 )
 async def test_run_sync_action(
     mcp_context_components_configs: Context,
     root_params: dict,
     root_storage: dict,
+    root_runtime: dict | None,
     row_params: dict | None,
     row_storage: dict | None,
     expected_params: dict,
     expected_storage: dict,
+    expected_runtime: dict | None,
 ):
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
@@ -1944,6 +1989,13 @@ async def test_run_sync_action(
     action_name = 'testConnection'
     expected_response = {'status': 'ok'}
 
+    root_configuration: dict[str, Any] = {
+        'parameters': root_params,
+        'storage': root_storage,
+    }
+    if root_runtime is not None:
+        root_configuration['runtime'] = root_runtime
+
     keboola_client.storage_client.configuration_detail.return_value = {
         'id': configuration_id,
         'componentId': component_id,
@@ -1951,10 +2003,7 @@ async def test_run_sync_action(
         'version': 1,
         'isDisabled': False,
         'isDeleted': False,
-        'configuration': {
-            'parameters': root_params,
-            'storage': root_storage,
-        },
+        'configuration': root_configuration,
         'rows': [],
     }
 
@@ -1982,14 +2031,18 @@ async def test_run_sync_action(
 
     assert result == expected_response
 
+    expected_config_data: dict[str, Any] = {
+        'parameters': expected_params,
+        'storage': expected_storage,
+    }
+    if expected_runtime is not None:
+        expected_config_data['runtime'] = expected_runtime
+
     keboola_client.storage_client.configuration_detail.assert_called_once_with(component_id, configuration_id)
     keboola_client.sync_actions_client.execute_action.assert_called_once_with(
         component_id=component_id,
         action=action_name,
-        config_data={
-            'parameters': expected_params,
-            'storage': expected_storage,
-        },
+        config_data=expected_config_data,
     )
 
     if row_id:

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.61.2"
+version = "1.61.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

Replaces #523 (closed when a branch rename inadvertently invalidated its head ref).

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`run_sync_action` was flattening the saved configuration to just `parameters` + `storage` when constructing the sync-actions payload, dropping the `runtime` block entirely. The sync-actions docker-runner reads `configData.runtime.image_tag` to pin the component image; without it the runner silently falls back to the default tag, so any `runtime.image_tag` pinned on the saved configuration was being ignored when the sync action was invoked through MCP.

The fix forwards the root configuration's `runtime` block in `configData` so `runtime.image_tag` (and any other runtime fields such as backend hints) from the saved configuration are respected by default — no new tool parameter needed, no caller change required.

Notes:
- `run_job` is unaffected by design: the Job Queue / docker-runner pipeline fetches the saved configuration server-side and applies `runtime.image_tag` on its own — confirmed against the `keboola/docker-bundle` `ImageCreator` / `Container` configuration schema.
- Rows do not override `runtime` in the docker-runner's contract, so only the root configuration's `runtime` is forwarded.
- `processors` is intentionally not forwarded — sync actions don't execute processors in the platform either.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)