### PR TITLE
chore: add 7-day dependency cooldown for supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot configuration.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+#
+# Cooldown (supply-chain hardening): Dependabot will not open an update PR for a
+# version until it has been published for at least `default-days` days. Most
+# malicious package releases are detected and yanked within this window, so we
+# avoid pulling a freshly published (potentially compromised) version. This
+# mirrors the `exclude-newer = "7 days"` setting in pyproject.toml [tool.uv],
+# which guards manual `uv lock` regeneration.
+version: 2
+updates:
+  # Python dependencies managed via uv / pyproject.toml + uv.lock
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+
+  # GitHub Actions used by our CI / release workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,17 @@ line_length = 120
 multi_line_output = 3
 use_parentheses = true
 
+[tool.uv]
+# Dependency cooldown (supply-chain hardening): never resolve a package version
+# published within the last 7 days. Freshly published malicious releases are
+# typically detected and yanked within hours to a few days, so a 7-day buffer
+# removes most of that attack window before a version can reach our lock file.
+# This is a resolution-time filter — it applies whenever `uv lock` regenerates
+# the lock; CI installs with `uv sync --frozen` and is unaffected.
+# Temporarily relax this (e.g. `--exclude-newer` on the CLI) when an urgent
+# security fix needs to be picked up before the window elapses.
+exclude-newer = "7 days"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/keboola_mcp_server"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiofile"
 version = "3.9.0"


### PR DESCRIPTION
## Description

**Linear**: N/A — originates from a Slack suggestion (Tomáš) referencing the UI repo's "delayed update" practice for supply-chain hardening. Tracks uv feature request https://github.com/astral-sh/uv/issues/14992.

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Introduces a **7-day dependency cooldown** so freshly published package versions are not adopted immediately. Most malicious package releases are detected and yanked within hours to a few days, so a 7-day buffer removes that version from our resolution window before it can reach the lock file.

Two complementary enforcement points:

- **`pyproject.toml` `[tool.uv]` → `exclude-newer = "7 days"`** — a resolution-time filter that guards **manual `uv lock`** regeneration. Relocking recorded `exclude-newer-span = "P7D"` in `uv.lock` with **no package downgrades**. CI installs with `uv sync --frozen`, so the install step is unaffected; the cooldown only constrains what a new resolution may pick.
- **`.github/dependabot.yml`** (new) — introduces version-update PRs for the `uv` and `github-actions` ecosystems with `cooldown.default-days: 7`, so Dependabot only opens an update PR once a version has aged past the window. We previously had no version-update config (only Dependabot alerts).
- Version bump `1.63.3` → `1.63.4`.

To pick up an urgent security fix before the window elapses, temporarily relax via `uv lock --exclude-newer <date>` on the CLI.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Local `tox`: black, isort, flake8, check-tools-docs all pass; 1386/1387 unit tests pass. The one failure (`test_json_logging`) is an environment-dependent test requiring `KBC_STORAGE_TOKEN` (spawns a real MCP server subprocess) and is unrelated to this config-only change — it passes in CI where the token is available.

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable) — N/A, dependency-management config only
- [ ] Integration tests added/updated (if applicable) — N/A
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable) — inline rationale comments in `pyproject.toml` and `dependabot.yml`
