### PR TITLE
docs(flow): AJDA-2810 RFC — fetch conditional-flow schema from Developer Portal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.68.0"
+version = "1.69.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.68.0"
+version = "1.69.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AJDA-2810 — CF variables: Update MCP](https://linear.app/keboola/issue/AJDA-2810/cf-variables-update-mcp)

> ⚠️ **RFC-only PR for design review.** This PR contains *only* the RFC document
> (`feature_spec/conditional_flow_schema_from_devportal/RFC.md`). No code, no version bump, no lock
> changes — implementation will follow in a separate PR once this RFC is approved (per
> `CONTRIBUTING.md`, RFC must be agreed before implementation).

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new data flow — describes the upcoming change; the implementation PR will carry the minor bump)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Conditional Flows (`keboola.flow`) are gaining a **Variables** capability, delivered by updating the
`keboola.flow` JSON schema **in the Developer Portal** (AJDA-2351). The MCP server currently ships a
**static, bundled** copy of that schema (`resources/conditional-flow-schema.json`), so it would not
pick up the new variables fields without a re-bundle + release.

This RFC proposes that the MCP server fetch the `keboola.flow` `configuration_schema` **live from the
Developer Portal** (reusing the existing `fetch_component()` path), delete the bundled copy, and
hard-fail with a clear error if the fetch fails. Legacy orchestrator + storage schemas are unchanged.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

_N/A for this RFC-only PR — testing strategy is documented in the RFC and will be exercised by the
implementation PR._

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (implementation PR)
- [ ] Integration tests added/updated (implementation PR)
- [ ] Project version bumped according to the change type (implementation PR)
- [x] Documentation updated (RFC added)

## Release Notes
- **Justification**
    - Conditional Flows are gaining a Variables feature whose definition lives in the `keboola.flow`
      Developer-Portal schema. The MCP server must use that live schema so the agent always validates
      and advertises the current set of flow capabilities. Bundling the schema means it silently goes
      stale on every change and requires a release to update.
    - This PR is the design RFC only; it describes switching the MCP server from a bundled schema to a
      live Developer-Portal fetch.

- **Plans for Customer Communication**
    - None for the RFC. The implementation enables CF Variables in MCP-driven flow creation; that will
      be covered by the Conditional Flows feature communication, not as a standalone MCP announcement.

- **Impact Analysis**
    - Implementation impact (not this PR): conditional-flow create/update/`get_flow_schema` will make a
      live call to fetch the `keboola.flow` schema. If the Developer Portal is unreachable, those
      operations hard-fail with a clear error instead of silently using a stale bundled schema. Legacy
      orchestrator flows are unaffected. Not behind a feature flag; gated by the existing
      `conditional_flows` project capability check. No single-tenant-specific impact expected.

- **Deployment Plan**
    - Continuous deployment with the normal MCP server release. Independent of AJDA-2351 — can ship
      first; CF variables behavior activates once the portal schema is published.

- **Rollback Plan**
    - Two-way door. Revert the implementation PR to restore the bundled-schema behavior.

- **Post-Release Support Plan**
    - No special support needed. Verify against a stack whose `keboola.flow` schema already includes
      variables before closing AJDA-2810.
