### PR TITLE
AJDA-2801: route BigQuery workspace queries through the Query Service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.63.3"
+version = "1.63.4"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -3,7 +3,6 @@ import math
 from datetime import datetime
 from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, cast
 
-import httpx
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from keboola_mcp_server.clients.base import JsonDict, KeboolaServiceClient, RawKeboolaClient
@@ -984,28 +983,6 @@ class AsyncStorageClient(KeboolaServiceClient):
         :return: Workspace details as dictionary
         """
         return cast(JsonDict, await self.get(endpoint=f'branch/{self._branch_id}/workspaces/{workspace_id}'))
-
-    # TODO: The /v2/storage/branch/{self._branch_id}/workspaces/{workspace_id}/query endpoint is deprecated
-    #  and replaced by QueryService.
-    #  Unfortunately the QueryService supports only Snowflake backends. We use it in _SnowflakeWorkspace implementation,
-    #  but not in _BigQueryWorkspace implementation, which still uses this function.
-    async def workspace_query(self, workspace_id: int, query: str, timeout: httpx.Timeout | None = None) -> JsonDict:
-        """
-        Executes a query in a given workspace.
-
-        :param workspace_id: The id of the workspace
-        :param query: The query to execute
-        :param timeout: Optional per-call timeout override; falls back to the client default when None
-        :return: The SAPI call response - query result or raise an error.
-        """
-        return cast(
-            JsonDict,
-            await self.post(
-                endpoint=f'branch/{self._branch_id}/workspaces/{workspace_id}/query',
-                data={'query': query},
-                timeout=timeout,
-            ),
-        )
 
     async def workspace_list(self) -> list[JsonDict]:
         """

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -285,6 +285,7 @@ class _Workspace(abc.ABC):
                 break
 
             page_data = page_data[:rows_to_fetch]
+            char_limit_reached = False
             if max_chars is not None:
                 for row in page_data:
                     chars = sum(len(str(v)) for v in row if v is not None)
@@ -292,6 +293,10 @@ class _Workspace(abc.ABC):
                         all_rows.append(row)
                         all_rows_chars += chars
                     else:
+                        # The first row that does not fit ends pagination so that the result
+                        # is a contiguous prefix; we must not skip this row and then append
+                        # later smaller rows that happen to fit.
+                        char_limit_reached = True
                         break
             else:
                 all_rows.extend(page_data)
@@ -302,7 +307,7 @@ class _Workspace(abc.ABC):
             if max_rows is not None and len(all_rows) >= max_rows:
                 break
 
-            if max_chars is not None and all_rows_chars >= max_chars:
+            if char_limit_reached or (max_chars is not None and all_rows_chars >= max_chars):
                 break
 
             offset += len(page_data)

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -35,8 +35,10 @@ class TableFqn:
     """The properly quoted parts of a fully qualified table name."""
 
     # TODO: refactor this and probably use just a simple string
-    db_name: str  # project_id in a BigQuery
-    schema_name: str  # dataset in a BigQuery
+    # Snowflake FQNs are database.schema.table. BigQuery has no cross-project access, so the
+    # database tier is meaningless there — `db_name` is empty and the FQN is just dataset.table.
+    db_name: str  # database (Snowflake); empty for BigQuery
+    schema_name: str  # schema (Snowflake); dataset (BigQuery)
     table_name: str
     quote_char: str = ''
 
@@ -44,7 +46,9 @@ class TableFqn:
     def identifier(self) -> str:
         """Returns the properly quoted database identifier."""
         return '.'.join(
-            f'{self.quote_char}{n}{self.quote_char}' for n in [self.db_name, self.schema_name, self.table_name]
+            f'{self.quote_char}{n}{self.quote_char}'
+            for n in [self.db_name, self.schema_name, self.table_name]
+            if n
         )
 
     def __repr__(self) -> str:
@@ -428,13 +432,15 @@ class _BigQueryWorkspace(_Workspace):
             LOG.warning(f'No backendPath available for table {table_id}, cannot construct FQN')
             return None
 
-        # BigQuery backendPath[0] is the dataset name; normalize separators for BQ dataset naming
+        # BigQuery backendPath[0] is the dataset name; normalize separators for BQ dataset naming.
+        # BigQuery has no cross-project access, so the FQN is dataset.table with no project/database
+        # tier (db_name is left empty) — see editor-service SapiDataProvider::parseBackendPath.
         schema_name = bp[0].replace('.', '_').replace('-', '_')
         table_name = table['name']
 
         return DbTableInfo(
             id=table_id,
-            fqn=TableFqn(self._project_id, schema_name, table_name, quote_char='`'),
+            fqn=TableFqn(db_name='', schema_name=schema_name, table_name=table_name, quote_char='`'),
             columns={},
         )
 

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -2,14 +2,14 @@ import abc
 import asyncio
 import json
 import logging
+import re
 import time
 import uuid
 from typing import Any, Literal, Mapping, Sequence, cast
 from urllib.parse import urlunparse
 
-import httpx
 from httpx import HTTPStatusError
-from pydantic import Field, TypeAdapter
+from pydantic import Field
 from pydantic.dataclasses import dataclass
 
 from keboola_mcp_server.clients.base import JsonDict
@@ -102,9 +102,12 @@ class _Workspace(abc.ABC):
     _QUERY_TIMEOUT = 300.0  # 5 minutes
     _CANCELLATION_TIMEOUT = 30.0  # 30 seconds to wait for cancellation
     _SELECTED_ROWS_MSG = 'Returning {rows} of {total} selected rows.'
+    _PAGE_SIZE = 1_000
 
-    def __init__(self, workspace_id: int) -> None:
+    def __init__(self, workspace_id: int, client: KeboolaClient) -> None:
         self._workspace_id = workspace_id
+        self._client = client
+        self._qsclient: QueryServiceClient | None = None
 
     @property
     def id(self) -> int:
@@ -124,45 +127,6 @@ class _Workspace(abc.ABC):
     ) -> DbTableInfo | None:
         # TODO: use a pydantic class for the 'table' param
         pass
-
-    @abc.abstractmethod
-    async def execute_query(
-        self, sql_query: str, *, max_rows: int | None = None, max_chars: int | None = None
-    ) -> QueryResult:
-        """
-        Runs a given SQL query.
-
-        :param sql_query: The SQL query to be executed.
-        :param max_rows: The maximum number of rows to fetch from the query results. If None, no limit is applied.
-        :param max_chars: The maximum number of chars to fetch from the query results. If None, no limit is applied.
-        :return: The result of the executed query.
-        """
-        pass
-
-    @abc.abstractmethod
-    async def get_branch_id(self) -> str:
-        """Returns the branch ID."""
-        pass
-
-    @classmethod
-    def _dump(cls, json_data: Mapping[str, Any]) -> str:
-        return json.dumps(json_data, ensure_ascii=False, separators=(',', ':'))
-
-
-class _SnowflakeWorkspace(_Workspace):
-    _PAGE_SIZE = 1_000
-
-    def __init__(self, workspace_id: int, schema: str, client: KeboolaClient):
-        super().__init__(workspace_id)
-        self._schema = schema  # default schema created for the workspace
-        self._client = client
-        self._qsclient: QueryServiceClient | None = None
-
-    def get_sql_dialect(self) -> str:
-        return 'Snowflake'
-
-    def get_quoted_name(self, name: str) -> str:
-        return f'"{name}"'  # wrap name in double quotes
 
     async def _cancel_job_with_timeout(self, job_id: str, reason: str) -> tuple[bool, bool]:
         """
@@ -215,38 +179,20 @@ class _SnowflakeWorkspace(_Workspace):
             LOG.exception(f'Unexpected error during query cancellation: job_id={job_id}')
             return (False, False)
 
-    async def get_table_info(
-        self, table: Mapping[str, Any], backend_path: list[str] | None = None
-    ) -> DbTableInfo | None:
-        table_id = table['id']
-
-        if source_table := table.get('sourceTable'):
-            # Cross-project linked table — prefer caller-supplied backend_path, fall back to sourceTable
-            bp = backend_path or get_backend_path(source_table)
-            if not bp or len(bp) < 2:
-                LOG.warning(f'No backendPath in sourceTable for {table_id}, cannot construct FQN')
-                return None
-            db_name = bp[0]
-            schema_name = bp[1]
-            table_name = source_table['id'].rsplit(sep='.', maxsplit=1)[1]
-        else:
-            bp = backend_path or get_backend_path(table)
-            if not bp or len(bp) < 2:
-                LOG.warning(f'No backendPath available for table {table_id}, cannot construct FQN')
-                return None
-            db_name = bp[0]
-            schema_name = bp[1]
-            table_name = table['name']
-
-        return DbTableInfo(
-            id=table_id,
-            fqn=TableFqn(db_name, schema_name, table_name, quote_char='"'),
-            columns={},
-        )
-
     async def execute_query(
         self, sql_query: str, *, max_rows: int | None = None, max_chars: int | None = None
     ) -> QueryResult:
+        """
+        Runs a given SQL query through the Query Service.
+
+        The Query Service is backend-agnostic; the SQL itself must follow the dialect of the
+        workspace backend (see :meth:`get_sql_dialect` / :meth:`get_quoted_name`).
+
+        :param sql_query: The SQL query to be executed.
+        :param max_rows: The maximum number of rows to fetch from the query results. If None, no limit is applied.
+        :param max_chars: The maximum number of chars to fetch from the query results. If None, no limit is applied.
+        :return: The result of the executed query.
+        """
         if max_rows is not None and max_rows <= 0:
             raise ValueError('The "max_rows" must be a positive integer or None.')
         if max_chars is not None and max_chars <= 0:
@@ -324,7 +270,7 @@ class _SnowflakeWorkspace(_Workspace):
                 total_query_rows = results.get('numberOfRows')
 
                 if status in ['failed', 'canceled', 'cancelled']:
-                    return QueryResult(status='error', data=None, message=message)
+                    return QueryResult(status='error', data=None, message=self._format_error_message(message))
                 elif status != 'completed':
                     raise ValueError(f'Unexpected query status: {status}')
 
@@ -401,15 +347,70 @@ class _SnowflakeWorkspace(_Workspace):
             headers=self._client.headers,
         )
 
+    def _format_error_message(self, message: str | None) -> str | None:
+        """
+        Normalizes a failed-query error message returned by the Query Service into a clean,
+        human-readable string. The base implementation passes the message through unchanged;
+        backends whose Query Service responses wrap the error may override this.
+        """
+        return message
+
+    @classmethod
+    def _dump(cls, json_data: Mapping[str, Any]) -> str:
+        return json.dumps(json_data, ensure_ascii=False, separators=(',', ':'))
+
+
+class _SnowflakeWorkspace(_Workspace):
+    def __init__(self, workspace_id: int, schema: str, client: KeboolaClient):
+        super().__init__(workspace_id, client)
+        self._schema = schema  # default schema created for the workspace
+
+    def get_sql_dialect(self) -> str:
+        return 'Snowflake'
+
+    def get_quoted_name(self, name: str) -> str:
+        return f'"{name}"'  # wrap name in double quotes
+
+    async def get_table_info(
+        self, table: Mapping[str, Any], backend_path: list[str] | None = None
+    ) -> DbTableInfo | None:
+        table_id = table['id']
+
+        if source_table := table.get('sourceTable'):
+            # Cross-project linked table — prefer caller-supplied backend_path, fall back to sourceTable
+            bp = backend_path or get_backend_path(source_table)
+            if not bp or len(bp) < 2:
+                LOG.warning(f'No backendPath in sourceTable for {table_id}, cannot construct FQN')
+                return None
+            db_name = bp[0]
+            schema_name = bp[1]
+            table_name = source_table['id'].rsplit(sep='.', maxsplit=1)[1]
+        else:
+            bp = backend_path or get_backend_path(table)
+            if not bp or len(bp) < 2:
+                LOG.warning(f'No backendPath available for table {table_id}, cannot construct FQN')
+                return None
+            db_name = bp[0]
+            schema_name = bp[1]
+            table_name = table['name']
+
+        return DbTableInfo(
+            id=table_id,
+            fqn=TableFqn(db_name, schema_name, table_name, quote_char='"'),
+            columns={},
+        )
+
 
 class _BigQueryWorkspace(_Workspace):
-    _BQ_FIELDS = {'_timestamp'}
+    # The Query Service surfaces BigQuery errors as a serialized error object, e.g.
+    #   {Location: "query"; Message: "Syntax error: Unexpected identifier ..."; Reason: "invalidQuery"}
+    # Extract the human-readable `Message: "..."` part so the error reads like Snowflake's plain text.
+    _BQ_ERROR_MESSAGE_RE = re.compile(r'Message:\s*"((?:[^"\\]|\\.)*)"')
 
     def __init__(self, workspace_id: int, dataset_id: str, project_id: str, client: KeboolaClient):
-        super().__init__(workspace_id)
+        super().__init__(workspace_id, client)
         self._dataset_id = dataset_id  # default dataset created for the workspace
         self._project_id = project_id
-        self._client = client
 
     def get_sql_dialect(self) -> str:
         return 'BigQuery'
@@ -437,46 +438,10 @@ class _BigQueryWorkspace(_Workspace):
             columns={},
         )
 
-    async def execute_query(
-        self, sql_query: str, *, max_rows: int | None = None, max_chars: int | None = None
-    ) -> QueryResult:
-        if max_rows is not None and max_rows <= 0:
-            raise ValueError('The "max_rows" must be a positive integer or None.')
-        if max_chars is not None and max_chars <= 0:
-            raise ValueError('The "max_chars" must be a positive integer or None.')
-
-        resp = await self._client.storage_client.workspace_query(
-            workspace_id=self.id,
-            query=sql_query,
-            timeout=httpx.Timeout(connect=5.0, read=self._QUERY_TIMEOUT, write=10.0, pool=5.0),
-        )
-        qr = cast(QueryResult, TypeAdapter(QueryResult).validate_python(resp))
-        if qr.data:
-            total_query_rows = len(qr.data.rows)
-            max_rows = max_rows or total_query_rows
-            if max_chars is not None:
-                rows: list[SqlSelectDataRow] = []
-                total_chars = 0
-                for row in qr.data.rows[:max_rows]:
-                    chars = sum(len(str(v)) for v in row.values() if v is not None)
-                    if total_chars + chars <= max_chars:
-                        rows.append(row)
-                        total_chars += chars
-            else:
-                rows = cast(list[SqlSelectDataRow], qr.data.rows[:max_rows])
-
-            qr = QueryResult(
-                status=qr.status,
-                data=SqlSelectData(columns=qr.data.columns, rows=rows),
-                message=' '.join(
-                    filter(None, [qr.message, self._SELECTED_ROWS_MSG.format(rows=len(rows), total=total_query_rows)])
-                ),
-            )
-
-        return qr
-
-    async def get_branch_id(self) -> str:
-        return self._client.branch_id or 'default'
+    def _format_error_message(self, message: str | None) -> str | None:
+        if message and (m := self._BQ_ERROR_MESSAGE_RE.search(message)):
+            return m.group(1).replace('\\"', '"')
+        return message
 
 
 @dataclass(frozen=True)

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -400,6 +400,52 @@ class TestWorkspaceManagerSnowflake:
             ]
         )
 
+    @pytest.mark.asyncio
+    async def test_execute_query_max_chars_stops_on_first_rejection(
+        self, keboola_client: KeboolaClient, context: Context, mocker
+    ):
+        """
+        max_chars must yield a contiguous prefix across pages: once a row would exceed the
+        budget, pagination stops — later (smaller) rows that happen to fit must not sneak in.
+        """
+        keboola_client.storage_client.branches_list.return_value = [{'id': 1234, 'isDefault': True}]
+
+        qsclient = mocker.AsyncMock(QueryServiceClient)
+        qsclient.submit_job.return_value = 'qs-job-1234'
+        qsclient.get_job_status.return_value = {
+            'status': 'completed',
+            'statements': [{'id': 'qs-job-statement-1234', 'status': 'completed'}],
+        }
+        # Page 1: John (17 chars) fits, Joe (16 chars) does not (17+16=33 > 20) → pagination
+        # must stop here. The page 2 row (5 chars) would fit individually, but appending it
+        # would break the contiguous-prefix semantic and must not happen.
+        qsclient.get_job_results.side_effect = [
+            {
+                'status': 'completed',
+                'data': [[1, 'John', 'john@foo.com'], [2, 'Joe', 'joe@bar.com']],
+                'columns': [{'name': 'id'}, {'name': 'name'}, {'name': 'email'}],
+                'message': None,
+                'numberOfRows': 3,
+            },
+            {
+                'status': 'completed',
+                'data': [[3, 'X', 'x@y']],
+                'columns': [{'name': 'id'}, {'name': 'name'}, {'name': 'email'}],
+                'message': None,
+                'numberOfRows': 3,
+            },
+        ]
+        mocker.patch.object(QueryServiceClient, 'create', return_value=qsclient)
+        mocker.patch.object(_SnowflakeWorkspace, '_PAGE_SIZE', 2)
+
+        m = WorkspaceManager.from_state(context.session.state)
+        actual = await m.execute_query('select id, name, email from user;', max_chars=20)
+
+        assert actual.data is not None
+        assert actual.data.rows == [{'id': 1, 'name': 'John', 'email': 'john@foo.com'}]
+        # Page 2 must not be fetched once page 1 hit the char budget.
+        qsclient.get_job_results.assert_called_once()
+
 
 class TestWorkspaceManagerBigQuery:
     @pytest.fixture

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -435,7 +435,7 @@ class TestWorkspaceManagerBigQuery:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ('table', 'expected'),
+        ('table', 'expected', 'expected_identifier'),
         [
             (
                 # storage-branches: backendPath with branch-prefixed dataset name (1 element in BQ)
@@ -445,11 +445,12 @@ class TestWorkspaceManagerBigQuery:
                     'bucket': {'id': 'out.c-model', 'backendPath': ['35403_out_c_model']},
                 },
                 TableFqn(
-                    db_name='project_1234',
+                    db_name='',
                     schema_name='35403_out_c_model',
                     table_name='customers',
                     quote_char='`',
                 ),
+                '`35403_out_c_model`.`customers`',
             ),
             (
                 # production bucket — backendPath is single dataset name
@@ -459,11 +460,12 @@ class TestWorkspaceManagerBigQuery:
                     'bucket': {'id': 'in.c-shopify', 'backendPath': ['in_c_shopify']},
                 },
                 TableFqn(
-                    db_name='project_1234',
+                    db_name='',
                     schema_name='in_c_shopify',
                     table_name='orders',
                     quote_char='`',
                 ),
+                '`in_c_shopify`.`orders`',
             ),
             (
                 # linked (non-alias) bucket — data copied to destination dataset, queryable via backendPath FQN
@@ -474,16 +476,23 @@ class TestWorkspaceManagerBigQuery:
                     'sourceTable': {'project': {'id': '9999'}, 'id': 'in.c-abc.customers', 'isAlias': False},
                 },
                 TableFqn(
-                    db_name='project_1234',
+                    db_name='',
                     schema_name='in_c_abc',
                     table_name='customers',
                     quote_char='`',
                 ),
+                '`in_c_abc`.`customers`',
             ),
         ],
     )
     async def test_get_table_fqn(
-        self, table: dict[str, Any], expected: TableFqn, keboola_client: KeboolaClient, context: Context, mocker
+        self,
+        table: dict[str, Any],
+        expected: TableFqn,
+        expected_identifier: str,
+        keboola_client: KeboolaClient,
+        context: Context,
+        mocker,
     ):
         mocker.patch.object(QueryServiceClient, 'create', side_effect=AssertionError('no SQL should be issued'))
 
@@ -491,6 +500,8 @@ class TestWorkspaceManagerBigQuery:
         info = await m.get_table_info(table)
         assert info is not None
         assert info.fqn == expected
+        # BigQuery FQN has no project/database tier — just dataset.table.
+        assert info.fqn.identifier == expected_identifier
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -1,11 +1,9 @@
 import json
 from typing import Any
-from unittest.mock import call
+from unittest.mock import Mock, call
 
-import httpx
 import pytest
 from mcp.server.fastmcp import Context
-from pydantic import TypeAdapter
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
@@ -485,13 +483,14 @@ class TestWorkspaceManagerBigQuery:
         ],
     )
     async def test_get_table_fqn(
-        self, table: dict[str, Any], expected: TableFqn, keboola_client: KeboolaClient, context: Context
+        self, table: dict[str, Any], expected: TableFqn, keboola_client: KeboolaClient, context: Context, mocker
     ):
+        mocker.patch.object(QueryServiceClient, 'create', side_effect=AssertionError('no SQL should be issued'))
+
         m = WorkspaceManager.from_state(context.session.state)
         info = await m.get_table_info(table)
         assert info is not None
         assert info.fqn == expected
-        keboola_client.storage_client.workspace_query.assert_not_called()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -508,12 +507,13 @@ class TestWorkspaceManagerBigQuery:
         ],
     )
     async def test_get_table_info_returns_none(
-        self, table: dict[str, Any], keboola_client: KeboolaClient, context: Context
+        self, table: dict[str, Any], keboola_client: KeboolaClient, context: Context, mocker
     ):
+        mocker.patch.object(QueryServiceClient, 'create', side_effect=AssertionError('no SQL should be issued'))
+
         m = WorkspaceManager.from_state(context.session.state)
         info = await m.get_table_info(table)
         assert info is None
-        keboola_client.storage_client.workspace_query.assert_not_called()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -581,8 +581,25 @@ class TestWorkspaceManagerBigQuery:
         max_chars: int | None,
         keboola_client: KeboolaClient,
         context: Context,
+        mocker,
     ):
-        keboola_client.storage_client.workspace_query.return_value = TypeAdapter(QueryResult).dump_python(db_data)
+        # BigQuery now runs queries through the backend-agnostic Query Service, just like Snowflake.
+        keboola_client.storage_client.branches_list.return_value = [{'id': 1234, 'isDefault': True}]
+
+        qsclient = mocker.AsyncMock(QueryServiceClient)
+        qsclient.submit_job.return_value = 'qs-job-1234'
+        qsclient.get_job_status.return_value = {
+            'status': 'completed',
+            'statements': [{'id': 'qs-job-statement-1234', 'status': 'completed'}],
+        }
+        qsclient.get_job_results.return_value = {
+            'status': 'completed' if db_data.is_ok else 'failed',
+            'data': [list(row.values()) for row in db_data.data.rows] if db_data.data else [],
+            'columns': [{'name': col_name} for col_name in db_data.data.columns] if db_data.data else [],
+            'message': db_data.message,
+            'numberOfRows': len(db_data.data.rows) if db_data.data else None,
+        }
+        mocker.patch.object(QueryServiceClient, 'create', return_value=qsclient)
 
         if db_data.data is not None:
             expected = _truncate_data(db_data, max_rows, max_chars)
@@ -593,11 +610,40 @@ class TestWorkspaceManagerBigQuery:
         actual = await m.execute_query(query, max_rows=max_rows, max_chars=max_chars)
 
         assert actual == expected
-        keboola_client.storage_client.workspace_query.assert_called_once_with(
-            workspace_id=1234,
-            query=query,
-            timeout=httpx.Timeout(connect=5.0, read=_BigQueryWorkspace._QUERY_TIMEOUT, write=10.0, pool=5.0),
+
+        keboola_client.storage_client.branches_list.assert_called_once()
+        qsclient.submit_job.assert_called_once()
+        qsclient.get_job_status.assert_called_once_with('qs-job-1234')
+        qsclient.get_job_results.assert_called_once_with(
+            'qs-job-1234', 'qs-job-statement-1234', offset=0, limit=1000 if max_rows is None else max(max_rows, 100)
         )
+
+    @pytest.mark.parametrize(
+        ('raw_message', 'expected'),
+        [
+            # Query Service wraps BigQuery errors as a serialized error object; we extract `Message`.
+            (
+                '{Location: "query"; Message: "Syntax error: Unexpected identifier \\"INVALID\\" at [1:1]"; '
+                'Reason: "invalidQuery"}',
+                'Syntax error: Unexpected identifier "INVALID" at [1:1]',
+            ),
+            (
+                '{Location: ""; Message: "Access Denied: Table foo: User does not have permission to query '
+                'table foo, or perhaps it does not exist."; Reason: "accessDenied"}',
+                'Access Denied: Table foo: User does not have permission to query table foo, '
+                'or perhaps it does not exist.',
+            ),
+            # A plain message (no wrapper) is passed through unchanged.
+            ('400 Invalid SQL...', '400 Invalid SQL...'),
+            (None, None),
+        ],
+        ids=['syntax_error', 'access_denied', 'plain_message', 'none'],
+    )
+    def test_format_error_message_unwraps_bigquery_error(self, raw_message: str | None, expected: str | None):
+        workspace = _BigQueryWorkspace(
+            workspace_id=1234, dataset_id='workspace_1234', project_id='project_1234', client=Mock(spec=KeboolaClient)
+        )
+        assert workspace._format_error_message(raw_message) == expected
 
 
 class TestQueryCancellation:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.63.3"
+version = "1.63.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AJDA-2801](https://linear.app/keboola/issue/AJDA-2801/mcp-server-uses-bq-query-service)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

The Keboola Query Service supports both Snowflake and BigQuery, but the MCP server only used it for Snowflake workspaces; `_BigQueryWorkspace` still ran queries through the deprecated Storage API `branch/{id}/workspaces/{id}/query` endpoint.

This PR makes BigQuery use the Query Service too. The Query Service plumbing is backend-agnostic, so the shared machinery — `execute_query`, timeout-triggered cancellation, default-branch resolution, `QueryServiceClient` creation, and result pagination — is lifted from `_SnowflakeWorkspace` into the base `_Workspace` class. Only the genuinely backend-specific bits stay in the subclasses (SQL dialect, identifier quoting, FQN construction, error-message formatting). The now-dead `StorageClient.workspace_query` method and its only caller are removed.

Two backend differences surfaced via the BigQuery integration tests and are handled here:

- **FQN shape.** BigQuery has no cross-project access, so a fully qualified name is just `` `dataset`.`table` `` — not `project.dataset.table`. Qualifying with the workspace `project_id` made the Query Service resolve the wrong project (`Access Denied ... or perhaps it does not exist`). `TableFqn` now drops the empty database tier when rendering, and `_BigQueryWorkspace` builds the FQN without a project. This matches editor-service `SapiDataProvider::parseBackendPath` (BigQuery → `database: null`). Snowflake FQNs (`database.schema.table`) are unchanged.
- **Error messages.** The Query Service wraps BigQuery errors as a serialized object (`{Location: ...; Message: "..."; Reason: ...}`) instead of the plain text Snowflake returns. `_BigQueryWorkspace` unwraps the inner `Message` so failed queries read cleanly, matching Snowflake.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Unit tests: BigQuery `execute_query` / `get_table_info` now mock `QueryServiceClient` like the Snowflake tests (same asserted result shape); added coverage for the dataset-only FQN identifier and for the BigQuery error unwrapping. Validated against the live BigQuery integration tests on CI.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [x] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)