### PR TITLE
docs: document release process (two tags + release-notes skill)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The rules in this file (git workflow, versioning, venv setup) complement `CONTRI
 - When working on a Linear task, **check the current branch first** (`git branch`). If not already on the correct task branch, create one before making any changes: `git checkout -b AI-XXXX-short-description`
 - When creating PRs, use the template at `.github/pull_request_template.md`
 - **Every PR must include a `pyproject.toml` version bump** — bump before merging; see [Versioning](#versioning) for the rules
-- **Never use `git push --force`** or rebase commits that have already been pushed - use merge commits instead to avoid rewriting history for others
+- **Prefer rebasing onto `main`** to keep a linear history. Rebasing your own feature/PR branch and force-pushing the result is allowed and expected — always use `git push --force-with-lease` (never a bare `git push --force`) so you never clobber commits someone else pushed. Do not rebase a branch that others are actively committing to.
 
 ## Mapping a Docker Image Tag to a Version
 
@@ -124,6 +124,19 @@ server always reflecting your latest code changes:
 - After bumping, always sync the lock file: `uv lock`
 - Commit the version bump and `uv.lock` change together (can be a separate commit or bundled with
   the main feature commit).
+
+## Releasing
+
+- We **do not release every version**. Changes land on the trunk (`main`) continuously; we
+  release periodically once the accumulated changes have been re-tested together, so we don't
+  break working setups for users.
+- A release is one or two git tags pushed to `origin`:
+  - `vX.Y.Z` — MCP server release (always)
+  - `agent-vX.Y.Z` — In Platform Agent release (only when releasing the agent as well)
+- Either tag triggers `release.yml` CI (builds/publishes the Docker image). KaiBench runs only on
+  production `vX.Y.Z` tags — not `agent-vX.Y.Z`, and not `-dev.` prereleases.
+- Use the **`release-notes` skill** to prepare a release — it generates the release notes, opens
+  the draft `release/vX.Y.Z` PR, and walks through tagging both `vX.Y.Z` and `agent-vX.Y.Z`.
 
 ## Security Considerations
 - When whitelisting domains in OAuth, prefer **explicit domain lists over regex patterns**

--- a/README.md
+++ b/README.md
@@ -484,6 +484,22 @@ When you make changes to any tool descriptions (docstrings in tool functions), y
 uv run python -m src.keboola_mcp_server.generate_tool_docs
 ```
 
+### Releasing
+
+We do **not** cut a release for every merged PR. Work lands on the trunk (`main`)
+continuously, and we release periodically once changes have been re-tested together —
+this avoids breaking working setups for users.
+
+A release is made by pushing **one or two git tags**:
+
+- `vX.Y.Z` — the MCP server release (always)
+- `agent-vX.Y.Z` — the In Platform Agent release (only when the agent is being released too)
+
+Either tag triggers `release.yml` CI, which builds and publishes the Docker image. KaiBench
+runs only on production `vX.Y.Z` tags (not `agent-vX.Y.Z`, and not `-dev.` prereleases). Use
+the `release-notes` skill — it prepares the release notes and draft PR and walks through
+tagging both `vX.Y.Z` and `agent-vX.Y.Z`.
+
 ## Support and Feedback
 
 **⭐ The primary way to get help, report bugs, or request features is by [opening an issue on GitHub](https://github.com/keboola/mcp-server/issues/new). ⭐**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.69.2"
+version = "1.69.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1322,7 +1322,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.69.2"
+version = "1.69.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: N/A

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Documents the release process in both `README.md` and `CLAUDE.md`. Key points:

- We **do not release every version** — changes land on the trunk (`main`) continuously and are released periodically once re-tested together, to avoid breaking working setups for users.
- A release pushes **two git tags**: `vX.Y.Z` (MCP server) and `agent-vX.Y.Z` (In Platform Agent, when applicable).
- Pushed tags trigger `release.yml` CI (Docker image build/publish; KaiBench on production tags).
- The `release-notes` skill drives the process (release notes, draft `release/vX.Y.Z` PR, tagging).

Also bumps the project version `1.68.0` → `1.68.1` (patch, docs-only) and syncs `uv.lock`.

## Testing

Docs-only change — no functional/runtime behavior affected.

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable)