### PR TITLE
fix(security): encrypt #-prefixed secrets before save and redact them on reads [AI-3327]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.64.0"
+version = "1.65.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/client.py
+++ b/src/keboola_mcp_server/clients/client.py
@@ -164,12 +164,17 @@ class KeboolaClient:
 
         # Initialize clients for individual services
         bearer_or_sapi_token = f'Bearer {bearer_token}' if bearer_token else self._token
+        # The encryption service does not require an authorization header, so we pass None as the token
+        self._encryption_client = EncryptionClient.create(
+            root_url=encryption_api_url, token=None, headers=self._headers
+        )
         self._storage_client = AsyncStorageClient.create(
             root_url=self._storage_api_url,
             token=bearer_or_sapi_token,
             branch_id=branch_id,
             headers=self._headers,
             readonly=readonly,
+            encryption_client=self._encryption_client,
         )
         self._jobs_queue_client = JobsQueueClient.create(
             root_url=queue_api_url, token=self._token, branch_id=branch_id, headers=self._headers, readonly=readonly
@@ -183,10 +188,6 @@ class KeboolaClient:
             branch_id=branch_id,
             headers=self._headers,
             readonly=readonly,
-        )
-        # The encryption service does not require an authorization header, so we pass None as the token
-        self._encryption_client = EncryptionClient.create(
-            root_url=encryption_api_url, token=None, headers=self._headers
         )
         self._scheduler_client = SchedulerClient.create(
             root_url=scheduler_api_url, token=bearer_or_sapi_token, headers=self._headers, readonly=readonly

--- a/src/keboola_mcp_server/clients/encryption.py
+++ b/src/keboola_mcp_server/clients/encryption.py
@@ -1,8 +1,61 @@
-from typing import Any, cast
+from typing import Any, Iterator, cast
 
 from keboola_mcp_server.clients.base import JsonDict, KeboolaServiceClient, RawKeboolaClient
 
 EncValue = str | JsonDict
+
+# Keys starting with this prefix hold secret values that must never be stored in plaintext.
+SECRET_KEY_PREFIX = '#'
+# Values already encrypted by the encryption service start with this prefix.
+ENCRYPTED_VALUE_PREFIX = 'KBC::'
+# Placeholder that the MCP server returns instead of plaintext secret values on config reads.
+REDACTED_SECRET_VALUE = '[REDACTED]'
+
+
+def is_encrypted_value(value: Any) -> bool:
+    """Checks if the value is a cipher created by the encryption service."""
+    return isinstance(value, str) and value.startswith(ENCRYPTED_VALUE_PREFIX)
+
+
+def iter_secret_items(value: Any) -> Iterator[tuple[str, Any]]:
+    """
+    Recursively walks dicts and lists and yields (key, value) pairs for every key
+    starting with the '#' secret prefix.
+    """
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if isinstance(key, str) and key.startswith(SECRET_KEY_PREFIX):
+                yield key, item
+            else:
+                yield from iter_secret_items(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from iter_secret_items(item)
+
+
+def contains_plaintext_secrets(value: Any) -> bool:
+    """Checks if the value contains any '#'-prefixed key whose value is not yet encrypted."""
+    return any(not is_encrypted_value(item) for _, item in iter_secret_items(value))
+
+
+def redact_secrets(value: Any, *, mask: str = REDACTED_SECRET_VALUE) -> Any:
+    """
+    Returns a deep copy of the value with plaintext '#'-prefixed secret values replaced by the mask.
+    Values already encrypted by the encryption service ('KBC::' ciphers) are kept as they are opaque.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (
+                mask
+                if isinstance(key, str) and key.startswith(SECRET_KEY_PREFIX) and not is_encrypted_value(item)
+                else redact_secrets(item, mask=mask)
+            )
+            for key, item in value.items()
+        }
+    elif isinstance(value, list):
+        return [redact_secrets(item, mask=mask) for item in value]
+    else:
+        return value
 
 
 class EncryptionClient(KeboolaServiceClient):

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -6,6 +6,12 @@ from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, cast
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from keboola_mcp_server.clients.base import JsonDict, KeboolaServiceClient, RawKeboolaClient
+from keboola_mcp_server.clients.encryption import (
+    REDACTED_SECRET_VALUE,
+    EncryptionClient,
+    is_encrypted_value,
+    iter_secret_items,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -282,15 +288,24 @@ class CreateConfigurationAPIResponse(BaseModel):
 
 class AsyncStorageClient(KeboolaServiceClient):
 
-    def __init__(self, raw_client: RawKeboolaClient, branch_id: str | None = None) -> None:
+    def __init__(
+        self,
+        raw_client: RawKeboolaClient,
+        branch_id: str | None = None,
+        encryption_client: EncryptionClient | None = None,
+    ) -> None:
         """
         Creates an AsyncStorageClient from a RawKeboolaClient and a branch id.
 
         :param raw_client: The raw client to use
         :param branch_id: The id of the Keboola project branch to work on
+        :param encryption_client: The encryption service client used to encrypt '#'-prefixed secret values
+            before they are written to the Storage API. If None, writing a configuration that contains
+            plaintext secrets raises an error (fail-closed).
         """
         super().__init__(raw_client=raw_client)
         self._branch_id: str = branch_id or 'default'
+        self._encryption_client = encryption_client
 
     @classmethod
     def create(
@@ -302,6 +317,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         branch_id: str | None = None,
         headers: dict[str, Any] | None = None,
         readonly: bool | None = None,
+        encryption_client: EncryptionClient | None = None,
     ) -> 'AsyncStorageClient':
         """
         Creates an AsyncStorageClient from a Keboola Storage API token.
@@ -312,6 +328,8 @@ class AsyncStorageClient(KeboolaServiceClient):
         :param branch_id: The id of the Keboola project branch to work on
         :param headers: Additional headers for the requests
         :param readonly: If True, the client will only use HTTP GET, HEAD operations.
+        :param encryption_client: The encryption service client used to encrypt '#'-prefixed secret values
+            before they are written to the Storage API.
         :return: A new instance of AsyncStorageClient
         """
         return cls(
@@ -322,7 +340,45 @@ class AsyncStorageClient(KeboolaServiceClient):
                 readonly=readonly,
             ),
             branch_id=branch_id,
+            encryption_client=encryption_client,
         )
+
+    async def _encrypt_secrets(self, component_id: str, configuration: dict[str, Any]) -> dict[str, Any]:
+        """
+        Encrypts plaintext '#'-prefixed secret values in the configuration using the Encryption API
+        before the configuration is written to the Storage API. The Storage API does not encrypt
+        '#'-values server-side, so without this step the secrets would be stored in plaintext.
+
+        Fail-closed: if the configuration contains plaintext secrets and they cannot be encrypted,
+        this raises an error rather than letting the plaintext be stored.
+
+        :param component_id: The id of the component the configuration belongs to.
+        :param configuration: The configuration definition as a dictionary.
+        :return: The configuration with all '#'-prefixed values encrypted.
+        """
+        plaintext_keys = [key for key, value in iter_secret_items(configuration) if not is_encrypted_value(value)]
+        if not plaintext_keys:
+            return configuration
+
+        redacted_keys = [key for key, value in iter_secret_items(configuration) if value == REDACTED_SECRET_VALUE]
+        if redacted_keys:
+            raise ValueError(
+                f'The configuration contains redacted secret values for keys: {sorted(set(redacted_keys))}. '
+                f'These are placeholders returned on configuration reads, not the actual secret values. '
+                f'Either leave the existing secret values untouched or ask the user to provide new ones.'
+            )
+
+        if self._encryption_client is None:
+            raise ValueError(
+                f'The configuration contains plaintext secret values for keys: {sorted(set(plaintext_keys))}, '
+                f'but no encryption client is available. Refusing to store secrets in plaintext.'
+            )
+
+        project_id = await self.project_id()
+        encrypted = await self._encryption_client.encrypt(
+            configuration, component_id=component_id, project_id=project_id
+        )
+        return cast(dict[str, Any], encrypted)
 
     async def branches_list(self) -> list[JsonDict]:
         """
@@ -505,7 +561,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         payload = {
             'name': name,
             'description': description,
-            'configuration': configuration,
+            'configuration': await self._encrypt_secrets(component_id, configuration),
         }
         return cast(JsonDict, await self.post(endpoint=endpoint, data=payload))
 
@@ -646,7 +702,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         endpoint = f'branch/{self._branch_id}/components/{component_id}/configs/{configuration_id}'
 
         payload: dict[str, Any] = {
-            'configuration': configuration,
+            'configuration': await self._encrypt_secrets(component_id, configuration),
             'changeDescription': change_description,
         }
         if updated_name:
@@ -681,7 +737,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         payload = {
             'name': name,
             'description': description,
-            'configuration': configuration,
+            'configuration': await self._encrypt_secrets(component_id, configuration),
         }
 
         return cast(
@@ -720,7 +776,7 @@ class AsyncStorageClient(KeboolaServiceClient):
         """
 
         payload: dict[str, Any] = {
-            'configuration': configuration,
+            'configuration': await self._encrypt_secrets(component_id, configuration),
             'changeDescription': change_description,
         }
         if updated_name:

--- a/src/keboola_mcp_server/tools/components/model.py
+++ b/src/keboola_mcp_server/tools/components/model.py
@@ -40,6 +40,7 @@ from typing import Annotated, Any, Literal, Optional, Sequence, Union, get_args
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 from keboola_mcp_server.clients.client import get_metadata_property
+from keboola_mcp_server.clients.encryption import redact_secrets
 from keboola_mcp_server.clients.storage import ComponentAPIResponse, ComponentType, ConfigurationAPIResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
@@ -266,9 +267,11 @@ class ConfigurationRoot(BaseModel):
             is_disabled=api_config.is_disabled,
             is_deleted=api_config.is_deleted,
             folder=get_metadata_property(api_config.metadata, MetadataField.CONFIGURATION_FOLDER_NAME) or '',
-            parameters=api_config.configuration.get('parameters', {}),
+            # Plaintext '#'-prefixed secret values are redacted so that they never reach the model's context.
+            # 'KBC::' ciphers are kept as they are opaque.
+            parameters=redact_secrets(api_config.configuration.get('parameters', {})),
             storage=api_config.configuration.get('storage'),
-            processors=api_config.configuration.get('processors'),
+            processors=redact_secrets(api_config.configuration.get('processors')),
             configuration_metadata=api_config.metadata,
         )
 
@@ -336,9 +339,10 @@ class ConfigurationRow(BaseModel):
             version=row_data['version'],
             is_disabled=row_data.get('isDisabled', False),
             is_deleted=row_data.get('isDeleted', False),
-            parameters=row_data.get('configuration', {}).get('parameters', {}),
+            # Plaintext '#'-prefixed secret values are redacted so that they never reach the model's context.
+            parameters=redact_secrets(row_data.get('configuration', {}).get('parameters', {})),
             storage=row_data.get('configuration', {}).get('storage'),
-            processors=row_data.get('configuration', {}).get('processors'),
+            processors=redact_secrets(row_data.get('configuration', {}).get('processors')),
             configuration_metadata=row_data.get('configuration', {}).get('metadata', []),
         )
 

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -46,9 +46,7 @@ class TableFqn:
     def identifier(self) -> str:
         """Returns the properly quoted database identifier."""
         return '.'.join(
-            f'{self.quote_char}{n}{self.quote_char}'
-            for n in [self.db_name, self.schema_name, self.table_name]
-            if n
+            f'{self.quote_char}{n}{self.quote_char}' for n in [self.db_name, self.schema_name, self.table_name] if n
         )
 
     def __repr__(self) -> str:

--- a/tests/clients/test_encryption.py
+++ b/tests/clients/test_encryption.py
@@ -1,0 +1,96 @@
+from typing import Any
+
+import pytest
+
+from keboola_mcp_server.clients.encryption import (
+    REDACTED_SECRET_VALUE,
+    contains_plaintext_secrets,
+    is_encrypted_value,
+    iter_secret_items,
+    redact_secrets,
+)
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('KBC::ProjectSecure::abcd', True),
+        ('plaintext', False),
+        ('', False),
+        (None, False),
+        (123, False),
+        ({'KBC::': 'foo'}, False),
+    ],
+)
+def test_is_encrypted_value(value: Any, expected: bool) -> None:
+    assert is_encrypted_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        # no secrets at all
+        ({'host': 'db.example.com', 'port': 5432}, []),
+        # top-level secret
+        ({'#password': 'secret'}, [('#password', 'secret')]),
+        # nested in dicts and lists
+        (
+            {'parameters': {'db': {'#password': 'secret'}, 'tables': [{'#api_key': 'key'}]}},
+            [('#password', 'secret'), ('#api_key', 'key')],
+        ),
+        # non-dict, non-list values
+        ('just-a-string', []),
+        (None, []),
+        # already encrypted values are still yielded (filtering is up to the caller)
+        ({'#token': 'KBC::ProjectSecure::abcd'}, [('#token', 'KBC::ProjectSecure::abcd')]),
+    ],
+)
+def test_iter_secret_items(value: Any, expected: list[tuple[str, Any]]) -> None:
+    assert list(iter_secret_items(value)) == expected
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ({'host': 'db.example.com'}, False),
+        ({'#password': 'secret'}, True),
+        ({'#password': 'KBC::ProjectSecure::abcd'}, False),
+        ({'parameters': {'#password': 'KBC::ProjectSecure::abcd', 'nested': [{'#key': 'plain'}]}}, True),
+        # a '#'-key holding a non-string value is treated as plaintext (fail-safe)
+        ({'#config': {'user': 'admin'}}, True),
+        ({}, False),
+        (None, False),
+    ],
+)
+def test_contains_plaintext_secrets(value: Any, expected: bool) -> None:
+    assert contains_plaintext_secrets(value) == expected
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        # plaintext secret is masked
+        ({'#password': 'secret'}, {'#password': REDACTED_SECRET_VALUE}),
+        # encrypted secret is kept as-is
+        ({'#password': 'KBC::ProjectSecure::abcd'}, {'#password': 'KBC::ProjectSecure::abcd'}),
+        # non-secret values are kept, nested structures are walked
+        (
+            {'db': {'host': 'db.example.com', '#password': 'secret'}, 'list': [{'#api_key': 'key'}, 'foo']},
+            {
+                'db': {'host': 'db.example.com', '#password': REDACTED_SECRET_VALUE},
+                'list': [{'#api_key': REDACTED_SECRET_VALUE}, 'foo'],
+            },
+        ),
+        # non-container values pass through
+        ('just-a-string', 'just-a-string'),
+        (None, None),
+    ],
+)
+def test_redact_secrets(value: Any, expected: Any) -> None:
+    assert redact_secrets(value) == expected
+
+
+def test_redact_secrets_does_not_mutate_input() -> None:
+    original = {'db': {'#password': 'secret'}}
+    redact_secrets(original)
+    assert original == {'db': {'#password': 'secret'}}

--- a/tests/clients/test_storage.py
+++ b/tests/clients/test_storage.py
@@ -1,0 +1,137 @@
+from typing import Any, Awaitable, Callable
+
+import pytest
+from pytest_mock import MockerFixture
+
+from keboola_mcp_server.clients.base import JsonDict, RawKeboolaClient
+from keboola_mcp_server.clients.encryption import REDACTED_SECRET_VALUE, EncryptionClient
+from keboola_mcp_server.clients.storage import AsyncStorageClient
+
+WriteCall = Callable[[AsyncStorageClient, dict[str, Any]], Awaitable[JsonDict]]
+
+
+def _create_config(client: AsyncStorageClient, configuration: dict[str, Any]) -> Awaitable[JsonDict]:
+    return client.configuration_create(
+        component_id='keboola.ex-test', name='test', description='test', configuration=configuration
+    )
+
+
+def _update_config(client: AsyncStorageClient, configuration: dict[str, Any]) -> Awaitable[JsonDict]:
+    return client.configuration_update(
+        component_id='keboola.ex-test',
+        configuration_id='config-1',
+        configuration=configuration,
+        change_description='change',
+    )
+
+
+def _create_row(client: AsyncStorageClient, configuration: dict[str, Any]) -> Awaitable[JsonDict]:
+    return client.configuration_row_create(
+        component_id='keboola.ex-test', config_id='config-1', name='row', description='row', configuration=configuration
+    )
+
+
+def _update_row(client: AsyncStorageClient, configuration: dict[str, Any]) -> Awaitable[JsonDict]:
+    return client.configuration_row_update(
+        component_id='keboola.ex-test',
+        config_id='config-1',
+        configuration_row_id='row-1',
+        configuration=configuration,
+        change_description='change',
+    )
+
+
+WRITE_CALLS: list[WriteCall] = [_create_config, _update_config, _create_row, _update_row]
+
+
+@pytest.fixture
+def raw_client(mocker: MockerFixture) -> RawKeboolaClient:
+    raw = mocker.AsyncMock(RawKeboolaClient)
+    raw.post.return_value = {'id': 'config-1', 'version': 1}
+    raw.put.return_value = {'id': 'config-1', 'version': 2}
+    # used by project_id() -> GET tokens/verify
+    raw.get.return_value = {'owner': {'id': 4214}}
+    return raw
+
+
+@pytest.fixture
+def encryption_client(mocker: MockerFixture) -> EncryptionClient:
+    return mocker.AsyncMock(EncryptionClient)
+
+
+class TestConfigurationWriteEncryption:
+    """The storage client must encrypt plaintext '#'-prefixed secrets before writing configurations."""
+
+    @pytest.mark.parametrize('write_call', WRITE_CALLS)
+    @pytest.mark.asyncio
+    async def test_plaintext_secrets_are_encrypted_before_save(
+        self, raw_client: RawKeboolaClient, encryption_client: EncryptionClient, write_call: WriteCall
+    ) -> None:
+        plaintext_config = {'parameters': {'user': 'admin', '#password': 'plain-secret'}}
+        encrypted_config = {'parameters': {'user': 'admin', '#password': 'KBC::ProjectSecure::abcd'}}
+        encryption_client.encrypt.return_value = encrypted_config
+
+        client = AsyncStorageClient(raw_client=raw_client, encryption_client=encryption_client)
+        await write_call(client, plaintext_config)
+
+        encryption_client.encrypt.assert_called_once_with(
+            plaintext_config, component_id='keboola.ex-test', project_id='4214'
+        )
+        # the payload sent to the Storage API must contain the encrypted configuration
+        http_call = raw_client.post if raw_client.post.called else raw_client.put
+        sent_payload = http_call.call_args.kwargs['data']
+        assert sent_payload['configuration'] == encrypted_config
+
+    @pytest.mark.parametrize(
+        'configuration',
+        [
+            {'parameters': {'user': 'admin'}},  # no secrets at all
+            {'parameters': {'#password': 'KBC::ProjectSecure::abcd'}},  # already encrypted
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_no_plaintext_secrets_skips_encryption(
+        self,
+        raw_client: RawKeboolaClient,
+        encryption_client: EncryptionClient,
+        configuration: dict[str, Any],
+    ) -> None:
+        client = AsyncStorageClient(raw_client=raw_client, encryption_client=encryption_client)
+        await _create_config(client, configuration)
+
+        encryption_client.encrypt.assert_not_called()
+        sent_payload = raw_client.post.call_args.kwargs['data']
+        assert sent_payload['configuration'] == configuration
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_without_encryption_client(self, raw_client: RawKeboolaClient) -> None:
+        client = AsyncStorageClient(raw_client=raw_client, encryption_client=None)
+
+        with pytest.raises(ValueError, match='plaintext secret values'):
+            await _create_config(client, {'parameters': {'#password': 'plain-secret'}})
+
+        raw_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_redacted_placeholder_values(
+        self, raw_client: RawKeboolaClient, encryption_client: EncryptionClient
+    ) -> None:
+        client = AsyncStorageClient(raw_client=raw_client, encryption_client=encryption_client)
+
+        with pytest.raises(ValueError, match='redacted secret values'):
+            await _create_config(client, {'parameters': {'#password': REDACTED_SECRET_VALUE}})
+
+        encryption_client.encrypt.assert_not_called()
+        raw_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_encryption_failure_aborts_save(
+        self, raw_client: RawKeboolaClient, encryption_client: EncryptionClient
+    ) -> None:
+        encryption_client.encrypt.side_effect = RuntimeError('encryption service unavailable')
+        client = AsyncStorageClient(raw_client=raw_client, encryption_client=encryption_client)
+
+        with pytest.raises(RuntimeError, match='encryption service unavailable'):
+            await _create_config(client, {'parameters': {'#password': 'plain-secret'}})
+
+        raw_client.post.assert_not_called()

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -12,6 +12,7 @@ from keboola_mcp_server.clients.client import (
     ORCHESTRATOR_COMPONENT_ID,
     KeboolaClient,
 )
+from keboola_mcp_server.clients.encryption import REDACTED_SECRET_VALUE
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.components.api_models import ConfigurationAPIResponse
@@ -562,6 +563,53 @@ def test_configuration_row_rejects_non_empty_list_processors(invalid_processors:
             component_id='keboola.ex-aws-s3',
             configuration_id='123',
         )
+
+
+def test_configuration_root_redacts_plaintext_secrets() -> None:
+    """Plaintext '#'-values are masked on reads while 'KBC::' ciphers pass through unchanged."""
+    api_config = ConfigurationAPIResponse.model_validate(
+        {
+            'componentId': 'keboola.ex-aws-s3',
+            'id': '123',
+            'name': 'My Config',
+            'version': 1,
+            'configuration': {
+                'parameters': {'user': 'admin', '#password': 'plain-secret', '#token': 'KBC::ProjectSecure::abcd'},
+                'processors': {'after': [{'definition': {'component': 'x'}, 'parameters': {'#key': 'plain'}}]},
+            },
+            'metadata': [],
+        }
+    )
+    root = ConfigurationRoot.from_api_response(api_config)
+    assert root.parameters == {
+        'user': 'admin',
+        '#password': REDACTED_SECRET_VALUE,
+        '#token': 'KBC::ProjectSecure::abcd',
+    }
+    assert root.processors == {
+        'after': [{'definition': {'component': 'x'}, 'parameters': {'#key': REDACTED_SECRET_VALUE}}]
+    }
+
+
+def test_configuration_row_redacts_plaintext_secrets() -> None:
+    """Plaintext '#'-values in row parameters are masked on reads."""
+    row = ConfigurationRow.from_api_row_data(
+        row_data={
+            'id': 'row-1',
+            'name': 'Row 1',
+            'version': 1,
+            'configuration': {
+                'parameters': {'#api_key': 'plain-secret', '#token': 'KBC::ProjectSecure::abcd', 'period': 'daily'}
+            },
+        },
+        component_id='keboola.ex-aws-s3',
+        configuration_id='123',
+    )
+    assert row.parameters == {
+        '#api_key': REDACTED_SECRET_VALUE,
+        '#token': 'KBC::ProjectSecure::abcd',
+        'period': 'daily',
+    }
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.64.0"
+version = "1.65.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3327](https://linear.app/keboola/issue/AI-3327/keboola-mcp-server-stores-prefixed-secrets-as-plaintext-on-config)

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

The Storage API does not encrypt `#`-prefixed values server-side — the client must pre-encrypt them via the Encryption API. The MCP server forwarded configurations as-is, so secrets set through `create_config` / `update_config` / config-row tools landed in Storage as plaintext, readable project-wide, persisted in config version history, and re-fed into model context on subsequent reads.

**Encrypt before save (fail-closed):**
- `AsyncStorageClient` now holds an `EncryptionClient` and encrypts plaintext `#`-values in `configuration_create`, `configuration_update`, `configuration_row_create`, and `configuration_row_update` before any write, scoped to `componentId` + `projectId` (same pattern data apps already used).
- Centralizing in the storage client covers all callers automatically: component tools, SQL transformations, flows, scheduler, and workspace.
- Fail-closed: if the Encryption API call fails or no encryption client is available, the save is aborted — plaintext never reaches Storage.
- No extra API call when the configuration contains no plaintext secrets (already-encrypted `KBC::` values pass through unchanged; the encryption service is idempotent).

**Redact on reads:**
- `get_configs` detail responses now mask plaintext `#`-values with a `[REDACTED]` placeholder in `parameters` and `processors` (root and rows). `KBC::` ciphers pass through as they are opaque. This protects legacy configs that already contain plaintext secrets.
- Writes reject configurations containing the `[REDACTED]` placeholder with a clear error, so an agent echoing a redacted read can never overwrite a real secret. (`update_config` is unaffected anyway — it performs read-modify-write from the raw API response.)

New shared helpers in `clients/encryption.py`: `iter_secret_items()`, `contains_plaintext_secrets()`, `is_encrypted_value()`, `redact_secrets()`.

Note: the unrelated reformat in `workspace.py` comes from the tox black 26.x formatting pass.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)