### PR TITLE
fix: use OAuth bearer token for MetastoreClient when available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.61.0"
+version = "1.61.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/client.py
+++ b/src/keboola_mcp_server/clients/client.py
@@ -200,7 +200,7 @@ class KeboolaClient:
         )
         self._metastore_client = MetastoreClient.create(
             root_url=metastore_api_url,
-            token=self._token,
+            token=bearer_or_sapi_token,
             branch_id=branch_id,
             headers=self._headers,
             readonly=readonly,

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -451,6 +451,36 @@ class TestKeboolaClient:
         assert client.metastore_client.raw_client.base_api_url == 'https://metastore.canary-orion.keboola.dev'
         assert client.metastore_client.raw_client.headers['X-StorageAPI-Token'] == 'sapi_token_456'
 
+    @pytest.mark.parametrize(
+        ('bearer_token', 'storage_token', 'expected_metastore_token'),
+        [
+            ('oauth_bearer_123', 'sapi_token_456', 'Bearer oauth_bearer_123'),
+            (None, 'sapi_token_456', 'sapi_token_456'),
+            ('', 'sapi_token_456', 'sapi_token_456'),
+        ],
+        ids=['with_bearer_token', 'without_bearer_token', 'empty_bearer_token'],
+    )
+    def test_metastore_client_token_selection(
+        self, bearer_token: str | None, storage_token: str, expected_metastore_token: str
+    ):
+        """Test MetastoreClient uses bearer token when available, falls back to storage token."""
+        client = KeboolaClient(
+            storage_api_url='https://connection.keboola.com',
+            storage_api_token=storage_token,
+            bearer_token=bearer_token,
+        )
+
+        metastore_headers = client.metastore_client.raw_client.headers
+
+        if expected_metastore_token.startswith('Bearer '):
+            assert 'Authorization' in metastore_headers
+            assert metastore_headers['Authorization'] == expected_metastore_token
+            assert 'X-StorageAPI-Token' not in metastore_headers
+        else:
+            assert 'X-StorageAPI-Token' in metastore_headers
+            assert metastore_headers['X-StorageAPI-Token'] == expected_metastore_token
+            assert 'Authorization' not in metastore_headers
+
 
 @pytest.mark.parametrize(
     ('metadata', 'key', 'provider', 'preferred_providers', 'default', 'expected'),

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.61.0"
+version = "1.61.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: AI-3217

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Now that Metastore supports OAuth (AI-3212), the MCP server should pass the OAuth bearer token to `MetastoreClient` when available.

Previously, `MetastoreClient` was always initialized with `self._token` (the storage API token), which causes 401 errors in OAuth scenarios because the OAuth-generated sapi_token lacks project scope.

This PR updates `MetastoreClient.create()` to use `bearer_or_sapi_token` — the same variable already used by `AsyncStorageClient` and `SchedulerClient`. When an OAuth bearer token is present, it sends `Bearer <token>`; otherwise it falls back to the storage API token.

A parametrized unit test (`test_metastore_client_token_selection`) was added covering bearer, `None`, and empty-string token cases, matching the existing `test_scheduler_client_token_selection` pattern.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)

## Release Notes
**Justification, description**

Fix 401 errors when using OAuth authentication with MetastoreClient by passing the OAuth bearer token instead of the storage API token.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk — aligns MetastoreClient token handling with the existing pattern used by StorageClient and SchedulerClient. Falls back to storage API token when no bearer token is present, so non-OAuth flows are unaffected.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/1585aae991694a76a233b4ade0515197
Requested by: @davidesner