### PR TITLE
AI-3216: Fix get_flows validation errors on unknown variants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.61.1"
+version = "1.61.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/resources/conditional-flow-schema.json
+++ b/src/keboola_mcp_server/resources/conditional-flow-schema.json
@@ -392,8 +392,7 @@
         },
         "function": {
           "type": "string",
-          "enum": ["COUNT", "DATE"],
-          "description": "Function type: 'COUNT' (counts elements in array, requires 1 operand), 'DATE' (formats current date/time using PHP DateTime::format, requires 1 operand with format string)"
+          "description": "Function name. Supported values: 'COUNT' (returns the number of elements in its single array operand) and 'DATE' (returns the current date/time formatted via PHP DateTime::format; takes one operand that resolves to a format string such as 'Y', 'm', 'd', 'H', 'i', 's', or 'U'). The enum is intentionally omitted so unknown server-side values do not break flow listing; only the two values above are accepted at execution time."
         },
         "operands": {
           "type": "array",

--- a/src/keboola_mcp_server/tools/flow/model.py
+++ b/src/keboola_mcp_server/tools/flow/model.py
@@ -2,16 +2,19 @@
 Flow models for Keboola MCP server.
 """
 
+import logging
 from datetime import datetime
-from typing import Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, ValidationError
 
 from keboola_mcp_server.clients.client import ORCHESTRATOR_COMPONENT_ID, FlowType, get_metadata_property
 from keboola_mcp_server.clients.storage import APIFlowResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.flow.scheduler_model import SchedulesOutput
+
+LOG = logging.getLogger(__name__)
 
 # =============================================================================
 # RESPONSE MODELS
@@ -205,7 +208,15 @@ class FunctionCondition(BaseModel):
     """Function-based condition."""
 
     type: Literal['function'] = Field(description='Condition type')
-    function: Literal['COUNT', 'DATE'] = Field(description='Function type')
+    function: str = Field(
+        description=(
+            "Function name. Supported values: 'COUNT' (returns the number of elements in its single "
+            "array operand) and 'DATE' (returns the current date/time formatted via PHP "
+            "DateTime::format; takes one operand that resolves to a format string such as 'Y', 'm', "
+            "'d', 'H', 'i', 's', or 'U'). Typed as str rather than Literal so unknown server-side "
+            'values do not break flow listing; only the two values above are accepted at execution time.'
+        )
+    )
     operands: list['VariableSourceObject'] = Field(description='List of operand conditions')
 
 
@@ -262,9 +273,12 @@ class NotificationTaskConfiguration(BaseModel):
     message: Optional[str] = Field(default=None, description='Notification message')
 
 
-# Variable source object (limited subset of conditions)
-VariableSourceObject = Union[
-    ConstantCondition, PhaseCondition, TaskCondition, VariableCondition, FunctionCondition, ArrayCondition
+# Variable source object (limited subset of conditions). Each member has a unique `type`
+# literal, so we discriminate on it: pydantic dispatches directly to the matching model and
+# reports one targeted error instead of trying every member and producing a cascade.
+VariableSourceObject = Annotated[
+    Union[ConstantCondition, PhaseCondition, TaskCondition, VariableCondition, FunctionCondition, ArrayCondition],
+    Field(discriminator='type'),
 ]
 
 
@@ -277,7 +291,10 @@ class VariableTaskConfiguration(BaseModel):
     source: Optional[VariableSourceObject] = Field(default=None, description='Variable source')
 
 
-TaskConfiguration = Union[JobTaskConfiguration, NotificationTaskConfiguration, VariableTaskConfiguration]
+TaskConfiguration = Annotated[
+    Union[JobTaskConfiguration, NotificationTaskConfiguration, VariableTaskConfiguration],
+    Field(discriminator='type'),
+]
 
 
 # =============================================================================
@@ -340,6 +357,31 @@ class ConditionalFlowConfiguration(BaseModel):
     tasks: list[ConditionalFlowTask] = Field(description='List of tasks in the flow')
 
 
+_T = Union[ConditionalFlowPhase, ConditionalFlowTask]
+
+
+def _safe_validate(model_cls: type[_T], raw: dict[str, Any], flow_id: str, kind: str) -> _T:
+    """Validate a flow element; on failure log and fall back to ``model_construct``.
+
+    The READ path (``get_flows``) must keep returning data even when the backend ships a task
+    or phase shape the schema hasn't caught up to — silently dropping items would hide flows
+    from the agent. ``model_construct`` skips validation, so unknown variants pass through as
+    raw dicts on the typed field; this is safe for display/serialization but is intentionally
+    NOT used on the WRITE paths (``utils.get_flow_configuration``), which must remain strict.
+    """
+    try:
+        return model_cls.model_validate(raw)
+    except ValidationError as exc:
+        LOG.warning(
+            'Flow %s: %s %r failed strict validation, falling back to permissive parse: %s',
+            flow_id,
+            kind,
+            raw.get('id'),
+            exc,
+        )
+        return model_cls.model_construct(**raw)
+
+
 # =============================================================================
 # DOMAIN MODELS
 # =============================================================================
@@ -391,8 +433,14 @@ class Flow(BaseModel):
             tasks = [FlowTask.model_validate(t) for t in api_config.configuration.get('tasks', [])]
             config = FlowConfiguration(phases=phases, tasks=tasks)
         else:
-            phases = [ConditionalFlowPhase.model_validate(p) for p in api_config.configuration.get('phases', [])]
-            tasks = [ConditionalFlowTask.model_validate(p) for p in api_config.configuration.get('tasks', [])]
+            phases = [
+                _safe_validate(ConditionalFlowPhase, p, api_config.configuration_id, 'phase')
+                for p in api_config.configuration.get('phases', [])
+            ]
+            tasks = [
+                _safe_validate(ConditionalFlowTask, p, api_config.configuration_id, 'task')
+                for p in api_config.configuration.get('tasks', [])
+            ]
             config = ConditionalFlowConfiguration(phases=phases, tasks=tasks)
 
         return cls.model_construct(

--- a/tests/tools/flow/test_model.py
+++ b/tests/tools/flow/test_model.py
@@ -1,15 +1,23 @@
 from typing import Any
 
-from keboola_mcp_server.clients.client import ORCHESTRATOR_COMPONENT_ID
+import pytest
+from pydantic import ValidationError
+
+from keboola_mcp_server.clients.client import CONDITIONAL_FLOW_COMPONENT_ID, ORCHESTRATOR_COMPONENT_ID
 from keboola_mcp_server.clients.storage import APIFlowResponse
 from keboola_mcp_server.tools.flow.model import (
+    ConditionalFlowConfiguration,
     ConditionalFlowPhase,
+    ConditionalFlowTask,
     ConditionalFlowTransition,
     Flow,
     FlowConfiguration,
     FlowPhase,
     FlowSummary,
     FlowTask,
+    FunctionCondition,
+    JobTaskConfiguration,
+    VariableTaskConfiguration,
 )
 
 # --- Test Model Parsing ---
@@ -142,3 +150,133 @@ class TestConditionalFlowPhase:
         assert len(serialized_excluding_unset['next']) == 2
         assert serialized_excluding_unset['next'][0]['goto'] == 'phase-2'
         assert serialized_excluding_unset['next'][1]['goto'] is None
+
+
+class TestConditionalFlowValidationResilience:
+    """Regression tests for AI-3216 — `get_flows` should not crash on unknown variants.
+
+    The bug: a real conditional flow on stack `com-keboola-gcp-europe-west3` contained a
+    `variable` task whose `source.function` was `'YEAR'`. The strict `Literal['COUNT','DATE']`
+    on `FunctionCondition.function` failed, and the undiscriminated `TaskConfiguration` union
+    surfaced 18 cascading validation errors that aborted the entire `get_flows` response.
+    """
+
+    @pytest.mark.parametrize('function_name', ['COUNT', 'DATE', 'YEAR', 'MONTH', 'DAY_OF_WEEK'])
+    def test_function_condition_accepts_arbitrary_function_names(self, function_name: str):
+        """The `function` field is now permissive — the backend evolves independently of MCP."""
+        cond = FunctionCondition.model_validate(
+            {'type': 'function', 'function': function_name, 'operands': [{'type': 'const', 'value': 'U'}]}
+        )
+        assert cond.function == function_name
+
+    def test_variable_task_with_year_function_no_longer_raises(self):
+        """The exact shape from the Datadog alert in AI-3216 must parse without raising."""
+        raw_task = {
+            'id': 'task-1',
+            'name': 'compute year',
+            'phase': 'phase-1',
+            'task': {
+                'type': 'variable',
+                'name': 'current_year',
+                'source': {
+                    'type': 'function',
+                    'function': 'YEAR',
+                    'operands': [{'type': 'const', 'value': 'U'}],
+                },
+            },
+        }
+        task = ConditionalFlowTask.model_validate(raw_task)
+        assert isinstance(task.task, VariableTaskConfiguration)
+        assert isinstance(task.task.source, FunctionCondition)
+        assert task.task.source.function == 'YEAR'
+
+    def test_task_configuration_uses_discriminator(self):
+        """Discriminator on `type` collapses the 18-error cascade to a single targeted error.
+
+        Pre-fix: pydantic tried Job/Notification/Variable in turn and reported every literal
+        mismatch — 18 errors for one bad source value. Post-fix: pydantic dispatches by `type`,
+        so a `variable` task only triggers `VariableTaskConfiguration` validation.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            ConditionalFlowTask.model_validate(
+                {
+                    'id': 'task-1',
+                    'name': 'broken',
+                    'phase': 'phase-1',
+                    'task': {'type': 'variable'},  # missing required `name`
+                }
+            )
+        errors = exc_info.value.errors()
+        # All errors should be scoped to the matched variant only.
+        assert all('VariableTaskConfiguration' in str(e.get('loc', ())) or e['loc'][-1] == 'name' for e in errors)
+        # Confirm no cascading errors about Job/Notification literals.
+        assert not any('JobTaskConfiguration' in str(e.get('loc', ())) for e in errors)
+        assert not any('NotificationTaskConfiguration' in str(e.get('loc', ())) for e in errors)
+
+    def test_unknown_task_type_falls_back_in_read_path(self, caplog: pytest.LogCaptureFixture):
+        """`Flow.from_api_response` must keep returning the flow even when a task type is unknown.
+
+        Pre-fix: one unknown task type took down the entire `get_flows` response. Post-fix:
+        `_safe_validate` logs and falls back to `model_construct` for that task while keeping
+        the rest of the flow intact.
+        """
+        raw = {
+            'id': '99',
+            'name': 'Flow with unknown task variant',
+            'description': '',
+            'version': 1,
+            'isDisabled': False,
+            'isDeleted': False,
+            'configuration': {
+                'phases': [{'id': 'p1', 'name': 'Phase 1', 'next': [{'id': 't1', 'goto': None}]}],
+                'tasks': [
+                    {
+                        'id': 'task-good',
+                        'name': 'good',
+                        'phase': 'p1',
+                        'task': {'type': 'job', 'componentId': 'keboola.ex-aws-s3', 'mode': 'run'},
+                    },
+                    {
+                        'id': 'task-bad',
+                        'name': 'bad',
+                        'phase': 'p1',
+                        'task': {'type': 'unknown-future-variant', 'foo': 'bar'},
+                    },
+                ],
+            },
+            'metadata': [],
+            'created': '2026-01-01T00:00:00+0000',
+        }
+        api_model = APIFlowResponse.model_validate(raw)
+        with caplog.at_level('WARNING'):
+            flow = Flow.from_api_response(api_config=api_model, flow_component_id=CONDITIONAL_FLOW_COMPONENT_ID)
+
+        assert isinstance(flow.configuration, ConditionalFlowConfiguration)
+        assert len(flow.configuration.tasks) == 2
+        good, bad = flow.configuration.tasks
+        assert isinstance(good.task, JobTaskConfiguration)
+        # Bad task survives as raw passthrough; agent still sees the entry instead of nothing.
+        assert bad.id == 'task-bad'
+        assert any('failed strict validation' in m for m in caplog.messages)
+
+    def test_unknown_task_type_still_strict_in_write_path(self):
+        """Write paths (`utils.get_flow_configuration`) must remain strict to reject agent garbage.
+
+        The fallback is intentionally scoped to `Flow.from_api_response` (the READ path). Agents
+        constructing flows should still get loud failures so they can correct themselves.
+        """
+        from keboola_mcp_server.tools.flow.utils import get_flow_configuration
+
+        with pytest.raises(ValidationError):
+            get_flow_configuration(
+                phases=[{'id': 'p1', 'name': 'Phase 1', 'next': [{'id': 't1', 'goto': None}]}],
+                tasks=[
+                    {
+                        'id': 'task-bad',
+                        'name': 'bad',
+                        'phase': 'p1',
+                        'task': {'type': 'unknown-future-variant'},
+                    }
+                ],
+                flow_type=CONDITIONAL_FLOW_COMPONENT_ID,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.61.1"
+version = "1.61.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3216](https://linear.app/keboola/issue/AI-3216/fix-mcp-flow-validation-errors-in-get-flows)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`get_flows` is failing on stack `com-keboola-gcp-europe-west3` with **18 pydantic validation errors** for a single `ConditionalFlowTask`. The errors all originate from one real mismatch — the rest are cascading noise from a non-discriminated `Union`.

#### Root cause

For a flow task with shape:

```jsonc
{
  "type": "variable",
  "name": "...",
  "source": {
    "type": "function",
    "function": "YEAR",        // <-- not in our Literal['COUNT', 'DATE']
    "operands": [{ "type": "const", "value": "U" }]
  }
}
```

1. `FunctionCondition.function` is declared `Literal['COUNT', 'DATE']` in `src/keboola_mcp_server/tools/flow/model.py:208`. The actual backend produces `YEAR` (and likely other PHP `DateTime::format`-style tokens). The bundled `conditional-flow-schema.json` also enums only `COUNT`/`DATE`, so the schema/backend are out of sync.
2. `TaskConfiguration = Union[JobTaskConfiguration, NotificationTaskConfiguration, VariableTaskConfiguration]` (model.py:280) has **no discriminator**. When the inner `VariableTaskConfiguration` fails (because of #1), pydantic also tries `Job` and `Notification`, producing 12 noisy literal/missing-field errors that hide the real problem.
3. `Flow.from_api_response` (model.py:394-396) validates every task via `ConditionalFlowTask.model_validate(...)`. A single bad task in a single flow takes down the **entire `get_flows` response** (`unwrap_results` re-raises).

#### Proposed fix (incremental, low-risk)

| Step | Change | Why |
|------|--------|-----|
| A | Relax `FunctionCondition.function` from `Literal['COUNT', 'DATE']` to `str` (and update the JSON schema enum or drop it) | The comment at model.py:106-107 already says these models will be replaced by AI-service-fetched schema. Until then, the MCP shouldn't be stricter than the backend. |
| B | Make `TaskConfiguration` a **discriminated union** on `type` via `Annotated[Union[...], Field(discriminator='type')]`. Same for `ConditionObject` and `VariableSourceObject`. | Collapses cascading 18-error reports into one targeted error; clear "unknown task type" when a new variant lands. |
| C | In `Flow.from_api_response`, **catch `ValidationError` per task/phase** and log a warning, keeping the flow returnable with skipped/raw-passthrough tasks. | One malformed flow today nukes `get_flows` for the whole project. The MCP server's job is to display flows, not gatekeep them. |
| D | Add parametrized tests in `tests/tools/flow/test_tools.py` covering: `YEAR` function value, unknown task `type`, malformed-task-tolerant `get_flows`. | Locks in resilience; prevents future regression of the cascade. |

#### Out of scope

- Confirming the full canonical list of `function` values (`YEAR`, `MONTH`, `DAY`, `HOUR`, ...) — that's a follow-up for the AI-service schema endpoint mentioned in the model comment.
- Reworking `get_flow_schema` output (this PR only relaxes runtime parsing, not the schema we hand back to agents).

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)

## Checklist

- [ ] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (1.61.0 -> 1.61.1)
- [ ] Documentation updated (if applicable)