### PR TITLE
AI-3286: redesign python-js data app draft flow

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2004,6 +2004,11 @@ as a dev version of the data app (hot reload + auto-auth for iframe preview); us
 branch-delete — is yours. MCP gives you authenticated clone URLs and manages configs/deploys;
 it never invokes git.
 
+**The draft flow below is mandatory — never edit prod source directly.** Every source-code
+change goes through a draft branch that the user previews and explicitly approves first. NEVER
+push directly to `main`: `main` only ever advances by merging an approved draft branch, and
+only after the user has approved that draft's preview.
+
 Three scenarios the agent has to distinguish:
 
 ## Scenario A — Create a brand-new data app

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -38,8 +38,10 @@ name or description.
 - [create_oauth_url](#create_oauth_url): Generates an OAuth authorization URL for a Keboola component configuration.
 
 ### Other Tools
-- [create_python_js_data_app_git_credential](#create_python_js_data_app_git_credential): Mints a one-time HTTPS token on a python-js data app so the caller can clone, pull, and push
-to the app's managed git repo over HTTPS.
+- [create_python_js_data_app_git_credential](#create_python_js_data_app_git_credential): Mints a one-time HTTPS token on a python-js **prod** data app so the caller can clone, pull,
+and push to the app's managed git repo over HTTPS.
+- [delete_python_js_data_app_draft](#delete_python_js_data_app_draft): Deletes a python-js DRAFT data app — both the data-app instance (DSAPI) and its Storage
+configuration.
 - [deploy_data_app](#deploy_data_app): Deploys/redeploys a data app or stops a running data app in the Keboola environment asynchronously, given the
 action and the configuration ID.
 - [get_data_apps](#get_data_apps): Lists summaries of data apps in the project given the limit and offset or gets details of a data apps by
@@ -1712,8 +1714,15 @@ Example 4 - Update storage mappings:
 
 **Description**:
 
-Mints a one-time HTTPS token on a python-js data app so the caller can clone, pull, and push
-to the app's managed git repo over HTTPS.
+Mints a one-time HTTPS token on a python-js **prod** data app so the caller can clone, pull,
+and push to the app's managed git repo over HTTPS.
+
+**Always call against the prod app's configuration_id** — drafts have no managed repo of their
+own, so calling this on a draft fails. The prod app is the canonical repo owner; drafts
+iterate against branches of that same repo.
+
+**MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
+branch-delete — is yours. This tool only mints credentials.
 
 Returns a ready-to-use `git_clone_url` of the form `https://kai:<secret>@<host>/<path>.git`
 plus the raw `secret`. The token is returned **only** at creation — the platform cannot return
@@ -1725,19 +1734,21 @@ additional token without invalidating any tokens already held by other clients.
 
 ## When to call
 
-1. **Right after `modify_python_js_data_app` create** — the new app has a managed repo but no
-   credentials yet. Call this tool with the new app's `configuration_id` to enable git access.
+1. **Right after `modify_python_js_data_app` create of a prod app** — the new prod has a
+   managed repo but no credentials yet. Call this tool with the new app's `configuration_id`
+   to enable git access. (Note: when creating a **draft**, the prod-side token is minted and
+   embedded into the returned `git_clone_url` automatically — no separate call needed.)
 
-2. **Recovery when the cached token is gone** (e.g., a fresh Kai sandbox continuing an old draft
-   — the previous sandbox's filesystem was wiped, taking the cached `git_clone_url` with it).
-   If `git clone`/`pull`/`push` against a python-js app the LLM did not create in the current
-   session fails with `Authentication failed` (HTTP 401), call this tool with the same
-   `configuration_id` to mint a fresh token. Existing credentials remain valid, so other clients
-   are not disrupted.
+2. **Recovery when the cached token is gone / continuing an unfinished draft** — e.g., a fresh
+   sandbox continuing yesterday's work, with the previous sandbox's filesystem wiped. The
+   cached `git_clone_url` is lost; the configuration ID for the prod app is all you have.
+   Call this tool with the **prod app's** `configuration_id` to mint a fresh token (drafts
+   have no managed repo, so always mint against prod). Existing credentials remain valid, so
+   other clients are not disrupted.
 
 ## Constraints
-- Only python-js data apps have a managed git repo. Streamlit apps reject the call with a clear
-  error.
+- Only python-js prod data apps have a managed git repo. Streamlit apps reject the call with
+  a clear error.
 - Permissions are always `readWrite` — the LLM virtually always needs push access. The
   data-science API supports read-only credentials, but the tool does not expose that knob;
   revisit once a real use case appears.
@@ -1761,6 +1772,56 @@ additional token without invalidating any tokens already held by other clients.
 ```
 
 ---
+<a name="delete_python_js_data_app_draft"></a>
+## delete_python_js_data_app_draft
+**Annotations**: `destructive`
+
+**Tags**: `data-apps`
+
+**Description**:
+
+Deletes a python-js DRAFT data app — both the data-app instance (DSAPI) and its Storage
+configuration.
+
+**MCP never runs git on your behalf.** Deleting the feature branch on the remote is your job;
+this tool only tears down the draft config and its data-app instance.
+
+WHEN TO CALL: at the end of a promote-to-prod sequence, after you have merged the draft's
+branch into `main`, pushed, deleted the feature branch from the remote, and redeployed the
+prod app. The Keboola UI lists drafts under their parent prod app; once you call this tool,
+the draft disappears from that list.
+
+WHAT THIS TOOL REFUSES:
+  - prod apps (no `isDraft` flag) — protects against accidental prod deletion;
+  - Streamlit apps — they have no draft concept.
+
+WHAT THIS TOOL DOES NOT DO:
+  - Run git. Deleting the feature branch on the remote is your job.
+  - Revoke the prod-side git credential minted when the draft was created. Credential
+    rotation is the user's job via the Keboola UI.
+
+After a successful call, pivot back to the parent prod app (its configuration_id is returned
+in the response) or to `get_data_apps` for further work.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "configuration_id": {
+      "description": "Storage configuration ID of the python-js draft data app to delete.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "configuration_id"
+  ],
+  "type": "object"
+}
+```
+
+---
 <a name="deploy_data_app"></a>
 ## deploy_data_app
 **Annotations**: 
@@ -1772,13 +1833,21 @@ additional token without invalidating any tokens already held by other clients.
 Deploys/redeploys a data app or stops a running data app in the Keboola environment asynchronously, given the
 action and the configuration ID.
 
+**MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
+branch-delete — is yours. This tool only triggers deploys against existing git state.
+
 ## Mode and branch (python-js apps)
-- `mode='dev'` enables the in-platform preview for a python-js dev twin. Pair with `branch` to deploy a
-  specific git branch (edit flow); without `branch`, the dev twin deploys `main`.
-- For prod redeploys (including after merging a feature branch into `main` during the edit flow), use
-  no `mode` and no `branch` — the prod app picks up the current `main`.
-- python-js apps do NOT fetch a Storage `configVersion` for deployment (their source lives in git, not in
-  the Storage configuration); this is handled automatically.
+- `mode='dev'` deploys the target as a **dev version of the data app** — the runtime uses a
+  development `setup.sh` (hot reload) and the data-app proxy enables an auto-auth path so an
+  iframe preview can render without a manual login. Only meaningful on **draft** configs
+  (python-js apps with `isDraft=true`).
+- For prod redeploys (including after merging a draft's branch into `main`), use no `mode` and
+  no `branch` — the prod app picks up the current `main`.
+- The optional `branch=` argument overrides the branch the draft deploys from for this single
+  deploy. Normally unnecessary — drafts have their draft branch pinned in
+  `parameters.dataApp.git.branch` at create time.
+- python-js apps do NOT fetch a Storage `configVersion` for deployment (their source lives in
+  git, not in the Storage configuration); this is handled automatically.
 
 ## Streamlit apps
 Streamlit apps have no managed git repo, so `mode` and `branch` have no effect on the
@@ -1826,7 +1895,7 @@ error for any app type (Streamlit or python-js).
         }
       ],
       "default": null,
-      "description": "Deployment mode. Set to \"dev\" to enable the in-platform preview for python-js data apps. Leave None (default) for Streamlit apps and for production deploys."
+      "description": "Deployment mode. Set to \"dev\" to deploy a python-js draft as a **dev version of the data app** \u2014 the runtime uses a development `setup.sh` (hot reload), and the data-app proxy enables an auto-auth path so an iframe preview can render without a manual login. Only meaningful on **draft** configs (python-js apps with `isDraft=true`). Leave None (default) for prod redeploys and for Streamlit apps."
     },
     "branch": {
       "anyOf": [
@@ -1838,7 +1907,7 @@ error for any app type (Streamlit or python-js).
         }
       ],
       "default": null,
-      "description": "Git branch to deploy from. Only meaningful when `mode=\"dev\"` for python-js apps backed by a managed repo \u2014 the dev twin will deploy from this branch instead of `main`, enabling branch-based preview during the edit flow. Leave None for prod deploys and for Streamlit apps."
+      "description": "Git branch to deploy from. Only meaningful when `mode=\"dev\"` for python-js drafts. Normally unnecessary \u2014 drafts have their branch pinned in `parameters.dataApp.git.branch` at create time; this argument overrides that pin for this single deploy (escape hatch). Leave None for prod deploys and for Streamlit apps."
     }
   },
   "required": [
@@ -1875,6 +1944,12 @@ data app logs to investigate in-app errors. The logs may be updated after openin
   (when `configuration_ids` is provided). The inventory list always returns `repo_url=None`,
   even for python-js apps with a managed repo — to retrieve the URL, call this tool again
   with the target `configuration_ids`.
+- When called with `configuration_ids=[<prod-cfg>]` for a python-js **prod** app, the response
+  includes a `drafts: [...]` array of every draft (configs with `isDraft=true` and
+  `parentConfigurationId == <prod-cfg>`) currently in the project. Drafts in trash are not
+  included. Use this to discover existing drafts when continuing a previously abandoned
+  iteration (Scenario C in `modify_python_js_data_app`). The array is empty for drafts
+  themselves and for Streamlit apps.
 
 
 **Input JSON Schema**:
@@ -1916,66 +1991,91 @@ data app logs to investigate in-app errors. The logs may be updated after openin
 
 Creates or updates a python-js data app.
 
-Two-app project model: every python-js project has a persistent **prod app** that owns the only
-managed git repository for the project, and one or more **dev twins** that are *external-git* apps
-pointing back at the prod app's managed repo for LLM iteration. Dev twins appear in the Keboola UI
-under their parent prod app in a "Drafts" section; the user discards them manually via a "Discard"
-button when no longer needed. The MCP server does not delete dev twins.
+Two-app project model. Every python-js project has a persistent **prod app** that owns the
+only managed git repository for the project, and zero or more **drafts** parented to that
+prod app. A draft is a Storage configuration with `parameters.dataApp.isDraft=true` and
+`parameters.dataApp.parentConfigurationId=<prod cfg id>`; it's an *external-git* app that
+clones the parent prod's repo at a pinned branch on every deploy. Drafts are surfaced in the
+Keboola UI under their parent prod app. Use `deploy_data_app(mode='dev')` to deploy a draft
+as a dev version of the data app (hot reload + auto-auth for iframe preview); use
+`delete_python_js_data_app_draft` to tear a draft down after its branch has been promoted.
 
-Why this ownership split (MVP, AI-3005): the data-science platform does not yet support sharing a
-managed repo across apps. Until the platform-side drafts mechanism lands (AI-3240), the dev twin
-is configured to clone the prod app's repo on every deploy by setting its
-`parameters.dataApp.git = {repository, username, '#password', branch}`. The prod-side credential
-is minted automatically inside this tool when creating a dev twin — the agent does NOT need to
-call `create_python_js_data_app_git_credential` separately on a dev twin.
+**MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
+branch-delete — is yours. MCP gives you authenticated clone URLs and manages configs/deploys;
+it never invokes git.
 
-## Create flow (new project bootstrap)
-No `configuration_id`, no `parent_configuration_id`. `slug` is required.
-Steps:
-1. Call this tool with `slug` (the user-facing name, e.g. `demo`). Creates the **prod app** with
-   its own managed git repo. Returns `(configuration_id=PROD, repo_url=R)`. `R` is the bare HTTPS
-   URL (no credentials).
-2. Call this tool again with `slug` (e.g. `demo-dev-<rand>`) and `parent_configuration_id=PROD`.
-   Creates the **dev twin** as an external-git app pointing at `R` on a fresh iteration branch.
-   Returns `(configuration_id=DEV, repo_url=R, git_clone_url=U, branch=B)` — `U` has the
-   prod-issued token embedded so the agent can clone immediately, and `B` is the branch the
-   dev twin is pinned to (`iter-<6-hex>` if `branch` was not passed).
-3. `git clone U`, `git checkout B`, write source, push.
-4. `deploy_data_app(action='deploy', configuration_id=DEV, mode='dev')` → preview URL serving
-   branch `B`. Iterate with the user.
-5. After approval, locally `git checkout main && git merge B && git push`.
-6. `deploy_data_app(action='deploy', configuration_id=PROD)` — no `mode`, no `branch`. The prod
-   app picks up the merged `main`. The dev twin stays listed under the prod app in the UI's
-   "Drafts" section until the user discards it.
+Three scenarios the agent has to distinguish:
 
-## Edit flow (modifying an existing prod app)
-Same as steps 2–6 above. The agent already has the prod's `configuration_id`; it just calls
-this tool with `parent_configuration_id=<prod>` and (optionally) `branch=<name>` to create the
-dev twin. No `get_data_apps` pre-lookup is needed.
+## Scenario A — Create a brand-new data app
 
-## Update flow (modifying an existing app's deployment metadata)
-When `configuration_id` is set: updates the Storage configuration (auto-suspend, name, description,
-`authentication_type`). `slug`, `parent_configuration_id`, and `branch` are all rejected here —
-slug is immutable, the repo binding is fixed at creation, and the iteration branch only makes
-sense at create time. Use `authentication_type='default'` to keep the existing auth setup
-(including OIDC configured outside the MCP); pass `'no-auth'` or `'basic-auth'` to overwrite.
-After updating, ALWAYS call `deploy_data_app(action='deploy', ...)` to restart the app so the
-changes take effect.
+1. `modify_python_js_data_app(slug='demo')` → `(configuration_id=PROD, repo_url=R)`.
+   PROD owns the only managed repo for this app.
+2. `modify_python_js_data_app(slug='demo-draft', parent_configuration_id=PROD)`
+   → `(configuration_id=DRAFT, repo_url=R, git_clone_url=U, branch='init')`.
+   Default draft branch is `'init'`. Override with `branch=<name>` for a descriptive name.
+3. YOU: `git clone U`; `git checkout init` (creating it if the repo is empty); write source;
+   `git push origin init`.
+4. `deploy_data_app(action='deploy', configuration_id=DRAFT, mode='dev')`
+   → preview URL serving the `init` branch as a dev version. Iterate with the user.
+5. Once approved — YOU: `git checkout main`; `git merge init`; `git push origin main`;
+   `git push origin --delete init`.
+6. `deploy_data_app(action='deploy', configuration_id=PROD)`
+   → prod URL now serves the merged `main`.
+7. `delete_python_js_data_app_draft(configuration_id=DRAFT)`
+   → tears down the draft's config + data-app instance. Always run this once promoted.
+
+## Scenario B — Edit an existing data app
+
+You already have PROD's `configuration_id` (from `get_data_apps` or earlier conversation).
+
+1. `create_python_js_data_app_git_credential(configuration_id=PROD)`
+   → fresh `git_clone_url U` with an embedded one-time token.
+2. `modify_python_js_data_app(
+        slug='demo-draft-<short suffix>',
+        parent_configuration_id=PROD,
+        branch='<describes-the-change>',   # e.g. 'add-revenue-filter'
+   )` → `(DRAFT, R, U2, branch)`. Use U2 (it has its own fresh token).
+3. YOU: `git clone U2`; `git checkout <branch>` (creating it from `main`); edit source;
+   `git push origin <branch>`.
+4–7. Same as Scenario A steps 4–7.
+
+## Scenario C — Continue an unfinished draft
+
+The previous sandbox is gone. You have PROD's `configuration_id` but no working clone and no
+draft handle.
+
+1. `get_data_apps(configuration_ids=[PROD])` → returns PROD's detail including `drafts: [...]`.
+   Pick the draft the user means (ask if multiple and unclear). Each entry exposes its
+   `configuration_id`, slug, and pinned branch.
+2. `create_python_js_data_app_git_credential(configuration_id=PROD)`
+   → fresh `git_clone_url U` (the previous one was minted in a wiped sandbox and is lost).
+   Drafts have no managed repo of their own — always mint against PROD.
+3. YOU: `git clone U`; `git checkout <draft's pinned branch>`; resume work; `git push`.
+4. `deploy_data_app(action='deploy', configuration_id=<DRAFT>, mode='dev')` → preview URL.
+   The draft's branch is already pinned in its config, no override needed.
+5–7. Same promote/cleanup sequence as Scenario A steps 5–7.
+
+## Argument rules
+
+- `parent_configuration_id` is **create-only**. Rejected on update.
+- `branch` is **create-only** and only valid when `parent_configuration_id` is set.
+  Defaults to `'init'`. Must not be `'main'`. Rejected on prod create and on update.
+- `slug` is required on create and immutable after.
+- The **update path** (passing `configuration_id`) is for changing `name`, `description`,
+  `authentication_type`, `auto_suspend_after_seconds`, `storage` on either a prod app or
+  a draft. Source code changes go through the git flow above, not this tool.
 
 ## Authentication
+
 New apps default to HTTP basic authentication for safety. Pass `authentication_type='no-auth'`
-explicitly to expose the app publicly. OIDC and other advanced auth setups are managed outside the
-MCP — when updating such an app, leave `authentication_type='default'` to preserve them.
+to expose publicly. On update, `authentication_type='default'` preserves the existing
+`authorization` block (including OIDC setups configured outside the MCP); `'basic-auth'` /
+`'no-auth'` overwrite it.
 
 ## Slug constraint
-Must be DNS-label-safe (lowercase letters, digits, hyphens, ≤63 chars). For dev twins, append a
-short suffix (e.g. `-dev-abc123`) to keep slugs unique across the prod app and its twins.
 
-## Source code
-Source code lives in the managed git repo, NOT in this tool's input. This tool only manages
-deployment metadata and the git binding. Source code changes are pushed via `git push` to the
-prod app's repo URL (`repo_url` in this tool's output, embedded with credentials in
-`git_clone_url` on the dev-twin create path).
+Must be DNS-label-safe (lowercase letters, digits, hyphens, ≤63 chars). For drafts, append a
+short suffix (e.g. `-draft-abc123`) to keep slugs unique across the prod and its drafts.
 
 
 **Input JSON Schema**:
@@ -2023,7 +2123,7 @@ prod app's repo URL (`repo_url` in this tool's output, embedded with credentials
         }
       ],
       "default": null,
-      "description": "Storage configuration ID of the prod python-js data app this dev twin will iterate against. When set on create, the new app is created as a **dev twin**: no managed repo is provisioned for it; instead its `parameters.dataApp.git` block is populated to point at the prod app's managed repo, with a freshly-minted prod-app HTTPS token and the chosen iteration branch. Leave None on create to make a **prod app** (which gets its own managed repo). Rejected on update."
+      "description": "Storage configuration ID of the prod python-js data app this draft will iterate against. When set on create, the new app is created as a **draft**: no managed repo is provisioned for it; instead its `parameters.dataApp.git` block is populated to point at the prod app's managed repo, with a freshly-minted prod-app HTTPS token and the chosen draft branch. Leave None on create to make a **prod app** (which gets its own managed repo). Rejected on update."
     },
     "branch": {
       "anyOf": [
@@ -2035,7 +2135,7 @@ prod app's repo URL (`repo_url` in this tool's output, embedded with credentials
         }
       ],
       "default": null,
-      "description": "Iteration branch for the dev twin to deploy from. Only valid on the dev-twin create path (when `parent_configuration_id` is set). Defaults to `iter-<6-hex>` when unset. Must not be `main` (reserved for the prod app). Rejected on prod create and on update."
+      "description": "Draft branch to pin the new draft to. Only valid on the draft create path (when `parent_configuration_id` is set). Defaults to `init` when unset (a sensible name for the first draft of a brand-new prod app). For subsequent edit-existing drafts, pass a descriptive branch name like 'add-revenue-filter'. Must not be `main` (reserved for the prod app). Rejected on prod create and on update."
     },
     "authentication_type": {
       "default": "default",

--- a/docs/python-js-data-apps.md
+++ b/docs/python-js-data-apps.md
@@ -1,73 +1,74 @@
-# Python-JS Data Apps: Prod + External-Git Dev Twin
+# Python-JS Data Apps: Prod + Drafts
 
-**Linear**: [AI-3005](https://linear.app/keboola/issue/AI-3005)
-**Status**: MVP shipped in v1.63.0. Replaces the broken shared-managed-repo design from v1.62.0.
+**Linear**: [AI-3286](https://linear.app/keboola/issue/AI-3286)
+(supersedes the MVP shipped in v1.63.0 under [AI-3005](https://linear.app/keboola/issue/AI-3005))
+**Status**: shipped in v1.64.0.
 **Long-term tracker (platform-side drafts)**: [AI-3240](https://linear.app/keboola/issue/AI-3240)
 
 ---
 
 ## Overview
 
-Python-JS data apps are backed by a **git repository**: source code lives in the repo, not in the Storage configuration. The MCP server exposes a small set of primitives (`modify_python_js_data_app`, `deploy_data_app`, `create_python_js_data_app_git_credential`, `get_data_apps`) that together support a **two-app project model**:
+Python-JS data apps are backed by a **git repository**: source code lives in the repo, not in the Storage configuration. The MCP server exposes a small set of primitives — `modify_python_js_data_app`, `deploy_data_app`, `create_python_js_data_app_git_credential`, `get_data_apps`, `delete_python_js_data_app_draft` — that together support a **two-app project model**:
 
 - A persistent **prod app** that users actually run. The prod app **owns the only managed git repo** in the project.
-- One or more **dev twins** that are *external-git* apps configured to clone the prod app's repo on every deploy. Dev twins serve as the LLM's iteration sandbox.
+- Zero or more **drafts** parented to that prod app. A draft is a Storage configuration with `parameters.dataApp.isDraft=true` and `parameters.dataApp.parentConfigurationId=<prod cfg id>`; it's an *external-git* app that clones the parent prod's repo at a pinned branch on every deploy. Drafts serve as the LLM's iteration sandbox.
 
-Dev twins are surfaced in the Keboola UI under their parent prod app in a **"Drafts"** section, each with its own **"Discard"** button. Cleanup is a user action — there is no platform-side GC and the MCP server does not delete dev twins.
+Drafts are surfaced in the Keboola UI under their parent prod app. They are also discoverable via `get_data_apps`: detail responses for a python-js **prod** app carry a `drafts: [...]` array. Cleanup is explicit — the agent calls `delete_python_js_data_app_draft` once the draft's branch has been promoted to `main`.
+
+**MCP never invokes git.** All git operations (clone, branch, commit, push, merge, branch-delete) are owned by the agent. MCP owns: credentials minting, configs, deploys, draft lifecycle (create + delete).
 
 ```
 ┌─────────────────────────── Project ───────────────────────────┐
 │                                                                │
 │   ┌────────────────┐                       ┌────────────────┐ │
-│   │   Prod App     │                       │   Dev Twin     │ │
-│   │ (persistent)   │                       │  (Draft)       │ │
-│   │                │                       │                │ │
-│   │ slug: demo     │                       │ slug:          │ │
-│   │ branch: main   │                       │  demo-dev-xyz  │ │
-│   │ mode: prod     │                       │ mode: dev      │ │
-│   │                │  external-git config  │ parameters.    │ │
-│   │ owns managed   │ ◄──── points at ──────┤   dataApp.git: │ │
-│   │   git repo R   │      repo R, branch   │  { repo: R,    │ │
-│   │                │      iter-feat, with  │    #password,  │ │
-│   │                │      prod-issued      │    branch:     │ │
-│   │                │      token            │     iter-feat }│ │
+│   │   Prod App     │                       │     Draft      │ │
+│   │ (persistent)   │                       │                │ │
+│   │                │                       │ slug:          │ │
+│   │ slug: demo     │                       │  demo-draft    │ │
+│   │ branch: main   │  external-git config  │ isDraft: true  │ │
+│   │ mode: prod     │ ◄──── points at ──────┤ parentConfig:  │ │
+│   │                │                       │  PROD          │ │
+│   │ owns managed   │                       │ parameters.    │ │
+│   │   git repo R   │                       │  dataApp.git:  │ │
+│   │                │                       │  { repo: R,    │ │
+│   │                │                       │    #password,  │ │
+│   │                │                       │    branch:     │ │
+│   │                │                       │     init }     │ │
 │   └────────────────┘                       └────────────────┘ │
 │         │                                            │         │
 │         ▼                                            ▼         │
-│    Prod URL                                     Preview URL    │
+│    Prod URL                              Preview URL (dev mode)│
 └────────────────────────────────────────────────────────────────┘
-                                                       │
-                                          (listed under prod app
-                                          in UI "Drafts" section;
-                                          user clicks "Discard"
-                                          to remove)
+                         ▲
+                         │
+                         └── get_data_apps([PROD]) returns
+                             prod detail + drafts: [DRAFT]
 ```
 
 ---
 
 ## Why prod owns the repo
 
-The original design (v1.62.0) was the opposite: the dev iteration app was created first with its own managed repo, and the prod app was created via `existing_repo_url=<dev's repo>` so both apps shared one managed repo. End-to-end testing on canary-orion proved that `existingRepoUrl` is silently dropped by `POST /apps` — the platform always provisions a fresh managed repo per app and provides no mechanism to share or link managed repos across apps.
-
-The MVP workaround (this design): **flip the ownership** so the prod app is the canonical managed-repo owner, and the dev twin is an *external-git* app whose `parameters.dataApp.git` block tells the data-app runtime to clone the prod repo on deploy. The prod-side credential is minted by the MCP server when creating the dev twin (the platform accepts unlimited per-app credentials, so this is non-destructive).
-
-This unlocks the same dev/prod iteration loop without requiring shared-repo support from the platform. The long-term fix — a first-class "drafts" mechanism — is tracked in [AI-3240](https://linear.app/keboola/issue/AI-3240).
+The data-science platform does not yet support sharing a managed repo across apps (`existingRepoUrl` on `POST /apps` is silently dropped; every app gets a fresh managed repo). Until the platform-side drafts mechanism lands ([AI-3240](https://linear.app/keboola/issue/AI-3240)), we **flip the ownership**: the prod app is the canonical managed-repo owner, and each draft is an *external-git* app whose `parameters.dataApp.git` block tells the data-app runtime to clone the prod repo on deploy. The prod-side credential is minted by the MCP server when creating the draft (the platform accepts unlimited per-app credentials, so this is non-destructive).
 
 ---
 
 ## Tool surface
 
-| Tool | Change in v1.63.0 | Purpose |
+| Tool | Change in v1.64.0 | Purpose |
 |---|---|---|
-| `modify_python_js_data_app` | Replaced `existing_repo_url` (create-only) with `parent_configuration_id` (create-only) and `branch` (create-only, dev-twin only) | Create a dev twin bound to the parent prod app's managed repo. |
-| `deploy_data_app` | No change | Same as before: `mode='dev'` plus optional `branch` to override the branch the dev twin deploys from. |
-| `create_python_js_data_app_git_credential` | No change | Mint a one-time HTTPS token on a prod app's managed repo. Used for the lost-token recovery flow; **not** needed for the standard dev-twin create flow (the token is minted and embedded into the returned `git_clone_url` automatically). |
+| `modify_python_js_data_app` | Default draft branch is now `'init'` (was `iter-<6-hex>`). Drafts persist `parameters.dataApp.parentConfigurationId` so they can be discovered cheaply. Docstring rewritten to drop "dev twin". | Create/update a prod app; create a draft bound to the parent prod app's managed repo. |
+| `deploy_data_app` | No behaviour change. Docstring reframes `mode='dev'` as "deploys the draft as a **dev version of the data app**" (hot reload + auto-auth for iframe preview). | Deploy/redeploy or stop. `mode='dev'` only meaningful on drafts. |
+| `create_python_js_data_app_git_credential` | No behaviour change. Docstring tightens the prod-only contract: drafts have no managed repo, always mint against prod. | Mint a one-time HTTPS token on a python-js prod app's managed repo. |
+| `get_data_apps` | Detail responses for python-js **prod** apps now include a `drafts: [...]` array of `DataAppSummary` entries — every draft (`isDraft=true`, `parentConfigurationId == <prod-cfg>`) parented to that prod, fetched with one extra `configuration_list` round-trip. Empty for drafts themselves and for Streamlit apps. | List or detail-fetch data apps; discover drafts. |
+| **NEW** `delete_python_js_data_app_draft` | New tool. Deletes a draft's data-app instance (DSAPI) and its Storage configuration. Refuses prod apps (no `isDraft` flag) and Streamlit apps. | Cleanup primitive — call after a draft's branch has been promoted to `main`. |
 
-The flow is taught to the LLM exclusively through the tool docstrings; there is no MCP prompt.
+The flow is taught to the LLM exclusively through tool docstrings; there is no MCP prompt.
 
 ### Runtime image version
 
-The runtime image version is currently **hardcoded** in the MCP server (constant `_HARDCODED_PYTHON_JS_IMAGE_VERSION` in `src/keboola_mcp_server/tools/data_apps.py` — see the source for the current value). The tool does not expose it as an argument. Remove the hardcoded constant and re-introduce the argument (or simply drop the field from the payload) once the platform sets a default image for python-js apps.
+The data-science platform now picks a default runtime image for python-js apps, so the MCP server **does not write `runtime.image.version`** into newly created python-js configs. Legacy configs written by earlier MCP versions may still carry a pinned image — those values are preserved verbatim on update via deepcopy, but the MCP never sets or overwrites the pin. To change the image used by a specific app, edit the config directly in the Keboola UI.
 
 ### Per-app workspace
 
@@ -81,15 +82,21 @@ Newly created python-js apps carry `runtime.workspace.enabled = true` in their S
 
 Managed repos authenticate over **HTTPS** with one-time tokens minted by sandboxes-service. The MCP server does not surface SSH at all — no keypair generation, no `GIT_SSH_COMMAND`, no `~/.ssh` plumbing.
 
-For the standard dev-twin create flow, `modify_python_js_data_app` mints the prod-side token internally and returns a ready-to-use `git_clone_url` of the form `https://kai:<secret>@<host>/<path>.git`. For the lost-token recovery flow, `create_python_js_data_app_git_credential` does the same on demand. The hardcoded username `kai` is set by the constant `_MANAGED_GIT_REPO_USERNAME` in `src/keboola_mcp_server/tools/data_apps.py`; the git-service ignores the username portion and only validates the token.
+For the standard draft create flow, `modify_python_js_data_app` mints the prod-side token internally and returns a ready-to-use `git_clone_url` of the form `https://kai:<secret>@<host>/<path>.git`. For the lost-token recovery flow, `create_python_js_data_app_git_credential` does the same on demand. The hardcoded username `kai` is set by the constant `_MANAGED_GIT_REPO_USERNAME` in `src/keboola_mcp_server/tools/data_apps.py`; the git-service ignores the username portion and only validates the token.
 
 The platform supports multiple credentials per app, so minting a fresh credential never invalidates earlier ones — important for the recovery flow below and for parallel iteration.
+
+### Credential lifecycle
+
+- A new credential is minted on the parent **prod** app every time a draft is created. The prod-side credential is encrypted into the draft's `parameters.dataApp.git.#password`.
+- **Deleting a draft via `delete_python_js_data_app_draft` does NOT revoke that credential.** The MCP surface has no list/delete-credential affordance; rotation is the user's job via the Keboola UI. (DSAPI does support `DELETE /apps/{id}/git-repo/credentials/{credentialId}`, but the MCP server does not store the credential ID on the draft to make targeted revocation possible.)
+- Because the platform accepts unlimited per-app credentials and ignores stale ones for auth purposes, accumulated drafts produce stale-but-harmless credentials on the prod app over time. Treat this as a known trade-off until the platform-side drafts feature lands ([AI-3240](https://linear.app/keboola/issue/AI-3240)).
 
 ---
 
 ## Create flow (new project bootstrap)
 
-Use when there is no prod app yet. The LLM creates the prod app first (which owns the managed repo), then creates a dev twin bound to that repo, iterates with the user on an iteration branch, and finally merges into `main` and redeploys prod.
+Use when there is no prod app yet. The agent creates the prod app first (which owns the managed repo), then creates a draft bound to that repo, iterates with the user on the draft branch, finally merges into `main`, redeploys prod, and tears down the draft.
 
 ```
 Step 1: modify_python_js_data_app(
@@ -99,26 +106,28 @@ Step 1: modify_python_js_data_app(
                                         │
                                         ▼
 Step 2: modify_python_js_data_app(
-            slug='demo-dev-abc',
+            slug='demo-draft',
             parent_configuration_id=PROD,
-        )                    ──► { configuration_id: DEV, repo_url: R,
-                                   git_clone_url: U, branch: B }
-                                  (U = https://kai:<secret>@host/path.git,
-                                   B = 'iter-<6-hex>' or caller-supplied)
+        )                    ──► { configuration_id: DRAFT, repo_url: R,
+                                   git_clone_url: U, branch: 'init' }
+                                  (U = https://kai:<secret>@host/path.git)
                                         │
                                         ▼
-Step 3: git clone U; git checkout B; write app.py; git push origin B
+Step 3: YOU: git clone U; git checkout init (create if empty);
+        write app.py; git push origin init
                                         │
                                         ▼
 Step 4: deploy_data_app(
             action='deploy',
-            configuration_id=DEV,
+            configuration_id=DRAFT,
             mode='dev',
-        )                    ──► preview URL serving B — iterate with user
+        )                    ──► preview URL serving 'init' as a dev version
+                                 (hot reload + auto-auth iframe preview)
                                         │
                                         ▼ (user approves)
                                         │
-Step 5: git checkout main; git merge B; git push origin main
+Step 5: YOU: git checkout main; git merge init;
+        git push origin main; git push origin --delete init
                                         │
                                         ▼
 Step 6: deploy_data_app(
@@ -127,61 +136,115 @@ Step 6: deploy_data_app(
         )                    ──► prod URL now serves merged main
                                         │
                                         ▼
-Step 7: DEV stays listed under PROD in the UI's "Drafts"
-        section; user clicks "Discard" to remove it.
+Step 7: delete_python_js_data_app_draft(
+            configuration_id=DRAFT,
+        )                    ──► DRAFT (config + data-app instance) torn down
 ```
 
 Key invariants:
 
-- Only **PROD** owns a managed repo (`use_managed_git_repo=True`). The dev twin is created with `use_managed_git_repo=False` and a populated `parameters.dataApp.git` block.
-- The dev twin's `repo_url` equals PROD's `repo_url` — they are the same physical repo on the git-service side.
-- The token embedded in `git_clone_url` was minted against **PROD**, not the dev twin. Existing prod-side tokens are not invalidated.
-- Step 4 uses `mode='dev'` to mark the app as a draft in the UI and trigger the data-app runtime to clone the configured external branch. Step 6 (prod redeploy) uses no `mode` / no `branch` — prod always deploys `main` from its own managed repo.
+- Only **PROD** owns a managed repo (`use_managed_git_repo=True`). The draft is created with `use_managed_git_repo=False`, a populated `parameters.dataApp.git` block, `isDraft=true`, and `parentConfigurationId=PROD`.
+- The draft's `repo_url` equals PROD's `repo_url` — they are the same physical repo on the git-service side.
+- The token embedded in `git_clone_url` was minted against **PROD**, not the draft. Existing prod-side tokens are not invalidated.
+- Step 4 uses `mode='dev'` to deploy the draft as a dev version (hot reload + iframe auto-auth). Step 6 (prod redeploy) uses no `mode` / no `branch` — prod always deploys `main` from its own managed repo.
+- Step 7 deletes the draft via the MCP tool. The draft's prod-side credential is **not** revoked.
 
 ---
 
-## Edit flow (modifying an existing prod app)
+## Edit flow (modifying an existing data app)
 
-Use when the user wants to change an existing prod app. Same shape as steps 2–6 of the create flow — the agent already has the prod's `configuration_id`, so it goes straight to dev-twin creation.
+Use when the user wants to change an existing prod app. The agent already has the prod's `configuration_id`, so it goes straight to a fresh credential + draft creation with a descriptive branch.
 
 ```
-Step 1: modify_python_js_data_app(
-            slug='demo-dev-xyz',
+Step 1: create_python_js_data_app_git_credential(
+            configuration_id=PROD,
+        )                    ──► { git_clone_url: U }
+                                 (mint a fresh prod-side token)
+                                        │
+                                        ▼
+Step 2: modify_python_js_data_app(
+            slug='demo-draft-<suffix>',
             parent_configuration_id=PROD,
-            branch='feature-x',   (optional; auto-generated if omitted)
-        )                    ──► { configuration_id: DEV, repo_url: R,
-                                   git_clone_url: U, branch: B }
+            branch='add-revenue-filter',   (descriptive — pick a useful name)
+        )                    ──► { configuration_id: DRAFT, repo_url: R,
+                                   git_clone_url: U2, branch: <as supplied> }
                                         │
                                         ▼
-Step 2: git clone U; git checkout B; write changes; git push origin B
+Step 3: YOU: git clone U2; git checkout <branch> (create from main);
+        edit source; git push origin <branch>
                                         │
                                         ▼
-Step 3: deploy_data_app(
+Step 4: deploy_data_app(
             action='deploy',
-            configuration_id=DEV,
+            configuration_id=DRAFT,
             mode='dev',
-        )                    ──► preview URL serving B
+        )                    ──► preview URL serving the draft branch
                                         │
                                         ▼ (user approves)
                                         │
-Step 4: git checkout main; git merge B; git push origin main
+Step 5: YOU: git checkout main; git merge <branch>;
+        git push origin main; git push origin --delete <branch>
                                         │
                                         ▼
-Step 5: deploy_data_app(
+Step 6: deploy_data_app(
             action='deploy',
             configuration_id=PROD,
         )                    ──► prod URL now serves merged main
                                         │
                                         ▼
-Step 6: DEV stays listed under PROD in the UI's "Drafts"
-        section; user clicks "Discard" to remove it.
+Step 7: delete_python_js_data_app_draft(
+            configuration_id=DRAFT,
+        )                    ──► DRAFT torn down
 ```
 
 Key invariants:
 
 - The prod app's `configuration_id` is **never** modified in this flow — only its underlying git `main` is updated and the app is redeployed.
-- The dev twin's pinned branch is set in its `parameters.dataApp.git.branch` at create time. Passing `branch` to `deploy_data_app(mode='dev')` lets the agent override that pin for an ad-hoc preview, but normally it is not needed because the dev-twin config already points at the correct branch.
-- The slug for the dev twin needs a short unique suffix (e.g. `-dev-xyz`) — both apps live in the same project and the slug is a DNS label.
+- The draft's pinned branch is set in its `parameters.dataApp.git.branch` at create time. Passing `branch` to `deploy_data_app(mode='dev')` lets the agent override that pin for an ad-hoc preview, but normally it is not needed because the draft's config already points at the correct branch.
+- Slugs must be unique across the prod and its drafts — append a short suffix (e.g. `-draft-abc123`).
+
+---
+
+## Continue-draft flow (resuming an unfinished iteration)
+
+Use when the user wants to continue work on a draft they started earlier but never promoted. The agent has the prod's `configuration_id` but no working clone and no draft handle.
+
+```
+Step 1: get_data_apps(
+            configuration_ids=[PROD],
+        )                    ──► prod detail with drafts: [...]
+                                 (Pick the draft the user means — ask if
+                                  multiple and unclear. Each entry exposes
+                                  configuration_id, slug, and pinned branch
+                                  via its config.)
+                                        │
+                                        ▼
+Step 2: create_python_js_data_app_git_credential(
+            configuration_id=PROD,         (always mint against prod —
+        )                    ──►            drafts have no repo of their own)
+                                 { git_clone_url: U }
+                                        │
+                                        ▼
+Step 3: YOU: git clone U; git checkout <draft's pinned branch>;
+        resume work; git push
+                                        │
+                                        ▼
+Step 4: deploy_data_app(
+            action='deploy',
+            configuration_id=<DRAFT>,
+            mode='dev',
+        )                    ──► preview URL — the draft's branch is already
+                                 pinned in its config, no override needed
+                                        │
+                                        ▼ (user approves)
+                                        │
+Step 5-7: Same promote/cleanup sequence as Scenario A steps 5–7.
+```
+
+Key invariants:
+
+- `get_data_apps(configuration_ids=[PROD])` is the discovery primitive. There is no `list_drafts` tool — the drafts surface inline on the prod's detail response.
+- Drafts in trash (deleted via `delete_python_js_data_app_draft` or the UI) are not included in `drafts: [...]`.
 
 ---
 
@@ -189,8 +252,8 @@ Key invariants:
 
 Distinct from create / edit: when only `auto_suspend_after_seconds`, `name`, `description`, `authentication_type`, or `storage` need to change on an existing app, call `modify_python_js_data_app(configuration_id=<id>, ...)`. The update path:
 
-- Updates the Storage configuration in place.
-- **Rejects** `slug` (immutable subdomain), `parent_configuration_id` (repo binding is fixed at creation), and `branch` (only meaningful for dev-twin creates).
+- Updates the Storage configuration in place — works on both prod apps and drafts.
+- **Rejects** `slug` (immutable subdomain), `parent_configuration_id` (repo binding is fixed at creation), and `branch` (only meaningful for draft creates).
 - After updating, the caller MUST call `deploy_data_app(...)` to restart the app so changes take effect.
 
 The update flow does NOT involve git — source code changes go through the edit flow. To rotate or add a token, use `create_python_js_data_app_git_credential` on the prod app.
@@ -199,7 +262,7 @@ The update flow does NOT involve git — source code changes go through the edit
 
 ## Recovering when the cached HTTPS token is lost
 
-The Kai sandbox the LLM iterates in is ephemeral: when a user returns later to continue an old draft, a fresh sandbox spins up and the conversation is restored, but the `git_clone_url` returned in the previous session is gone with the wiped filesystem. The LLM now holds a `configuration_id` for an existing prod app (and maybe a dev twin) but cannot `git clone`/`pull`/`push` against the managed repo.
+The sandbox the LLM iterates in is ephemeral: when a user returns later to continue an old draft, a fresh sandbox spins up and the conversation is restored, but the `git_clone_url` returned in the previous session is gone with the wiped filesystem. The LLM now holds a `configuration_id` for an existing prod app (and maybe a draft via `get_data_apps`) but cannot `git clone`/`pull`/`push` against the managed repo.
 
 The data-science API accepts **multiple credentials per app**, so registering a fresh one never invalidates credentials already held by other clients (e.g. a teammate iterating against the same prod app's repo).
 
@@ -212,7 +275,7 @@ One-call recovery:
                             git access restored — clone with git_clone_url
 ```
 
-Always call against the **prod** app's configuration ID — the dev twin has no managed repo of its own. (Calling against a dev twin's configuration ID returns a clear "only python-js managed-repo apps have a credentials endpoint" error.)
+Always call against the **prod** app's configuration ID — the draft has no managed repo of its own. (Calling against a draft's configuration ID returns a clear "only python-js managed-repo apps have a credentials endpoint" error.)
 
 ---
 
@@ -222,29 +285,48 @@ Always call against the **prod** app's configuration ID — the dev twin has no 
 
 - **Type**: `Optional[str]`
 - **When valid**: create only (raises `ValueError` if set on update).
-- **Semantics**: when set, the new app is created as a dev twin: `use_managed_git_repo=False`, and its `parameters.dataApp.git` block is populated with the parent's managed repo URL, a freshly minted prod-side HTTPS token (encrypted via the Keboola encryption service), and the iteration branch. The parent app must be a python-js app with a managed repo — Streamlit and dev-twin parents are rejected.
+- **Semantics**: when set, the new app is created as a draft: `use_managed_git_repo=False`, `isDraft=true`, `parentConfigurationId=<this value>`, and `parameters.dataApp.git` populated with the parent's managed repo URL, a freshly minted prod-side HTTPS token (encrypted via the Keboola encryption service), and the draft branch. The parent app must be a python-js app with a managed repo — Streamlit and draft parents are rejected.
 - **Returned**: the parent's `repo_url` is returned as `repo_url` unchanged; a `git_clone_url` with the embedded prod-issued token is returned alongside.
+- **Stored**: `parentConfigurationId` is **create-only** and immutable. It powers cheap draft discovery via `get_data_apps` detail.
 
 ### `modify_python_js_data_app(branch=...)`
 
 - **Type**: `Optional[str]`
-- **When valid**: dev-twin create only (must be paired with `parent_configuration_id`). Rejected on prod create and on update.
-- **Semantics**: pins the dev twin to this iteration branch (`parameters.dataApp.git.branch`). When unset, defaults to `iter-<6-hex>`. Must not be `main` (reserved for the prod app); must be non-empty and contain no whitespace.
+- **When valid**: draft create only (must be paired with `parent_configuration_id`). Rejected on prod create and on update.
+- **Semantics**: pins the draft to this branch (`parameters.dataApp.git.branch`). When unset, defaults to `'init'` (a sensible default for the first draft of a brand-new prod app — descriptive branches are agent-supplied on edit-existing flows). Must not be `main` (reserved for the prod app); must be non-empty and contain no whitespace. **Uniqueness across drafts is the agent's responsibility** — if `'init'` collides with an existing branch on the prod's repo, the agent sees the error from its own `git push` or from `deploy_data_app`.
+
+### `deploy_data_app(mode=...)`
+
+- **Type**: `Optional[Literal['dev', 'production']]`
+- **Semantics**: `mode='dev'` deploys the target as a **dev version of the data app** — the runtime uses a development `setup.sh` (hot reload), and the data-app proxy enables an auto-auth path so an iframe preview can render without a manual login. Only meaningful on drafts (python-js apps with `isDraft=true`). For prod redeploys, omit `mode`.
 
 ### `deploy_data_app(branch=...)`
 
 - **Type**: `Optional[str]`
 - **When valid**: only with `mode='dev'`. Raises `ValueError` otherwise.
-- **Semantics**: for python-js apps, overrides the branch the dev twin deploys from for this single deploy. Without `branch`, the dev twin deploys whatever branch is pinned in its `parameters.dataApp.git.branch`. Silently ignored for Streamlit apps (which have no managed git repo).
+- **Semantics**: for python-js apps, overrides the branch the draft deploys from for this single deploy. Without `branch`, the draft deploys whatever branch is pinned in its `parameters.dataApp.git.branch`. Silently ignored for Streamlit apps (which have no managed git repo).
 
 ### `create_python_js_data_app_git_credential(configuration_id=...)`
 
-- **`configuration_id`** (`str`, required): Storage configuration ID of an existing python-js **prod** app (i.e. one with a managed repo). The tool resolves it to the underlying `data_app_id` and rejects Streamlit apps with a clear error.
+- **`configuration_id`** (`str`, required): Storage configuration ID of an existing python-js **prod** app (i.e. one with a managed repo). The tool resolves it to the underlying `data_app_id` and rejects Streamlit apps with a clear error. Drafts also reject — always mint against prod.
 - **Returns**:
   - `credential_id` — UUID of the credential row on sandboxes-service. Useful only for diagnostics; the MCP surface does not expose list/delete endpoints.
   - `secret` — the one-time HTTPS token. **Cannot be retrieved again** by any subsequent read — store it if you need to reuse it outside of `git_clone_url`.
   - `git_clone_url` — ready-to-use authenticated URL of the form `https://kai:<secret>@<host>/<path>.git`. Pass directly to `git clone`.
   - `permissions` — always `readWrite` (the tool does not expose a permissions knob).
+
+### `delete_python_js_data_app_draft(configuration_id=...)`
+
+- **`configuration_id`** (`str`, required): Storage configuration ID of an existing python-js **draft** (i.e. one with `parameters.dataApp.isDraft=true`). Refuses prod apps and Streamlit apps.
+- **Behaviour**: calls DSAPI `DELETE /apps/{data_app_id}` (deletes the data-app instance) followed by Storage `DELETE /branch/{branch}/components/keboola.data-apps/configs/{cfg}` (with `skip_trash=False`, so the config goes to trash for the platform-standard 7 days). Stale prod-side credentials are NOT revoked.
+- **Returns**: `{response: 'deleted', configuration_id, data_app_id, parent_configuration_id, links}`. The parent configuration_id is surfaced so the agent can pivot back to the prod app for the next step (e.g. a prod redeploy).
+
+### `get_data_apps(configuration_ids=[<prod-cfg>])` — `drafts: [...]`
+
+- For a python-js **prod** app, the detail response includes a `drafts: list[DataAppSummary]` field containing every draft whose `parameters.dataApp.parentConfigurationId == <prod-cfg>`.
+- Empty `[]` for: drafts themselves, Streamlit apps, prod apps with no drafts.
+- Drafts in trash are not listed (the storage configuration list endpoint omits them).
+- Cost: one extra `configuration_list` call + up to N parallel detail fetches (N = number of drafts). Acceptable in practice — N is typically 0–3 and detail fetches are already heavier than the summary list path.
 
 ### `modify_python_js_data_app(authentication_type=...)`
 
@@ -259,25 +341,28 @@ Always call against the **prod** app's configuration ID — the dev twin has no 
 
 Several variants of this flow could have been packaged as dedicated tools but were left out:
 
-- **`create_dev_twin_data_app(parent_configuration_id)`** — `modify_python_js_data_app` with the new `parent_configuration_id` parameter is already exactly that; adding a separate tool name would just duplicate the surface.
-- **MCP-side deletion of dev twins** — the UI lists each dev twin under its parent prod app in the "Drafts" section with a "Discard" button. Cleanup is an explicit user action; there's no platform-side GC and no need for an MCP tool to delete twins.
+- **`create_draft_data_app(parent_configuration_id)`** — `modify_python_js_data_app` with the `parent_configuration_id` parameter is already exactly that; adding a separate tool name would just duplicate the surface.
 - **Credential listing/deletion** — out of scope; per-app credentials are append-only from the MCP surface (sandboxes-service supports listing/getting/deleting via `GET /apps/{id}/git-repo/credentials`, `GET .../credentials/{credentialId}`, and `DELETE .../credentials/{credentialId}`, but the MCP server does not expose them). The platform UI is the rotation/cleanup affordance.
+- **Single promote-to-prod tool** — the agent does merge+push+branch-delete locally, then `delete_python_js_data_app_draft` + `deploy_data_app(prod_id)`. No bundled MCP tool, because MCP does not run git.
 - **SSH credential support** — the swagger lets sandboxes-service issue `ssh_key` credentials as well, but the MCP surface mints only `http_token` credentials. Users who need SSH access provision it through the platform UI directly.
 
 ---
 
-## Wire-level details (data-science API)
+## Wire-level details (data-science API + Storage)
 
-The tool surface maps to the data-science API as follows. Confirm field names with the platform team if they ever change — adjusting `DataScienceClient` is a one-line tweak per field.
+The tool surface maps to the underlying APIs as follows. Confirm field names with the platform team if they ever change.
 
 | Tool parameter | API endpoint | Field on the wire |
 |---|---|---|
 | Prod create (default) | `POST /apps` | `useManagedGitRepo: true`. No `parameters.dataApp.git` block. |
-| `parent_configuration_id` (dev twin) | `POST /apps` | `useManagedGitRepo` omitted/false. `configuration.parameters.dataApp.git = {repository, username, '#password' (encrypted via EncryptionClient), branch}`. |
+| `parent_configuration_id` (draft) | `POST /apps` | `useManagedGitRepo` omitted/false. `configuration.parameters.dataApp.git = {repository, username, '#password' (encrypted via EncryptionClient), branch}`. Also writes `isDraft: true` and `parentConfigurationId: <prod cfg id>`. |
 | `deploy_data_app(branch=...)` | `PATCH /apps/{id}` | `branch` (alongside `desiredState: 'running'`, `mode: 'dev'`) |
 | `create_python_js_data_app_git_credential` | `POST /apps/{id}/git-repo/credentials` | Request: `{type: 'http_token', permissions: 'readWrite'}`. Response: `{id, type, permissions, secret, ...}`. The one-time `secret` is what we embed (with `kai` as username) into `git_clone_url`. |
 | (clone URL lookup) | `GET /apps/{id}/git-repo` | Response: `{sshUrl, httpsUrl, isManagedGitRepo}`. The MCP server uses `httpsUrl` only. |
 | auto-workspace flag (hardcoded `true` on create) | `POST /apps` | `configuration.runtime.workspace.enabled` |
+| `delete_python_js_data_app_draft` | `DELETE /apps/{id}` + `DELETE /branch/{branch}/components/keboola.data-apps/configs/{cfg}` | Two-call sequence: DSAPI delete first, then Storage delete (without `skip_trash`). |
+| `get_data_apps` drafts lookup | `GET /branch/{branch}/components/keboola.data-apps/configs` | One Storage list call per prod detail fetch; results filtered by `configuration.parameters.dataApp.parentConfigurationId`. |
+| `parentConfigurationId` (in draft config) | (none — Storage-only field) | Lives at `configuration.parameters.dataApp.parentConfigurationId`. Create-only, immutable. |
 
 ---
 
@@ -288,26 +373,37 @@ Against `data-science.canary-orion.keboola.dev`:
 **Create flow**
 
 - [ ] `modify_python_js_data_app(slug='demo')` returns `(PROD, R)`. `R` starts with `https://` (no `git@`).
-- [ ] `modify_python_js_data_app(slug='demo-dev-abc', parent_configuration_id=PROD)` returns `(DEV, R, git_clone_url, branch)`. `git_clone_url` matches `https://kai:<secret>@<host>/<path>.git`; `branch` matches `iter-[0-9a-f]{6}`.
-- [ ] Inspect `DEV`'s Storage config in the UI:
+- [ ] `modify_python_js_data_app(slug='demo-draft', parent_configuration_id=PROD)` returns `(DRAFT, R, git_clone_url, 'init')`. `git_clone_url` matches `https://kai:<secret>@<host>/<path>.git`.
+- [ ] Inspect `DRAFT`'s Storage config in the UI:
   - [ ] `parameters.dataApp.git.repository == R`.
   - [ ] `parameters.dataApp.git.#password` is encrypted ciphertext (`KBC::ConfigSecureGKMS::...`).
-  - [ ] `parameters.dataApp.git.branch == <returned branch>`.
+  - [ ] `parameters.dataApp.git.branch == 'init'`.
+  - [ ] `parameters.dataApp.isDraft == true`.
+  - [ ] `parameters.dataApp.parentConfigurationId == <PROD cfg id>`.
 - [ ] `git clone <git_clone_url>` works with no local key plumbing.
-- [ ] Push a minimal `app.py` on the returned branch.
-- [ ] `deploy_data_app(configuration_id=DEV, mode='dev')` produces a working preview URL serving the branch.
-- [ ] Locally `git checkout main && git merge <branch> && git push`.
+- [ ] Push a minimal `app.py` on the `init` branch.
+- [ ] `deploy_data_app(configuration_id=DRAFT, mode='dev')` produces a working preview URL serving the branch as a dev version.
+- [ ] `get_data_apps(configuration_ids=[PROD])` returns prod detail with `DRAFT` listed in `drafts: [...]`.
+- [ ] Locally `git checkout main && git merge init && git push && git push origin --delete init`.
 - [ ] `deploy_data_app(configuration_id=PROD)` produces a working prod URL serving merged `main`.
-- [ ] `DEV` is listed under `PROD` in the UI's "Drafts" section; clicking "Discard" removes it.
+- [ ] `delete_python_js_data_app_draft(configuration_id=DRAFT)` returns `{response: 'deleted', parent_configuration_id: PROD}` and `DRAFT` disappears from `drafts: [...]` on the next `get_data_apps(configuration_ids=[PROD])`.
 
 **Edit flow**
 
-- [ ] Given an existing `PROD`, `modify_python_js_data_app(slug='demo-dev-xyz', parent_configuration_id=PROD, branch='feature-x')` returns `(DEV2, R, U, 'feature-x')`.
-- [ ] Push `feature-x` to `R` via the embedded credential.
-- [ ] `deploy_data_app(configuration_id=DEV2, mode='dev')` previews the branch.
-- [ ] Merge `feature-x` into `main` and push.
+- [ ] Given an existing `PROD`, `create_python_js_data_app_git_credential(configuration_id=PROD)` returns a fresh `git_clone_url`.
+- [ ] `modify_python_js_data_app(slug='demo-draft-xyz', parent_configuration_id=PROD, branch='add-revenue-filter')` returns `(DRAFT2, R, U, 'add-revenue-filter')`.
+- [ ] Push `add-revenue-filter` to `R` via the embedded credential.
+- [ ] `deploy_data_app(configuration_id=DRAFT2, mode='dev')` previews the branch.
+- [ ] Merge into `main` and push.
 - [ ] `deploy_data_app(configuration_id=PROD)` now serves the merged code.
-- [ ] `DEV2` is listed under `PROD` in the UI's "Drafts" section; clicking "Discard" removes it.
+- [ ] `delete_python_js_data_app_draft(configuration_id=DRAFT2)` cleans up.
+
+**Continue-draft flow**
+
+- [ ] Given an existing `PROD` with a draft `DRAFT3` pinned to branch `wip-add-chart`, `get_data_apps(configuration_ids=[PROD])` returns `drafts: [...]` with `DRAFT3` and its branch visible.
+- [ ] `create_python_js_data_app_git_credential(configuration_id=PROD)` returns a fresh `git_clone_url`.
+- [ ] `git clone`, `git checkout wip-add-chart`, push another commit.
+- [ ] `deploy_data_app(configuration_id=DRAFT3, mode='dev')` deploys the branch as a dev version (no `branch=` override needed — the draft's config pins it).
 
 **Lost-token recovery flow**
 
@@ -317,24 +413,24 @@ Against `data-science.canary-orion.keboola.dev`:
 - [ ] Existing clones from before the recovery remain usable (server accepts multiple credentials; old ones are not revoked).
 - [ ] `create_python_js_data_app_git_credential(configuration_id=<streamlit cfg>)` raises a clear "only python-js apps" error.
 
+**Safety**
+
+- [ ] `delete_python_js_data_app_draft(configuration_id=PROD)` raises a clear "prod app, not a draft" error and does not delete anything.
+- [ ] `delete_python_js_data_app_draft(configuration_id=<streamlit cfg>)` raises "only supports python-js data apps".
+
 ---
 
-## v1.62.0 → v1.63.0 migration
+## v1.63 → v1.64 migration
 
-`existing_repo_url` (introduced in v1.62.0) has been **removed**. It was never honored by the platform — `POST /apps` silently dropped the field and provisioned a fresh managed repo for every app, so any caller relying on it was hitting silent failures. Replace it with `parent_configuration_id`:
+The dev-twin terminology is gone. Internally, "dev twin" → "draft"; in the wire, drafts now persist `parentConfigurationId` and the default branch is `'init'` (not `iter-<6-hex>`). User-facing tool parameters did not change shape — `parent_configuration_id` and `branch` keep their names — but the doc framing, docstrings, and default branch differ. A new tool `delete_python_js_data_app_draft` ships in v1.64.0.
 
-```diff
-- modify_python_js_data_app(slug='dev', existing_repo_url=R)     # broken, ignored
-+ modify_python_js_data_app(slug='dev', parent_configuration_id=PROD)
-```
-
-The ownership flips at the same time:
-
-| | v1.62.0 (broken) | v1.63.0 (MVP) |
+| | v1.63 (MVP) | v1.64 (this doc) |
 |---|---|---|
-| Created first | Dev iteration app (managed repo) | **Prod app** (managed repo) |
-| Created second | Prod (`existing_repo_url=...` — silently ignored) | **Dev twin** (`parent_configuration_id=PROD`, external-git) |
-| Repo ownership | Dev (intended); both apps in practice | **Prod** |
-| Tool docs to read | `docs/python-js-data-apps.md` v1.62 | this file |
+| Iteration entity name | "dev twin" | "draft" |
+| Default iteration branch | `iter-<6-hex>` (random) | `'init'` (literal; descriptive branches agent-supplied for edits) |
+| Draft → prod linkage on the wire | (not stored) | `parameters.dataApp.parentConfigurationId` (Storage config; create-only) |
+| Drafts of a prod, discovery | Scan all configs and filter by repo URL (no MCP surface) | `get_data_apps(configuration_ids=[PROD])` returns `drafts: [...]` |
+| Cleanup affordance | UI "Discard" button only | `delete_python_js_data_app_draft` MCP tool |
+| Tool docs | `docs/python-js-data-apps.md` v1.63 | this file |
 
 For background on why the platform behaves this way and the long-term fix, see [AI-3240](https://linear.app/keboola/issue/AI-3240).

--- a/docs/python-js-data-apps.md
+++ b/docs/python-js-data-apps.md
@@ -3,7 +3,6 @@
 **Linear**: [AI-3286](https://linear.app/keboola/issue/AI-3286)
 (supersedes the MVP shipped in v1.63.0 under [AI-3005](https://linear.app/keboola/issue/AI-3005))
 **Status**: shipped in v1.64.0.
-**Long-term tracker (platform-side drafts)**: [AI-3240](https://linear.app/keboola/issue/AI-3240)
 
 ---
 
@@ -50,7 +49,7 @@ Drafts are surfaced in the Keboola UI under their parent prod app. They are also
 
 ## Why prod owns the repo
 
-The data-science platform does not yet support sharing a managed repo across apps (`existingRepoUrl` on `POST /apps` is silently dropped; every app gets a fresh managed repo). Until the platform-side drafts mechanism lands ([AI-3240](https://linear.app/keboola/issue/AI-3240)), we **flip the ownership**: the prod app is the canonical managed-repo owner, and each draft is an *external-git* app whose `parameters.dataApp.git` block tells the data-app runtime to clone the prod repo on deploy. The prod-side credential is minted by the MCP server when creating the draft (the platform accepts unlimited per-app credentials, so this is non-destructive).
+The data-science platform does not yet support sharing a managed repo across apps (`existingRepoUrl` on `POST /apps` is silently dropped; every app gets a fresh managed repo). Until the platform gains native draft support, we **flip the ownership**: the prod app is the canonical managed-repo owner, and each draft is an *external-git* app whose `parameters.dataApp.git` block tells the data-app runtime to clone the prod repo on deploy. The prod-side credential is minted by the MCP server when creating the draft (the platform accepts unlimited per-app credentials, so this is non-destructive).
 
 ---
 
@@ -90,7 +89,7 @@ The platform supports multiple credentials per app, so minting a fresh credentia
 
 - A new credential is minted on the parent **prod** app every time a draft is created. The prod-side credential is encrypted into the draft's `parameters.dataApp.git.#password`.
 - **Deleting a draft via `delete_python_js_data_app_draft` does NOT revoke that credential.** The MCP surface has no list/delete-credential affordance; rotation is the user's job via the Keboola UI. (DSAPI does support `DELETE /apps/{id}/git-repo/credentials/{credentialId}`, but the MCP server does not store the credential ID on the draft to make targeted revocation possible.)
-- Because the platform accepts unlimited per-app credentials and ignores stale ones for auth purposes, accumulated drafts produce stale-but-harmless credentials on the prod app over time. Treat this as a known trade-off until the platform-side drafts feature lands ([AI-3240](https://linear.app/keboola/issue/AI-3240)).
+- Because the platform accepts unlimited per-app credentials and ignores stale ones for auth purposes, accumulated drafts produce stale-but-harmless credentials on the prod app over time. Treat this as a known trade-off until the platform gains native draft support.
 
 ---
 
@@ -433,4 +432,4 @@ The dev-twin terminology is gone. Internally, "dev twin" → "draft"; in the wir
 | Cleanup affordance | UI "Discard" button only | `delete_python_js_data_app_draft` MCP tool |
 | Tool docs | `docs/python-js-data-apps.md` v1.63 | this file |
 
-For background on why the platform behaves this way and the long-term fix, see [AI-3240](https://linear.app/keboola/issue/AI-3240).
+For background on why the platform behaves this way, see the **Why prod owns the repo** section above.

--- a/integtests/test_mcp_server.py
+++ b/integtests/test_mcp_server.py
@@ -171,6 +171,7 @@ async def _assert_basic_setup(client: Client):
         'create_oauth_url',
         'create_python_js_data_app_git_credential',
         'create_sql_transformation',
+        'delete_python_js_data_app_draft',
         'deploy_data_app',
         'docs_query',
         'find_component_id',

--- a/integtests/tools/test_data_apps.py
+++ b/integtests/tools/test_data_apps.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import subprocess
 import uuid
 from pathlib import Path
@@ -258,7 +257,7 @@ async def test_data_app_lifecycle(
     assert set(fetched_data_app_parameters['packages']) == set(['streamlit'] + _DEFAULT_PACKAGES)
 
 
-# ===== python-js data app: prod + external-git dev twin (AI-3005) =====
+# ===== python-js data app: prod + external-git draft (AI-3005 / AI-3286) =====
 
 
 @pytest.fixture
@@ -284,21 +283,26 @@ def _git(*args: str, cwd: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_python_js_data_app_prod_and_dev_twin_lifecycle(
+async def test_python_js_data_app_prod_and_draft_lifecycle(
     mcp_client: Client,
     keboola_client: KeboolaClient,
     tmp_path: Path,
     python_js_app_py: str,
 ) -> None:
-    """End-to-end on canary-orion: create prod (managed repo), create dev twin
-    (external-git pointing at prod's repo), push branch, deploy dev in mode='dev',
-    merge into main, redeploy prod, then tear down both apps."""
+    """End-to-end on canary-orion: create prod (managed repo), create draft
+    (external-git pointing at prod's repo), push branch, deploy draft in mode='dev',
+    merge into main, redeploy prod, then delete the draft via the new MCP tool.
+
+    Also asserts that fetching the prod's detail surfaces the draft in `drafts: [...]`
+    before deletion and returns an empty `drafts` array after.
+    """
 
     unique = uuid.uuid4().hex[:8]
     prod_slug = f'int-prod-{unique}'
-    dev_slug = f'int-dev-{unique}'
+    draft_slug = f'int-draft-{unique}'
     prod_output: ModifiedPythonJsDataAppOutput | None = None
-    dev_output: ModifiedPythonJsDataAppOutput | None = None
+    draft_output: ModifiedPythonJsDataAppOutput | None = None
+    draft_deleted_via_tool = False
 
     try:
         # Step 1: create prod (managed repo).
@@ -306,7 +310,7 @@ async def test_python_js_data_app_prod_and_dev_twin_lifecycle(
             name='modify_python_js_data_app',
             arguments={
                 'name': f'Integration prod {unique}',
-                'description': 'AI-3005 prod app integration test',
+                'description': 'AI-3286 prod app integration test',
                 'slug': prod_slug,
                 'authentication_type': 'no-auth',
             },
@@ -319,32 +323,31 @@ async def test_python_js_data_app_prod_and_dev_twin_lifecycle(
         assert prod_output.git_clone_url is None
         assert prod_output.branch is None
 
-        # Step 2: create dev twin pointing at prod's repo.
-        dev_result = await mcp_client.call_tool(
+        # Step 2: create draft pointing at prod's repo. Branch defaults to 'init'.
+        draft_result = await mcp_client.call_tool(
             name='modify_python_js_data_app',
             arguments={
-                'name': f'Integration dev {unique}',
-                'description': 'AI-3005 dev twin integration test',
-                'slug': dev_slug,
+                'name': f'Integration draft {unique}',
+                'description': 'AI-3286 draft integration test',
+                'slug': draft_slug,
                 'parent_configuration_id': prod_output.data_app.configuration_id,
                 'authentication_type': 'no-auth',
             },
         )
-        assert dev_result.structured_content is not None
-        dev_output = ModifiedPythonJsDataAppOutput.model_validate(dev_result.structured_content)
-        assert dev_output.response == 'created'
-        assert dev_output.repo_url == prod_output.repo_url
-        assert dev_output.git_clone_url is not None
-        assert dev_output.git_clone_url.startswith('https://kai:')
-        assert dev_output.branch is not None
-        assert re.fullmatch(r'iter-[0-9a-f]{6}', dev_output.branch)
+        assert draft_result.structured_content is not None
+        draft_output = ModifiedPythonJsDataAppOutput.model_validate(draft_result.structured_content)
+        assert draft_output.response == 'created'
+        assert draft_output.repo_url == prod_output.repo_url
+        assert draft_output.git_clone_url is not None
+        assert draft_output.git_clone_url.startswith('https://kai:')
+        assert draft_output.branch == 'init'
 
         # Step 3: clone via the embedded credential. Initialize main if the freshly provisioned
-        # repo is empty, then branch off and push the iteration branch.
+        # repo is empty, then branch off and push the draft branch.
         repo_dir = tmp_path / 'repo'
         env = {**os.environ, 'GIT_TERMINAL_PROMPT': '0'}
         subprocess.run(
-            ['git', 'clone', dev_output.git_clone_url, str(repo_dir)],
+            ['git', 'clone', draft_output.git_clone_url, str(repo_dir)],
             check=True,
             capture_output=True,
             text=True,
@@ -376,12 +379,12 @@ async def test_python_js_data_app_prod_and_dev_twin_lifecycle(
                 text=True,
                 env=env,
             )
-        _git('checkout', '-b', dev_output.branch, 'main', cwd=repo_dir)
+        _git('checkout', '-b', draft_output.branch, 'main', cwd=repo_dir)
         (repo_dir / 'app.py').write_text(python_js_app_py)
         _git('add', 'app.py', cwd=repo_dir)
-        _git('commit', '-m', f'AI-3005 integration test commit {unique}', cwd=repo_dir)
+        _git('commit', '-m', f'AI-3286 integration test commit {unique}', cwd=repo_dir)
         subprocess.run(
-            ['git', 'push', '-u', 'origin', dev_output.branch],
+            ['git', 'push', '-u', 'origin', draft_output.branch],
             cwd=repo_dir,
             check=True,
             capture_output=True,
@@ -389,22 +392,58 @@ async def test_python_js_data_app_prod_and_dev_twin_lifecycle(
             env=env,
         )
 
-        # Step 4: deploy dev twin in mode='dev'.
-        dev_deploy = await mcp_client.call_tool(
+        # Step 4: deploy draft in mode='dev'.
+        draft_deploy = await mcp_client.call_tool(
             name='deploy_data_app',
             arguments={
                 'action': 'deploy',
-                'configuration_id': dev_output.data_app.configuration_id,
+                'configuration_id': draft_output.data_app.configuration_id,
                 'mode': 'dev',
             },
         )
-        assert dev_deploy.structured_content is not None
+        assert draft_deploy.structured_content is not None
         # The data-app runtime is async — we only assert the deploy call was accepted; not its
         # eventual state, since CI cannot afford to poll the full startup loop.
 
+        # Fetching the prod's detail must now list the draft under `drafts`.
+        prod_detail_before = await mcp_client.call_tool(
+            name='get_data_apps',
+            arguments={'configuration_ids': [prod_output.data_app.configuration_id]},
+        )
+        assert prod_detail_before.structured_content is not None
+        prod_apps_before = GetDataAppsOutput.model_validate(prod_detail_before.structured_content)
+        assert len(prod_apps_before.data_apps) == 1
+        prod_app_before = prod_apps_before.data_apps[0]
+        assert isinstance(prod_app_before, DataApp)
+        draft_cfg_ids_before = [d.configuration_id for d in prod_app_before.drafts]
+        assert draft_output.data_app.configuration_id in draft_cfg_ids_before
+
+        # Confirm the draft's stored config carries the external-git block we sent and the
+        # parent linkage we expect.
+        draft_detail = await mcp_client.call_tool(
+            name='get_data_apps',
+            arguments={'configuration_ids': [draft_output.data_app.configuration_id]},
+        )
+        assert draft_detail.structured_content is not None
+        draft_apps = GetDataAppsOutput.model_validate(draft_detail.structured_content)
+        assert len(draft_apps.data_apps) == 1
+        draft_detail_app = draft_apps.data_apps[0]
+        assert isinstance(draft_detail_app, DataApp)
+        draft_data_app_block = draft_detail_app.configuration.get('parameters', {}).get('dataApp', {})
+        draft_git_block = draft_data_app_block.get('git', {})
+        assert draft_git_block.get('repository') == prod_output.repo_url
+        assert draft_git_block.get('branch') == draft_output.branch
+        assert draft_git_block.get('username') == 'kai'
+        encrypted_pw = draft_git_block.get('#password', '')
+        assert encrypted_pw.startswith('KBC::'), f'expected encrypted #password, got {encrypted_pw!r}'
+        assert draft_data_app_block.get('isDraft') is True
+        assert draft_data_app_block.get('parentConfigurationId') == prod_output.data_app.configuration_id
+        # Drafts of a draft are always empty.
+        assert draft_detail_app.drafts == []
+
         # Step 5: merge into main and push.
         _git('checkout', 'main', cwd=repo_dir)
-        _git('merge', '--no-ff', '-m', f'Merge {dev_output.branch}', dev_output.branch, cwd=repo_dir)
+        _git('merge', '--no-ff', '-m', f'Merge {draft_output.branch}', draft_output.branch, cwd=repo_dir)
         subprocess.run(
             ['git', 'push', 'origin', 'main'],
             cwd=repo_dir,
@@ -424,35 +463,47 @@ async def test_python_js_data_app_prod_and_dev_twin_lifecycle(
         )
         assert prod_deploy.structured_content is not None
 
-        # Confirm the dev twin's stored config carries the external-git block we sent.
-        dev_detail = await mcp_client.call_tool(
-            name='get_data_apps',
-            arguments={'configuration_ids': [dev_output.data_app.configuration_id]},
+        # Step 7: delete the draft via the new MCP tool, then verify it's gone from prod's drafts.
+        # Stop the draft first — DSAPI delete requires desiredState == currentState.
+        try:
+            await keboola_client.data_science_client.suspend_data_app(draft_output.data_app.data_app_id)
+        except Exception as exc:
+            LOG.info(f'suspend failed for {draft_output.data_app.data_app_id}: {exc}')
+        delete_result = await mcp_client.call_tool(
+            name='delete_python_js_data_app_draft',
+            arguments={'configuration_id': draft_output.data_app.configuration_id},
         )
-        assert dev_detail.structured_content is not None
-        dev_apps = GetDataAppsOutput.model_validate(dev_detail.structured_content)
-        assert len(dev_apps.data_apps) == 1
-        dev_detail_app = dev_apps.data_apps[0]
-        assert isinstance(dev_detail_app, DataApp)
-        dev_git_block = dev_detail_app.configuration.get('parameters', {}).get('dataApp', {}).get('git', {})
-        assert dev_git_block.get('repository') == prod_output.repo_url
-        assert dev_git_block.get('branch') == dev_output.branch
-        assert dev_git_block.get('username') == 'kai'
-        encrypted_pw = dev_git_block.get('#password', '')
-        assert encrypted_pw.startswith('KBC::'), f'expected encrypted #password, got {encrypted_pw!r}'
+        assert delete_result.structured_content is not None
+        deleted = delete_result.structured_content
+        assert deleted['response'] == 'deleted'
+        assert deleted['configuration_id'] == draft_output.data_app.configuration_id
+        assert deleted['parent_configuration_id'] == prod_output.data_app.configuration_id
+        draft_deleted_via_tool = True
+
+        prod_detail_after = await mcp_client.call_tool(
+            name='get_data_apps',
+            arguments={'configuration_ids': [prod_output.data_app.configuration_id]},
+        )
+        assert prod_detail_after.structured_content is not None
+        prod_apps_after = GetDataAppsOutput.model_validate(prod_detail_after.structured_content)
+        prod_app_after = prod_apps_after.data_apps[0]
+        assert isinstance(prod_app_after, DataApp)
+        draft_cfg_ids_after = [d.configuration_id for d in prod_app_after.drafts]
+        assert draft_output.data_app.configuration_id not in draft_cfg_ids_after
 
     finally:
-        # Teardown: delete dev first then prod. DSAPI requires desiredState == currentState,
-        # so stop running apps before deletion (best-effort — these may raise if already in the
-        # desired state, which is fine).
-        for app in (dev_output, prod_output):
+        # Teardown: best-effort cleanup. Skip draft if the test already deleted it via the tool.
+        cleanup_targets = [(prod_output, 'prod')]
+        if not draft_deleted_via_tool:
+            cleanup_targets.insert(0, (draft_output, 'draft'))
+        for app, role in cleanup_targets:
             if app is None:
                 continue
             try:
                 await keboola_client.data_science_client.suspend_data_app(app.data_app.data_app_id)
             except Exception as exc:
-                LOG.info(f'suspend failed for {app.data_app.data_app_id}: {exc}')
+                LOG.info(f'suspend failed for {role} {app.data_app.data_app_id}: {exc}')
             try:
                 await keboola_client.data_science_client.delete_data_app(app.data_app.data_app_id)
             except Exception as exc:
-                LOG.error(f'delete failed for {app.data_app.data_app_id}: {exc}')
+                LOG.error(f'delete failed for {role} {app.data_app.data_app_id}: {exc}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.63.4"
+version = "1.64.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -101,7 +101,7 @@ class CodeDataAppConfig(BaseModel):
 
     Unlike `DataAppConfig` (Streamlit), python-js apps don't embed source code in the config.
     Code lives in the managed git repo; the config only carries deployment metadata
-    (slug, auto-suspend, runtime image version).
+    (slug, auto-suspend, optional runtime overrides).
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -109,15 +109,15 @@ class CodeDataAppConfig(BaseModel):
     class Parameters(BaseModel):
         class DataApp(BaseModel):
             class Git(BaseModel):
-                """External-git binding for a python-js dev twin.
+                """External-git binding for a python-js draft data app.
 
                 When set, the data-science API treats the app as externally configured: it does NOT
                 provision a managed repo for it, and the data-app runtime clones the configured
                 `repository` (at `branch`) using `username`/`#password` as HTTPS basic auth on every
                 deploy.
 
-                MVP use case (AI-3005): a dev twin points at its parent prod app's managed repo,
-                with credentials minted on the prod app via `create_app_git_credential`.
+                Use case: a draft points at its parent prod app's managed repo, with credentials
+                minted on the prod app via `create_app_git_credential`.
                 """
 
                 model_config = ConfigDict(populate_by_name=True)
@@ -156,8 +156,8 @@ class CodeDataAppConfig(BaseModel):
             git: 'CodeDataAppConfig.Parameters.DataApp.Git | None' = Field(
                 default=None,
                 description=(
-                    "External-git binding. Set on dev twins to point at the parent prod app's "
-                    'managed repo + a fresh prod-issued credential + the iteration branch. Leave '
+                    "External-git binding. Set on drafts to point at the parent prod app's "
+                    'managed repo + a fresh prod-issued credential + the draft branch. Leave '
                     'unset on prod apps (which own their own managed repo via `useManagedGitRepo`).'
                 ),
             )
@@ -166,8 +166,17 @@ class CodeDataAppConfig(BaseModel):
                 serialization_alias='isDraft',
                 default=None,
                 description=(
-                    'When true, the UI hides this app from the main data-apps list. '
-                    'Set automatically on dev-twin creation (UT-4000).'
+                    'When true, the UI hides this app from the main data-apps list and lists it '
+                    'under its parent prod app instead. Set automatically on draft creation.'
+                ),
+            )
+            parent_configuration_id: str | None = Field(
+                validation_alias=AliasChoices('parentConfigurationId', 'parent_configuration_id'),
+                serialization_alias='parentConfigurationId',
+                default=None,
+                description=(
+                    'Storage configuration ID of the prod python-js data app this draft iterates against. '
+                    "Set automatically on draft creation. Used by get_data_apps to list a prod app's drafts."
                 ),
             )
 
@@ -194,7 +203,13 @@ class CodeDataAppConfig(BaseModel):
                 ),
             )
 
-        image: 'CodeDataAppConfig.Runtime.Image' = Field(description='The runtime image.')
+        image: 'CodeDataAppConfig.Runtime.Image | None' = Field(
+            default=None,
+            description=(
+                'Optional pin of the runtime image version. Omit to let the data-science platform '
+                'apply its default for python-js apps.'
+            ),
+        )
         workspace: 'CodeDataAppConfig.Runtime.Workspace | None' = Field(
             default=None,
             description=(
@@ -204,7 +219,13 @@ class CodeDataAppConfig(BaseModel):
         )
 
     parameters: 'CodeDataAppConfig.Parameters' = Field(description='The parameters of the data app.')
-    runtime: 'CodeDataAppConfig.Runtime' = Field(description='The runtime configuration (image version, etc.).')
+    runtime: 'CodeDataAppConfig.Runtime | None' = Field(
+        default=None,
+        description=(
+            'Optional runtime configuration block (image pin, per-app workspace, etc.). Omit '
+            'entirely when no runtime overrides are needed — the platform picks defaults.'
+        ),
+    )
     authorization: DataAppConfig.Authorization | None = Field(
         default=None,
         description=(
@@ -344,10 +365,12 @@ class DataScienceClient(KeboolaServiceClient):
         :param data_app_id: The ID of the data app
         :param config_version: The version of the config to deploy. Required for Streamlit apps; omit for python-js
                     apps backed by a managed git repo (they have no Storage configVersion).
-        :param mode: Deployment mode. Set to 'dev' to enable the in-platform preview for python-js apps.
-                    Leave None for Streamlit apps.
+        :param mode: Deployment mode. Set to 'dev' to deploy a python-js draft as a dev version
+                    (hot reload + auto-auth for iframe preview). Leave None for Streamlit apps and
+                    for prod deploys.
         :param branch: Git branch to deploy from. Only meaningful for python-js apps in `mode='dev'`; when set,
-                    the dev twin deploys from this branch instead of `main`. Leave None for `main` / prod deploys.
+                    the draft deploys from this branch instead of the branch pinned in its config.
+                    Leave None for prod deploys.
         :param restart_if_running: Whether to restart the data app if it is already running
         :param update_dependencies: If set to `true`, latest package versions are installed during app startup,
                     instead of using frozen versions.
@@ -402,7 +425,7 @@ class DataScienceClient(KeboolaServiceClient):
         :param configuration: The simplified configuration of the data app
         :param app_type: The data app type, e.g. 'streamlit' or 'python-js'. Defaults to 'streamlit'.
         :param use_managed_git_repo: When True, the data-science API provisions a managed git repo for the app.
-                    Only meaningful for python-js apps. Pass False on dev twins that bring their own
+                    Only meaningful for python-js apps. Pass False on drafts that bring their own
                     external-git binding via `configuration.parameters.dataApp.git`.
         :return: The data app
         """

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -50,6 +50,17 @@ SEMANTIC_TOOL_NAMES = {
     'get_semantic_schema',
     'validate_semantic_query',
 }
+# Data app tools are supported only in the main/production branch. This single set is the source of
+# truth for both the on_list_tools filter and the on_call_tool guard — keeping them in sync is what
+# prevents a new (possibly destructive) data app tool from leaking onto non-main branches.
+DATA_APP_BRANCH_GATED_TOOLS = {
+    'modify_streamlit_data_app',
+    'modify_python_js_data_app',
+    'create_python_js_data_app_git_credential',
+    'get_data_apps',
+    'deploy_data_app',
+    'delete_python_js_data_app_draft',
+}
 
 
 def is_read_only_tool(tool: Tool) -> bool:
@@ -370,18 +381,7 @@ class ToolsFilteringMiddleware(fmw.Middleware):
 
         if not self.is_client_using_main_branch(context.fastmcp_context):
             # Filter out data app tools when the client is not using the main/production branch
-            tools = [
-                t
-                for t in tools
-                if t.name
-                not in {
-                    'modify_streamlit_data_app',
-                    'modify_python_js_data_app',
-                    'create_python_js_data_app_git_credential',
-                    'get_data_apps',
-                    'deploy_data_app',
-                }
-            ]
+            tools = [t for t in tools if t.name not in DATA_APP_BRANCH_GATED_TOOLS]
 
         if token_role == 'readonly':
             tools = [t for t in tools if is_read_only_tool(t)]
@@ -446,13 +446,7 @@ class ToolsFilteringMiddleware(fmw.Middleware):
                     f'Use "{UPDATE_FLOW_TOOL_NAME}" to update flow configuration instead.'
                 )
 
-        if tool.name in (
-            'modify_streamlit_data_app',
-            'modify_python_js_data_app',
-            'create_python_js_data_app_git_credential',
-            'get_data_apps',
-            'deploy_data_app',
-        ):
+        if tool.name in DATA_APP_BRANCH_GATED_TOOLS:
             if not self.is_client_using_main_branch(context.fastmcp_context):
                 raise ToolError('Data apps are supported only in the main production branch.')
 

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -1599,6 +1599,11 @@ async def _fetch_prod_drafts(client: KeboolaClient, *, prod_configuration_id: st
     draft_cfg_ids: list[str] = []
     for cfg in configs:
         cfg_body = cast(Mapping[str, Any], cfg.get('configuration') or {})
+        # A draft must satisfy BOTH halves of the contract: `isDraft=true` AND `parentConfigurationId`
+        # pointing at this prod. Checking only the parent pointer would surface a misconfigured
+        # non-draft (e.g. a clone that kept the pointer but lost the flag) as a draft.
+        if not _is_draft_config(cfg_body):
+            continue
         data_app_block = cast(Mapping[str, Any], cfg_body.get('parameters') or {}).get('dataApp') or {}
         if data_app_block.get('parentConfigurationId') == prod_configuration_id:
             cfg_id = cfg.get('id')

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -726,6 +726,11 @@ async def modify_python_js_data_app(
     branch-delete — is yours. MCP gives you authenticated clone URLs and manages configs/deploys;
     it never invokes git.
 
+    **The draft flow below is mandatory — never edit prod source directly.** Every source-code
+    change goes through a draft branch that the user previews and explicitly approves first. NEVER
+    push directly to `main`: `main` only ever advances by merging an approved draft branch, and
+    only after the user has approved that draft's preview.
+
     Three scenarios the agent has to distinguish:
 
     ## Scenario A — Create a brand-new data app

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -900,6 +900,14 @@ async def modify_python_js_data_app(
                     f'parent_configuration_id "{parent_configuration_id}" is type "{parent.type}", but only '
                     f'python-js prod apps can parent a draft.'
                 )
+            if _is_draft_config(parent.configuration):
+                # A draft has no managed repo of its own and cannot parent another draft. Reject it
+                # explicitly instead of falling through to the misleading "no repo URL" error below.
+                raise ValueError(
+                    f'parent_configuration_id "{parent_configuration_id}" is itself a python-js **draft**, '
+                    "not a prod app. Drafts iterate against the prod app's repo and cannot parent another "
+                    "draft — pass the prod app's configuration_id (a draft's parentConfigurationId points to it)."
+                )
             if not parent.repo_url:
                 raise ValueError(
                     f'Parent python-js data app "{parent_configuration_id}" has no managed git repo URL. '

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -1438,9 +1438,12 @@ async def delete_python_js_data_app_draft(
             'draft — treating as already removed.'
         )
 
+    # When a parent prod app is known, the links pivot to it. We don't have the parent's name here,
+    # so label it explicitly as the parent rather than reusing the (now-deleted) draft's name, which
+    # would mislabel a link that points at a different configuration.
     links = links_manager.get_data_app_links(
         configuration_id=parent_configuration_id or configuration_id,
-        configuration_name=data_app.name,
+        configuration_name='parent prod app' if parent_configuration_id else data_app.name,
         deployment_link=None,
         uses_basic_authentication=False,
     )

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -2,7 +2,6 @@ import copy
 import importlib.resources as resources
 import logging
 import re
-import secrets
 from typing import Annotated, Any, Literal, Mapping, Optional, Sequence, Union, cast
 from urllib.parse import quote, urlsplit, urlunsplit
 
@@ -74,6 +73,13 @@ def add_data_app_tools(mcp: FastMCP) -> None:
             annotations=ToolAnnotations(destructiveHint=False),
         )
     )
+    mcp.add_tool(
+        FunctionTool.from_function(
+            delete_python_js_data_app_draft,
+            tags={DATA_APP_TOOLS_TAG},
+            annotations=ToolAnnotations(destructiveHint=True),
+        )
+    )
     LOG.info('Data app tools initialized.')
 
 
@@ -100,23 +106,17 @@ _DEFAULT_STREAMLIT_THEME = (
 )
 _DEFAULT_PACKAGES = ['pandas', 'httpx']
 
-# TODO: Remove this hardcoded image version once the platform sets it as the default for python-js apps.
-_HARDCODED_PYTHON_JS_IMAGE_VERSION = '1.6.1'
-
 # Username embedded in the HTTPS clone URL alongside the one-time token returned by the
 # managed git-repo credentials endpoint. The git-service ignores the username portion of
 # basic auth — only the password (token) is checked — but a non-empty username is required
 # for `git clone` to accept the URL without prompting.
 _MANAGED_GIT_REPO_USERNAME = 'kai'
 
-# Prefix used to auto-generate iteration branch names for dev twins when the caller does
-# not supply one. Format: `iter-<6 hex chars>`, e.g. `iter-a3f9c1`.
-_DEV_TWIN_BRANCH_PREFIX = 'iter-'
-
-
-def _generate_dev_twin_branch_name() -> str:
-    """Generate a random iteration branch name for a python-js dev twin."""
-    return f'{_DEV_TWIN_BRANCH_PREFIX}{secrets.token_hex(3)}'
+# Default branch name used for the very first draft of a brand-new prod app, when the agent
+# doesn't supply a descriptive branch via `branch=`. Uniqueness across drafts is the agent's
+# responsibility — if `init` collides with an existing branch on the prod's repo, the agent
+# will see the error from its own `git push` or from `deploy_data_app`.
+_DEFAULT_DRAFT_BRANCH = 'init'
 
 
 INJECTED_BLOCK_RE = re.compile(
@@ -242,6 +242,15 @@ class DataApp(BaseModel):
         description='Deployment info of the data app including a url of the app and logs to diagnose in-app errors.',
         default=None,
     )
+    drafts: list[DataAppSummary] = Field(
+        default_factory=list,
+        description=(
+            'Draft python-js data apps that iterate against this prod app (each carries '
+            '`parameters.dataApp.parentConfigurationId == this.configuration_id`). Populated only '
+            'when the detail path is used for a python-js **prod** app — empty for drafts '
+            'themselves and for non-python-js apps.'
+        ),
+    )
     links: list[Link] = Field(description='Navigation links for the web interface.', default_factory=list)
 
     @classmethod
@@ -309,17 +318,17 @@ class ModifiedPythonJsDataAppOutput(BaseModel):
         description=(
             'HTTPS clone URL of the managed git repo (without embedded credentials). Returned on create so the '
             'caller can clone the repo and push initial source code. On update, populated when the repo info can '
-            "be fetched. On the dev-twin create path this is the **parent prod app's** managed repo URL — that "
+            "be fetched. On the draft create path this is the **parent prod app's** managed repo URL — that "
             'is the repo the agent should clone, branch, and push to. Mint a token via '
             '`create_python_js_data_app_git_credential` to authenticate (or use `git_clone_url` returned by this '
-            'tool on the dev-twin path).'
+            'tool on the draft create path).'
         ),
     )
     git_clone_url: Optional[str] = Field(
         default=None,
         description=(
             'Ready-to-use authenticated HTTPS clone URL embedding the freshly-minted prod-app token (format: '
-            '`https://kai:<secret>@<host>/<path>.git`). Only populated on the **dev-twin create path** — the '
+            '`https://kai:<secret>@<host>/<path>.git`). Only populated on the **draft create path** — the '
             'token was minted on the parent prod app and is one-time, so it is surfaced here so the agent can '
             'clone immediately without a separate `create_python_js_data_app_git_credential` call. None on prod '
             'create and on update.'
@@ -328,10 +337,10 @@ class ModifiedPythonJsDataAppOutput(BaseModel):
     branch: Optional[str] = Field(
         default=None,
         description=(
-            'Iteration branch the dev twin is pinned to (set in `parameters.dataApp.git.branch`). Only populated '
-            'on the **dev-twin create path** — defaults to `iter-<6-hex>` when the caller does not pass a branch '
-            'name. The agent should `git checkout -b <branch>` and push code on this branch before calling '
-            '`deploy_data_app(mode="dev")`. None on prod create and on update.'
+            'Draft branch the new draft is pinned to (set in `parameters.dataApp.git.branch`). Only populated '
+            'on the **draft create path** — defaults to `init` when the caller does not pass `branch`. The '
+            'agent should `git checkout <branch>` (creating it if needed) and push code on this branch before '
+            'calling `deploy_data_app(mode="dev")`. None on prod create and on update.'
         ),
     )
     links: list[Link] = Field(description='Navigation links for the web interface.')
@@ -369,6 +378,23 @@ class DeploymentDataAppOutput(BaseModel):
         description='Deployment info with a link to the app and logs to diagnose in-app errors.', default=None
     )
     links: list[Link] = Field(description='Navigation links for the web interface.')
+
+
+class DeletedDraftOutput(BaseModel):
+    """Output for `delete_python_js_data_app_draft`."""
+
+    response: str = Field(description='Status of the delete operation, e.g. "deleted".')
+    configuration_id: str = Field(description='Storage configuration ID of the deleted draft.')
+    data_app_id: str = Field(description='Data-science API ID of the deleted draft data app.')
+    parent_configuration_id: Optional[str] = Field(
+        default=None,
+        description=(
+            'Storage configuration ID of the parent prod app the draft was iterating against. '
+            'Surfaced so the agent can pivot back to the prod app after cleanup. May be None if '
+            'the draft was orphaned (parent already deleted).'
+        ),
+    )
+    links: list[Link] = Field(description='Navigation links for the web interface.', default_factory=list)
 
 
 class GetDataAppsOutput(BaseModel):
@@ -628,10 +654,10 @@ async def modify_python_js_data_app(
         Optional[str],
         Field(
             description=(
-                'Storage configuration ID of the prod python-js data app this dev twin will iterate against. '
-                'When set on create, the new app is created as a **dev twin**: no managed repo is provisioned '
+                'Storage configuration ID of the prod python-js data app this draft will iterate against. '
+                'When set on create, the new app is created as a **draft**: no managed repo is provisioned '
                 "for it; instead its `parameters.dataApp.git` block is populated to point at the prod app's "
-                'managed repo, with a freshly-minted prod-app HTTPS token and the chosen iteration branch. '
+                'managed repo, with a freshly-minted prod-app HTTPS token and the chosen draft branch. '
                 'Leave None on create to make a **prod app** (which gets its own managed repo). Rejected on '
                 'update.'
             ),
@@ -641,9 +667,11 @@ async def modify_python_js_data_app(
         Optional[str],
         Field(
             description=(
-                'Iteration branch for the dev twin to deploy from. Only valid on the dev-twin create path '
-                '(when `parent_configuration_id` is set). Defaults to `iter-<6-hex>` when unset. Must not '
-                'be `main` (reserved for the prod app). Rejected on prod create and on update.'
+                'Draft branch to pin the new draft to. Only valid on the draft create path '
+                '(when `parent_configuration_id` is set). Defaults to `init` when unset (a sensible '
+                'name for the first draft of a brand-new prod app). For subsequent edit-existing '
+                "drafts, pass a descriptive branch name like 'add-revenue-filter'. Must not be `main` "
+                '(reserved for the prod app). Rejected on prod create and on update.'
             ),
         ),
     ] = None,
@@ -685,81 +713,104 @@ async def modify_python_js_data_app(
 ) -> ModifiedPythonJsDataAppOutput:
     """Creates or updates a python-js data app.
 
-    Two-app project model: every python-js project has a persistent **prod app** that owns the only
-    managed git repository for the project, and one or more **dev twins** that are *external-git* apps
-    pointing back at the prod app's managed repo for LLM iteration. Dev twins appear in the Keboola UI
-    under their parent prod app in a "Drafts" section; the user discards them manually via a "Discard"
-    button when no longer needed. The MCP server does not delete dev twins.
+    Two-app project model. Every python-js project has a persistent **prod app** that owns the
+    only managed git repository for the project, and zero or more **drafts** parented to that
+    prod app. A draft is a Storage configuration with `parameters.dataApp.isDraft=true` and
+    `parameters.dataApp.parentConfigurationId=<prod cfg id>`; it's an *external-git* app that
+    clones the parent prod's repo at a pinned branch on every deploy. Drafts are surfaced in the
+    Keboola UI under their parent prod app. Use `deploy_data_app(mode='dev')` to deploy a draft
+    as a dev version of the data app (hot reload + auto-auth for iframe preview); use
+    `delete_python_js_data_app_draft` to tear a draft down after its branch has been promoted.
 
-    Why this ownership split (MVP, AI-3005): the data-science platform does not yet support sharing a
-    managed repo across apps. Until the platform-side drafts mechanism lands (AI-3240), the dev twin
-    is configured to clone the prod app's repo on every deploy by setting its
-    `parameters.dataApp.git = {repository, username, '#password', branch}`. The prod-side credential
-    is minted automatically inside this tool when creating a dev twin — the agent does NOT need to
-    call `create_python_js_data_app_git_credential` separately on a dev twin.
+    **MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
+    branch-delete — is yours. MCP gives you authenticated clone URLs and manages configs/deploys;
+    it never invokes git.
 
-    ## Create flow (new project bootstrap)
-    No `configuration_id`, no `parent_configuration_id`. `slug` is required.
-    Steps:
-    1. Call this tool with `slug` (the user-facing name, e.g. `demo`). Creates the **prod app** with
-       its own managed git repo. Returns `(configuration_id=PROD, repo_url=R)`. `R` is the bare HTTPS
-       URL (no credentials).
-    2. Call this tool again with `slug` (e.g. `demo-dev-<rand>`) and `parent_configuration_id=PROD`.
-       Creates the **dev twin** as an external-git app pointing at `R` on a fresh iteration branch.
-       Returns `(configuration_id=DEV, repo_url=R, git_clone_url=U, branch=B)` — `U` has the
-       prod-issued token embedded so the agent can clone immediately, and `B` is the branch the
-       dev twin is pinned to (`iter-<6-hex>` if `branch` was not passed).
-    3. `git clone U`, `git checkout B`, write source, push.
-    4. `deploy_data_app(action='deploy', configuration_id=DEV, mode='dev')` → preview URL serving
-       branch `B`. Iterate with the user.
-    5. After approval, locally `git checkout main && git merge B && git push`.
-    6. `deploy_data_app(action='deploy', configuration_id=PROD)` — no `mode`, no `branch`. The prod
-       app picks up the merged `main`. The dev twin stays listed under the prod app in the UI's
-       "Drafts" section until the user discards it.
+    Three scenarios the agent has to distinguish:
 
-    ## Edit flow (modifying an existing prod app)
-    Same as steps 2–6 above. The agent already has the prod's `configuration_id`; it just calls
-    this tool with `parent_configuration_id=<prod>` and (optionally) `branch=<name>` to create the
-    dev twin. No `get_data_apps` pre-lookup is needed.
+    ## Scenario A — Create a brand-new data app
 
-    ## Update flow (modifying an existing app's deployment metadata)
-    When `configuration_id` is set: updates the Storage configuration (auto-suspend, name, description,
-    `authentication_type`). `slug`, `parent_configuration_id`, and `branch` are all rejected here —
-    slug is immutable, the repo binding is fixed at creation, and the iteration branch only makes
-    sense at create time. Use `authentication_type='default'` to keep the existing auth setup
-    (including OIDC configured outside the MCP); pass `'no-auth'` or `'basic-auth'` to overwrite.
-    After updating, ALWAYS call `deploy_data_app(action='deploy', ...)` to restart the app so the
-    changes take effect.
+    1. `modify_python_js_data_app(slug='demo')` → `(configuration_id=PROD, repo_url=R)`.
+       PROD owns the only managed repo for this app.
+    2. `modify_python_js_data_app(slug='demo-draft', parent_configuration_id=PROD)`
+       → `(configuration_id=DRAFT, repo_url=R, git_clone_url=U, branch='init')`.
+       Default draft branch is `'init'`. Override with `branch=<name>` for a descriptive name.
+    3. YOU: `git clone U`; `git checkout init` (creating it if the repo is empty); write source;
+       `git push origin init`.
+    4. `deploy_data_app(action='deploy', configuration_id=DRAFT, mode='dev')`
+       → preview URL serving the `init` branch as a dev version. Iterate with the user.
+    5. Once approved — YOU: `git checkout main`; `git merge init`; `git push origin main`;
+       `git push origin --delete init`.
+    6. `deploy_data_app(action='deploy', configuration_id=PROD)`
+       → prod URL now serves the merged `main`.
+    7. `delete_python_js_data_app_draft(configuration_id=DRAFT)`
+       → tears down the draft's config + data-app instance. Always run this once promoted.
+
+    ## Scenario B — Edit an existing data app
+
+    You already have PROD's `configuration_id` (from `get_data_apps` or earlier conversation).
+
+    1. `create_python_js_data_app_git_credential(configuration_id=PROD)`
+       → fresh `git_clone_url U` with an embedded one-time token.
+    2. `modify_python_js_data_app(
+            slug='demo-draft-<short suffix>',
+            parent_configuration_id=PROD,
+            branch='<describes-the-change>',   # e.g. 'add-revenue-filter'
+       )` → `(DRAFT, R, U2, branch)`. Use U2 (it has its own fresh token).
+    3. YOU: `git clone U2`; `git checkout <branch>` (creating it from `main`); edit source;
+       `git push origin <branch>`.
+    4–7. Same as Scenario A steps 4–7.
+
+    ## Scenario C — Continue an unfinished draft
+
+    The previous sandbox is gone. You have PROD's `configuration_id` but no working clone and no
+    draft handle.
+
+    1. `get_data_apps(configuration_ids=[PROD])` → returns PROD's detail including `drafts: [...]`.
+       Pick the draft the user means (ask if multiple and unclear). Each entry exposes its
+       `configuration_id`, slug, and pinned branch.
+    2. `create_python_js_data_app_git_credential(configuration_id=PROD)`
+       → fresh `git_clone_url U` (the previous one was minted in a wiped sandbox and is lost).
+       Drafts have no managed repo of their own — always mint against PROD.
+    3. YOU: `git clone U`; `git checkout <draft's pinned branch>`; resume work; `git push`.
+    4. `deploy_data_app(action='deploy', configuration_id=<DRAFT>, mode='dev')` → preview URL.
+       The draft's branch is already pinned in its config, no override needed.
+    5–7. Same promote/cleanup sequence as Scenario A steps 5–7.
+
+    ## Argument rules
+
+    - `parent_configuration_id` is **create-only**. Rejected on update.
+    - `branch` is **create-only** and only valid when `parent_configuration_id` is set.
+      Defaults to `'init'`. Must not be `'main'`. Rejected on prod create and on update.
+    - `slug` is required on create and immutable after.
+    - The **update path** (passing `configuration_id`) is for changing `name`, `description`,
+      `authentication_type`, `auto_suspend_after_seconds`, `storage` on either a prod app or
+      a draft. Source code changes go through the git flow above, not this tool.
 
     ## Authentication
+
     New apps default to HTTP basic authentication for safety. Pass `authentication_type='no-auth'`
-    explicitly to expose the app publicly. OIDC and other advanced auth setups are managed outside the
-    MCP — when updating such an app, leave `authentication_type='default'` to preserve them.
+    to expose publicly. On update, `authentication_type='default'` preserves the existing
+    `authorization` block (including OIDC setups configured outside the MCP); `'basic-auth'` /
+    `'no-auth'` overwrite it.
 
     ## Slug constraint
-    Must be DNS-label-safe (lowercase letters, digits, hyphens, ≤63 chars). For dev twins, append a
-    short suffix (e.g. `-dev-abc123`) to keep slugs unique across the prod app and its twins.
 
-    ## Source code
-    Source code lives in the managed git repo, NOT in this tool's input. This tool only manages
-    deployment metadata and the git binding. Source code changes are pushed via `git push` to the
-    prod app's repo URL (`repo_url` in this tool's output, embedded with credentials in
-    `git_clone_url` on the dev-twin create path).
+    Must be DNS-label-safe (lowercase letters, digits, hyphens, ≤63 chars). For drafts, append a
+    short suffix (e.g. `-draft-abc123`) to keep slugs unique across the prod and its drafts.
     """
     if configuration_id:
         if slug:
             raise ValueError('slug cannot be changed after the data app is created.')
         if parent_configuration_id:
-            raise ValueError('parent_configuration_id is only valid when creating a dev twin ' '(no configuration_id).')
+            raise ValueError('parent_configuration_id is only valid when creating a draft (no configuration_id).')
         if branch:
-            raise ValueError('branch is only valid when creating a dev twin (no configuration_id).')
+            raise ValueError('branch is only valid when creating a draft (no configuration_id).')
     else:
         if not slug:
             raise ValueError('slug is required when creating a python-js data app.')
         if branch is not None and not parent_configuration_id:
-            raise ValueError(
-                'branch is only valid on the dev-twin create path ' '(pair it with parent_configuration_id).'
-            )
+            raise ValueError('branch is only valid on the draft create path (pair it with parent_configuration_id).')
 
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
@@ -779,7 +830,6 @@ async def modify_python_js_data_app(
         data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
         updated_config = _update_existing_code_data_app_config(
             existing_config=data_app.configuration,
-            image_version=_HARDCODED_PYTHON_JS_IMAGE_VERSION,
             auto_suspend_after_seconds=auto_suspend_after_seconds,
             authentication_type=authentication_type,
             secrets=legacy_secrets,
@@ -825,7 +875,7 @@ async def modify_python_js_data_app(
             links=links,
         )
     else:
-        # Create new python-js data app — either a prod app (own managed repo) or a dev twin
+        # Create new python-js data app — either a prod app (own managed repo) or a draft
         # (external-git binding pointing at the parent prod app's managed repo).
         # Narrowed by the validation block at the top of this function.
         assert slug is not None
@@ -834,27 +884,27 @@ async def modify_python_js_data_app(
         authorization_model = DataAppConfig.Authorization.model_validate(_get_authorization(uses_basic_auth))
 
         git_clone_url: Optional[str] = None
-        twin_branch: Optional[str] = None
+        draft_branch: Optional[str] = None
         git_block: Optional[CodeDataAppConfig.Parameters.DataApp.Git] = None
         if parent_configuration_id:
-            # Dev-twin create path: resolve the parent's repo + mint a parent-side credential, then
-            # serialize an external-git block into the dev twin's config.
+            # Draft create path: resolve the parent's repo + mint a parent-side credential, then
+            # serialize an external-git block into the draft's config.
             parent = await _fetch_data_app(client, configuration_id=parent_configuration_id, data_app_id=None)
             if parent.type != 'python-js':
                 raise ValueError(
                     f'parent_configuration_id "{parent_configuration_id}" is type "{parent.type}", but only '
-                    f'python-js prod apps can parent a dev twin.'
+                    f'python-js prod apps can parent a draft.'
                 )
             if not parent.repo_url:
                 raise ValueError(
                     f'Parent python-js data app "{parent_configuration_id}" has no managed git repo URL. '
                     'This indicates a platform-side bug — retry or contact support.'
                 )
-            twin_branch = (branch or _generate_dev_twin_branch_name()).strip()
-            if not twin_branch or any(c.isspace() for c in twin_branch):
+            draft_branch = (branch or _DEFAULT_DRAFT_BRANCH).strip()
+            if not draft_branch or any(c.isspace() for c in draft_branch):
                 raise ValueError(f'branch "{branch}" is not a valid git branch name.')
-            if twin_branch == 'main':
-                raise ValueError('branch "main" is reserved for the prod app — pick a different iteration branch.')
+            if draft_branch == 'main':
+                raise ValueError('branch "main" is reserved for the prod app — pick a different draft branch.')
             cred = await client.data_science_client.create_app_git_credential(parent.data_app_id)
             if not cred.secret:
                 raise ValueError(
@@ -865,7 +915,7 @@ async def modify_python_js_data_app(
                 repository=parent.repo_url,
                 username=_MANAGED_GIT_REPO_USERNAME,
                 password=cred.secret,
-                branch=twin_branch,
+                branch=draft_branch,
             )
             git_clone_url = _build_authenticated_clone_url(parent.repo_url, cred.secret)
 
@@ -877,11 +927,13 @@ async def modify_python_js_data_app(
                     secrets=legacy_secrets,
                     git=git_block,
                     is_draft=True if parent_configuration_id is not None else None,
+                    parent_configuration_id=parent_configuration_id,
                 ),
             ),
-            runtime=CodeDataAppConfig.Runtime(
-                image=CodeDataAppConfig.Runtime.Image(version=_HARDCODED_PYTHON_JS_IMAGE_VERSION),
-                workspace=(CodeDataAppConfig.Runtime.Workspace(enabled=True) if has_storage_workspace else None),
+            runtime=(
+                CodeDataAppConfig.Runtime(workspace=CodeDataAppConfig.Runtime.Workspace(enabled=True))
+                if has_storage_workspace
+                else None
             ),
             authorization=authorization_model,
             storage=validated_storage,
@@ -945,7 +997,7 @@ async def modify_python_js_data_app(
             data_app=data_app_summary,
             repo_url=repo_url,
             git_clone_url=git_clone_url,
-            branch=twin_branch,
+            branch=draft_branch,
             links=links,
         )
 
@@ -955,8 +1007,15 @@ async def create_python_js_data_app_git_credential(
     ctx: Context,
     configuration_id: Annotated[str, Field(description='Storage configuration ID of the python-js data app.')],
 ) -> CreatedGitCredentialOutput:
-    """Mints a one-time HTTPS token on a python-js data app so the caller can clone, pull, and push
-    to the app's managed git repo over HTTPS.
+    """Mints a one-time HTTPS token on a python-js **prod** data app so the caller can clone, pull,
+    and push to the app's managed git repo over HTTPS.
+
+    **Always call against the prod app's configuration_id** — drafts have no managed repo of their
+    own, so calling this on a draft fails. The prod app is the canonical repo owner; drafts
+    iterate against branches of that same repo.
+
+    **MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
+    branch-delete — is yours. This tool only mints credentials.
 
     Returns a ready-to-use `git_clone_url` of the form `https://kai:<secret>@<host>/<path>.git`
     plus the raw `secret`. The token is returned **only** at creation — the platform cannot return
@@ -968,19 +1027,21 @@ async def create_python_js_data_app_git_credential(
 
     ## When to call
 
-    1. **Right after `modify_python_js_data_app` create** — the new app has a managed repo but no
-       credentials yet. Call this tool with the new app's `configuration_id` to enable git access.
+    1. **Right after `modify_python_js_data_app` create of a prod app** — the new prod has a
+       managed repo but no credentials yet. Call this tool with the new app's `configuration_id`
+       to enable git access. (Note: when creating a **draft**, the prod-side token is minted and
+       embedded into the returned `git_clone_url` automatically — no separate call needed.)
 
-    2. **Recovery when the cached token is gone** (e.g., a fresh Kai sandbox continuing an old draft
-       — the previous sandbox's filesystem was wiped, taking the cached `git_clone_url` with it).
-       If `git clone`/`pull`/`push` against a python-js app the LLM did not create in the current
-       session fails with `Authentication failed` (HTTP 401), call this tool with the same
-       `configuration_id` to mint a fresh token. Existing credentials remain valid, so other clients
-       are not disrupted.
+    2. **Recovery when the cached token is gone / continuing an unfinished draft** — e.g., a fresh
+       sandbox continuing yesterday's work, with the previous sandbox's filesystem wiped. The
+       cached `git_clone_url` is lost; the configuration ID for the prod app is all you have.
+       Call this tool with the **prod app's** `configuration_id` to mint a fresh token (drafts
+       have no managed repo, so always mint against prod). Existing credentials remain valid, so
+       other clients are not disrupted.
 
     ## Constraints
-    - Only python-js data apps have a managed git repo. Streamlit apps reject the call with a clear
-      error.
+    - Only python-js prod data apps have a managed git repo. Streamlit apps reject the call with
+      a clear error.
     - Permissions are always `readWrite` — the LLM virtually always needs push access. The
       data-science API supports read-only credentials, but the tool does not expose that knob;
       revisit once a real use case appears.
@@ -1080,7 +1141,6 @@ def _validate_data_app_storage(
 
 def _update_existing_code_data_app_config(
     existing_config: Mapping[str, Any],
-    image_version: Optional[str],
     auto_suspend_after_seconds: int,
     authentication_type: AuthenticationType = 'default',
     secrets: Optional[dict[str, Any]] = None,
@@ -1088,7 +1148,9 @@ def _update_existing_code_data_app_config(
 ) -> dict[str, Any]:
     """Apply requested updates to the existing python-js data app storage configuration.
 
-    Slug is intentionally not updated here (immutable post-create).
+    Slug is intentionally not updated here (immutable post-create). `runtime.image.version` is
+    not touched either — the platform now picks a default for python-js apps, and any legacy
+    `image.version` pin already in the stored config is preserved verbatim via deepcopy.
     `authentication_type='default'` preserves the existing `authorization` block (including OIDC
     setups configured outside the MCP); 'no-auth' / 'basic-auth' overwrite it.
     `secrets` are merged into the existing `parameters.dataApp.secrets` map without overwriting
@@ -1100,10 +1162,6 @@ def _update_existing_code_data_app_config(
     new_config = cast(dict[str, Any], copy.deepcopy(existing_config))
     new_config.setdefault('parameters', {})
     new_config['parameters']['autoSuspendAfterSeconds'] = auto_suspend_after_seconds
-    if image_version:
-        runtime = new_config.setdefault('runtime', {})
-        image = runtime.setdefault('image', {})
-        image['version'] = image_version
     if authentication_type != 'default':
         new_config['authorization'] = _get_authorization(authentication_type == 'basic-auth')
     if secrets:
@@ -1142,6 +1200,12 @@ async def get_data_apps(
       (when `configuration_ids` is provided). The inventory list always returns `repo_url=None`,
       even for python-js apps with a managed repo — to retrieve the URL, call this tool again
       with the target `configuration_ids`.
+    - When called with `configuration_ids=[<prod-cfg>]` for a python-js **prod** app, the response
+      includes a `drafts: [...]` array of every draft (configs with `isDraft=true` and
+      `parentConfigurationId == <prod-cfg>`) currently in the project. Drafts in trash are not
+      included. Use this to discover existing drafts when continuing a previously abandoned
+      iteration (Scenario C in `modify_python_js_data_app`). The array is empty for drafts
+      themselves and for Streamlit apps.
     """
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
@@ -1179,8 +1243,11 @@ async def deploy_data_app(
         Optional[Literal['dev', 'production']],
         Field(
             description=(
-                'Deployment mode. Set to "dev" to enable the in-platform preview for python-js data apps. '
-                'Leave None (default) for Streamlit apps and for production deploys.'
+                'Deployment mode. Set to "dev" to deploy a python-js draft as a **dev version of the data '
+                'app** — the runtime uses a development `setup.sh` (hot reload), and the data-app proxy '
+                'enables an auto-auth path so an iframe preview can render without a manual login. '
+                'Only meaningful on **draft** configs (python-js apps with `isDraft=true`). Leave None '
+                '(default) for prod redeploys and for Streamlit apps.'
             ),
         ),
     ] = None,
@@ -1188,9 +1255,10 @@ async def deploy_data_app(
         Optional[str],
         Field(
             description=(
-                'Git branch to deploy from. Only meaningful when `mode="dev"` for python-js apps backed by a '
-                'managed repo — the dev twin will deploy from this branch instead of `main`, enabling '
-                'branch-based preview during the edit flow. Leave None for prod deploys and for Streamlit apps.'
+                'Git branch to deploy from. Only meaningful when `mode="dev"` for python-js drafts. '
+                'Normally unnecessary — drafts have their branch pinned in `parameters.dataApp.git.branch` '
+                'at create time; this argument overrides that pin for this single deploy (escape hatch). '
+                'Leave None for prod deploys and for Streamlit apps.'
             ),
         ),
     ] = None,
@@ -1198,13 +1266,21 @@ async def deploy_data_app(
     """Deploys/redeploys a data app or stops a running data app in the Keboola environment asynchronously, given the
     action and the configuration ID.
 
+    **MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
+    branch-delete — is yours. This tool only triggers deploys against existing git state.
+
     ## Mode and branch (python-js apps)
-    - `mode='dev'` enables the in-platform preview for a python-js dev twin. Pair with `branch` to deploy a
-      specific git branch (edit flow); without `branch`, the dev twin deploys `main`.
-    - For prod redeploys (including after merging a feature branch into `main` during the edit flow), use
-      no `mode` and no `branch` — the prod app picks up the current `main`.
-    - python-js apps do NOT fetch a Storage `configVersion` for deployment (their source lives in git, not in
-      the Storage configuration); this is handled automatically.
+    - `mode='dev'` deploys the target as a **dev version of the data app** — the runtime uses a
+      development `setup.sh` (hot reload) and the data-app proxy enables an auto-auth path so an
+      iframe preview can render without a manual login. Only meaningful on **draft** configs
+      (python-js apps with `isDraft=true`).
+    - For prod redeploys (including after merging a draft's branch into `main`), use no `mode` and
+      no `branch` — the prod app picks up the current `main`.
+    - The optional `branch=` argument overrides the branch the draft deploys from for this single
+      deploy. Normally unnecessary — drafts have their draft branch pinned in
+      `parameters.dataApp.git.branch` at create time.
+    - python-js apps do NOT fetch a Storage `configVersion` for deployment (their source lives in
+      git, not in the Storage configuration); this is handled automatically.
 
     ## Streamlit apps
     Streamlit apps have no managed git repo, so `mode` and `branch` have no effect on the
@@ -1268,6 +1344,78 @@ async def deploy_data_app(
         return DeploymentDataAppOutput(state=data_app.state, links=links, deployment_info=None)
     else:
         raise ValueError(f'Invalid action: {action}')
+
+
+@tool_errors()
+async def delete_python_js_data_app_draft(
+    ctx: Context,
+    configuration_id: Annotated[
+        str, Field(description='Storage configuration ID of the python-js draft data app to delete.')
+    ],
+) -> DeletedDraftOutput:
+    """Deletes a python-js DRAFT data app — both the data-app instance (DSAPI) and its Storage
+    configuration.
+
+    **MCP never runs git on your behalf.** Deleting the feature branch on the remote is your job;
+    this tool only tears down the draft config and its data-app instance.
+
+    WHEN TO CALL: at the end of a promote-to-prod sequence, after you have merged the draft's
+    branch into `main`, pushed, deleted the feature branch from the remote, and redeployed the
+    prod app. The Keboola UI lists drafts under their parent prod app; once you call this tool,
+    the draft disappears from that list.
+
+    WHAT THIS TOOL REFUSES:
+      - prod apps (no `isDraft` flag) — protects against accidental prod deletion;
+      - Streamlit apps — they have no draft concept.
+
+    WHAT THIS TOOL DOES NOT DO:
+      - Run git. Deleting the feature branch on the remote is your job.
+      - Revoke the prod-side git credential minted when the draft was created. Credential
+        rotation is the user's job via the Keboola UI.
+
+    After a successful call, pivot back to the parent prod app (its configuration_id is returned
+    in the response) or to `get_data_apps` for further work.
+    """
+    client = KeboolaClient.from_state(ctx.session.state)
+    links_manager = await ProjectLinksManager.from_client(client)
+
+    data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
+    if data_app.type != 'python-js':
+        raise ValueError(
+            f'delete_python_js_data_app_draft only supports python-js data apps, but configuration '
+            f'"{configuration_id}" is type "{data_app.type}".'
+        )
+    if not _is_draft_config(data_app.configuration):
+        raise ValueError(
+            f'Configuration "{configuration_id}" is a python-js **prod** app, not a draft '
+            '(parameters.dataApp.isDraft is not true). This tool only deletes drafts — '
+            'prod apps must be deleted from the Keboola UI.'
+        )
+
+    data_app_block = cast(Mapping[str, Any], data_app.configuration.get('parameters') or {}).get('dataApp') or {}
+    parent_cfg_id = data_app_block.get('parentConfigurationId')
+    parent_configuration_id: Optional[str] = parent_cfg_id if isinstance(parent_cfg_id, str) else None
+
+    await client.data_science_client.delete_data_app(data_app.data_app_id)
+    await client.storage_client.configuration_delete(
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id=configuration_id,
+        skip_trash=False,
+    )
+
+    links = links_manager.get_data_app_links(
+        configuration_id=parent_configuration_id or configuration_id,
+        configuration_name=data_app.name,
+        deployment_link=None,
+        uses_basic_authentication=False,
+    )
+    return DeletedDraftOutput(
+        response='deleted',
+        configuration_id=configuration_id,
+        data_app_id=data_app.data_app_id,
+        parent_configuration_id=parent_configuration_id,
+        links=links,
+    )
 
 
 def _build_data_app_config(
@@ -1415,10 +1563,53 @@ async def _fetch_data_app_details_task(
             uses_basic_authentication=_uses_basic_authentication(data_app.configuration.get('authorization') or {}),
         )
         logs = await _fetch_logs(client, data_app.data_app_id)
-        return data_app.with_links(links).with_deployment_info(logs)
+        data_app = data_app.with_links(links).with_deployment_info(logs)
+        # Drafts of a python-js prod are surfaced inline so the agent can find them in one round-trip
+        # — see Scenario C in `modify_python_js_data_app`. Skip for drafts themselves and for Streamlit
+        # (neither has children).
+        if data_app.type == 'python-js' and not _is_draft_config(data_app.configuration):
+            data_app.drafts = await _fetch_prod_drafts(client, prod_configuration_id=data_app.configuration_id)
+        return data_app
     except Exception:
         LOG.exception(f'Failed to fetch data app by configuration ID: {configuration_id}')
         return configuration_id
+
+
+def _is_draft_config(configuration: Mapping[str, Any]) -> bool:
+    """True iff the data app's stored configuration carries `parameters.dataApp.isDraft = true`."""
+    return cast(Mapping[str, Any], configuration.get('parameters') or {}).get('dataApp', {}).get('isDraft') is True
+
+
+async def _fetch_prod_drafts(client: KeboolaClient, *, prod_configuration_id: str) -> list[DataAppSummary]:
+    """List the drafts (configs with `parentConfigurationId == prod_configuration_id`) of a python-js
+    prod app. Returns full `DataAppSummary` entries (one extra DSAPI fetch per draft, capped at
+    10 parallel). Drafts in trash are not returned by `configuration_list` and so do not appear here.
+    """
+    configs = await client.storage_client.configuration_list(DATA_APP_COMPONENT_ID)
+    draft_cfg_ids: list[str] = []
+    for cfg in configs:
+        cfg_body = cast(Mapping[str, Any], cfg.get('configuration') or {})
+        data_app_block = cast(Mapping[str, Any], cfg_body.get('parameters') or {}).get('dataApp') or {}
+        if data_app_block.get('parentConfigurationId') == prod_configuration_id:
+            cfg_id = cfg.get('id')
+            if isinstance(cfg_id, str):
+                draft_cfg_ids.append(cfg_id)
+
+    if not draft_cfg_ids:
+        return []
+
+    async def fetch_summary(cfg_id: str) -> DataAppSummary | None:
+        try:
+            draft = await _fetch_data_app(client, configuration_id=cfg_id, data_app_id=None)
+        except Exception:
+            LOG.exception(f'Failed to fetch draft data app by configuration ID: {cfg_id}')
+            return None
+        summary = DataAppSummary.model_validate(draft.model_dump())
+        summary.repo_url = draft.repo_url
+        return summary
+
+    results = await process_concurrently(draft_cfg_ids, fetch_summary, max_concurrency=10)
+    return [s for s in results if isinstance(s, DataAppSummary)]
 
 
 async def _fetch_logs(client: KeboolaClient, data_app_id: str) -> list[str]:

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -251,6 +251,15 @@ class DataApp(BaseModel):
             'themselves and for non-python-js apps.'
         ),
     )
+    drafts_unavailable: int = Field(
+        default=0,
+        description=(
+            'Count of drafts that exist for this prod app but whose details could not be fetched on '
+            'this call (transient DSAPI failure — expired token, timeout, 5xx). A non-zero value means '
+            '`drafts` is INCOMPLETE: those drafts still exist and were NOT deleted, so do not treat '
+            'their absence as "no drafts" before a teardown decision. Retry to get the full list.'
+        ),
+    )
     links: list[Link] = Field(description='Navigation links for the web interface.', default_factory=list)
 
     @classmethod
@@ -1606,7 +1615,9 @@ async def _fetch_data_app_details_task(
         # — see Scenario C in `modify_python_js_data_app`. Skip for drafts themselves and for Streamlit
         # (neither has children).
         if data_app.type == 'python-js' and not _is_draft_config(data_app.configuration):
-            data_app.drafts = await _fetch_prod_drafts(client, prod_configuration_id=data_app.configuration_id)
+            data_app.drafts, data_app.drafts_unavailable = await _fetch_prod_drafts(
+                client, prod_configuration_id=data_app.configuration_id
+            )
         return data_app
     except Exception:
         LOG.exception(f'Failed to fetch data app by configuration ID: {configuration_id}')
@@ -1628,10 +1639,12 @@ def _is_draft_config(configuration: Mapping[str, Any]) -> bool:
     return data_app.get('isDraft') is True
 
 
-async def _fetch_prod_drafts(client: KeboolaClient, *, prod_configuration_id: str) -> list[DataAppSummary]:
+async def _fetch_prod_drafts(client: KeboolaClient, *, prod_configuration_id: str) -> tuple[list[DataAppSummary], int]:
     """List the drafts (configs with `parentConfigurationId == prod_configuration_id`) of a python-js
     prod app. Returns full `DataAppSummary` entries (one extra DSAPI fetch per draft, capped at
-    10 parallel). Drafts in trash are not returned by `configuration_list` and so do not appear here.
+    10 parallel) plus the count of drafts whose detail fetch transiently failed and were omitted —
+    so the caller can tell "temporarily unreachable" from "deleted". Drafts in trash are not returned
+    by `configuration_list` and so do not appear here.
     """
     configs = await client.storage_client.configuration_list(DATA_APP_COMPONENT_ID)
     draft_cfg_ids: list[str] = []
@@ -1649,7 +1662,7 @@ async def _fetch_prod_drafts(client: KeboolaClient, *, prod_configuration_id: st
                 draft_cfg_ids.append(cfg_id)
 
     if not draft_cfg_ids:
-        return []
+        return [], 0
 
     async def fetch_summary(cfg_id: str) -> DataAppSummary | None:
         try:
@@ -1662,7 +1675,8 @@ async def _fetch_prod_drafts(client: KeboolaClient, *, prod_configuration_id: st
         return summary
 
     results = await process_concurrently(draft_cfg_ids, fetch_summary, max_concurrency=10)
-    return [s for s in results if isinstance(s, DataAppSummary)]
+    drafts = [s for s in results if isinstance(s, DataAppSummary)]
+    return drafts, len(draft_cfg_ids) - len(drafts)
 
 
 async def _fetch_logs(client: KeboolaClient, data_app_id: str) -> list[str]:

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -1055,6 +1055,17 @@ async def create_python_js_data_app_git_credential(
             f'create_python_js_data_app_git_credential only supports python-js data apps, but configuration '
             f'"{configuration_id}" is type "{data_app.type}".'
         )
+    if _is_draft_config(data_app.configuration):
+        # Drafts have no managed repo of their own — they iterate against branches of the parent
+        # prod's repo. Reject early with an actionable message instead of letting get_app_git_repo
+        # return https_url=None below and raising a misleading "platform-side bug" error.
+        data_app_block = cast(Mapping[str, Any], data_app.configuration.get('parameters') or {}).get('dataApp') or {}
+        parent_cfg_id = data_app_block.get('parentConfigurationId')
+        hint = f' (parentConfigurationId="{parent_cfg_id}")' if isinstance(parent_cfg_id, str) else ''
+        raise ValueError(
+            f'Configuration "{configuration_id}" is a python-js **draft**, which has no managed git repo '
+            f'of its own. Mint credentials against the parent prod app instead{hint}.'
+        )
 
     repo_resp = await client.data_science_client.get_app_git_repo(data_app.data_app_id)
     if repo_resp.https_url is None:

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -1576,8 +1576,18 @@ async def _fetch_data_app_details_task(
 
 
 def _is_draft_config(configuration: Mapping[str, Any]) -> bool:
-    """True iff the data app's stored configuration carries `parameters.dataApp.isDraft = true`."""
-    return cast(Mapping[str, Any], configuration.get('parameters') or {}).get('dataApp', {}).get('isDraft') is True
+    """True iff the data app's stored configuration carries `parameters.dataApp.isDraft = true`.
+
+    Shape-safe: a malformed/corrupted config whose `parameters` or `dataApp` is not a mapping is
+    simply "not a draft" rather than an `AttributeError` (this helper runs in the detail-fetch path).
+    """
+    parameters = configuration.get('parameters')
+    if not isinstance(parameters, Mapping):
+        return False
+    data_app = parameters.get('dataApp')
+    if not isinstance(data_app, Mapping):
+        return False
+    return data_app.get('isDraft') is True
 
 
 async def _fetch_prod_drafts(client: KeboolaClient, *, prod_configuration_id: str) -> list[DataAppSummary]:

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -1408,11 +1408,22 @@ async def delete_python_js_data_app_draft(
     parent_configuration_id: Optional[str] = parent_cfg_id if isinstance(parent_cfg_id, str) else None
 
     await client.data_science_client.delete_data_app(data_app.data_app_id)
-    await client.storage_client.configuration_delete(
-        component_id=DATA_APP_COMPONENT_ID,
-        configuration_id=configuration_id,
-        skip_trash=False,
-    )
+    # DSAPI delete may also remove the Storage config (its docstring says so, and removal can be
+    # eventually-consistent). Tolerate a 404 so the tool stays idempotent if the config is already
+    # gone; any other status is a real error and must propagate.
+    try:
+        await client.storage_client.configuration_delete(
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=configuration_id,
+            skip_trash=False,
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 404:
+            raise
+        LOG.info(
+            f'Storage config "{configuration_id}" was already deleted (404) while tearing down the '
+            'draft — treating as already removed.'
+        )
 
     links = links_manager.get_data_app_links(
         configuration_id=parent_configuration_id or configuration_id,

--- a/tests/clients/test_data_science.py
+++ b/tests/clients/test_data_science.py
@@ -156,7 +156,7 @@ async def test_create_data_app_defaults_to_streamlit_without_managed_repo_flag()
         (None, 'production', None, {'mode': 'production'}),
         (None, None, None, {}),  # bare deploy (python-js without explicit mode)
         ('5', 'dev', None, {'configVersion': '5', 'mode': 'dev'}),  # both
-        (None, 'dev', 'feature-x', {'mode': 'dev', 'branch': 'feature-x'}),  # python-js dev twin on a branch
+        (None, 'dev', 'feature-x', {'mode': 'dev', 'branch': 'feature-x'}),  # python-js draft on a branch
     ],
 )
 async def test_deploy_data_app_payload_with_mode_and_optional_config_version(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -393,12 +393,13 @@ class TestToolsFilteringMiddleware:
         keboola_client.branch_id = branch_id
         keboola_client.storage_client.verify_token = AsyncMock(return_value={'owner': {'features': []}, 'admin': {}})
 
-        tools = [
-            _tool('modify_streamlit_data_app'),
-            _tool('get_data_apps'),
-            _tool('deploy_data_app'),
-            _tool('other_tool'),
+        data_app_tools = [
+            'modify_streamlit_data_app',
+            'get_data_apps',
+            'deploy_data_app',
+            'delete_python_js_data_app_draft',
         ]
+        tools = [_tool(name) for name in data_app_tools] + [_tool('other_tool')]
 
         async def call_next(_):
             return tools
@@ -408,14 +409,11 @@ class TestToolsFilteringMiddleware:
         result = await middleware.on_list_tools(context, call_next)
 
         result_names = {t.name for t in result}
-        if expect_filtered:
-            assert 'modify_streamlit_data_app' not in result_names
-            assert 'get_data_apps' not in result_names
-            assert 'deploy_data_app' not in result_names
-        else:
-            assert 'modify_streamlit_data_app' in result_names
-            assert 'get_data_apps' in result_names
-            assert 'deploy_data_app' in result_names
+        for name in data_app_tools:
+            if expect_filtered:
+                assert name not in result_names
+            else:
+                assert name in result_names
         assert 'other_tool' in result_names
 
     @pytest.mark.asyncio
@@ -522,6 +520,13 @@ class TestToolsFilteringMiddleware:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
+        'tool_name',
+        [
+            'modify_streamlit_data_app',
+            'delete_python_js_data_app_draft',
+        ],
+    )
+    @pytest.mark.parametrize(
         ('branch_id', 'expect_error'),
         [
             ('5678', True),
@@ -533,16 +538,15 @@ class TestToolsFilteringMiddleware:
         mcp_context_client,
         branch_id: str | None,
         expect_error: bool,
+        tool_name: str,
     ) -> None:
         keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
         keboola_client.branch_id = branch_id
         keboola_client.storage_client.verify_token = AsyncMock(return_value={'owner': {'features': []}, 'admin': {}})
 
-        tool = _tool('modify_streamlit_data_app')
+        tool = _tool(tool_name)
         mcp_context_client.fastmcp = SimpleNamespace(get_tool=AsyncMock(return_value=tool))
-        context = SimpleNamespace(
-            fastmcp_context=mcp_context_client, message=SimpleNamespace(name='modify_streamlit_data_app')
-        )
+        context = SimpleNamespace(fastmcp_context=mcp_context_client, message=SimpleNamespace(name=tool_name))
 
         expected = MagicMock()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,6 +47,7 @@ class TestServer:
             'create_oauth_url',
             'create_python_js_data_app_git_credential',
             'create_sql_transformation',
+            'delete_python_js_data_app_draft',
             'deploy_data_app',
             'docs_query',
             'find_component_id',

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -836,6 +836,7 @@ from keboola_mcp_server.clients.data_science import (  # noqa: E402
 from keboola_mcp_server.tools.data_apps import (  # noqa: E402
     CreatedGitCredentialOutput,
     ModifiedPythonJsDataAppOutput,
+    _is_draft_config,
     _update_existing_code_data_app_config,
     create_python_js_data_app_git_credential,
     modify_python_js_data_app,
@@ -2168,6 +2169,35 @@ def _build_storage_config_entry(*, cfg_id: str, parent_configuration_id: str | N
         },
         'version': 1,
     }
+
+
+@pytest.mark.parametrize(
+    ('configuration', 'expected'),
+    [
+        ({'parameters': {'dataApp': {'isDraft': True}}}, True),
+        ({'parameters': {'dataApp': {'isDraft': False}}}, False),
+        ({'parameters': {'dataApp': {'slug': 'prod'}}}, False),
+        ({'parameters': {}}, False),
+        ({}, False),
+        # Malformed/corrupted shapes must be treated as "not a draft", never raise AttributeError.
+        ({'parameters': {'dataApp': 'corrupted'}}, False),
+        ({'parameters': 'corrupted'}, False),
+        ({'parameters': None}, False),
+    ],
+    ids=[
+        'is_draft',
+        'not_draft',
+        'no_flag',
+        'no_data_app',
+        'empty',
+        'data_app_not_mapping',
+        'parameters_not_mapping',
+        'parameters_none',
+    ],
+)
+def test_is_draft_config(configuration: dict, expected: bool) -> None:
+    """`_is_draft_config` is true only for `isDraft=true` and is shape-safe against malformed configs."""
+    assert _is_draft_config(configuration) is expected
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -2060,6 +2060,34 @@ async def test_create_python_js_data_app_git_credential_rejects_streamlit_app(
 
 
 @pytest.mark.asyncio
+async def test_create_python_js_data_app_git_credential_rejects_draft(
+    mocker,
+    mcp_context_client: Context,
+) -> None:
+    """Drafts have no managed repo of their own — the tool must reject them early (before touching
+    get_app_git_repo) and point at the parent prod app, rather than falling through to the
+    misleading https_url=None 'platform bug' error."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.data_science_client = mocker.AsyncMock()
+
+    draft = _make_python_js_draft_data_app(
+        configuration_id='cfg-draft-1', data_app_id='app-draft-1', parent_configuration_id='cfg-prod-1'
+    )
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=draft))
+
+    with pytest.raises(ValueError, match=r'is a python-js \*\*draft\*\*') as excinfo:
+        await create_python_js_data_app_git_credential(
+            ctx=mcp_context_client,
+            configuration_id='cfg-draft-1',
+        )
+
+    # The error must steer the caller to the parent prod app, and no repo/credential calls happen.
+    assert 'parentConfigurationId="cfg-prod-1"' in str(excinfo.value)
+    keboola_client.data_science_client.get_app_git_repo.assert_not_called()
+    keboola_client.data_science_client.create_app_git_credential.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_create_python_js_data_app_git_credential_invalid_configuration_id(
     mocker,
     mcp_context_client: Context,

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -2421,6 +2421,12 @@ async def test_delete_python_js_data_app_draft_success(
         configuration_id='cfg-draft-1',
         skip_trash=False,
     )
+    # The config link pivots to the parent prod and is labelled as such — not with the draft's name,
+    # which would mislabel a link pointing at a different configuration.
+    config_link = next(link for link in result.links if 'Data App Configuration' in link.title)
+    assert 'data-apps/cfg-prod-1' in config_link.url
+    assert 'parent prod app' in config_link.title
+    assert draft.name not in config_link.title
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -2155,12 +2155,17 @@ def _make_python_js_draft_data_app(
     )
 
 
-def _build_storage_config_entry(*, cfg_id: str, parent_configuration_id: str | None) -> dict:
-    """Mirror the shape returned by `storage_client.configuration_list` for python-js apps."""
+def _build_storage_config_entry(*, cfg_id: str, parent_configuration_id: str | None, is_draft: bool = True) -> dict:
+    """Mirror the shape returned by `storage_client.configuration_list` for python-js apps.
+
+    `is_draft=False` with a `parent_configuration_id` set models a misconfigured non-draft that
+    points at a prod but lacks the `isDraft` flag — it must NOT be surfaced as a draft.
+    """
     data_app_block: dict = {'slug': f'app-{cfg_id}'}
     if parent_configuration_id is not None:
-        data_app_block['isDraft'] = True
         data_app_block['parentConfigurationId'] = parent_configuration_id
+        if is_draft:
+            data_app_block['isDraft'] = True
     return {
         'id': cfg_id,
         'name': f'app-{cfg_id}',
@@ -2231,6 +2236,11 @@ async def test_get_data_apps_detail_for_prod_lists_drafts(
         _build_storage_config_entry(cfg_id=cfg_id, parent_configuration_id=prod_cfg_id) for cfg_id in draft_cfg_ids
     ]
     configs.append(foreign_cfg)
+    # A config that points at THIS prod but lacks `isDraft` is a misconfiguration, not a draft —
+    # it must be excluded (and never even fetched, or fake_fetch below would KeyError).
+    configs.append(
+        _build_storage_config_entry(cfg_id='cfg-non-draft-child', parent_configuration_id=prod_cfg_id, is_draft=False)
+    )
     # Also include the prod's own config (no parentConfigurationId) — must not be matched.
     configs.append(_build_storage_config_entry(cfg_id=prod_cfg_id, parent_configuration_id=None))
 

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -2327,6 +2327,47 @@ async def test_get_data_apps_detail_for_prod_lists_drafts(
     assert isinstance(detail, DataApp)
     returned_draft_ids = sorted(d.configuration_id for d in detail.drafts)
     assert returned_draft_ids == sorted(draft_cfg_ids)
+    # All drafts fetched successfully, so nothing was omitted.
+    assert detail.drafts_unavailable == 0
+
+
+@pytest.mark.asyncio
+async def test_get_data_apps_detail_for_prod_counts_unavailable_drafts(
+    mocker,
+    mcp_context_client: Context,
+) -> None:
+    """A transient DSAPI failure on one draft's detail fetch must NOT silently shrink the list:
+    the surviving draft is still returned and `drafts_unavailable` counts the omission so the
+    caller can tell "temporarily unreachable" from "deleted"."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    prod_cfg_id = 'cfg-prod-1'
+    prod = _make_python_js_prod_data_app(configuration_id=prod_cfg_id)
+    ok_cfg_id, failing_cfg_id = 'cfg-draft-ok', 'cfg-draft-fail'
+    ok_draft = _make_python_js_draft_data_app(
+        configuration_id=ok_cfg_id, data_app_id=f'app-{ok_cfg_id}', parent_configuration_id=prod_cfg_id
+    )
+    configs = [
+        _build_storage_config_entry(cfg_id=ok_cfg_id, parent_configuration_id=prod_cfg_id),
+        _build_storage_config_entry(cfg_id=failing_cfg_id, parent_configuration_id=prod_cfg_id),
+        _build_storage_config_entry(cfg_id=prod_cfg_id, parent_configuration_id=None),
+    ]
+    keboola_client.storage_client.configuration_list = mocker.AsyncMock(return_value=configs)
+
+    async def fake_fetch(client, *, configuration_id, data_app_id):
+        if configuration_id == prod_cfg_id:
+            return prod
+        if configuration_id == failing_cfg_id:
+            raise RuntimeError('transient DSAPI failure (timeout)')
+        return ok_draft
+
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', side_effect=fake_fetch)
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_logs', mocker.AsyncMock(return_value=[]))
+
+    result = await get_data_apps(ctx=mcp_context_client, configuration_ids=[prod_cfg_id])
+    detail = result.data_apps[0]
+    assert isinstance(detail, DataApp)
+    assert [d.configuration_id for d in detail.drafts] == [ok_cfg_id]
+    assert detail.drafts_unavailable == 1
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -950,11 +950,12 @@ async def test_modify_python_js_data_app_create_calls_full_provisioning_chain(
     create_kwargs = keboola_client.data_science_client.create_data_app.await_args.kwargs
     assert create_kwargs['app_type'] == 'python-js'
     assert create_kwargs['use_managed_git_repo'] is True
-    # Verify auto_suspend_after_seconds flows through and image_version is hardcoded
+    # Verify auto_suspend_after_seconds flows through and we don't pin runtime.image (the
+    # platform now picks a default for python-js apps).
     serialized = create_kwargs['configuration'].model_dump(by_alias=True, exclude_none=True)
     assert serialized['parameters']['autoSuspendAfterSeconds'] == 300
     assert serialized['parameters']['dataApp']['slug'] == 'my-app'
-    assert serialized['runtime']['image']['version'] == '1.6.1'
+    assert 'image' not in serialized.get('runtime', {})
     # Created with the auto-workspace flag so the platform provisions a per-app workspace
     # and sets WORKSPACE_ID itself.
     assert serialized['runtime']['workspace'] == {'enabled': True}
@@ -1084,8 +1085,9 @@ async def test_modify_python_js_data_app_update_patches_storage_config(
     patch_kwargs = keboola_client.storage_client.configuration_update.await_args.kwargs
     new_cfg = patch_kwargs['configuration']
     assert new_cfg['parameters']['autoSuspendAfterSeconds'] == 600
-    # image version is always forced to the hardcoded value
-    assert new_cfg['runtime']['image']['version'] == '1.6.1'
+    # The platform now picks a default image for python-js apps; the MCP must NOT overwrite a
+    # legacy image pin already in the config, but must NOT force it to any new value either.
+    assert new_cfg['runtime']['image']['version'] == 'old-version'
     # slug must remain untouched (immutable)
     assert new_cfg['parameters']['dataApp']['slug'] == 'old-slug'
     # Update does NOT backfill `runtime.workspace` — only the create path sets it.
@@ -1131,7 +1133,9 @@ async def test_modify_python_js_data_app_create_without_workspace_feature(
     serialized = keboola_client.data_science_client.create_data_app.await_args.kwargs['configuration'].model_dump(
         by_alias=True, exclude_none=True
     )
-    assert 'workspace' not in serialized['runtime']
+    # Without the workspace feature, the `runtime` block carries no fields the MCP wants to
+    # set (image is platform-default, workspace is off), so it's omitted entirely.
+    assert 'runtime' not in serialized
     assert serialized['parameters']['dataApp']['secrets'] == {'WORKSPACE_ID': 'wid-legacy'}
 
 
@@ -1330,25 +1334,19 @@ async def test_modify_python_js_data_app_storage_validation_rejects_missing_sour
         )
 
 
-def test_update_existing_code_data_app_config_keeps_image_when_not_provided() -> None:
+def test_update_existing_code_data_app_config_leaves_legacy_image_pin_alone() -> None:
+    """The MCP no longer manages `runtime.image.version` — the platform picks a default for
+    python-js apps. A legacy pin already in the stored config must survive the deepcopy
+    verbatim (we don't overwrite it, even though we also don't set it ourselves)."""
     existing = {
         'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'x'}},
         'runtime': {'image': {'version': 'old'}},
     }
-    new = _update_existing_code_data_app_config(existing, image_version=None, auto_suspend_after_seconds=600)
+    new = _update_existing_code_data_app_config(existing, auto_suspend_after_seconds=600)
     assert new['runtime']['image']['version'] == 'old'
     assert new['parameters']['autoSuspendAfterSeconds'] == 600
     # original must not be mutated
     assert existing['parameters']['autoSuspendAfterSeconds'] == 900
-
-
-def test_update_existing_code_data_app_config_replaces_image_version() -> None:
-    existing = {
-        'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'x'}},
-        'runtime': {'image': {'version': 'old'}},
-    }
-    new = _update_existing_code_data_app_config(existing, image_version='v2', auto_suspend_after_seconds=900)
-    assert new['runtime']['image']['version'] == 'v2'
 
 
 def test_update_existing_code_data_app_config_default_auth_preserves_existing() -> None:
@@ -1361,12 +1359,9 @@ def test_update_existing_code_data_app_config_default_auth_preserves_existing() 
     }
     existing = {
         'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'x'}},
-        'runtime': {'image': {'version': 'v1'}},
         'authorization': existing_authorization,
     }
-    new = _update_existing_code_data_app_config(
-        existing, image_version='v1', auto_suspend_after_seconds=900, authentication_type='default'
-    )
+    new = _update_existing_code_data_app_config(existing, auto_suspend_after_seconds=900, authentication_type='default')
     # Deepcopy makes it equal-but-not-identical.
     assert new['authorization'] == existing_authorization
 
@@ -1374,11 +1369,10 @@ def test_update_existing_code_data_app_config_default_auth_preserves_existing() 
 def test_update_existing_code_data_app_config_basic_auth_overwrites() -> None:
     existing = {
         'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'x'}},
-        'runtime': {'image': {'version': 'v1'}},
         'authorization': {'app_proxy': {'auth_providers': [], 'auth_rules': []}},
     }
     new = _update_existing_code_data_app_config(
-        existing, image_version='v1', auto_suspend_after_seconds=900, authentication_type='basic-auth'
+        existing, auto_suspend_after_seconds=900, authentication_type='basic-auth'
     )
     assert new['authorization']['app_proxy']['auth_rules'] == [
         {'type': 'pathPrefix', 'value': '/', 'auth_required': True, 'auth': ['simpleAuth']}
@@ -1397,11 +1391,9 @@ def test_update_existing_code_data_app_config_preserves_legacy_secrets() -> None
                 'secrets': {'WORKSPACE_ID': 'wid-legacy', 'KEEP': 'x'},
             },
         },
-        'runtime': {'image': {'version': 'v1'}},
     }
     new = _update_existing_code_data_app_config(
         existing,
-        image_version='v1',
         auto_suspend_after_seconds=900,
     )
     assert new['parameters']['dataApp']['secrets'] == {'WORKSPACE_ID': 'wid-legacy', 'KEEP': 'x'}
@@ -1410,7 +1402,6 @@ def test_update_existing_code_data_app_config_preserves_legacy_secrets() -> None
 def test_update_existing_code_data_app_config_no_auth_overwrites() -> None:
     existing = {
         'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'x'}},
-        'runtime': {'image': {'version': 'v1'}},
         'authorization': {
             'app_proxy': {
                 'auth_providers': [{'id': 'simpleAuth', 'type': 'password'}],
@@ -1418,9 +1409,7 @@ def test_update_existing_code_data_app_config_no_auth_overwrites() -> None:
             }
         },
     }
-    new = _update_existing_code_data_app_config(
-        existing, image_version='v1', auto_suspend_after_seconds=900, authentication_type='no-auth'
-    )
+    new = _update_existing_code_data_app_config(existing, auto_suspend_after_seconds=900, authentication_type='no-auth')
     assert new['authorization']['app_proxy']['auth_rules'] == [
         {'type': 'pathPrefix', 'value': '/', 'auth_required': False}
     ]
@@ -1447,12 +1436,10 @@ def test_update_existing_code_data_app_config_storage_semantics(
     """`storage=None` preserves; `storage={}` wipes; a non-empty dict replaces wholesale."""
     existing = {
         'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'x'}},
-        'runtime': {'image': {'version': 'v1'}},
         'storage': {'input': {'tables': [{'source': 'in.c-main.kept', 'destination': 'kept.csv'}]}},
     }
     new = _update_existing_code_data_app_config(
         existing,
-        image_version='v1',
         auto_suspend_after_seconds=900,
         storage=passed_storage,
     )
@@ -1525,7 +1512,7 @@ async def test_deploy_data_app_streamlit_still_passes_config_version(
     )
 
 
-# ===== Tests for modify_python_js_data_app dev-twin create path =====
+# ===== Tests for modify_python_js_data_app draft create path =====
 
 
 def _make_python_js_parent_data_app(
@@ -1552,12 +1539,12 @@ def _make_python_js_parent_data_app(
 
 
 @pytest.mark.asyncio
-async def test_modify_python_js_data_app_create_dev_twin_uses_external_git(
+async def test_modify_python_js_data_app_create_draft_uses_external_git(
     mocker,
     mcp_context_client: Context,
     workspace_manager,
 ) -> None:
-    """When `parent_configuration_id` is set, the new app is a dev twin: no managed repo of its own,
+    """When `parent_configuration_id` is set, the new app is a draft: no managed repo of its own,
     `parameters.dataApp.git` populated with the parent's repo URL + a freshly minted prod-app token,
     and the config is encrypted before being sent to data-science."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
@@ -1579,9 +1566,9 @@ async def test_modify_python_js_data_app_create_dev_twin_uses_external_git(
     )
     twin_response = _make_python_js_data_app_response(data_app_id='app-dev-1', config_id='cfg-dev-1')
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=twin_response)
-    # The dev twin has no managed repo, so get_app_git_repo must NOT be called for it.
+    # The draft has no managed repo, so get_app_git_repo must NOT be called for it.
     keboola_client.data_science_client.get_app_git_repo = mocker.AsyncMock(
-        side_effect=AssertionError('Should not fetch a git repo URL for a dev twin')
+        side_effect=AssertionError('Should not fetch a git repo URL for a draft')
     )
 
     keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
@@ -1650,12 +1637,13 @@ async def test_modify_python_js_data_app_create_dev_twin_uses_external_git(
 
 
 @pytest.mark.asyncio
-async def test_modify_python_js_data_app_create_dev_twin_generates_branch_when_unspecified(
+async def test_modify_python_js_data_app_create_draft_defaults_branch_to_init(
     mocker,
     mcp_context_client: Context,
     workspace_manager,
 ) -> None:
-    """Omitting `branch` triggers an auto-generated `iter-<6-hex>` name."""
+    """Omitting `branch` pins the draft to the literal `init` branch (sensible default for the very
+    first draft of a brand-new prod app — descriptive branches are agent-supplied on edits)."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
@@ -1679,16 +1667,18 @@ async def test_modify_python_js_data_app_create_dev_twin_generates_branch_when_u
 
     result = await modify_python_js_data_app(
         ctx=mcp_context_client,
-        name='Dev Twin',
-        description='dev iteration twin',
-        slug='demo-dev',
+        name='Draft',
+        description='draft iteration',
+        slug='demo-draft',
         parent_configuration_id='cfg-prod-1',
     )
 
-    assert result.branch is not None
-    import re
-
-    assert re.fullmatch(r'iter-[0-9a-f]{6}', result.branch), f'unexpected branch name {result.branch!r}'
+    assert result.branch == 'init'
+    # And the stored config carries the same branch as the pin and the parent linkage.
+    create_kwargs = keboola_client.data_science_client.create_data_app.await_args.kwargs
+    serialized = create_kwargs['configuration'].model_dump(by_alias=True, exclude_none=True)
+    assert serialized['parameters']['dataApp']['git']['branch'] == 'init'
+    assert serialized['parameters']['dataApp']['parentConfigurationId'] == 'cfg-prod-1'
 
 
 @pytest.mark.asyncio
@@ -1705,7 +1695,7 @@ async def test_modify_python_js_data_app_create_dev_twin_generates_branch_when_u
         ),
     ],
 )
-async def test_modify_python_js_data_app_create_dev_twin_still_requires_slug(
+async def test_modify_python_js_data_app_create_draft_still_requires_slug(
     mcp_context_client: Context,
     kwargs: dict,
     error_match: str,
@@ -1727,7 +1717,7 @@ async def test_modify_python_js_data_app_create_dev_twin_still_requires_slug(
                 'configuration_id': 'cfg-1',
                 'parent_configuration_id': 'cfg-prod-1',
             },
-            'parent_configuration_id is only valid when creating a dev twin',
+            'parent_configuration_id is only valid when creating a draft',
         ),
         (
             'branch',
@@ -1735,30 +1725,30 @@ async def test_modify_python_js_data_app_create_dev_twin_still_requires_slug(
                 'name': 'A',
                 'description': '',
                 'configuration_id': 'cfg-1',
-                'branch': 'iter-x',
+                'branch': 'add-revenue-filter',
             },
-            'branch is only valid when creating a dev twin',
+            'branch is only valid when creating a draft',
         ),
     ],
 )
-async def test_modify_python_js_data_app_update_rejects_dev_twin_args(
+async def test_modify_python_js_data_app_update_rejects_draft_args(
     mcp_context_client: Context,
     disallowed_arg: str,
     kwargs: dict,
     error_match: str,
 ) -> None:
-    """The update path rejects dev-twin-only args (`parent_configuration_id`, `branch`)."""
+    """The update path rejects draft-only args (`parent_configuration_id`, `branch`)."""
     with pytest.raises(ValueError, match=error_match):
         await modify_python_js_data_app(ctx=mcp_context_client, **kwargs)
 
 
 @pytest.mark.asyncio
-async def test_modify_python_js_data_app_create_dev_twin_rejects_when_parent_is_streamlit(
+async def test_modify_python_js_data_app_create_draft_rejects_when_parent_is_streamlit(
     mocker,
     mcp_context_client: Context,
     workspace_manager,
 ) -> None:
-    """A Streamlit `parent_configuration_id` is rejected — only python-js prods can parent a dev twin."""
+    """A Streamlit `parent_configuration_id` is rejected — only python-js prods can parent a draft."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
@@ -1767,18 +1757,18 @@ async def test_modify_python_js_data_app_create_dev_twin_rejects_when_parent_is_
     streamlit_parent = _make_python_js_parent_data_app(type='streamlit', repo_url=None)
     mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=streamlit_parent))
 
-    with pytest.raises(ValueError, match='only python-js prod apps can parent a dev twin'):
+    with pytest.raises(ValueError, match='only python-js prod apps can parent a draft'):
         await modify_python_js_data_app(
             ctx=mcp_context_client,
-            name='Dev Twin',
+            name='Draft',
             description='',
-            slug='demo-dev',
+            slug='demo-draft',
             parent_configuration_id='cfg-prod-1',
         )
 
 
 @pytest.mark.asyncio
-async def test_modify_python_js_data_app_create_dev_twin_rejects_when_parent_missing_repo_url(
+async def test_modify_python_js_data_app_create_draft_rejects_when_parent_missing_repo_url(
     mocker,
     mcp_context_client: Context,
     workspace_manager,
@@ -1846,7 +1836,7 @@ async def test_deploy_data_app_python_js_with_branch_forwards_to_client(
     mocker,
     mcp_context_client: Context,
 ) -> None:
-    """For python-js dev twins, `branch` must be forwarded to the underlying DSAPI deploy call."""
+    """For python-js drafts, `branch` must be forwarded to the underlying DSAPI deploy call."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
 
@@ -2096,3 +2086,294 @@ async def test_create_python_js_data_app_git_credential_invalid_configuration_id
         )
 
     keboola_client.data_science_client.create_app_git_credential.assert_not_called()
+
+
+# ===== Tests for get_data_apps drafts list (detail path, python-js prod) =====
+
+
+from keboola_mcp_server.tools.data_apps import (  # noqa: E402
+    DeletedDraftOutput,
+    delete_python_js_data_app_draft,
+)
+
+
+def _make_python_js_prod_data_app(
+    *,
+    configuration_id: str = 'cfg-prod-1',
+    data_app_id: str = 'app-prod-1',
+    repo_url: str | None = 'https://managed.repo/org/prod.git',
+    state: str = 'running',
+) -> DataApp:
+    """A python-js **prod** app — no `isDraft` flag, no `parentConfigurationId`."""
+    return DataApp(
+        name='Prod App',
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id=configuration_id,
+        data_app_id=data_app_id,
+        project_id='proj-1',
+        branch_id='branch-1',
+        config_version='1',
+        type='python-js',
+        configuration={'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'prod'}}},
+        state=state,
+        repo_url=repo_url,
+    )
+
+
+def _make_python_js_draft_data_app(
+    *,
+    configuration_id: str,
+    data_app_id: str,
+    parent_configuration_id: str,
+    branch: str = 'init',
+    state: str = 'created',
+) -> DataApp:
+    """A python-js **draft** app — `isDraft=true` and `parentConfigurationId` set."""
+    return DataApp(
+        name=f'Draft {configuration_id}',
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id=configuration_id,
+        data_app_id=data_app_id,
+        project_id='proj-1',
+        branch_id='branch-1',
+        config_version='1',
+        type='python-js',
+        configuration={
+            'parameters': {
+                'autoSuspendAfterSeconds': 900,
+                'dataApp': {
+                    'slug': f'draft-{configuration_id}',
+                    'isDraft': True,
+                    'parentConfigurationId': parent_configuration_id,
+                    'git': {'repository': 'https://managed.repo/org/prod.git', 'branch': branch},
+                },
+            },
+        },
+        state=state,
+        repo_url=None,
+    )
+
+
+def _build_storage_config_entry(*, cfg_id: str, parent_configuration_id: str | None) -> dict:
+    """Mirror the shape returned by `storage_client.configuration_list` for python-js apps."""
+    data_app_block: dict = {'slug': f'app-{cfg_id}'}
+    if parent_configuration_id is not None:
+        data_app_block['isDraft'] = True
+        data_app_block['parentConfigurationId'] = parent_configuration_id
+    return {
+        'id': cfg_id,
+        'name': f'app-{cfg_id}',
+        'configuration': {
+            'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': data_app_block},
+        },
+        'version': 1,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'n_drafts',
+    [0, 1, 3],
+    ids=['no_drafts', 'one_draft', 'three_drafts'],
+)
+async def test_get_data_apps_detail_for_prod_lists_drafts(
+    mocker,
+    mcp_context_client: Context,
+    n_drafts: int,
+) -> None:
+    """When fetching detail for a python-js prod, the response includes a `drafts: [...]` array
+    of every draft configured against it. Includes the 0-draft case to guard the empty path."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    prod_cfg_id = 'cfg-prod-1'
+    prod = _make_python_js_prod_data_app(configuration_id=prod_cfg_id)
+    draft_cfg_ids = [f'cfg-draft-{i}' for i in range(n_drafts)]
+    drafts = {
+        cfg_id: _make_python_js_draft_data_app(
+            configuration_id=cfg_id,
+            data_app_id=f'app-{cfg_id}',
+            parent_configuration_id=prod_cfg_id,
+        )
+        for cfg_id in draft_cfg_ids
+    }
+    # Throw in a config that's parented to a DIFFERENT prod to verify we filter properly.
+    foreign_cfg = _build_storage_config_entry(cfg_id='cfg-other-draft', parent_configuration_id='cfg-prod-other')
+    configs = [
+        _build_storage_config_entry(cfg_id=cfg_id, parent_configuration_id=prod_cfg_id) for cfg_id in draft_cfg_ids
+    ]
+    configs.append(foreign_cfg)
+    # Also include the prod's own config (no parentConfigurationId) — must not be matched.
+    configs.append(_build_storage_config_entry(cfg_id=prod_cfg_id, parent_configuration_id=None))
+
+    keboola_client.storage_client.configuration_list = mocker.AsyncMock(return_value=configs)
+
+    async def fake_fetch(client, *, configuration_id, data_app_id):
+        if configuration_id == prod_cfg_id:
+            return prod
+        return drafts[configuration_id]
+
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', side_effect=fake_fetch)
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_logs', mocker.AsyncMock(return_value=[]))
+
+    result = await get_data_apps(ctx=mcp_context_client, configuration_ids=[prod_cfg_id])
+    assert len(result.data_apps) == 1
+    detail = result.data_apps[0]
+    assert isinstance(detail, DataApp)
+    returned_draft_ids = sorted(d.configuration_id for d in detail.drafts)
+    assert returned_draft_ids == sorted(draft_cfg_ids)
+
+
+@pytest.mark.asyncio
+async def test_get_data_apps_detail_for_draft_returns_empty_drafts(
+    mocker,
+    mcp_context_client: Context,
+) -> None:
+    """Fetching detail for a draft must not recurse — its `drafts` array stays empty and the
+    cheap `configuration_list` lookup is skipped entirely."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    draft = _make_python_js_draft_data_app(
+        configuration_id='cfg-draft-1', data_app_id='app-draft-1', parent_configuration_id='cfg-prod-1'
+    )
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=draft))
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_logs', mocker.AsyncMock(return_value=[]))
+    keboola_client.storage_client.configuration_list = mocker.AsyncMock(
+        side_effect=AssertionError('Drafts must not trigger a drafts lookup')
+    )
+
+    result = await get_data_apps(ctx=mcp_context_client, configuration_ids=['cfg-draft-1'])
+    detail = result.data_apps[0]
+    assert isinstance(detail, DataApp)
+    assert detail.drafts == []
+    keboola_client.storage_client.configuration_list.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_data_apps_detail_for_streamlit_returns_empty_drafts(
+    mocker,
+    mcp_context_client: Context,
+    data_app: DataApp,
+) -> None:
+    """Streamlit apps have no draft concept — the detail path must not call `configuration_list`."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    data_app.type = 'streamlit'
+    data_app.configuration = {'parameters': {'dataApp': {'slug': 'sl'}}}
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=data_app))
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_logs', mocker.AsyncMock(return_value=[]))
+    keboola_client.storage_client.configuration_list = mocker.AsyncMock(
+        side_effect=AssertionError('Streamlit apps must not trigger a drafts lookup')
+    )
+
+    result = await get_data_apps(ctx=mcp_context_client, configuration_ids=['cfg-streamlit-1'])
+    detail = result.data_apps[0]
+    assert isinstance(detail, DataApp)
+    assert detail.drafts == []
+    keboola_client.storage_client.configuration_list.assert_not_called()
+
+
+# ===== Tests for delete_python_js_data_app_draft =====
+
+
+@pytest.mark.asyncio
+async def test_delete_python_js_data_app_draft_success(
+    mocker,
+    mcp_context_client: Context,
+) -> None:
+    """Happy path: deletes the data app via DSAPI and the Storage config (with skip_trash=False),
+    and returns the parent configuration_id so the agent can pivot back."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    draft = _make_python_js_draft_data_app(
+        configuration_id='cfg-draft-1', data_app_id='app-draft-1', parent_configuration_id='cfg-prod-1'
+    )
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=draft))
+    keboola_client.data_science_client.delete_data_app = mocker.AsyncMock(return_value=None)
+    keboola_client.storage_client.configuration_delete = mocker.AsyncMock(return_value=None)
+
+    result = await delete_python_js_data_app_draft(ctx=mcp_context_client, configuration_id='cfg-draft-1')
+
+    assert isinstance(result, DeletedDraftOutput)
+    assert result.response == 'deleted'
+    assert result.configuration_id == 'cfg-draft-1'
+    assert result.data_app_id == 'app-draft-1'
+    assert result.parent_configuration_id == 'cfg-prod-1'
+    keboola_client.data_science_client.delete_data_app.assert_awaited_once_with('app-draft-1')
+    keboola_client.storage_client.configuration_delete.assert_awaited_once_with(
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id='cfg-draft-1',
+        skip_trash=False,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('configuration', 'error_match'),
+    [
+        (
+            {'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'prod'}}},
+            'is a python-js .*prod.* app, not a draft',
+        ),
+        (
+            {'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'prod', 'isDraft': False}}},
+            'is a python-js .*prod.* app, not a draft',
+        ),
+    ],
+    ids=['no_isDraft_key', 'isDraft_false'],
+)
+async def test_delete_python_js_data_app_draft_refuses_prod(
+    mocker,
+    mcp_context_client: Context,
+    configuration: dict,
+    error_match: str,
+) -> None:
+    """Refusing to delete prod apps is the single safety check — both shapes (missing flag or
+    explicit `false`) must be rejected, and neither delete endpoint must be called."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    prod = DataApp(
+        name='Prod',
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id='cfg-prod-1',
+        data_app_id='app-prod-1',
+        project_id='proj-1',
+        branch_id='branch-1',
+        config_version='1',
+        type='python-js',
+        configuration=configuration,
+        state='running',
+    )
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=prod))
+    keboola_client.data_science_client.delete_data_app = mocker.AsyncMock()
+    keboola_client.storage_client.configuration_delete = mocker.AsyncMock()
+
+    with pytest.raises(ValueError, match=error_match):
+        await delete_python_js_data_app_draft(ctx=mcp_context_client, configuration_id='cfg-prod-1')
+
+    keboola_client.data_science_client.delete_data_app.assert_not_called()
+    keboola_client.storage_client.configuration_delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_python_js_data_app_draft_refuses_streamlit(
+    mocker,
+    mcp_context_client: Context,
+) -> None:
+    """Streamlit apps have no draft concept — the tool must refuse and never call delete."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    streamlit_app = DataApp(
+        name='SL',
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id='cfg-sl-1',
+        data_app_id='app-sl-1',
+        project_id='proj-1',
+        branch_id='branch-1',
+        config_version='1',
+        type='streamlit',
+        configuration={'parameters': {'dataApp': {'slug': 'sl'}}},
+        state='running',
+    )
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=streamlit_app))
+    keboola_client.data_science_client.delete_data_app = mocker.AsyncMock()
+    keboola_client.storage_client.configuration_delete = mocker.AsyncMock()
+
+    with pytest.raises(ValueError, match='only supports python-js data apps'):
+        await delete_python_js_data_app_draft(ctx=mcp_context_client, configuration_id='cfg-sl-1')
+
+    keboola_client.data_science_client.delete_data_app.assert_not_called()
+    keboola_client.storage_client.configuration_delete.assert_not_called()

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -2,6 +2,7 @@ import sys
 from types import ModuleType
 from typing import Literal, cast
 
+import httpx
 import pytest
 from fastmcp import Context
 
@@ -2340,20 +2341,34 @@ async def test_get_data_apps_detail_for_streamlit_returns_empty_drafts(
 # ===== Tests for delete_python_js_data_app_draft =====
 
 
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError carrying the given status code, as the Storage client raises."""
+    request = httpx.Request('DELETE', 'https://connection.keboola.test/v2/storage/...')
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f'HTTP {status_code}', request=request, response=response)
+
+
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'storage_delete_side_effect',
+    [None, _http_status_error(404)],
+    ids=['storage_config_present', 'storage_config_already_gone_404'],
+)
 async def test_delete_python_js_data_app_draft_success(
     mocker,
     mcp_context_client: Context,
+    storage_delete_side_effect,
 ) -> None:
     """Happy path: deletes the data app via DSAPI and the Storage config (with skip_trash=False),
-    and returns the parent configuration_id so the agent can pivot back."""
+    and returns the parent configuration_id so the agent can pivot back. A 404 from the Storage
+    delete (DSAPI already removed the config) is tolerated — the tool stays idempotent."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     draft = _make_python_js_draft_data_app(
         configuration_id='cfg-draft-1', data_app_id='app-draft-1', parent_configuration_id='cfg-prod-1'
     )
     mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=draft))
     keboola_client.data_science_client.delete_data_app = mocker.AsyncMock(return_value=None)
-    keboola_client.storage_client.configuration_delete = mocker.AsyncMock(return_value=None)
+    keboola_client.storage_client.configuration_delete = mocker.AsyncMock(side_effect=storage_delete_side_effect)
 
     result = await delete_python_js_data_app_draft(ctx=mcp_context_client, configuration_id='cfg-draft-1')
 
@@ -2368,6 +2383,25 @@ async def test_delete_python_js_data_app_draft_success(
         configuration_id='cfg-draft-1',
         skip_trash=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_delete_python_js_data_app_draft_propagates_non_404_storage_error(
+    mocker,
+    mcp_context_client: Context,
+) -> None:
+    """Only 404 (already gone) is tolerated — any other Storage delete failure must propagate so a
+    real error is not silently swallowed."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    draft = _make_python_js_draft_data_app(
+        configuration_id='cfg-draft-1', data_app_id='app-draft-1', parent_configuration_id='cfg-prod-1'
+    )
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=draft))
+    keboola_client.data_science_client.delete_data_app = mocker.AsyncMock(return_value=None)
+    keboola_client.storage_client.configuration_delete = mocker.AsyncMock(side_effect=_http_status_error(500))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await delete_python_js_data_app_draft(ctx=mcp_context_client, configuration_id='cfg-draft-1')
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -1523,8 +1523,17 @@ def _make_python_js_parent_data_app(
     configuration_id: str = 'cfg-prod-1',
     repo_url: str | None = 'https://managed.repo/org/prod.git',
     type: str = 'python-js',
+    is_draft: bool = False,
 ) -> DataApp:
-    """Build a DataApp the way `_fetch_data_app` would when looking up the parent."""
+    """Build a DataApp the way `_fetch_data_app` would when looking up the parent.
+
+    `is_draft=True` models a caller mistakenly passing a draft as the parent — drafts cannot
+    parent another draft.
+    """
+    data_app_block: dict = {'slug': 'demo'}
+    if is_draft:
+        data_app_block['isDraft'] = True
+        data_app_block['parentConfigurationId'] = 'cfg-grandparent'
     return DataApp(
         name='Prod App',
         component_id=DATA_APP_COMPONENT_ID,
@@ -1534,7 +1543,7 @@ def _make_python_js_parent_data_app(
         branch_id='branch-1',
         config_version='1',
         type=type,
-        configuration={'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'demo'}}},
+        configuration={'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': data_app_block}},
         state='running',
         repo_url=repo_url,
     )
@@ -1767,6 +1776,35 @@ async def test_modify_python_js_data_app_create_draft_rejects_when_parent_is_str
             slug='demo-draft',
             parent_configuration_id='cfg-prod-1',
         )
+
+
+@pytest.mark.asyncio
+async def test_modify_python_js_data_app_create_draft_rejects_when_parent_is_draft(
+    mocker,
+    mcp_context_client: Context,
+    workspace_manager,
+) -> None:
+    """A python-js *draft* parent is rejected with a clear message (not the misleading 'no repo URL'
+    error): drafts can't parent another draft, so no credential is minted."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.data_science_client = mocker.AsyncMock()
+    keboola_client.has_feature = mocker.AsyncMock(return_value=True)
+    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+
+    # A draft has no repo_url of its own; the guard must fire before the repo_url check below.
+    draft_parent = _make_python_js_parent_data_app(is_draft=True, repo_url=None)
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=draft_parent))
+
+    with pytest.raises(ValueError, match=r'is itself a python-js \*\*draft\*\*'):
+        await modify_python_js_data_app(
+            ctx=mcp_context_client,
+            name='Draft',
+            description='',
+            slug='demo-draft',
+            parent_configuration_id='cfg-prod-1',
+        )
+
+    keboola_client.data_science_client.create_app_git_credential.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1306,7 +1306,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.63.4"
+version = "1.64.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3286](https://linear.app/keboola/issue/AI-3286)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Replaces the v1.63 MVP "dev twin" surface with a coherent **draft** flow. Three agent-facing scenarios are now first-class and taught entirely through tool docstrings (no MCP prompt):

1. **Create-from-scratch** — prod + draft on branch `init` → preview in dev mode → merge → redeploy prod → delete draft.
2. **Edit-existing** — fresh credential + new draft on an agent-chosen descriptive branch → preview → merge → redeploy → delete.
3. **Continue an unfinished draft** — `get_data_apps([PROD])` now returns `drafts: [...]` inline, so the agent finds an abandoned iteration in one round-trip without scanning all configs.

Cross-cutting rule, stated in every relevant docstring: **MCP never runs git on your behalf**. All git work (clone, branch, commit, push, merge, branch-delete) is the agent's. MCP owns credentials, configs, deploys, and draft lifecycle.

**Surface changes**

| Tool | Change |
|---|---|
| `modify_python_js_data_app` | Default draft branch is `'init'` (was random `iter-<6-hex>`). Draft configs persist `parameters.dataApp.parentConfigurationId`. Docstring rewritten with the three scenarios. |
| `get_data_apps` | Detail responses for python-js **prod** apps now include `drafts: [...]` of every draft parented to that prod. One extra Storage list call per prod detail fetch; skipped for drafts and Streamlit. |
| **NEW** `delete_python_js_data_app_draft` | Deletes a draft's data-app instance (DSAPI) + Storage config. Refuses prod apps (no `isDraft`) and Streamlit. Returns the parent's `configuration_id` so the agent can pivot back. |
| `create_python_js_data_app_git_credential` | Docstring tightened: always mint against **prod** (drafts have no managed repo of their own). |
| `deploy_data_app` | Docstring reframes `mode='dev'` as "deploys the draft as a dev version of the data app" (hot reload + auto-auth iframe preview). No behaviour change. |

**Other**

- Drop `_HARDCODED_PYTHON_JS_IMAGE_VERSION = '1.6.1'`. Platform now applies a default; legacy pins on existing configs are preserved verbatim via deepcopy.
- `docs/python-js-data-apps.md` rewritten for v1.64.
- `pyproject.toml`: 1.63.3 → 1.64.0; `uv.lock` refreshed.
- `TOOLS.md` regenerated.

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

End-to-end verification of the three-scenario flow against `canary-orion` (per the verification section of the AI-3286 plan) is still TODO before un-drafting.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated — extended parametrized tests for draft create (parentConfigurationId, default `'init'`), drafts list (N=0/1/3, draft-of-draft empty, Streamlit empty), and `delete_python_js_data_app_draft` (success, reject prod with two `isDraft` shapes, reject Streamlit)
- [x] Integration tests updated — `test_python_js_data_app_prod_and_draft_lifecycle` now asserts drafts surface in prod detail, exercises the new delete tool, and verifies the draft disappears from `drafts: [...]` afterwards
- [x] Project version bumped (minor: new tool + new schema field)
- [x] Documentation updated — full rewrite of `docs/python-js-data-apps.md`