### PR TITLE
AI-3204: surface Snowflake job_id to MCP clients via progress notification

### DIFF
--- a/integtests/conftest.py
+++ b/integtests/conftest.py
@@ -536,6 +536,10 @@ def mcp_context(
     client_context.session_id = None
     client_context.request_context = mocker.MagicMock(RequestContext)
     client_context.request_context.lifespan_context = ServerState(mcp_config, ServerRuntimeInfo(transport='stdio'))
+    # `meta` is an instance attribute of RequestContext (set in __init__), not a class attribute,
+    # so MagicMock(spec=RequestContext) doesn't expose it. Default it to None so tools that read
+    # the progressToken (e.g. query_data) don't trip AttributeError; individual tests can override.
+    client_context.request_context.meta = None
 
     return client_context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.67.1"
+version = "1.67.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/query.py
+++ b/src/keboola_mcp_server/clients/query.py
@@ -97,6 +97,17 @@ class QueryServiceClient(KeboolaServiceClient):
         payload: JsonDict = {'reason': reason}
         return cast(JsonDict, await self.post(endpoint=f'queries/{job_id}/cancel', data=payload))
 
+    def build_cancel_url(self, job_id: str) -> str:
+        """
+        Returns the absolute URL clients should POST to in order to cancel the given query job.
+
+        Used to surface the cancellation handle to MCP clients via a progress notification so
+        that they can cancel the query directly against Query Service without routing through
+        the originating MCP server replica. The endpoint accepts the same auth header the client
+        already uses to talk to the MCP server (`X-StorageAPI-Token` or `Authorization: Bearer`).
+        """
+        return f'{self.raw_client.base_api_url}/queries/{job_id}/cancel'
+
     async def get_job_results(
         self, job_id: str, statement_id: str, *, offset: int | None = None, limit: int | None = None
     ) -> JsonDict:

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -5,7 +5,13 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
-from mcp.types import ProgressNotification, ProgressNotificationParams, ProgressToken, ToolAnnotations
+from mcp.types import (
+    ProgressNotification,
+    ProgressNotificationParams,
+    ProgressToken,
+    ServerNotification,
+    ToolAnnotations,
+)
 from pydantic import BaseModel, Field
 
 from keboola_mcp_server.errors import tool_errors
@@ -35,6 +41,15 @@ async def _emit_job_submitted_progress(ctx: Context, progress_token: ProgressTok
     """Surfaces the backend job handle to the client so it can cancel out-of-band by POSTing to
     `info.cancellation_url`. The structured data lives under `params._meta`; the human-readable
     `message` is for clients that surface progress as text only and ignore `_meta`.
+
+    We deliberately call the low-level `ctx.session.send_notification(...)` with
+    `related_request_id=ctx.request_id` instead of FastMCP's high-level `ctx.send_notification(...)`.
+    The MCP SDK's streamable_http message router (`mcp/server/streamable_http.py`, the
+    "Extract related_request_id from meta" branch) uses that field to pick which request's SSE
+    response stream receives the notification. Without it, notifications are addressed to
+    `GET_STREAM_KEY`, the standalone GET stream — which doesn't exist in `stateless_http=True`
+    mode (our deployment shape), so the notification is silently dropped and the client never
+    sees the job handle. `ctx.send_notification(...)` does NOT set this field, hence the bypass.
     """
     params = ProgressNotificationParams.model_validate(
         {
@@ -50,7 +65,23 @@ async def _emit_job_submitted_progress(ctx: Context, progress_token: ProgressTok
             },
         }
     )
-    await ctx.send_notification(ProgressNotification(method='notifications/progress', params=params))
+    notification = ProgressNotification(method='notifications/progress', params=params)
+    request_id = getattr(ctx, 'request_id', None)
+    if request_id is None:
+        # Without a request id we cannot route the notification — see the docstring above for why.
+        # Sending with `related_request_id=None` reproduces the bug we built this fix to prevent
+        # (silent drop onto GET_STREAM_KEY in stateless mode). Skip the emit and warn instead so
+        # the failure mode is at least visible in the logs; the query itself continues normally.
+        LOG.warning(
+            f'Skipping notifications/progress for job_id={info.job_id}: ctx.request_id is None — '
+            f'cannot route to originating SSE stream. Out-of-band cancellation will be unavailable.'
+        )
+        return
+    await ctx.session.send_notification(ServerNotification(notification), related_request_id=request_id)
+    LOG.info(
+        f'Emitted notifications/progress for job_id={info.job_id} '
+        f'related_request_id={request_id!r} backend={info.backend}'
+    )
 
 
 class QueryDataOutput(BaseModel):
@@ -159,4 +190,9 @@ async def query_data(
         return QueryDataOutput(query_name=query_name, csv_data=output.getvalue(), message=result.message)
 
     else:
+        # Surface cancellation cleanly: the workspace already produced a precise message
+        # ("Query was cancelled") for the cancel-by-client case, so don't wrap it in a
+        # generic "Failed to run SQL query, error: ..." prefix that hides what happened.
+        if result.message == 'Query was cancelled':
+            raise ValueError('Query was cancelled')
         raise ValueError(f'Failed to run SQL query, error: {result.message}')

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -5,17 +5,52 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import FunctionTool
-from mcp.types import ToolAnnotations
+from mcp.types import ProgressNotification, ProgressNotificationParams, ProgressToken, ToolAnnotations
 from pydantic import BaseModel, Field
 
 from keboola_mcp_server.errors import tool_errors
-from keboola_mcp_server.workspace import SqlSelectData, WorkspaceManager
+from keboola_mcp_server.workspace import JobSubmittedInfo, SqlSelectData, WorkspaceManager
 
 LOG = logging.getLogger(__name__)
 
 SQL_TOOLS_TAG = 'sql'
 MAX_ROWS = 1_000
 MAX_CHARS = 50_000
+
+
+def _client_progress_token(ctx: Context) -> ProgressToken | None:
+    """Returns the progress token the client included in the original `tools/call`, or None.
+
+    Per MCP spec, a server may only send `notifications/progress` for a request when the client
+    explicitly provided a `progressToken` in that request's `_meta`. Tools that fall through here
+    without a token must stay silent — emitting unsolicited progress can confuse strict clients.
+    """
+    rc = ctx.request_context
+    if rc is None or rc.meta is None:
+        return None
+    return rc.meta.progressToken
+
+
+async def _emit_job_submitted_progress(ctx: Context, progress_token: ProgressToken, info: JobSubmittedInfo) -> None:
+    """Surfaces the backend job handle to the client so it can cancel out-of-band by POSTing to
+    `info.cancellation_url`. The structured data lives under `params._meta`; the human-readable
+    `message` is for clients that surface progress as text only and ignore `_meta`.
+    """
+    params = ProgressNotificationParams.model_validate(
+        {
+            'progressToken': progress_token,
+            'progress': 0,
+            'message': f'Submitted to {info.backend}',
+            '_meta': {
+                'keboola.queryJobId': info.job_id,
+                'keboola.backend': info.backend,
+                # `cancellation_url` may be None when a backend does not expose an out-of-band
+                # cancel endpoint; clients should treat the field as optional.
+                'keboola.cancellationUrl': info.cancellation_url,
+            },
+        }
+    )
+    await ctx.send_notification(ProgressNotification(method='notifications/progress', params=params))
 
 
 class QueryDataOutput(BaseModel):
@@ -95,7 +130,18 @@ async def query_data(
     * Ensure valid filtering by checking actual data values first
     """
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
-    result = await workspace_manager.execute_query(sql_query, max_rows=MAX_ROWS, max_chars=MAX_CHARS)
+
+    progress_token = _client_progress_token(ctx)
+
+    async def _on_job_submitted(info: JobSubmittedInfo) -> None:
+        await _emit_job_submitted_progress(ctx, progress_token, info)
+
+    result = await workspace_manager.execute_query(
+        sql_query,
+        max_rows=MAX_ROWS,
+        max_chars=MAX_CHARS,
+        on_job_submitted=_on_job_submitted if progress_token is not None else None,
+    )
     LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
     if result.is_ok:
         if result.data:

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -34,7 +34,10 @@ def _client_progress_token(ctx: Context) -> ProgressToken | None:
     rc = ctx.request_context
     if rc is None or rc.meta is None:
         return None
-    return rc.meta.progressToken
+    # The MCP spec allows `_meta` to omit `progressToken`. The typed `RequestParams.Meta`
+    # always carries the attribute (default None), but transports that surface `_meta` as a
+    # plain mapping would not — so look it up defensively rather than assume the attribute.
+    return getattr(rc.meta, 'progressToken', None)
 
 
 async def _emit_job_submitted_progress(ctx: Context, progress_token: ProgressToken, info: JobSubmittedInfo) -> None:
@@ -66,14 +69,19 @@ async def _emit_job_submitted_progress(ctx: Context, progress_token: ProgressTok
         }
     )
     notification = ProgressNotification(method='notifications/progress', params=params)
-    request_id = getattr(ctx, 'request_id', None)
+    # `ctx.request_id` is a property that RAISES RuntimeError when `request_context` is None —
+    # `getattr(ctx, 'request_id', None)` would NOT catch that (its default only suppresses
+    # AttributeError). Read the request id off `request_context` directly so a missing context
+    # yields None and we hit the graceful-skip branch below instead of raising.
+    rc = ctx.request_context
+    request_id = str(rc.request_id) if rc is not None and rc.request_id is not None else None
     if request_id is None:
         # Without a request id we cannot route the notification — see the docstring above for why.
         # Sending with `related_request_id=None` reproduces the bug we built this fix to prevent
         # (silent drop onto GET_STREAM_KEY in stateless mode). Skip the emit and warn instead so
         # the failure mode is at least visible in the logs; the query itself continues normally.
         LOG.warning(
-            f'Skipping notifications/progress for job_id={info.job_id}: ctx.request_id is None — '
+            f'Skipping notifications/progress for job_id={info.job_id}: request id is unavailable — '
             f'cannot route to originating SSE stream. Out-of-band cancellation will be unavailable.'
         )
         return
@@ -173,8 +181,8 @@ async def query_data(
         max_chars=MAX_CHARS,
         on_job_submitted=_on_job_submitted if progress_token is not None else None,
     )
-    LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
     if result.is_ok:
+        LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
         if result.data:
             data = result.data
         else:
@@ -193,6 +201,9 @@ async def query_data(
         # Surface cancellation cleanly: the workspace already produced a precise message
         # ("Query was cancelled") for the cancel-by-client case, so don't wrap it in a
         # generic "Failed to run SQL query, error: ..." prefix that hides what happened.
+        # A client-initiated cancel is expected, so log it at INFO; genuine failures at WARNING.
         if result.message == 'Query was cancelled':
+            LOG.info(f'Query "{query_name}" was cancelled.')
             raise ValueError('Query was cancelled')
+        LOG.warning(' '.join(filter(None, [f'Query "{query_name}" failed.', result.message])))
         raise ValueError(f'Failed to run SQL query, error: {result.message}')

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -5,7 +5,7 @@ import logging
 import re
 import time
 import uuid
-from typing import Any, Literal, Mapping, Sequence, cast
+from typing import Any, Awaitable, Callable, Literal, Mapping, Sequence, cast
 from urllib.parse import urlunparse
 
 from httpx import HTTPStatusError
@@ -18,6 +18,27 @@ from keboola_mcp_server.clients.query import QueryServiceClient
 from keboola_mcp_server.tools.storage_helpers import has_storage_branches
 
 LOG = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class JobSubmittedInfo:
+    """Information surfaced to the tool layer the moment a backend job becomes addressable.
+
+    This fires immediately after Query Service returns a `queryJobId`. The tool layer turns
+    this into an MCP `notifications/progress` so clients (e.g. Kai, Claude Code) can record
+    the handle and use it to cancel out-of-band by POSTing to `cancellation_url` themselves,
+    regardless of which MCP replica the cancel lands on.
+    """
+
+    job_id: str
+    cancellation_url: str | None
+    backend: str
+
+
+# Async callback invoked exactly once per execute_query, immediately after the backend
+# returns a job handle. Callbacks are best-effort: any exception raised inside is suppressed
+# so a failed progress notification cannot abort the underlying query.
+JobSubmittedCallback = Callable[[JobSubmittedInfo], Awaitable[None]]
 
 
 def get_backend_path(table: Mapping[str, Any]) -> list[str] | None:
@@ -182,7 +203,12 @@ class _Workspace(abc.ABC):
             return (False, False)
 
     async def execute_query(
-        self, sql_query: str, *, max_rows: int | None = None, max_chars: int | None = None
+        self,
+        sql_query: str,
+        *,
+        max_rows: int | None = None,
+        max_chars: int | None = None,
+        on_job_submitted: JobSubmittedCallback | None = None,
     ) -> QueryResult:
         """
         Runs a given SQL query through the Query Service.
@@ -193,6 +219,9 @@ class _Workspace(abc.ABC):
         :param sql_query: The SQL query to be executed.
         :param max_rows: The maximum number of rows to fetch from the query results. If None, no limit is applied.
         :param max_chars: The maximum number of chars to fetch from the query results. If None, no limit is applied.
+        :param on_job_submitted: Optional async callback invoked with the backend job handle as soon as the job is
+            registered with the Query Service. Exceptions raised inside the callback are suppressed so a failed
+            notification cannot abort the query.
         :return: The result of the executed query.
         """
         if max_rows is not None and max_rows <= 0:
@@ -205,6 +234,23 @@ class _Workspace(abc.ABC):
 
         ts_start = time.perf_counter()
         job_id = await self._qsclient.submit_job(statements=[sql_query], workspace_id=str(self.id))
+        if on_job_submitted is not None:
+            info = JobSubmittedInfo(
+                job_id=job_id,
+                cancellation_url=self._qsclient.build_cancel_url(job_id),
+                backend=self.get_sql_dialect().lower(),
+            )
+            # Best-effort: a failed progress notification must not kill the running query.
+            # CancelledError is `BaseException` since Python 3.8, so `except Exception` already
+            # lets it propagate on the supported Python (>=3.10). The explicit branch below
+            # documents intent and guards against a future refactor that might widen the catch
+            # to `BaseException` and silently swallow cancellation.
+            try:
+                await on_job_submitted(info)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                LOG.warning(f'on_job_submitted callback raised for job_id={job_id}: {exc!r} — continuing')
         while (job_status := await self._qsclient.get_job_status(job_id)) and job_status['status'] not in [
             'completed',
             'failed',
@@ -707,10 +753,20 @@ class WorkspaceManager:
             raise ValueError('Failed to initialize Keboola Workspace.')
 
     async def execute_query(
-        self, sql_query: str, *, max_rows: int | None = None, max_chars: int | None = None
+        self,
+        sql_query: str,
+        *,
+        max_rows: int | None = None,
+        max_chars: int | None = None,
+        on_job_submitted: JobSubmittedCallback | None = None,
     ) -> QueryResult:
         workspace = await self._get_workspace()
-        return await workspace.execute_query(sql_query, max_rows=max_rows, max_chars=max_chars)
+        return await workspace.execute_query(
+            sql_query,
+            max_rows=max_rows,
+            max_chars=max_chars,
+            on_job_submitted=on_job_submitted,
+        )
 
     async def get_table_info(
         self, table: Mapping[str, Any], backend_path: list[str] | None = None

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -284,6 +284,18 @@ class _Workspace(abc.ABC):
                         f'The query may still be running on the server: job_id={job_id}'
                     )
 
+        # Short-circuit when the poll loop exited because the job was cancelled out-of-band
+        # (e.g. the user clicked STOP and the kai-agent backend POSTed
+        # `POST /api/v1/queries/{job_id}/cancel` directly to Query Service, or the in-flight
+        # request itself was aborted with notifications/cancelled). Going through the results
+        # fetch path here surfaces QS's generic "Job is still running or not completed yet"
+        # message, which is misleading — we already know the job reached a terminal CANCELLED
+        # state. Return a clear cancel result instead and skip the results fetch entirely.
+        terminal_status = job_status['status']
+        if terminal_status in ('canceled', 'cancelled'):
+            LOG.info(f'Query was cancelled (terminal status={terminal_status}): job_id={job_id}')
+            return QueryResult(status='error', data=None, message='Query was cancelled')
+
         statement_id = cast(list[JsonDict], job_status['statements'])[0]['id']
 
         # Fetch results with pagination

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,10 @@ def empty_context(mocker) -> Context:
     ctx.client_id = None
     ctx.request_context = mocker.MagicMock(RequestContext)
     ctx.request_context.lifespan_context = ServerState(Config(), ServerRuntimeInfo(transport='stdio'))
+    # `meta` is an instance attribute of RequestContext (set in __init__), not a class attribute,
+    # so MagicMock(spec=RequestContext) doesn't expose it. Default it to None so tools that read
+    # the progressToken don't trip AttributeError; individual tests can override.
+    ctx.request_context.meta = None
     return ctx
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6,7 +6,7 @@ from httpx import HTTPStatusError, Request, Response
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
-from keboola_mcp_server.workspace import WorkspaceManager, _SnowflakeWorkspace
+from keboola_mcp_server.workspace import JobSubmittedInfo, WorkspaceManager, _SnowflakeWorkspace
 
 
 @pytest.mark.asyncio
@@ -201,6 +201,116 @@ async def test_workspace_manager_create_is_branch_aware(
         input_client.has_feature.assert_not_called()
     else:
         input_client.has_feature.assert_awaited_once()
+
+
+def _make_snowflake_workspace_with_mocked_qs(job_id: str = 'job-abc-123') -> tuple[_SnowflakeWorkspace, AsyncMock]:
+    """Builds a _SnowflakeWorkspace whose QueryServiceClient is fully mocked to run a one-row query end to end.
+
+    Returns (workspace, qs_mock) so tests can assert on the mock and access build_cancel_url's return value.
+    """
+    qs_mock = AsyncMock(spec=QueryServiceClient)
+    qs_mock.submit_job.return_value = job_id
+    qs_mock.get_job_status.return_value = {
+        'status': 'completed',
+        'statements': [{'id': 'stmt-1'}],
+    }
+    # `data` (not `rows`) matches the QS response shape that
+    # `_SnowflakeWorkspace.execute_query()` reads via `results.get('data', [])`.
+    # Keeping the mock aligned with production prevents regressions where the
+    # results-fetch path silently misses a renamed/missing field.
+    qs_mock.get_job_results.return_value = {
+        'status': 'completed',
+        'message': 'ok',
+        'numberOfRows': 1,
+        'columns': [{'name': 'col'}],
+        'data': [['v']],
+    }
+    qs_mock.build_cancel_url = Mock(return_value=f'https://query.keboola.com/api/v1/queries/{job_id}/cancel')
+
+    workspace = _SnowflakeWorkspace(workspace_id=1, schema='S', client=Mock(spec=KeboolaClient))
+    workspace._qsclient = qs_mock
+    return workspace, qs_mock
+
+
+@pytest.mark.asyncio
+async def test_execute_query_invokes_on_job_submitted_with_full_info():
+    """The callback fires exactly once, immediately after submit_job, carrying the cancel URL."""
+    workspace, qs_mock = _make_snowflake_workspace_with_mocked_qs(job_id='job-xyz')
+
+    received: list[JobSubmittedInfo] = []
+
+    async def callback(info: JobSubmittedInfo) -> None:
+        received.append(info)
+
+    await workspace.execute_query('SELECT 1', on_job_submitted=callback)
+
+    assert len(received) == 1
+    assert received[0] == JobSubmittedInfo(
+        job_id='job-xyz',
+        cancellation_url='https://query.keboola.com/api/v1/queries/job-xyz/cancel',
+        backend='snowflake',
+    )
+    qs_mock.build_cancel_url.assert_called_once_with('job-xyz')
+
+
+@pytest.mark.asyncio
+async def test_execute_query_without_callback_does_not_call_build_cancel_url():
+    """When no callback is supplied, the workspace must not waste a call to build_cancel_url."""
+    workspace, qs_mock = _make_snowflake_workspace_with_mocked_qs()
+
+    await workspace.execute_query('SELECT 1')
+
+    qs_mock.build_cancel_url.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_query_swallows_callback_exception_and_completes_query():
+    """A misbehaving callback (network failure when sending the notification, anything) must
+    never abort the underlying query. The query still completes and returns its result."""
+    workspace, qs_mock = _make_snowflake_workspace_with_mocked_qs()
+
+    async def boom(info: JobSubmittedInfo) -> None:
+        raise RuntimeError('progress send failed')
+
+    result = await workspace.execute_query('SELECT 1', on_job_submitted=boom)
+
+    # The query completed despite the callback error.
+    assert result.is_ok
+    qs_mock.get_job_results.assert_awaited()
+
+
+def test_build_cancel_url_uses_raw_client_base_api_url():
+    """build_cancel_url must produce an absolute URL clients can POST to without further assembly."""
+    qs = QueryServiceClient.create(
+        root_url='https://query.keboola.com',
+        branch_id='42',
+        token='Bearer t',
+    )
+    url = qs.build_cancel_url('job-1')
+    assert url == 'https://query.keboola.com/api/v1/queries/job-1/cancel'
+
+
+@pytest.mark.asyncio
+async def test_workspace_manager_execute_query_forwards_callback():
+    """WorkspaceManager.execute_query must plumb on_job_submitted through to the active workspace.
+
+    Without this, the tool-layer notification path is silently disabled for any consumer that goes
+    through the manager (which is everyone, in practice).
+    """
+    workspace, qs_mock = _make_snowflake_workspace_with_mocked_qs(job_id='job-fwd')
+
+    manager = WorkspaceManager(Mock(spec=KeboolaClient))
+    manager._workspace = workspace
+
+    received: list[JobSubmittedInfo] = []
+
+    async def callback(info: JobSubmittedInfo) -> None:
+        received.append(info)
+
+    await manager.execute_query('SELECT 1', on_job_submitted=callback)
+
+    assert len(received) == 1
+    assert received[0].job_id == 'job-fwd'
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -100,6 +100,36 @@ async def test_query_client_token_selection_with_branch_lookup():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('terminal_status', ['canceled', 'cancelled'])
+async def test_execute_query_returns_clear_message_when_job_cancelled(terminal_status: str):
+    """When the QS poll loop exits because the job reached a CANCELLED terminal state
+    (typically because kai-agent POSTed to Query Service's cancel endpoint after the user
+    clicked STOP), we must short-circuit the results-fetch and surface a precise
+    "Query was cancelled" message — not the generic "Job is still running or not completed
+    yet" that QS returns from get_job_results for non-completed jobs.
+
+    Both 'canceled' (US spelling, the QS canonical form) and 'cancelled' (UK spelling,
+    seen in the wild) are accepted as terminal-cancel statuses by the poll loop, so both
+    must take this fast path.
+    """
+    workspace, qs_mock = _make_snowflake_workspace_with_mocked_qs(job_id='job-cancel')
+    # Override the polling status so the loop exits via the cancelled branch.
+    qs_mock.get_job_status.return_value = {
+        'status': terminal_status,
+        'statements': [{'id': 'stmt-1'}],
+    }
+
+    result = await workspace.execute_query('SELECT SYSTEM$WAIT(300)')
+
+    assert result.is_error
+    assert result.data is None
+    assert result.message == 'Query was cancelled'
+    # The fast path must skip the results fetch entirely; no need to ask QS for rows
+    # we know don't exist.
+    qs_mock.get_job_results.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_workspace_creation_cleans_up_config_on_failure():
     """Test that WorkspaceManager._create_ws cleans up config when workspace creation fails."""
     mock_client = Mock(spec=KeboolaClient)

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -108,7 +108,7 @@ async def test_query_data_emits_progress_notification_with_job_id(mcp_context_cl
 
     mcp_context_client.request_context.meta = mocker.MagicMock()
     mcp_context_client.request_context.meta.progressToken = 'tkn-1'
-    mcp_context_client.request_id = 'req-99'
+    mcp_context_client.request_context.request_id = 'req-99'
     mcp_context_client.session.send_notification = AsyncMock()
 
     await query_data('select 1;', 'q', mcp_context_client)
@@ -165,11 +165,14 @@ async def test_query_data_skips_progress_when_no_token(mcp_context_client: Conte
 
 @pytest.mark.asyncio
 async def test_query_data_skips_progress_when_request_id_missing(mcp_context_client: Context, mocker, caplog):
-    """If `ctx.request_id` is unavailable, the streamable_http router has no way to attach the
+    """If the request id is unavailable, the streamable_http router has no way to attach the
     notification to the originating tools/call SSE stream — it would silently fall through to
     GET_STREAM_KEY (which doesn't exist in stateless_http) and be dropped. The notification
     emitter must detect this and skip emitting, logging a warning so the failure mode is visible
     instead of swallowed. The underlying query still completes normally.
+
+    Note we null out `request_context.request_id` (not the `ctx.request_id` property, which raises
+    RuntimeError when the context is missing) — that is the field the emitter actually reads.
     """
     info = JobSubmittedInfo(job_id='job-no-rid', cancellation_url='https://q/cancel', backend='snowflake')
 
@@ -184,7 +187,7 @@ async def test_query_data_skips_progress_when_request_id_missing(mcp_context_cli
 
     mcp_context_client.request_context.meta = mocker.MagicMock()
     mcp_context_client.request_context.meta.progressToken = 'tkn-1'
-    mcp_context_client.request_id = None  # the case under test
+    mcp_context_client.request_context.request_id = None  # the case under test
     mcp_context_client.session.send_notification = AsyncMock()
 
     import logging
@@ -198,8 +201,8 @@ async def test_query_data_skips_progress_when_request_id_missing(mcp_context_cli
     mcp_context_client.session.send_notification.assert_not_called()
     # The warning must mention the job id so the operator can correlate against Snowflake.
     assert any(
-        'job-no-rid' in r.getMessage() and 'request_id is None' in r.getMessage() for r in caplog.records
-    ), f'expected warning mentioning job_id and request_id; got: {[r.getMessage() for r in caplog.records]}'
+        'job-no-rid' in r.getMessage() and 'request id is unavailable' in r.getMessage() for r in caplog.records
+    ), f'expected warning mentioning job_id and request id; got: {[r.getMessage() for r in caplog.records]}'
 
 
 class TestWorkspaceManagerSnowflake:

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -108,17 +108,29 @@ async def test_query_data_emits_progress_notification_with_job_id(mcp_context_cl
 
     mcp_context_client.request_context.meta = mocker.MagicMock()
     mcp_context_client.request_context.meta.progressToken = 'tkn-1'
-    mcp_context_client.send_notification = AsyncMock()
+    mcp_context_client.request_id = 'req-99'
+    mcp_context_client.session.send_notification = AsyncMock()
 
     await query_data('select 1;', 'q', mcp_context_client)
 
-    mcp_context_client.send_notification.assert_awaited_once()
-    sent = mcp_context_client.send_notification.await_args.args[0]
-    assert isinstance(sent, ProgressNotification)
-    assert sent.params.progressToken == 'tkn-1'
-    # `_meta` round-trips through the on-wire JSON (alias) — assert the full payload shape so a
-    # spec-compliant client following the MCP progress notification format can read the handle.
-    on_wire = json.loads(sent.model_dump_json(by_alias=True, exclude_none=True))
+    # We bypass FastMCP's ctx.send_notification() because it does not set
+    # `related_request_id` -- and without that, the streamable_http router (mcp/server/
+    # streamable_http.py:~1004) cannot route the notification to the originating
+    # tools/call SSE stream in stateless_http mode. The notification gets silently
+    # dropped onto GET_STREAM_KEY. Call the low-level session API with the request id
+    # so the notification reaches the correct response stream.
+    mcp_context_client.session.send_notification.assert_awaited_once()
+    call_args = mcp_context_client.session.send_notification.await_args
+    sent = call_args.args[0]
+    assert (
+        call_args.kwargs.get('related_request_id') == 'req-99'
+    ), f'related_request_id missing or wrong: {call_args.kwargs!r}'
+    # The wrapper is ServerNotification(root=ProgressNotification(...)); both .root and
+    # the wrapper's model_dump should expose the progress notification shape.
+    progress = sent.root if hasattr(sent, 'root') else sent
+    assert isinstance(progress, ProgressNotification)
+    assert progress.params.progressToken == 'tkn-1'
+    on_wire = json.loads(progress.model_dump_json(by_alias=True, exclude_none=True))
     assert on_wire['method'] == 'notifications/progress'
     assert on_wire['params']['_meta'] == {
         'keboola.queryJobId': 'job-xyz',
@@ -144,11 +156,50 @@ async def test_query_data_skips_progress_when_no_token(mcp_context_client: Conte
 
     # empty_context fixture defaults meta to None, which is the "no progressToken" shape.
     assert mcp_context_client.request_context.meta is None
-    mcp_context_client.send_notification = AsyncMock()
+    mcp_context_client.session.send_notification = AsyncMock()
 
     await query_data('select 1;', 'q', mcp_context_client)
 
-    mcp_context_client.send_notification.assert_not_called()
+    mcp_context_client.session.send_notification.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_skips_progress_when_request_id_missing(mcp_context_client: Context, mocker, caplog):
+    """If `ctx.request_id` is unavailable, the streamable_http router has no way to attach the
+    notification to the originating tools/call SSE stream — it would silently fall through to
+    GET_STREAM_KEY (which doesn't exist in stateless_http) and be dropped. The notification
+    emitter must detect this and skip emitting, logging a warning so the failure mode is visible
+    instead of swallowed. The underlying query still completes normally.
+    """
+    info = JobSubmittedInfo(job_id='job-no-rid', cancellation_url='https://q/cancel', backend='snowflake')
+
+    async def fake_execute_query(sql_query, *, max_rows, max_chars, on_job_submitted=None):
+        if on_job_submitted is not None:
+            await on_job_submitted(info)
+        return QueryResult(status='ok', data=SqlSelectData(columns=['a'], rows=[{'a': 1}]), message=None)
+
+    manager = mocker.AsyncMock(WorkspaceManager)
+    manager.execute_query.side_effect = fake_execute_query
+    mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+    mcp_context_client.request_context.meta = mocker.MagicMock()
+    mcp_context_client.request_context.meta.progressToken = 'tkn-1'
+    mcp_context_client.request_id = None  # the case under test
+    mcp_context_client.session.send_notification = AsyncMock()
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger='keboola_mcp_server.tools.sql'):
+        result = await query_data('select 1;', 'q', mcp_context_client)
+
+    # Query itself completes normally — guarding the notification must not abort the call.
+    assert isinstance(result, QueryDataOutput)
+    # No notification was sent (would have been dropped on GET_STREAM_KEY anyway).
+    mcp_context_client.session.send_notification.assert_not_called()
+    # The warning must mention the job id so the operator can correlate against Snowflake.
+    assert any(
+        'job-no-rid' in r.getMessage() and 'request_id is None' in r.getMessage() for r in caplog.records
+    ), f'expected warning mentioning job_id and request_id; got: {[r.getMessage() for r in caplog.records]}'
 
 
 class TestWorkspaceManagerSnowflake:

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -1,14 +1,16 @@
 import json
 from typing import Any
-from unittest.mock import Mock, call
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 from mcp.server.fastmcp import Context
+from mcp.types import ProgressNotification
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
 from keboola_mcp_server.tools.sql import QueryDataOutput, query_data
 from keboola_mcp_server.workspace import (
+    JobSubmittedInfo,
     QueryResult,
     SqlSelectData,
     TableFqn,
@@ -80,6 +82,73 @@ async def test_query_data(
     assert isinstance(result, QueryDataOutput)
     assert result.query_name == query_name
     assert result.csv_data == expected_csv
+
+
+@pytest.mark.asyncio
+async def test_query_data_emits_progress_notification_with_job_id(mcp_context_client: Context, mocker):
+    """When the client supplied a progressToken in the original tools/call, query_data must surface
+    the backend job id to the client by sending a `notifications/progress` whose `params._meta`
+    carries `keboola.queryJobId`, the backend name, and the absolute cancel URL. Without this,
+    clients cannot cancel a long-running query out-of-band against Query Service directly.
+    """
+    info = JobSubmittedInfo(
+        job_id='job-xyz',
+        cancellation_url='https://query.keboola.com/api/v1/queries/job-xyz/cancel',
+        backend='snowflake',
+    )
+
+    async def fake_execute_query(sql_query, *, max_rows, max_chars, on_job_submitted=None):
+        if on_job_submitted is not None:
+            await on_job_submitted(info)
+        return QueryResult(status='ok', data=SqlSelectData(columns=['a'], rows=[{'a': 1}]), message=None)
+
+    manager = mocker.AsyncMock(WorkspaceManager)
+    manager.execute_query.side_effect = fake_execute_query
+    mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+    mcp_context_client.request_context.meta = mocker.MagicMock()
+    mcp_context_client.request_context.meta.progressToken = 'tkn-1'
+    mcp_context_client.send_notification = AsyncMock()
+
+    await query_data('select 1;', 'q', mcp_context_client)
+
+    mcp_context_client.send_notification.assert_awaited_once()
+    sent = mcp_context_client.send_notification.await_args.args[0]
+    assert isinstance(sent, ProgressNotification)
+    assert sent.params.progressToken == 'tkn-1'
+    # `_meta` round-trips through the on-wire JSON (alias) — assert the full payload shape so a
+    # spec-compliant client following the MCP progress notification format can read the handle.
+    on_wire = json.loads(sent.model_dump_json(by_alias=True, exclude_none=True))
+    assert on_wire['method'] == 'notifications/progress'
+    assert on_wire['params']['_meta'] == {
+        'keboola.queryJobId': 'job-xyz',
+        'keboola.backend': 'snowflake',
+        'keboola.cancellationUrl': 'https://query.keboola.com/api/v1/queries/job-xyz/cancel',
+    }
+
+
+@pytest.mark.asyncio
+async def test_query_data_skips_progress_when_no_token(mcp_context_client: Context, mocker):
+    """Per MCP spec, the server must only emit progress notifications when the client provided a
+    progressToken. Without one we must stay silent — sending unsolicited progress can break clients
+    that strictly validate the protocol."""
+
+    async def fake_execute_query(sql_query, *, max_rows, max_chars, on_job_submitted=None):
+        # The tool should not even hand us a callback when no token is set.
+        assert on_job_submitted is None
+        return QueryResult(status='ok', data=SqlSelectData(columns=['a'], rows=[{'a': 1}]), message=None)
+
+    manager = mocker.AsyncMock(WorkspaceManager)
+    manager.execute_query.side_effect = fake_execute_query
+    mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+    # empty_context fixture defaults meta to None, which is the "no progressToken" shape.
+    assert mcp_context_client.request_context.meta is None
+    mcp_context_client.send_notification = AsyncMock()
+
+    await query_data('select 1;', 'q', mcp_context_client)
+
+    mcp_context_client.send_notification.assert_not_called()
 
 
 class TestWorkspaceManagerSnowflake:

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.67.1"
+version = "1.67.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3204](https://linear.app/keboola/issue/AI-3204/cancel-query-data-queries-when-chat-is-stopped) — follow-up to #526.

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Enables MCP clients to cancel a long-running `query_data` call **directly against Query Service**, bypassing the originating MCP replica. This closes the cross-replica gap that PR #526's in-memory cancellation registry leaves open.

**How it works**

1. **Server surfaces the backend job handle on the response stream.** `_SnowflakeWorkspace.execute_query` fires a new `on_job_submitted` callback the moment Query Service returns a `queryJobId`. `query_data` turns that into an MCP `notifications/progress` on POST #1's SSE stream, with `params._meta` carrying:
   - `keboola.queryJobId`
   - `keboola.backend` (e.g. `"snowflake"`)
   - `keboola.cancellationUrl` (absolute URL like `https://query.<stack>.keboola.com/api/v1/queries/<jobId>/cancel`)

2. **Clients call QS directly to cancel** — using the same auth header they already use to talk to the MCP server. `RawKeboolaClient` auto-detects the token shape (`clients/base.py:38-42`): `Authorization: Bearer <oauth-token>` for Claude Code / claude.ai, `X-StorageAPI-Token: <pat>` for Kai / in-platform agent. No special-case auth path on either side.

3. **Original `query_data` self-cleans.** The Snowflake poll loop already exits when the job transitions to `canceled` (`workspace.py:260-264`). POST #1's response stream finalizes with an error result — no `asyncio.CancelledError` plumbing, no shared store, no sticky LB routing required.

### What this fixes

PR #526's `cancellation.py` registry handles the same-replica case correctly, but in the production multi-replica deployment behind `mcp.keboola.com` the cancel `POST /mcp` is an independent HTTP request that the LB hashes separately from the original `tools/call`. When it lands on a different replica, the registry there is empty, the cancel is dropped, and the query keeps running. This PR removes the need for cancel notifications to find the right replica at all: clients hold the handle and act on it directly.

### Backends

Both Snowflake and BigQuery now execute through Query Service (`_Workspace.execute_query` →
`QueryServiceClient.submit_job`), so both receive a real `queryJobId` and the `on_job_submitted`
callback fires for either backend. `build_cancel_url` is backend-agnostic — it points at the
Query Service cancel endpoint `…/api/v1/queries/{jobId}/cancel`, which accepts the job handle
regardless of the underlying engine.

- **Snowflake**: full support. Callback fires after `submit_job`, cancellation URL surfaced.
- **BigQuery**: full support via the same shared Query Service path — callback fires, cancellation URL surfaced. (The job runs as a QS query job, so it is cancellable out-of-band exactly like Snowflake.)

### What's NOT in this PR

- **Client-side adoption** (Kai, Claude Code, claude.ai connector) — separate task per client. Stock clients that ignore unknown `_meta` keys are unaffected — they simply don't get out-of-band cancellation.

> Note: the original `cancellation.py` in-memory registry from #526 is **not present on this branch**;
> this PR's out-of-band contract (clients hold the handle and POST the cancel URL directly) supersedes it.

### Notes for client implementers

The notification follows the standard MCP `notifications/progress` shape. Spec-compliant clients that don't recognize the Keboola-specific `_meta` keys will simply ignore them and surface "Submitted to snowflake" as progress text. Clients that *do* read them should:

1. Persist `keboola.queryJobId` and `keboola.cancellationUrl` for the duration of the call.
2. On user-initiated stop, POST `{}` (or a JSON body with an optional `reason`) to `cancellationUrl` with the same auth header used for MCP.
3. The original `tools/call` SSE stream will finalize with an error result within one poll tick (~1-2s) of the Snowflake job actually canceling — no additional handling needed.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

**Unit tests added — full `tox` green (pytest + black + isort + flake8 + check-tools-docs):**

- `tests/test_workspace.py`:
  - `on_job_submitted` fires exactly once with the full `JobSubmittedInfo` carrying the cancel URL.
  - Callback omitted → `build_cancel_url` is not called (no wasted work).
  - Callback exception is suppressed → the query still completes.
  - `build_cancel_url` produces the expected absolute URL shape.
  - `WorkspaceManager.execute_query` forwards the callback to the active workspace.

- `tests/tools/test_sql.py`:
  - When `progressToken` is provided, `query_data` emits `notifications/progress` with `_meta.keboola.queryJobId` (+ backend, cancellationUrl).
  - When `progressToken` is absent, no notification is sent (MCP spec compliance).
  - On-wire JSON uses the `_meta` alias, so spec-compliant clients can parse it per spec.

**End-to-end verification recommended before merging:** start a deliberately heavy query against a real Snowflake workspace, capture the progress notification from the SSE stream, POST to the surfaced `cancellationUrl` with the user's token, and confirm the Snowflake query history shows `CANCELED` and the MCP response stream finalizes with an error result.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)
