### PR TITLE
AI-3204: cancel running Snowflake query when MCP client stops the tool call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.60.4"
+version = "1.60.5"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.60.5"
+version = "1.60.6"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.60.2"
+version = "1.60.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.60.3"
+version = "1.60.4"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/cancellation.py
+++ b/src/keboola_mcp_server/cancellation.py
@@ -35,6 +35,14 @@ LOG = logging.getLogger(__name__)
 
 _running: dict[str, asyncio.Task] = {}
 
+# Cancel-before-register intents: when `cancel()` arrives for a request id whose
+# task hasn't been registered yet (e.g. the cancel notification was processed by
+# the middleware before the tools/call coroutine reached `register()`), we record
+# the id here and the next `register()` for that id will honour it. Bounded to
+# avoid unbounded growth from orphaned cancels (request never reached this pod).
+_pending_cancels: set[str] = set()
+_MAX_PENDING_CANCELS = 1024
+
 
 def _normalize_request_id(request_id: str | int) -> str:
     """JSON-RPC ids can be int or str; we key everything as str to avoid type mismatches."""
@@ -43,11 +51,24 @@ def _normalize_request_id(request_id: str | int) -> str:
 
 async def register(request_id: str | int, task: asyncio.Task) -> None:
     """Register `task` as the worker for `request_id`. Overwrites silently if a
-    task is already registered (logged at WARNING — shouldn't normally happen)."""
+    task is already registered (logged at WARNING — shouldn't normally happen).
+
+    Honours any cancel intent recorded for this id before `register()` ran: if
+    `cancel()` was called for the same id earlier, the task is cancelled immediately.
+    """
     key = _normalize_request_id(request_id)
     if key in _running:
         LOG.warning(f'Cancellation registry: overwriting existing task for request_id={key}')
     _running[key] = task
+
+    if key in _pending_cancels:
+        _pending_cancels.discard(key)
+        if not task.done():
+            task.cancel()
+            LOG.info(
+                f'Cancellation registry: honoured pre-cancellation on register for request_id={key} '
+                f'(cancel notification arrived before the tool task was registered)'
+            )
 
 
 async def unregister(request_id: str | int) -> None:
@@ -58,15 +79,29 @@ async def unregister(request_id: str | int) -> None:
 async def cancel(request_id: str | int) -> bool:
     """Cancel the task registered for `request_id`.
 
-    Returns True if a live task was found and cancelled, False otherwise.
+    Returns True if a live task was found and cancelled. If no task is registered
+    at all, records the cancel intent so the next matching `register()` will honour
+    it — and returns False. If a task is registered but has already completed,
+    returns False without recording an intent (the work is already done).
     """
     key = _normalize_request_id(request_id)
     task = _running.get(key)
-    if task is None or task.done():
-        return False
-    task.cancel()
-    LOG.info(f'Cancellation registry: cancelled task for request_id={key}')
-    return True
+    if task is not None:
+        if task.done():
+            return False
+        task.cancel()
+        LOG.info(f'Cancellation registry: cancelled task for request_id={key}')
+        return True
+
+    # No task registered yet. Remember the intent for an upcoming register() —
+    # this closes the race window between `asyncio.create_task` in the tool
+    # coroutine and the registry registration that follows it.
+    if len(_pending_cancels) >= _MAX_PENDING_CANCELS:
+        # Drop an arbitrary existing intent to keep the set bounded. Pathological
+        # case only — in normal operation intents are consumed by register().
+        _pending_cancels.discard(next(iter(_pending_cancels)))
+    _pending_cancels.add(key)
+    return False
 
 
 @asynccontextmanager
@@ -80,13 +115,25 @@ async def track_request(request_id: str | int, task: asyncio.Task) -> AsyncItera
         await unregister(request_id)
 
 
+_MAX_INSPECT_BYTES = 8 * 1024
+_CANCEL_METHOD_TOKEN = b'notifications/cancelled'
+
+
 class CancellationInterceptorMiddleware:
     """ASGI middleware that intercepts MCP `notifications/cancelled` payloads on
     `POST /mcp` and routes them to the cancellation registry.
 
-    The body is buffered, peeked at, then replayed unchanged to the downstream app
-    so the MCP SDK still processes the notification normally (its own `_in_flight`
-    lookup will be empty in stateless mode — that's the gap this middleware fills).
+    We peek ONLY at the first body chunk (cancel notifications are always small,
+    well under a single ASGI chunk — typically ~100 bytes). If that chunk is fully
+    self-contained (`more_body=False`), fits within `_MAX_INSPECT_BYTES`, and
+    contains the literal `notifications/cancelled` substring, we parse it as JSON
+    and route to the registry. In every other case we skip inspection entirely.
+
+    Crucially, the body itself is NOT buffered into memory: we replay the first
+    chunk and pass the original receive callable through for any subsequent chunks,
+    so large `tools/call` payloads stream straight to the downstream app without
+    being duplicated in memory. The cheap substring check also avoids `json.loads`
+    on the (vast majority of) request bodies that aren't cancel notifications.
 
     Any parse error / unexpected shape is silently ignored: this layer must never
     break legitimate MCP traffic.
@@ -100,31 +147,34 @@ class CancellationInterceptorMiddleware:
             await self._app(scope, receive, send)
             return
 
-        chunks: list[Message] = []
-        while True:
-            msg = await receive()
-            chunks.append(msg)
-            if msg.get('type') != 'http.request' or not msg.get('more_body', False):
-                break
+        first_msg = await receive()
 
-        body = b''.join(c.get('body', b'') for c in chunks if c.get('type') == 'http.request')
+        if (
+            first_msg.get('type') == 'http.request'
+            and not first_msg.get('more_body', False)
+            and len(first_msg.get('body', b'')) <= _MAX_INSPECT_BYTES
+        ):
+            await self._try_cancel_from_body(first_msg['body'])
 
-        await self._try_cancel_from_body(body)
-
-        chunk_iter = iter(chunks)
+        sent_first = False
 
         async def replayed_receive() -> Message:
-            try:
-                return next(chunk_iter)
-            except StopIteration:
-                return await receive()
+            nonlocal sent_first
+            if not sent_first:
+                sent_first = True
+                return first_msg
+            return await receive()
 
         await self._app(scope, replayed_receive, send)
 
     @staticmethod
     async def _try_cancel_from_body(body: bytes) -> None:
+        # Cheap substring filter first: this skips the JSON parse for every body
+        # that doesn't even mention the cancel method name.
+        if _CANCEL_METHOD_TOKEN not in body:
+            return
         try:
-            payload = json.loads(body) if body else None
+            payload = json.loads(body)
         except json.JSONDecodeError:
             return
         if not isinstance(payload, dict):
@@ -141,7 +191,8 @@ class CancellationInterceptorMiddleware:
         if not cancelled:
             LOG.debug(
                 f'Cancellation interceptor: no live task for request_id={request_id} '
-                f'(likely already completed or running on a different replica)'
+                f'(likely already completed or running on a different replica); '
+                f'cancel intent recorded for an upcoming register() if any'
             )
 
 

--- a/src/keboola_mcp_server/cancellation.py
+++ b/src/keboola_mcp_server/cancellation.py
@@ -1,0 +1,154 @@
+"""Process-wide registry mapping MCP JSON-RPC request IDs to their running asyncio Tasks.
+
+In stateless streamable-HTTP mode (the deployment shape used by this server) every
+incoming MCP request creates a fresh transport with its own session. The MCP SDK's
+built-in cancellation routing (`mcp/shared/session.py`, `_in_flight` dict on the
+session) therefore cannot route a `notifications/cancelled` to the tool call it is
+meant to abort — they live on different transport instances.
+
+This module bridges that gap with a side-channel:
+
+  * Tools that may run long enough to need cancellation register their task here,
+    keyed by their JSON-RPC request id, for the duration of the call.
+  * An ASGI middleware (`CancellationInterceptorMiddleware`) peeks at incoming
+    `POST /mcp` bodies and, when it sees a `notifications/cancelled`, calls
+    `cancel(request_id)` to abort the registered task.
+  * The cancelled task surfaces `asyncio.CancelledError` inside the tool, which
+    (for `query_data` -> Snowflake) trips the existing CancelledError branch in
+    `_SnowflakeWorkspace.execute_query` and fires the backend `cancel_job`.
+
+Scope of this implementation: in-memory, single process. Cross-replica cancellation
+without sticky sessions requires a shared store (planned: Postgres) — the async
+function signatures here are designed to make that swap non-breaking.
+"""
+
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+LOG = logging.getLogger(__name__)
+
+
+_running: dict[str, asyncio.Task] = {}
+
+
+def _normalize_request_id(request_id: str | int) -> str:
+    """JSON-RPC ids can be int or str; we key everything as str to avoid type mismatches."""
+    return str(request_id)
+
+
+async def register(request_id: str | int, task: asyncio.Task) -> None:
+    """Register `task` as the worker for `request_id`. Overwrites silently if a
+    task is already registered (logged at WARNING — shouldn't normally happen)."""
+    key = _normalize_request_id(request_id)
+    if key in _running:
+        LOG.warning(f'Cancellation registry: overwriting existing task for request_id={key}')
+    _running[key] = task
+
+
+async def unregister(request_id: str | int) -> None:
+    """Remove `request_id` from the registry. No-op if not present."""
+    _running.pop(_normalize_request_id(request_id), None)
+
+
+async def cancel(request_id: str | int) -> bool:
+    """Cancel the task registered for `request_id`.
+
+    Returns True if a live task was found and cancelled, False otherwise.
+    """
+    key = _normalize_request_id(request_id)
+    task = _running.get(key)
+    if task is None or task.done():
+        return False
+    task.cancel()
+    LOG.info(f'Cancellation registry: cancelled task for request_id={key}')
+    return True
+
+
+@asynccontextmanager
+async def track_request(request_id: str | int, task: asyncio.Task) -> AsyncIterator[None]:
+    """Context manager: register `task` for `request_id` on entry, unregister on exit
+    (success or failure). Use this when you want exception-safe lifecycle management."""
+    await register(request_id, task)
+    try:
+        yield
+    finally:
+        await unregister(request_id)
+
+
+class CancellationInterceptorMiddleware:
+    """ASGI middleware that intercepts MCP `notifications/cancelled` payloads on
+    `POST /mcp` and routes them to the cancellation registry.
+
+    The body is buffered, peeked at, then replayed unchanged to the downstream app
+    so the MCP SDK still processes the notification normally (its own `_in_flight`
+    lookup will be empty in stateless mode — that's the gap this middleware fills).
+
+    Any parse error / unexpected shape is silently ignored: this layer must never
+    break legitimate MCP traffic.
+    """
+
+    def __init__(self, app: ASGIApp):
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not _should_inspect(scope):
+            await self._app(scope, receive, send)
+            return
+
+        chunks: list[Message] = []
+        while True:
+            msg = await receive()
+            chunks.append(msg)
+            if msg.get('type') != 'http.request' or not msg.get('more_body', False):
+                break
+
+        body = b''.join(c.get('body', b'') for c in chunks if c.get('type') == 'http.request')
+
+        await self._try_cancel_from_body(body)
+
+        chunk_iter = iter(chunks)
+
+        async def replayed_receive() -> Message:
+            try:
+                return next(chunk_iter)
+            except StopIteration:
+                return await receive()
+
+        await self._app(scope, replayed_receive, send)
+
+    @staticmethod
+    async def _try_cancel_from_body(body: bytes) -> None:
+        try:
+            payload = json.loads(body) if body else None
+        except json.JSONDecodeError:
+            return
+        if not isinstance(payload, dict):
+            return
+        if payload.get('method') != 'notifications/cancelled':
+            return
+        params = payload.get('params')
+        if not isinstance(params, dict):
+            return
+        request_id = params.get('requestId')
+        if request_id is None:
+            return
+        cancelled = await cancel(request_id)
+        if not cancelled:
+            LOG.debug(
+                f'Cancellation interceptor: no live task for request_id={request_id} '
+                f'(likely already completed or running on a different replica)'
+            )
+
+
+def _should_inspect(scope: Scope) -> bool:
+    if scope.get('type') != 'http':
+        return False
+    if scope.get('method') != 'POST':
+        return False
+    path = scope.get('path', '')
+    return path in ('/mcp', '/mcp/')

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -18,6 +18,7 @@ from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from keboola_mcp_server.cancellation import CancellationInterceptorMiddleware
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
 from keboola_mcp_server.mcp import ForwardSlashMiddleware
 from keboola_mcp_server.server import CustomRoutes, create_server
@@ -176,7 +177,14 @@ async def run_server(args: Optional[list[str]] = None) -> None:
                     yield
 
             app = Starlette(
-                middleware=[Middleware(ForwardSlashMiddleware)],
+                middleware=[
+                    Middleware(ForwardSlashMiddleware),
+                    # In stateless HTTP mode the MCP SDK cannot route `notifications/cancelled`
+                    # to the in-flight tool call's session — see `cancellation.py` docstring.
+                    # This middleware intercepts those notifications and cancels via a
+                    # process-wide registry that long-running tools register with.
+                    Middleware(CancellationInterceptorMiddleware),
+                ],
                 lifespan=lifespan,
                 exception_handlers=_exception_handlers,
             )

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -6,7 +6,6 @@ from io import StringIO
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.dependencies import get_http_request
 from fastmcp.tools import FunctionTool
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
@@ -20,9 +19,6 @@ LOG = logging.getLogger(__name__)
 SQL_TOOLS_TAG = 'sql'
 MAX_ROWS = 1_000
 MAX_CHARS = 50_000
-# How often to check whether the HTTP client has disconnected during a long query.
-# Mirrors the 1 s job-poll cadence in `_SnowflakeWorkspace.execute_query`.
-_DISCONNECT_POLL_INTERVAL = 1.0
 
 
 def _safe_request_id(ctx: Context) -> str | None:
@@ -30,47 +26,13 @@ def _safe_request_id(ctx: Context) -> str | None:
 
     The id is needed to register the running task in the cancellation registry so
     that `notifications/cancelled` can find and abort it. Outside of an active MCP
-    request (e.g. in some unit tests, or during initialization) the id is missing —
-    in that case we just skip registration and rely on the disconnect watcher.
+    request (e.g. some unit tests, or during initialization) the id is missing — in
+    that case we skip registration and the call cannot be cancelled by the registry.
     """
     try:
         return str(ctx.request_id)
     except (AttributeError, RuntimeError):
         return None
-
-
-async def _watch_for_http_disconnect(poll_interval: float = _DISCONNECT_POLL_INTERVAL) -> None:
-    """Return when the underlying HTTP request is torn down, or block forever otherwise.
-
-    In stateless streamable-HTTP mode (`stateless_http=True` in `cli.py`), the MCP
-    `notifications/cancelled` payload arrives on a fresh transport instance and cannot
-    reach the in-flight tool call's session — so `asyncio.CancelledError` is never
-    raised inside the running tool. Watching the underlying ASGI request for an
-    `http.disconnect` event lets us notice when the client gave up (closed the tab,
-    hit "stop" in Kai, lost network) and trigger the same cancellation path we
-    already have for SDK-driven cancels.
-
-    Returns silently when disconnect is detected. Blocks forever if there is no HTTP
-    request bound (e.g. stdio transport, background workers) — in that case the caller
-    will only stop on normal task completion or its own cancellation.
-
-    Any error from `is_disconnected()` is treated as "still connected" so a transient
-    ASGI hiccup never cancels an otherwise-working query.
-    """
-    try:
-        request = get_http_request()
-    except RuntimeError:
-        # No HTTP request context — never fire (e.g. stdio transport).
-        await asyncio.Event().wait()
-        return  # unreachable; satisfies the type checker
-
-    while True:
-        try:
-            if await request.is_disconnected():
-                return
-        except Exception:
-            LOG.debug('HTTP is_disconnected() check failed; treating as still-connected', exc_info=True)
-        await asyncio.sleep(poll_interval)
 
 
 class QueryDataOutput(BaseModel):
@@ -151,43 +113,27 @@ async def query_data(
     """
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
 
-    # Race the workspace task against an HTTP-disconnect watcher AND register it in
-    # the process-wide cancellation registry. The registry path is what actually
-    # works in stateless streamable-HTTP mode: when the client sends
-    # `notifications/cancelled` it lands on a different transport instance, but
-    # `CancellationInterceptorMiddleware` peeks at the body, looks the request id
-    # up here, and cancels the task. The cancellation then trips the CancelledError
-    # branch inside `_SnowflakeWorkspace.execute_query` and fires `cancel_job`.
-    # The disconnect watcher is kept as a belt-and-braces signal for clients that
-    # actually close the socket on stop (see `_watch_for_http_disconnect`).
+    # Run the query as a separate task and register it in the process-wide cancellation
+    # registry. When the client sends `notifications/cancelled`,
+    # `CancellationInterceptorMiddleware` peeks at the body, looks the request id up
+    # here, and cancels this task. That trips the CancelledError branch inside
+    # `_SnowflakeWorkspace.execute_query`, which fires `cancel_job` on the backend.
+    # We also cancel the inner task if our own coroutine is cancelled (e.g. by the
+    # MCP SDK on a stateful transport) so the inner task isn't left running.
     query_task = asyncio.create_task(workspace_manager.execute_query(sql_query, max_rows=MAX_ROWS, max_chars=MAX_CHARS))
-    disconnect_task = asyncio.create_task(_watch_for_http_disconnect())
     request_id = _safe_request_id(ctx)
     cancel_tracking = track_request(request_id, query_task) if request_id is not None else contextlib.nullcontext()
 
     async with cancel_tracking:
         try:
-            done, _pending = await asyncio.wait(
-                [query_task, disconnect_task],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            result = await query_task
         except BaseException:
-            query_task.cancel()
-            disconnect_task.cancel()
+            if not query_task.done():
+                query_task.cancel()
+                with contextlib.suppress(BaseException):
+                    await query_task
             raise
 
-        if query_task not in done:
-            LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')
-            query_task.cancel()
-            with contextlib.suppress(BaseException):
-                await query_task
-            raise asyncio.CancelledError(f'HTTP client disconnected during query_data "{query_name}"')
-
-        disconnect_task.cancel()
-        with contextlib.suppress(BaseException):
-            await disconnect_task
-
-        result = query_task.result()
     LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
     if result.is_ok:
         if result.data:

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -1,9 +1,12 @@
+import asyncio
+import contextlib
 import csv
 import logging
 from io import StringIO
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
+from fastmcp.server.dependencies import get_http_request
 from fastmcp.tools import FunctionTool
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
@@ -16,6 +19,43 @@ LOG = logging.getLogger(__name__)
 SQL_TOOLS_TAG = 'sql'
 MAX_ROWS = 1_000
 MAX_CHARS = 50_000
+# How often to check whether the HTTP client has disconnected during a long query.
+# Mirrors the 1 s job-poll cadence in `_SnowflakeWorkspace.execute_query`.
+_DISCONNECT_POLL_INTERVAL = 1.0
+
+
+async def _watch_for_http_disconnect(poll_interval: float = _DISCONNECT_POLL_INTERVAL) -> None:
+    """Return when the underlying HTTP request is torn down, or block forever otherwise.
+
+    In stateless streamable-HTTP mode (`stateless_http=True` in `cli.py`), the MCP
+    `notifications/cancelled` payload arrives on a fresh transport instance and cannot
+    reach the in-flight tool call's session — so `asyncio.CancelledError` is never
+    raised inside the running tool. Watching the underlying ASGI request for an
+    `http.disconnect` event lets us notice when the client gave up (closed the tab,
+    hit "stop" in Kai, lost network) and trigger the same cancellation path we
+    already have for SDK-driven cancels.
+
+    Returns silently when disconnect is detected. Blocks forever if there is no HTTP
+    request bound (e.g. stdio transport, background workers) — in that case the caller
+    will only stop on normal task completion or its own cancellation.
+
+    Any error from `is_disconnected()` is treated as "still connected" so a transient
+    ASGI hiccup never cancels an otherwise-working query.
+    """
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        # No HTTP request context — never fire (e.g. stdio transport).
+        await asyncio.Event().wait()
+        return  # unreachable; satisfies the type checker
+
+    while True:
+        try:
+            if await request.is_disconnected():
+                return
+        except Exception:
+            LOG.debug('HTTP is_disconnected() check failed; treating as still-connected', exc_info=True)
+        await asyncio.sleep(poll_interval)
 
 
 class QueryDataOutput(BaseModel):
@@ -95,7 +135,36 @@ async def query_data(
     * Ensure valid filtering by checking actual data values first
     """
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
-    result = await workspace_manager.execute_query(sql_query, max_rows=MAX_ROWS, max_chars=MAX_CHARS)
+
+    # Race the query against the HTTP client disconnecting. If the client gives up
+    # before the query finishes, cancelling `query_task` triggers the CancelledError
+    # branch inside `_SnowflakeWorkspace.execute_query`, which fires `cancel_job` on
+    # the backend so the scan stops. Needed because in stateless HTTP mode the MCP
+    # cancel notification cannot reach this running request — see `_watch_for_http_disconnect`.
+    query_task = asyncio.create_task(workspace_manager.execute_query(sql_query, max_rows=MAX_ROWS, max_chars=MAX_CHARS))
+    disconnect_task = asyncio.create_task(_watch_for_http_disconnect())
+    try:
+        done, _pending = await asyncio.wait(
+            [query_task, disconnect_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    except BaseException:
+        query_task.cancel()
+        disconnect_task.cancel()
+        raise
+
+    if query_task not in done:
+        LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')
+        query_task.cancel()
+        with contextlib.suppress(BaseException):
+            await query_task
+        raise asyncio.CancelledError(f'HTTP client disconnected during query_data "{query_name}"')
+
+    disconnect_task.cancel()
+    with contextlib.suppress(BaseException):
+        await disconnect_task
+
+    result = query_task.result()
     LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
     if result.is_ok:
         if result.data:

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -11,6 +11,7 @@ from fastmcp.tools import FunctionTool
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
+from keboola_mcp_server.cancellation import track_request
 from keboola_mcp_server.errors import tool_errors
 from keboola_mcp_server.workspace import SqlSelectData, WorkspaceManager
 
@@ -22,6 +23,20 @@ MAX_CHARS = 50_000
 # How often to check whether the HTTP client has disconnected during a long query.
 # Mirrors the 1 s job-poll cadence in `_SnowflakeWorkspace.execute_query`.
 _DISCONNECT_POLL_INTERVAL = 1.0
+
+
+def _safe_request_id(ctx: Context) -> str | None:
+    """Return the current JSON-RPC request id, or None if unavailable.
+
+    The id is needed to register the running task in the cancellation registry so
+    that `notifications/cancelled` can find and abort it. Outside of an active MCP
+    request (e.g. in some unit tests, or during initialization) the id is missing —
+    in that case we just skip registration and rely on the disconnect watcher.
+    """
+    try:
+        return str(ctx.request_id)
+    except (AttributeError, RuntimeError):
+        return None
 
 
 async def _watch_for_http_disconnect(poll_interval: float = _DISCONNECT_POLL_INTERVAL) -> None:
@@ -136,35 +151,43 @@ async def query_data(
     """
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
 
-    # Race the query against the HTTP client disconnecting. If the client gives up
-    # before the query finishes, cancelling `query_task` triggers the CancelledError
-    # branch inside `_SnowflakeWorkspace.execute_query`, which fires `cancel_job` on
-    # the backend so the scan stops. Needed because in stateless HTTP mode the MCP
-    # cancel notification cannot reach this running request — see `_watch_for_http_disconnect`.
+    # Race the workspace task against an HTTP-disconnect watcher AND register it in
+    # the process-wide cancellation registry. The registry path is what actually
+    # works in stateless streamable-HTTP mode: when the client sends
+    # `notifications/cancelled` it lands on a different transport instance, but
+    # `CancellationInterceptorMiddleware` peeks at the body, looks the request id
+    # up here, and cancels the task. The cancellation then trips the CancelledError
+    # branch inside `_SnowflakeWorkspace.execute_query` and fires `cancel_job`.
+    # The disconnect watcher is kept as a belt-and-braces signal for clients that
+    # actually close the socket on stop (see `_watch_for_http_disconnect`).
     query_task = asyncio.create_task(workspace_manager.execute_query(sql_query, max_rows=MAX_ROWS, max_chars=MAX_CHARS))
     disconnect_task = asyncio.create_task(_watch_for_http_disconnect())
-    try:
-        done, _pending = await asyncio.wait(
-            [query_task, disconnect_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-    except BaseException:
-        query_task.cancel()
+    request_id = _safe_request_id(ctx)
+    cancel_tracking = track_request(request_id, query_task) if request_id is not None else contextlib.nullcontext()
+
+    async with cancel_tracking:
+        try:
+            done, _pending = await asyncio.wait(
+                [query_task, disconnect_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        except BaseException:
+            query_task.cancel()
+            disconnect_task.cancel()
+            raise
+
+        if query_task not in done:
+            LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')
+            query_task.cancel()
+            with contextlib.suppress(BaseException):
+                await query_task
+            raise asyncio.CancelledError(f'HTTP client disconnected during query_data "{query_name}"')
+
         disconnect_task.cancel()
-        raise
-
-    if query_task not in done:
-        LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')
-        query_task.cancel()
         with contextlib.suppress(BaseException):
-            await query_task
-        raise asyncio.CancelledError(f'HTTP client disconnected during query_data "{query_name}"')
+            await disconnect_task
 
-    disconnect_task.cancel()
-    with contextlib.suppress(BaseException):
-        await disconnect_task
-
-    result = query_task.result()
+        result = query_task.result()
     LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
     if result.is_ok:
         if result.data:

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -256,38 +256,52 @@ class _SnowflakeWorkspace(_Workspace):
 
         ts_start = time.perf_counter()
         job_id = await self._qsclient.submit_job(statements=[sql_query], workspace_id=str(self.id))
-        while (job_status := await self._qsclient.get_job_status(job_id)) and job_status['status'] not in [
-            'completed',
-            'failed',
-            'canceled',
-            'cancelled',
-        ]:
-            await asyncio.sleep(1)
-            elapsed_time = time.perf_counter() - ts_start
-            if elapsed_time > self._QUERY_TIMEOUT:
-                # Cancel the query before raising timeout error
-                reason = f'Query timeout exceeded after {elapsed_time:.2f} seconds'
-                cancellation_confirmed, query_completed = await self._cancel_job_with_timeout(job_id, reason)
+        try:
+            while (job_status := await self._qsclient.get_job_status(job_id)) and job_status['status'] not in [
+                'completed',
+                'failed',
+                'canceled',
+                'cancelled',
+            ]:
+                await asyncio.sleep(1)
+                elapsed_time = time.perf_counter() - ts_start
+                if elapsed_time > self._QUERY_TIMEOUT:
+                    # Cancel the query before raising timeout error
+                    reason = f'Query timeout exceeded after {elapsed_time:.2f} seconds'
+                    cancellation_confirmed, query_completed = await self._cancel_job_with_timeout(job_id, reason)
 
-                # If query completed during cancellation, fetch and return results
-                if query_completed:
-                    LOG.info(f'Query completed during cancellation polling, returning results: job_id={job_id}')
-                    # Break out of the polling loop to fetch results below
-                    job_status = await self._qsclient.get_job_status(job_id)
-                    break
+                    # If query completed during cancellation, fetch and return results
+                    if query_completed:
+                        LOG.info(f'Query completed during cancellation polling, returning results: job_id={job_id}')
+                        # Break out of the polling loop to fetch results below
+                        job_status = await self._qsclient.get_job_status(job_id)
+                        break
 
-                # Query did not complete - raise timeout error
-                if cancellation_confirmed:
-                    raise RuntimeError(
-                        f'Query execution timed out after {elapsed_time:.2f} seconds. '
-                        f'The query has been cancelled: job_id={job_id}'
-                    )
-                else:
-                    raise RuntimeError(
-                        f'Query execution timed out after {elapsed_time:.2f} seconds. '
-                        f'Cancellation was attempted but could not be confirmed. '
-                        f'The query may still be running on the server: job_id={job_id}'
-                    )
+                    # Query did not complete - raise timeout error
+                    if cancellation_confirmed:
+                        raise RuntimeError(
+                            f'Query execution timed out after {elapsed_time:.2f} seconds. '
+                            f'The query has been cancelled: job_id={job_id}'
+                        )
+                    else:
+                        raise RuntimeError(
+                            f'Query execution timed out after {elapsed_time:.2f} seconds. '
+                            f'Cancellation was attempted but could not be confirmed. '
+                            f'The query may still be running on the server: job_id={job_id}'
+                        )
+        except asyncio.CancelledError:
+            # Client (e.g. MCP `notifications/cancelled`) cancelled the in-flight tool call.
+            # Propagate the cancel to the backend so the query doesn't keep scanning data.
+            # `asyncio.shield` keeps the cancel HTTP call alive even though our own task
+            # is being cancelled; without it the request would be torn down immediately.
+            LOG.info(f'Query cancelled by client: job_id={job_id}')
+            try:
+                await asyncio.shield(self._cancel_job_with_timeout(job_id, reason='Client cancelled the request'))
+            except asyncio.CancelledError:
+                # Outer scope was cancelled again while the shielded cancel was still running;
+                # we did our best — let the original CancelledError propagate below.
+                pass
+            raise
 
         statement_id = cast(list[JsonDict], job_status['statements'])[0]['id']
 
@@ -439,6 +453,13 @@ class _BigQueryWorkspace(_Workspace):
     async def execute_query(
         self, sql_query: str, *, max_rows: int | None = None, max_chars: int | None = None
     ) -> QueryResult:
+        # Note on cancellation: unlike Snowflake (see `_SnowflakeWorkspace.execute_query`),
+        # client-initiated cancellation cannot kill an in-flight BigQuery job from here.
+        # The SAPI `workspace_query` endpoint is a synchronous proxy and does not expose
+        # a job ID, so there is nothing to address a cancel request to. If the asyncio
+        # task is cancelled, the HTTP connection is dropped but the underlying BigQuery
+        # job keeps running until it finishes or hits its own timeout. Tracked separately
+        # — requires SAPI changes to expose the job handle and a cancel endpoint.
         if max_rows is not None and max_rows <= 0:
             raise ValueError('The "max_rows" must be a positive integer or None.')
         if max_chars is not None and max_chars <= 0:

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -1,6 +1,7 @@
 """Tests for the process-wide cancellation registry and ASGI interceptor."""
 
 import asyncio
+import contextlib
 import json
 
 import pytest
@@ -17,10 +18,12 @@ from keboola_mcp_server.cancellation import (
 
 @pytest.fixture(autouse=True)
 def _clear_registry():
-    """Ensure each test starts with an empty registry."""
+    """Ensure each test starts with an empty registry and no leftover cancel intents."""
     cancellation._running.clear()
+    cancellation._pending_cancels.clear()
     yield
     cancellation._running.clear()
+    cancellation._pending_cancels.clear()
 
 
 @pytest.mark.asyncio
@@ -49,6 +52,52 @@ async def test_register_then_cancel_aborts_the_task() -> None:
 @pytest.mark.asyncio
 async def test_cancel_returns_false_when_no_task() -> None:
     assert await cancel('does-not-exist') is False
+    # Intent must be recorded so a later register() honours it.
+    assert 'does-not-exist' in cancellation._pending_cancels
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_register_is_honoured_on_register() -> None:
+    """The cancel notification can race ahead of registration. When that happens,
+    the intent must survive and the upcoming register() must cancel the task."""
+    started = asyncio.Event()
+    cancelled_inside = asyncio.Event()
+
+    async def runner():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled_inside.set()
+            raise
+
+    # Cancel arrives FIRST — no task is registered yet.
+    assert await cancel('race-id') is False
+    assert 'race-id' in cancellation._pending_cancels
+
+    # Now the tool coroutine reaches its register() call.
+    task = asyncio.create_task(runner())
+    await started.wait()
+    await register('race-id', task)
+
+    # register() consumed the intent and cancelled the task.
+    assert 'race-id' not in cancellation._pending_cancels
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled_inside.is_set()
+
+
+@pytest.mark.asyncio
+async def test_pending_cancels_is_bounded() -> None:
+    """A flood of orphaned cancels must not grow the set unbounded."""
+    original_cap = cancellation._MAX_PENDING_CANCELS
+    try:
+        cancellation._MAX_PENDING_CANCELS = 4
+        for i in range(20):
+            await cancel(f'orphan-{i}')
+        assert len(cancellation._pending_cancels) <= 4
+    finally:
+        cancellation._MAX_PENDING_CANCELS = original_cap
 
 
 @pytest.mark.asyncio
@@ -60,6 +109,8 @@ async def test_cancel_returns_false_when_task_already_done() -> None:
     await task
     await register('req-done', task)
     assert await cancel('req-done') is False
+    # An already-completed task is "done work" — don't record a stale intent.
+    assert 'req-done' not in cancellation._pending_cancels
 
 
 @pytest.mark.asyncio
@@ -108,9 +159,19 @@ async def test_register_normalises_int_and_str_ids(request_id) -> None:
         await task
 
 
-async def _drive_middleware(body: bytes, *, path: str = '/mcp', method: str = 'POST') -> dict:
-    """Run the middleware against a single fake ASGI request and return what the
-    downstream app received (so we can assert the body was replayed unchanged)."""
+async def _drive_middleware(
+    body: bytes | None = None,
+    *,
+    chunks_override: list[dict] | None = None,
+    path: str = '/mcp',
+    method: str = 'POST',
+) -> dict:
+    """Run the middleware against a fake ASGI request and return what the downstream
+    app received (so we can assert the body was replayed unchanged).
+
+    Either pass a single-chunk `body` or override with a list of `http.request`
+    chunks (for multi-chunk tests).
+    """
     received_chunks: list[dict] = []
 
     async def downstream(scope, receive, send):
@@ -123,7 +184,10 @@ async def _drive_middleware(body: bytes, *, path: str = '/mcp', method: str = 'P
         await send({'type': 'http.response.body', 'body': b''})
 
     scope = {'type': 'http', 'method': method, 'path': path}
-    chunks_to_send = [{'type': 'http.request', 'body': body, 'more_body': False}]
+    if chunks_override is None:
+        chunks_to_send = [{'type': 'http.request', 'body': body or b'', 'more_body': False}]
+    else:
+        chunks_to_send = chunks_override
     sent_iter = iter(chunks_to_send)
 
     async def receive():
@@ -204,8 +268,75 @@ async def test_middleware_passes_non_cancel_payloads_through(payload: dict) -> N
 @pytest.mark.asyncio
 async def test_middleware_tolerates_garbage_body() -> None:
     # No registered tasks; the middleware must not crash on malformed input.
+    # The garbage doesn't contain the cancel-method token, so json.loads is never called.
     await _drive_middleware(b'not json')
     await _drive_middleware(b'')
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_parse_when_substring_missing(mocker) -> None:
+    """The cheap `b'notifications/cancelled' in body` substring check must run
+    BEFORE json.loads — large `tools/call` payloads pay no JSON-parse cost."""
+    spy = mocker.spy(cancellation.json, 'loads')
+    # A realistic-ish tools/call body that does NOT contain the cancel-method token.
+    big_body = json.dumps(
+        {
+            'jsonrpc': '2.0',
+            'method': 'tools/call',
+            'id': 1,
+            'params': {'name': 'query_data', 'arguments': {'sql_query': 'SELECT ' + 'x,' * 500}},
+        }
+    ).encode()
+    await _drive_middleware(big_body)
+    assert spy.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_inspection_for_multi_chunk_bodies() -> None:
+    """Cancel notifications are tiny and always fit in a single ASGI chunk. If the
+    body spans multiple chunks we don't bother inspecting — but we MUST still
+    stream-replay every chunk untouched to the downstream app."""
+    chunks = [
+        {'type': 'http.request', 'body': b'{"jsonrpc":"2.0","method":"', 'more_body': True},
+        {'type': 'http.request', 'body': b'notifications/cancelled","params":{"requestId":"x"}}', 'more_body': False},
+    ]
+    started = asyncio.Event()
+
+    async def runner():
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(runner())
+    await started.wait()
+    await register('x', task)
+    try:
+        result = await _drive_middleware(chunks_override=chunks)
+        await asyncio.sleep(0)
+        # Multi-chunk → we did not parse → task is still running.
+        assert not task.done()
+        # But the chunks must have reached downstream verbatim.
+        downstream_bodies = [c.get('body', b'') for c in result['received_chunks']]
+        assert downstream_bodies == [chunks[0]['body'], chunks[1]['body']]
+    finally:
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+        await unregister('x')
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_inspection_when_body_exceeds_cap(mocker) -> None:
+    """A single oversized chunk must NOT be parsed for cancel — protects against
+    a hostile or accidental large body being put through json.loads."""
+    spy = mocker.spy(cancellation.json, 'loads')
+    # Build a payload that exceeds the cap and happens to contain the cancel token
+    # (so the substring check would have matched, had we run it).
+    oversized = (
+        b'{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"x"},'
+        b'"_pad":"' + b'A' * (cancellation._MAX_INSPECT_BYTES + 16) + b'"}'
+    )
+    await _drive_middleware(oversized)
+    assert spy.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -1,0 +1,226 @@
+"""Tests for the process-wide cancellation registry and ASGI interceptor."""
+
+import asyncio
+import json
+
+import pytest
+
+from keboola_mcp_server import cancellation
+from keboola_mcp_server.cancellation import (
+    CancellationInterceptorMiddleware,
+    cancel,
+    register,
+    track_request,
+    unregister,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    """Ensure each test starts with an empty registry."""
+    cancellation._running.clear()
+    yield
+    cancellation._running.clear()
+
+
+@pytest.mark.asyncio
+async def test_register_then_cancel_aborts_the_task() -> None:
+    started = asyncio.Event()
+    done_inside_task = asyncio.Event()
+
+    async def runner():
+        started.set()
+        try:
+            await asyncio.Event().wait()  # block forever
+        except asyncio.CancelledError:
+            done_inside_task.set()
+            raise
+
+    task = asyncio.create_task(runner())
+    await started.wait()
+    await register('req-1', task)
+
+    assert await cancel('req-1') is True
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert done_inside_task.is_set()
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_false_when_no_task() -> None:
+    assert await cancel('does-not-exist') is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_false_when_task_already_done() -> None:
+    async def noop():
+        return 'ok'
+
+    task = asyncio.create_task(noop())
+    await task
+    await register('req-done', task)
+    assert await cancel('req-done') is False
+
+
+@pytest.mark.asyncio
+async def test_track_request_unregisters_on_normal_exit() -> None:
+    async def noop():
+        return None
+
+    task = asyncio.create_task(noop())
+    async with track_request('req-2', task):
+        assert 'req-2' in cancellation._running
+    assert 'req-2' not in cancellation._running
+    await task
+
+
+@pytest.mark.asyncio
+async def test_track_request_unregisters_on_exception() -> None:
+    async def noop():
+        return None
+
+    task = asyncio.create_task(noop())
+
+    async def raise_inside_context() -> None:
+        async with track_request('req-3', task):
+            raise ValueError('boom')
+
+    with pytest.raises(ValueError, match='boom'):
+        await raise_inside_context()
+    assert 'req-3' not in cancellation._running
+    await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('request_id', [42, '42', 'a-string-id'])
+async def test_register_normalises_int_and_str_ids(request_id) -> None:
+    async def noop():
+        return None
+
+    task = asyncio.create_task(noop())
+    try:
+        await register(request_id, task)
+        assert str(request_id) in cancellation._running
+        # Cancellation works whether caller passes the same form or its string version
+        await register(request_id, task)  # idempotent on re-register
+    finally:
+        await unregister(request_id)
+        await task
+
+
+async def _drive_middleware(body: bytes, *, path: str = '/mcp', method: str = 'POST') -> dict:
+    """Run the middleware against a single fake ASGI request and return what the
+    downstream app received (so we can assert the body was replayed unchanged)."""
+    received_chunks: list[dict] = []
+
+    async def downstream(scope, receive, send):
+        while True:
+            msg = await receive()
+            received_chunks.append(msg)
+            if msg.get('type') != 'http.request' or not msg.get('more_body', False):
+                break
+        await send({'type': 'http.response.start', 'status': 202, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b''})
+
+    scope = {'type': 'http', 'method': method, 'path': path}
+    chunks_to_send = [{'type': 'http.request', 'body': body, 'more_body': False}]
+    sent_iter = iter(chunks_to_send)
+
+    async def receive():
+        try:
+            return next(sent_iter)
+        except StopIteration:
+            return {'type': 'http.disconnect'}
+
+    async def send(_msg):
+        pass
+
+    middleware = CancellationInterceptorMiddleware(downstream)
+    await middleware(scope, receive, send)
+    return {'received_chunks': received_chunks}
+
+
+@pytest.mark.asyncio
+async def test_middleware_routes_cancel_notification_to_registry() -> None:
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+
+    async def runner():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled_flag.set()
+            raise
+
+    task = asyncio.create_task(runner())
+    await started.wait()  # ensure runner is inside the try block before cancelling
+    await register('req-mw', task)
+    try:
+        body = json.dumps(
+            {'jsonrpc': '2.0', 'method': 'notifications/cancelled', 'params': {'requestId': 'req-mw'}}
+        ).encode()
+        result = await _drive_middleware(body)
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert cancelled_flag.is_set()
+        # Body must have been replayed verbatim to the downstream app
+        replayed = b''.join(c.get('body', b'') for c in result['received_chunks'])
+        assert replayed == body
+    finally:
+        await unregister('req-mw')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'payload',
+    [
+        {'jsonrpc': '2.0', 'method': 'tools/call', 'id': 1, 'params': {}},  # unrelated request
+        {'jsonrpc': '2.0', 'method': 'notifications/progress', 'params': {'progressToken': 'x'}},  # non-cancel
+        {'jsonrpc': '2.0', 'method': 'notifications/cancelled', 'params': {}},  # missing requestId
+        {'jsonrpc': '2.0'},  # no method
+    ],
+    ids=['tools_call', 'progress_notification', 'cancel_without_request_id', 'no_method'],
+)
+async def test_middleware_passes_non_cancel_payloads_through(payload: dict) -> None:
+    async def runner():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+
+    task = asyncio.create_task(runner())
+    await register('untouched', task)
+    try:
+        body = json.dumps(payload).encode()
+        await _drive_middleware(body)
+        await asyncio.sleep(0)
+        assert not task.done()  # the unrelated task is still running
+    finally:
+        task.cancel()
+        await unregister('untouched')
+
+
+@pytest.mark.asyncio
+async def test_middleware_tolerates_garbage_body() -> None:
+    # No registered tasks; the middleware must not crash on malformed input.
+    await _drive_middleware(b'not json')
+    await _drive_middleware(b'')
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_non_mcp_paths() -> None:
+    async def runner():
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(runner())
+    await register('still-alive', task)
+    try:
+        # A cancel-shaped body, but on a different path — must not route to registry.
+        body = json.dumps({'method': 'notifications/cancelled', 'params': {'requestId': 'still-alive'}}).encode()
+        await _drive_middleware(body, path='/health')
+        await asyncio.sleep(0)
+        assert not task.done()
+    finally:
+        task.cancel()
+        await unregister('still-alive')

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import urlparse
 
@@ -129,3 +130,67 @@ async def test_workspace_creation_cleans_up_config_on_failure():
     mock_storage_client.configuration_delete.assert_called_once_with(
         WorkspaceManager.MCP_WORKSPACE_COMPONENT_ID, 'test-config-123'
     )
+
+
+def _make_cancel_test_workspace(*, cancel_job_side_effect=None) -> tuple[_SnowflakeWorkspace, AsyncMock, dict]:
+    """Build a `_SnowflakeWorkspace` whose `_qsclient` simulates a long-running query.
+
+    The mocked `get_job_status` returns ``running`` until `cancel_job` is invoked,
+    after which it returns ``canceled`` (mimicking Query Service confirming the cancel).
+    The ``state`` dict lets the caller inspect whether cancellation was issued.
+    """
+    workspace = _SnowflakeWorkspace(workspace_id=1, schema='test_schema', client=Mock(spec=KeboolaClient))
+    mock_qs = AsyncMock(spec=QueryServiceClient)
+    workspace._qsclient = mock_qs
+
+    mock_qs.submit_job.return_value = 'job-abc-123'
+
+    state = {'cancelled': False}
+
+    async def get_status(job_id: str):
+        return {'status': 'canceled' if state['cancelled'] else 'running'}
+
+    async def default_cancel(job_id: str, reason: str):
+        state['cancelled'] = True
+        return {}
+
+    mock_qs.get_job_status.side_effect = get_status
+    mock_qs.cancel_job.side_effect = cancel_job_side_effect or default_cancel
+    return workspace, mock_qs, state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('cancel_job_side_effect_factory', 'expect_cancel_call'),
+    [
+        (None, True),
+        (
+            lambda: HTTPStatusError(
+                'cancel failed',
+                request=Mock(spec=Request),
+                response=Mock(spec=Response, status_code=500, text='boom'),
+            ),
+            True,
+        ),
+    ],
+    ids=['backend_cancel_succeeds', 'backend_cancel_fails'],
+)
+async def test_execute_query_cancellation_propagates_to_backend(
+    cancel_job_side_effect_factory, expect_cancel_call: bool
+):
+    """Client cancellation (MCP `notifications/cancelled`) must trigger `cancel_job` on
+    the Snowflake side. If the backend cancel itself fails, the original CancelledError
+    must still propagate so the SDK can finalize the request cleanly."""
+    side_effect = cancel_job_side_effect_factory() if cancel_job_side_effect_factory else None
+    workspace, mock_qs, _state = _make_cancel_test_workspace(cancel_job_side_effect=side_effect)
+
+    task = asyncio.create_task(workspace.execute_query('SELECT 1'))
+    # Yield to let the task enter the poll loop and issue at least one get_job_status.
+    await asyncio.sleep(0.05)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    if expect_cancel_call:
+        mock_qs.cancel_job.assert_called_once_with('job-abc-123', reason='Client cancelled the request')

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -8,6 +8,7 @@ import pytest
 from mcp.server.fastmcp import Context
 from pydantic import TypeAdapter
 
+from keboola_mcp_server import cancellation
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
 from keboola_mcp_server.tools.sql import QueryDataOutput, _watch_for_http_disconnect, query_data
@@ -940,6 +941,48 @@ class TestQueryCancellation:
         result = await query_data('SELECT 1', 'test', mcp_context_client)
         assert isinstance(result, QueryDataOutput)
         assert result.csv_data == 'a\r\n1\r\n'
+
+    @pytest.mark.asyncio
+    async def test_query_data_registers_and_cancels_via_registry(self, mcp_context_client: Context, mocker) -> None:
+        """End-to-end stateless flow: query_data registers its task in the registry, an
+        external `cancel(request_id)` (as the middleware would do) aborts it, and the
+        workspace task receives CancelledError."""
+        cancellation._running.clear()
+        execute_query_cancelled = asyncio.Event()
+
+        async def long_running(*_a, **_kw):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                execute_query_cancelled.set()
+                raise
+
+        manager = AsyncMock(WorkspaceManager)
+        manager.execute_query.side_effect = long_running
+        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+        mcp_context_client.request_id = 'rpc-id-42'
+
+        # Pin the disconnect watcher off so this test exercises only the registry path.
+        mocker.patch(
+            'keboola_mcp_server.tools.sql.get_http_request',
+            side_effect=RuntimeError('No active HTTP request found.'),
+        )
+
+        task = asyncio.create_task(query_data('SELECT 1', 'cancel-test', mcp_context_client))
+        # Wait until query_data has registered the inner task.
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            if 'rpc-id-42' in cancellation._running:
+                break
+        assert 'rpc-id-42' in cancellation._running
+
+        assert await cancellation.cancel('rpc-id-42') is True
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert execute_query_cancelled.is_set()
+        # Registry must be cleaned up regardless of how query_data exited.
+        assert 'rpc-id-42' not in cancellation._running
 
     @pytest.mark.asyncio
     async def test_watch_for_http_disconnect_treats_errors_as_connected(self, mocker) -> None:

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, call
 
 import httpx
 import pytest
@@ -11,7 +11,7 @@ from pydantic import TypeAdapter
 from keboola_mcp_server import cancellation
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
-from keboola_mcp_server.tools.sql import QueryDataOutput, _watch_for_http_disconnect, query_data
+from keboola_mcp_server.tools.sql import QueryDataOutput, query_data
 from keboola_mcp_server.workspace import (
     QueryResult,
     SqlSelectData,
@@ -896,54 +896,7 @@ class TestQueryCancellation:
         qsclient.cancel_job.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_query_data_cancels_on_http_disconnect(self, mcp_context_client: Context, mocker) -> None:
-        """When the underlying HTTP request disconnects mid-flight, `query_data` must
-        cancel the workspace task so its CancelledError branch can fire `cancel_job`."""
-
-        # Workspace task that never completes — simulates a long-running query.
-        async def never_returns(*_a, **_kw):
-            await asyncio.Event().wait()
-
-        manager = AsyncMock(WorkspaceManager)
-        manager.execute_query.side_effect = never_returns
-        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
-
-        # Fake HTTP request: not disconnected for the first poll, then disconnected.
-        fake_request = MagicMock()
-        disconnect_states = iter([False, True])
-        fake_request.is_disconnected = AsyncMock(side_effect=lambda: next(disconnect_states))
-        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
-        # Speed the poll up so the test doesn't have to wait a full second.
-        mocker.patch('keboola_mcp_server.tools.sql._DISCONNECT_POLL_INTERVAL', 0.01)
-
-        with pytest.raises(asyncio.CancelledError):
-            await query_data('SELECT 1', 'test', mcp_context_client)
-
-        manager.execute_query.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_query_data_no_disconnect_watcher_in_stdio_mode(self, mcp_context_client: Context, mocker) -> None:
-        """When there is no HTTP request bound (stdio transport), the watcher must
-        block forever and the query must complete normally."""
-        manager = AsyncMock(WorkspaceManager)
-        manager.execute_query.return_value = QueryResult(
-            status='ok',
-            data=SqlSelectData(columns=['a'], rows=[{'a': 1}]),
-            message=None,
-        )
-        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
-
-        mocker.patch(
-            'keboola_mcp_server.tools.sql.get_http_request',
-            side_effect=RuntimeError('No active HTTP request found.'),
-        )
-
-        result = await query_data('SELECT 1', 'test', mcp_context_client)
-        assert isinstance(result, QueryDataOutput)
-        assert result.csv_data == 'a\r\n1\r\n'
-
-    @pytest.mark.asyncio
-    async def test_query_data_registers_and_cancels_via_registry(self, mcp_context_client: Context, mocker) -> None:
+    async def test_query_data_registers_and_cancels_via_registry(self, mcp_context_client: Context) -> None:
         """End-to-end stateless flow: query_data registers its task in the registry, an
         external `cancel(request_id)` (as the middleware would do) aborts it, and the
         workspace task receives CancelledError."""
@@ -962,12 +915,6 @@ class TestQueryCancellation:
         mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
         mcp_context_client.request_id = 'rpc-id-42'
 
-        # Pin the disconnect watcher off so this test exercises only the registry path.
-        mocker.patch(
-            'keboola_mcp_server.tools.sql.get_http_request',
-            side_effect=RuntimeError('No active HTTP request found.'),
-        )
-
         task = asyncio.create_task(query_data('SELECT 1', 'cancel-test', mcp_context_client))
         # Wait until query_data has registered the inner task.
         for _ in range(50):
@@ -983,17 +930,6 @@ class TestQueryCancellation:
         assert execute_query_cancelled.is_set()
         # Registry must be cleaned up regardless of how query_data exited.
         assert 'rpc-id-42' not in cancellation._running
-
-    @pytest.mark.asyncio
-    async def test_watch_for_http_disconnect_treats_errors_as_connected(self, mocker) -> None:
-        """A transient is_disconnected() failure must not be treated as a disconnect."""
-        fake_request = MagicMock()
-        # First call errors (still treated as connected); second call signals disconnect.
-        fake_request.is_disconnected = AsyncMock(side_effect=[RuntimeError('asgi hiccup'), True])
-        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
-
-        await asyncio.wait_for(_watch_for_http_disconnect(poll_interval=0.01), timeout=1.0)
-        assert fake_request.is_disconnected.await_count == 2
 
     @pytest.mark.asyncio
     async def test_query_completes_just_before_timeout(

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -1,6 +1,7 @@
+import asyncio
 import json
 from typing import Any
-from unittest.mock import call
+from unittest.mock import AsyncMock, MagicMock, call
 
 import httpx
 import pytest
@@ -9,7 +10,7 @@ from pydantic import TypeAdapter
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
-from keboola_mcp_server.tools.sql import QueryDataOutput, query_data
+from keboola_mcp_server.tools.sql import QueryDataOutput, _watch_for_http_disconnect, query_data
 from keboola_mcp_server.workspace import (
     QueryResult,
     SqlSelectData,
@@ -892,6 +893,64 @@ class TestQueryCancellation:
 
         # Verify cancellation was attempted
         qsclient.cancel_job.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_query_data_cancels_on_http_disconnect(self, mcp_context_client: Context, mocker) -> None:
+        """When the underlying HTTP request disconnects mid-flight, `query_data` must
+        cancel the workspace task so its CancelledError branch can fire `cancel_job`."""
+
+        # Workspace task that never completes — simulates a long-running query.
+        async def never_returns(*_a, **_kw):
+            await asyncio.Event().wait()
+
+        manager = AsyncMock(WorkspaceManager)
+        manager.execute_query.side_effect = never_returns
+        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+        # Fake HTTP request: not disconnected for the first poll, then disconnected.
+        fake_request = MagicMock()
+        disconnect_states = iter([False, True])
+        fake_request.is_disconnected = AsyncMock(side_effect=lambda: next(disconnect_states))
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
+        # Speed the poll up so the test doesn't have to wait a full second.
+        mocker.patch('keboola_mcp_server.tools.sql._DISCONNECT_POLL_INTERVAL', 0.01)
+
+        with pytest.raises(asyncio.CancelledError):
+            await query_data('SELECT 1', 'test', mcp_context_client)
+
+        manager.execute_query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_query_data_no_disconnect_watcher_in_stdio_mode(self, mcp_context_client: Context, mocker) -> None:
+        """When there is no HTTP request bound (stdio transport), the watcher must
+        block forever and the query must complete normally."""
+        manager = AsyncMock(WorkspaceManager)
+        manager.execute_query.return_value = QueryResult(
+            status='ok',
+            data=SqlSelectData(columns=['a'], rows=[{'a': 1}]),
+            message=None,
+        )
+        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+        mocker.patch(
+            'keboola_mcp_server.tools.sql.get_http_request',
+            side_effect=RuntimeError('No active HTTP request found.'),
+        )
+
+        result = await query_data('SELECT 1', 'test', mcp_context_client)
+        assert isinstance(result, QueryDataOutput)
+        assert result.csv_data == 'a\r\n1\r\n'
+
+    @pytest.mark.asyncio
+    async def test_watch_for_http_disconnect_treats_errors_as_connected(self, mocker) -> None:
+        """A transient is_disconnected() failure must not be treated as a disconnect."""
+        fake_request = MagicMock()
+        # First call errors (still treated as connected); second call signals disconnect.
+        fake_request.is_disconnected = AsyncMock(side_effect=[RuntimeError('asgi hiccup'), True])
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
+
+        await asyncio.wait_for(_watch_for_http_disconnect(poll_interval=0.01), timeout=1.0)
+        assert fake_request.is_disconnected.await_count == 2
 
     @pytest.mark.asyncio
     async def test_query_completes_just_before_timeout(

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.60.3"
+version = "1.60.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.60.5"
+version = "1.60.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.60.4"
+version = "1.60.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.60.2"
+version = "1.60.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3204](https://linear.app/keboola/issue/AI-3204/cancel-query-data-queries-when-chat-is-stopped)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Stopping Kai mid-conversation while a `query_data` tool call was in flight did not cancel the underlying SQL query — a reported incident had Kai start a ~400 GB Snowflake scan that could only be killed via the Query Service API directly.

This PR adds three layers so a client-initiated cancel actually kills the running Snowflake job. The first two are necessary but not sufficient on their own; the third (the side-channel registry) is what closes the loop in our current stateless deployment.

**1. Cancel the Snowflake job when the tool task receives `CancelledError`** — `src/keboola_mcp_server/workspace.py`

`_SnowflakeWorkspace.execute_query` now wraps the job-polling loop in `try` / `except asyncio.CancelledError`. On cancellation we invoke the existing `_cancel_job_with_timeout` helper inside `asyncio.shield(...)`, so the Query Service `cancel_job` HTTP call completes even though our own task is being torn down. The original `CancelledError` is then re-raised so the SDK can finalize the request cleanly. This reuses the same backend cancel pathway already used by the internal 300 s timeout — only the trigger is new.

**2. Process-wide cancellation registry** — new module `src/keboola_mcp_server/cancellation.py`

In stateless streamable-HTTP mode (`stateless_http=True` in `cli.py`) every incoming MCP request creates a fresh transport with its own session, so the MCP SDK's built-in cancellation routing (`mcp/shared/session.py`'s `_in_flight` dict) cannot route `notifications/cancelled` to the in-flight tool call — the cancel notification arrives on a different transport instance. This module bridges that gap with a side-channel: tools register their `asyncio.Task` here keyed by JSON-RPC request id, and `cancel(request_id)` aborts the registered task.

A bounded `_pending_cancels` set handles the race where a cancel arrives before its matching `register()` (e.g. between the SDK dispatching the `tools/call` and the tool coroutine reaching the registry): the intent is recorded and consumed by the next matching `register()`, which cancels the task immediately.

Scope: in-memory, single process. Cross-replica cancellation without sticky sessions will require a shared store (planned: Postgres). The function signatures are designed to make that swap non-breaking.

**3. ASGI middleware that intercepts cancel notifications** — `CancellationInterceptorMiddleware` (in the same module), installed in `src/keboola_mcp_server/cli.py`

Peeks at the first chunk of every `POST /mcp` body. If it is a single-chunk body under `_MAX_INSPECT_BYTES` and contains the literal substring `notifications/cancelled`, the middleware parses it as JSON and routes `params.requestId` to the registry's `cancel()`. The body is not buffered into memory: only the first chunk is captured for the substring/JSON check, and the original `receive` callable is passed through to the downstream app so large `tools/call` payloads stream straight through.

**`query_data`** (`src/keboola_mcp_server/tools/sql.py`) now creates the workspace call as a separate task, registers it in the registry via `track_request(request_id, query_task)`, and `await`s it. If our own coroutine is cancelled mid-await, the inner task is cancelled too so the Snowflake-cancel path in `execute_query` fires regardless of which cancellation signal triggered it.

**BigQuery is not covered by this PR.** The SAPI `workspace_query` endpoint is a synchronous proxy that does not expose a job handle, so the server has nothing to address a cancel against. This is documented in the BigQuery branch with a `# Note on cancellation` block; cancelling BigQuery requires SAPI changes and will be tracked separately.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

**Unit tests added** — full `tox` passes (72 tests):

- `tests/test_workspace.py` — `task.cancel()` invokes `cancel_job` with the right `job_id` and reason; the original `CancelledError` still propagates when `cancel_job` itself raises `HTTPStatusError`.
- `tests/test_cancellation.py` — registry register/cancel/unregister, the cancel-before-register race fix, bounded `_pending_cancels`, the middleware routing a cancel notification through the registry, replay of the body verbatim to downstream, cheap-substring short-circuit skips `json.loads`, multi-chunk and oversized bodies skip inspection.
- `tests/tools/test_sql.py` — end-to-end stateless flow: `query_data` registers its task, an external `cancel(request_id)` (as the middleware would issue) aborts it, the workspace task receives `CancelledError`, and the registry is cleaned up.

End-to-end verification against a real Snowflake workspace is recommended before merging: start a deliberately heavy query, hit stop in the client, and confirm the Query Service job transitions to `canceled` within ~30 s.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)