### PR TITLE
test(search): AJDA-2877 tolerate find_component_id AI-service timeout (ToolError) in CI

### DIFF
--- a/integtests/tools/test_search.py
+++ b/integtests/tools/test_search.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 import toon_format
 from fastmcp import Client
+from fastmcp.exceptions import ToolError
 
 from integtests.conftest import BucketDef, ConfigDef, TableDef
 from keboola_mcp_server.tools.search import SearchHit, SuggestedComponentOutput
@@ -83,13 +84,21 @@ async def test_search_end_to_end(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(raises=httpx.ReadTimeout, strict=False, reason='AI service may exceed read timeout in CI')
 async def test_find_component_id(mcp_client: Client):
     """Tests that `find_component_id` returns relevant component IDs for a query."""
     query = 'generic extractor - extract data from many APIs'
     generic_extractor_id = 'ex-generic-v2'
 
-    full_result = await mcp_client.call_tool('find_component_id', {'query': query})
+    try:
+        full_result = await mcp_client.call_tool('find_component_id', {'query': query})
+    except (httpx.ReadTimeout, ToolError) as e:
+        # The AI service backing `find_component_id` can exceed its read timeout in CI. The timeout
+        # surfaces either as a raw httpx.ReadTimeout or, when it round-trips through the MCP tool, as
+        # a ToolError carrying an "...timed out..." message. Tolerate only that timeout signature; any
+        # other ToolError is a real failure and must propagate.
+        if isinstance(e, httpx.ReadTimeout) or 'timed out' in str(e).lower():
+            pytest.xfail(f'AI service exceeded read timeout in CI: {e}')
+        raise
 
     assert full_result.structured_content is not None
     result = full_result.structured_content['result']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.67.2"
+version = "1.67.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.67.2"
+version = "1.67.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AJDA-2877](https://linear.app/keboola/issue/AJDA-2877) (child of AJDA-2290; split out from AJDA-2810 PR #564 babysitting)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`integtests/tools/test_search.py::test_find_component_id` is meant to tolerate the AI service exceeding its read timeout in CI, but its guard — `@pytest.mark.xfail(raises=httpx.ReadTimeout)` — is ineffective: the timeout doesn't reach the test as a raw `httpx.ReadTimeout`. It round-trips through the MCP tool and surfaces at the client as `fastmcp.exceptions.ToolError("Upstream request timed out, please retry")`, so the `xfail` never matches and the timeout becomes a **hard failure** that blocks the whole integration matrix (observed repeatedly flaking PR #564, e.g. 3.11/3.12 failing with `1 failed, 154 passed` purely on this timeout).

This replaces the decorator with a targeted try/except that xfails **only** on the timeout signature (a raw `httpx.ReadTimeout`, or a `ToolError` whose message contains "timed out"). Any other `ToolError` still propagates as a real failure, so genuine regressions in `find_component_id` are not masked.

## Testing

- [x] `tox -e black,isort,flake8` clean; `test_search.py` collects (7 tests). Behaviour only differs under a real AI-service timeout, which is CI/stack-dependent.
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)

## Checklist

- [x] Self-review completed
- [x] Unit/integration tests updated (test robustness only)
- [x] Project version bumped (patch: 1.67.0 → 1.67.1) + `uv.lock` synced
- [ ] Documentation updated (n/a)

## Release Notes

- **Justification**
    - **Why:** A non-deterministic AI-service timeout in one search integration test was failing the entire integration matrix and blocking unrelated PRs from merging. The existing `xfail` guard didn't match the real exception type, so the intended "tolerate CI timeout" never took effect.
    - **What:** Make the test xfail precisely on the timeout signature (raw `ReadTimeout` or a "timed out" `ToolError`), while still failing on any genuine tool error.
- **Plans for Customer Communication**
    - None — test-only change, no product/behaviour impact.
- **Impact Analysis**
    - CI only. No production code changes. Risk: if `find_component_id` ever times out *and* is also genuinely broken, the broken case could be masked — mitigated by matching only the "timed out" message and re-raising every other `ToolError`.
- **Deployment Plan**
    - Continuous; merges independently of other work.
- **Rollback Plan**
    - Trivially revertable (single test file + version bump).
- **Post-Release Support Plan**
    - None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
