### PR TITLE
AI-3005: pin dorny/test-reporter to v3.0.0 + tolerate Checks API flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
           uv run tox
 
       - name: Publish test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
+        # don't fail the job if the Checks API call flakes — the tests themselves already ran
+        continue-on-error: true
         # run this step even if a previous step failed, but only for push events or pull requests from the same repo
         if: (success() || failure()) && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
@@ -140,7 +142,9 @@ jobs:
           echo "Dependencies installed successfully - setup is working correctly"
 
       - name: Publish integration test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
+        # don't fail the job if the Checks API call flakes — the tests themselves already ran
+        continue-on-error: true
         # publish results only when actual tests were run (same repository)
         if: (always()) && github.repository == github.event.repository.full_name
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.63.0"
+version = "1.63.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.63.0"
+version = "1.63.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3005](https://linear.app/keboola/issue/AI-3005) (CI infra on top of #532)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Two flaky CI failures on this branch traced to `dorny/test-reporter@v1`:

1. **`HttpError: Sorry. Your account was suspended`** from the GitHub Checks API
   when the action calls `Updating check run conclusion …`. Non-deterministic:
   in [run 26445836174](https://github.com/keboola/mcp-server/actions/runs/26445836174)
   the 3.10 and 3.11 matrix legs succeeded with HTTP 200 while 3.12 (last to run
   under `max-parallel: 1`) failed. Same commit, same token, same repo.
2. **`An action could not be found at the URI .../dorny/test-reporter/tar.gz/<v1-sha>`**
   in [run 26445884176](https://github.com/keboola/mcp-server/actions/runs/26445884176)
   — a transient codeload outage fetching the pinned v1 archive.

The v1 action is also on borrowed time: every run logs the Node.js 20 deprecation
warning, which becomes forced on **2026-06-02** (next week).

**Changes:**

- Bump both `Publish test results` and `Publish integration test results` to
  `dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2` (`v3.0.0`,
  released 2026-03-21, runs on Node.js 24). Pinned to the commit SHA so a moved
  tag can't silently change what we run.
- Add `continue-on-error: true` to both steps. Failing to publish a test report
  shouldn't turn a green job red — the tests themselves already ran. This makes
  the pipeline resilient to transient Checks API glitches like the one above.
- Patch version bump `1.63.0` → `1.63.1` + `uv.lock` sync (chore-only change).

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

CI-only change — verified by re-running the workflow on this branch.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable) — N/A (CI workflow change)
- [x] Integration tests added/updated (if applicable) — N/A (CI workflow change)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable) — N/A