### PR TITLE
chore: add CODEOWNERS for ai-swimlane-kai-assistant team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @keboola/ai-swimlane-kai-assistant


### PR DESCRIPTION
## Description

**Linear**: N/A (chore — no Linear issue)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Adds a `.github/CODEOWNERS` file assigning `@keboola/ai-swimlane-kai-assistant` as the default code owner for all files in the repository. This ensures the team is automatically requested for review on every PR.

Also bumps `pyproject.toml` to `1.61.4` per project versioning policy and updates `uv.lock`.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

N/A — repo configuration only, no code changes.

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)