### PR TITLE
AI-3381: remove dead branch argument from deploy_data_app

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2035,26 +2035,21 @@ action and the configuration ID.
 **MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
 branch-delete — is yours. This tool only triggers deploys against existing git state.
 
-## Mode and branch (python-js apps)
+## Mode (python-js apps)
 - `mode='dev'` deploys the target as a **dev version of the data app** — the runtime uses a
   development `setup.sh` (hot reload) and the data-app proxy enables an auto-auth path so an
   iframe preview can render without a manual login. Only meaningful on **draft** configs
   (python-js apps with `isDraft=true`).
-- For prod redeploys (including after merging a draft's branch into `main`), use no `mode` and
-  no `branch` — the prod app picks up the current `main`.
-- The optional `branch=` argument overrides the branch the draft deploys from for this single
-  deploy. Normally unnecessary — drafts have their draft branch pinned in
-  `parameters.dataApp.git.branch` at create time.
+- For prod redeploys (including after merging a draft's branch into `main`), use no `mode` —
+  the prod app picks up the current `main`.
+- The branch a draft deploys from is pinned in `parameters.dataApp.git.branch` at create time;
+  there is no deploy-time override.
 - python-js apps do NOT fetch a Storage `configVersion` for deployment (their source lives in
   git, not in the Storage configuration); this is handled automatically.
 
 ## Streamlit apps
-Streamlit apps have no managed git repo, so `mode` and `branch` have no effect on the
-deployed app. `mode=None` is the expected call shape; don't pass `branch`.
-
-## Validation
-`branch` is only meaningful with `mode='dev'`; setting `branch` without `mode='dev'` raises an
-error for any app type (Streamlit or python-js).
+Streamlit apps have no managed git repo, so `mode` has no effect on the deployed app.
+`mode=None` is the expected call shape.
 
 ## General considerations
 - Redeploying a data app takes some time, and the app may temporarily report status "stopped" during the
@@ -2095,18 +2090,6 @@ error for any app type (Streamlit or python-js).
       ],
       "default": null,
       "description": "Deployment mode. Set to \"dev\" to deploy a python-js draft as a **dev version of the data app** \u2014 the runtime uses a development `setup.sh` (hot reload), and the data-app proxy enables an auto-auth path so an iframe preview can render without a manual login. Only meaningful on **draft** configs (python-js apps with `isDraft=true`). Leave None (default) for prod redeploys and for Streamlit apps."
-    },
-    "branch": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Git branch to deploy from. Only meaningful when `mode=\"dev\"` for python-js drafts. Normally unnecessary \u2014 drafts have their branch pinned in `parameters.dataApp.git.branch` at create time; this argument overrides that pin for this single deploy (escape hatch). Leave None for prod deploys and for Streamlit apps."
     }
   },
   "required": [
@@ -2256,7 +2239,7 @@ draft handle.
    Drafts have no managed repo of their own — always mint against PROD.
 3. YOU: `git clone U`; `git checkout <draft's pinned branch>`; resume work; `git push`.
 4. `deploy_data_app(action='deploy', configuration_id=<DRAFT>, mode='dev')` → preview URL.
-   The draft's branch is already pinned in its config, no override needed.
+   The draft's branch is already pinned in its config.
 5–7. Same promote/cleanup sequence as Scenario A steps 5–7.
 
 ## Argument rules

--- a/docs/python-js-data-apps.md
+++ b/docs/python-js-data-apps.md
@@ -199,7 +199,7 @@ Step 7: delete_python_js_data_app_draft(
 Key invariants:
 
 - The prod app's `configuration_id` is **never** modified in this flow — only its underlying git `main` is updated and the app is redeployed.
-- The draft's pinned branch is set in its `parameters.dataApp.git.branch` at create time. Passing `branch` to `deploy_data_app(mode='dev')` lets the agent override that pin for an ad-hoc preview, but normally it is not needed because the draft's config already points at the correct branch.
+- The draft's pinned branch is set in its `parameters.dataApp.git.branch` at create time. There is no deploy-time override — `deploy_data_app(mode='dev')` always deploys the pinned branch.
 - Slugs must be unique across the prod and its drafts — append a short suffix (e.g. `-draft-abc123`).
 
 ---
@@ -299,12 +299,6 @@ Always call against the **prod** app's configuration ID — the draft has no man
 - **Type**: `Optional[Literal['dev', 'production']]`
 - **Semantics**: `mode='dev'` deploys the target as a **dev version of the data app** — the runtime uses a development `setup.sh` (hot reload), and the data-app proxy enables an auto-auth path so an iframe preview can render without a manual login. Only meaningful on drafts (python-js apps with `isDraft=true`). For prod redeploys, omit `mode`.
 
-### `deploy_data_app(branch=...)`
-
-- **Type**: `Optional[str]`
-- **When valid**: only with `mode='dev'`. Raises `ValueError` otherwise.
-- **Semantics**: for python-js apps, overrides the branch the draft deploys from for this single deploy. Without `branch`, the draft deploys whatever branch is pinned in its `parameters.dataApp.git.branch`. Silently ignored for Streamlit apps (which have no managed git repo).
-
 ### `create_python_js_data_app_git_credential(configuration_id=...)`
 
 - **`configuration_id`** (`str`, required): Storage configuration ID of an existing python-js **prod** app (i.e. one with a managed repo). The tool resolves it to the underlying `data_app_id` and rejects Streamlit apps with a clear error. Drafts also reject — always mint against prod.
@@ -355,7 +349,7 @@ The tool surface maps to the underlying APIs as follows. Confirm field names wit
 |---|---|---|
 | Prod create (default) | `POST /apps` | `useManagedGitRepo: true`. No `parameters.dataApp.git` block. |
 | `parent_configuration_id` (draft) | `POST /apps` | `useManagedGitRepo` omitted/false. `configuration.parameters.dataApp.git = {repository, username, '#password' (encrypted via EncryptionClient), branch}`. Also writes `isDraft: true` and `parentConfigurationId: <prod cfg id>`. |
-| `deploy_data_app(branch=...)` | `PATCH /apps/{id}` | `branch` (alongside `desiredState: 'running'`, `mode: 'dev'`) |
+| `deploy_data_app(mode='dev')` | `PATCH /apps/{id}` | `mode: 'dev'` (alongside `desiredState: 'running'`). The deployed branch is whatever the draft's config pins — there is no deploy-time branch field. |
 | `create_python_js_data_app_git_credential` | `POST /apps/{id}/git-repo/credentials` | Request: `{type: 'http_token', permissions: 'readWrite'}`. Response: `{id, type, permissions, secret, ...}`. The one-time `secret` is what we embed (with `kai` as username) into `git_clone_url`. |
 | (clone URL lookup) | `GET /apps/{id}/git-repo` | Response: `{sshUrl, httpsUrl, isManagedGitRepo}`. The MCP server uses `httpsUrl` only. |
 | auto-workspace flag (hardcoded `true` on create) | `POST /apps` | `configuration.runtime.workspace.enabled` |
@@ -402,7 +396,7 @@ Against `data-science.canary-orion.keboola.dev`:
 - [ ] Given an existing `PROD` with a draft `DRAFT3` pinned to branch `wip-add-chart`, `get_data_apps(configuration_ids=[PROD])` returns `drafts: [...]` with `DRAFT3` and its branch visible.
 - [ ] `create_python_js_data_app_git_credential(configuration_id=PROD)` returns a fresh `git_clone_url`.
 - [ ] `git clone`, `git checkout wip-add-chart`, push another commit.
-- [ ] `deploy_data_app(configuration_id=DRAFT3, mode='dev')` deploys the branch as a dev version (no `branch=` override needed — the draft's config pins it).
+- [ ] `deploy_data_app(configuration_id=DRAFT3, mode='dev')` deploys the branch as a dev version (the draft's config pins the branch).
 
 **Lost-token recovery flow**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.68.0"
+version = "1.68.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -355,7 +355,6 @@ class DataScienceClient(KeboolaServiceClient):
         config_version: str | None = None,
         *,
         mode: str | None = None,
-        branch: str | None = None,
         restart_if_running: bool = True,
         update_dependencies: bool = False,
     ) -> DataAppResponse:
@@ -368,9 +367,6 @@ class DataScienceClient(KeboolaServiceClient):
         :param mode: Deployment mode. Set to 'dev' to deploy a python-js draft as a dev version
                     (hot reload + auto-auth for iframe preview). Leave None for Streamlit apps and
                     for prod deploys.
-        :param branch: Git branch to deploy from. Only meaningful for python-js apps in `mode='dev'`; when set,
-                    the draft deploys from this branch instead of the branch pinned in its config.
-                    Leave None for prod deploys.
         :param restart_if_running: Whether to restart the data app if it is already running
         :param update_dependencies: If set to `true`, latest package versions are installed during app startup,
                     instead of using frozen versions.
@@ -385,8 +381,6 @@ class DataScienceClient(KeboolaServiceClient):
             data['configVersion'] = config_version
         if mode is not None:
             data['mode'] = mode
-        if branch is not None:
-            data['branch'] = branch
         response = await self.patch(endpoint=f'apps/{data_app_id}', data=data)
         return DataAppResponse.model_validate(response)
 

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -788,7 +788,7 @@ async def modify_python_js_data_app(
        Drafts have no managed repo of their own — always mint against PROD.
     3. YOU: `git clone U`; `git checkout <draft's pinned branch>`; resume work; `git push`.
     4. `deploy_data_app(action='deploy', configuration_id=<DRAFT>, mode='dev')` → preview URL.
-       The draft's branch is already pinned in its config, no override needed.
+       The draft's branch is already pinned in its config.
     5–7. Same promote/cleanup sequence as Scenario A steps 5–7.
 
     ## Argument rules
@@ -1284,17 +1284,6 @@ async def deploy_data_app(
             ),
         ),
     ] = None,
-    branch: Annotated[
-        Optional[str],
-        Field(
-            description=(
-                'Git branch to deploy from. Only meaningful when `mode="dev"` for python-js drafts. '
-                'Normally unnecessary — drafts have their branch pinned in `parameters.dataApp.git.branch` '
-                'at create time; this argument overrides that pin for this single deploy (escape hatch). '
-                'Leave None for prod deploys and for Streamlit apps.'
-            ),
-        ),
-    ] = None,
 ) -> DeploymentDataAppOutput:
     """Deploys/redeploys a data app or stops a running data app in the Keboola environment asynchronously, given the
     action and the configuration ID.
@@ -1302,26 +1291,21 @@ async def deploy_data_app(
     **MCP never runs git on your behalf.** All git work — clone, branch, commit, push, merge,
     branch-delete — is yours. This tool only triggers deploys against existing git state.
 
-    ## Mode and branch (python-js apps)
+    ## Mode (python-js apps)
     - `mode='dev'` deploys the target as a **dev version of the data app** — the runtime uses a
       development `setup.sh` (hot reload) and the data-app proxy enables an auto-auth path so an
       iframe preview can render without a manual login. Only meaningful on **draft** configs
       (python-js apps with `isDraft=true`).
-    - For prod redeploys (including after merging a draft's branch into `main`), use no `mode` and
-      no `branch` — the prod app picks up the current `main`.
-    - The optional `branch=` argument overrides the branch the draft deploys from for this single
-      deploy. Normally unnecessary — drafts have their draft branch pinned in
-      `parameters.dataApp.git.branch` at create time.
+    - For prod redeploys (including after merging a draft's branch into `main`), use no `mode` —
+      the prod app picks up the current `main`.
+    - The branch a draft deploys from is pinned in `parameters.dataApp.git.branch` at create time;
+      there is no deploy-time override.
     - python-js apps do NOT fetch a Storage `configVersion` for deployment (their source lives in
       git, not in the Storage configuration); this is handled automatically.
 
     ## Streamlit apps
-    Streamlit apps have no managed git repo, so `mode` and `branch` have no effect on the
-    deployed app. `mode=None` is the expected call shape; don't pass `branch`.
-
-    ## Validation
-    `branch` is only meaningful with `mode='dev'`; setting `branch` without `mode='dev'` raises an
-    error for any app type (Streamlit or python-js).
+    Streamlit apps have no managed git repo, so `mode` has no effect on the deployed app.
+    `mode=None` is the expected call shape.
 
     ## General considerations
     - Redeploying a data app takes some time, and the app may temporarily report status "stopped" during the
@@ -1329,8 +1313,6 @@ async def deploy_data_app(
     - After deployment, the deployment info includes the app URL and the latest logs to help diagnose in-app
       errors.
     """
-    if branch is not None and mode != 'dev':
-        raise ValueError('branch is only meaningful with mode="dev"')
     client = KeboolaClient.from_state(ctx.session.state)
     links_manager = await ProjectLinksManager.from_client(client)
     if action == 'deploy':
@@ -1340,18 +1322,15 @@ async def deploy_data_app(
         # python-js apps don't carry a Storage configVersion in the deploy payload; only Streamlit apps do.
         if data_app.type == 'python-js':
             config_version_arg: str | None = None
-            branch_arg: str | None = branch
         else:
             config_version = await client.storage_client.configuration_version_latest(
                 DATA_APP_COMPONENT_ID, data_app.configuration_id
             )
             config_version_arg = str(config_version)
-            branch_arg = None
         _ = await client.data_science_client.deploy_data_app(
             data_app.data_app_id,
             config_version_arg,
             mode=mode,
-            branch=branch_arg,
         )
         data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
         data_app = data_app.with_deployment_info(await _fetch_logs(client, data_app.data_app_id))

--- a/tests/clients/test_data_science.py
+++ b/tests/clients/test_data_science.py
@@ -149,26 +149,24 @@ async def test_create_data_app_defaults_to_streamlit_without_managed_repo_flag()
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('config_version', 'mode', 'branch', 'expected_extra'),
+    ('config_version', 'mode', 'expected_extra'),
     [
-        ('42', None, None, {'configVersion': '42'}),  # Streamlit
-        (None, 'dev', None, {'mode': 'dev'}),  # python-js dev preview from main
-        (None, 'production', None, {'mode': 'production'}),
-        (None, None, None, {}),  # bare deploy (python-js without explicit mode)
-        ('5', 'dev', None, {'configVersion': '5', 'mode': 'dev'}),  # both
-        (None, 'dev', 'feature-x', {'mode': 'dev', 'branch': 'feature-x'}),  # python-js draft on a branch
+        ('42', None, {'configVersion': '42'}),  # Streamlit
+        (None, 'dev', {'mode': 'dev'}),  # python-js dev preview
+        (None, 'production', {'mode': 'production'}),
+        (None, None, {}),  # bare deploy (python-js without explicit mode)
+        ('5', 'dev', {'configVersion': '5', 'mode': 'dev'}),  # both
     ],
 )
 async def test_deploy_data_app_payload_with_mode_and_optional_config_version(
     config_version: str | None,
     mode: str | None,
-    branch: str | None,
     expected_extra: dict,
 ) -> None:
     client = DataScienceClient.create('https://api.example.com', token=None)
     client.patch = AsyncMock(return_value=_create_app_response())  # type: ignore[assignment]
 
-    _ = await client.deploy_data_app('app-123', config_version, mode=mode, branch=branch)
+    _ = await client.deploy_data_app('app-123', config_version, mode=mode)
 
     expected_payload = {
         'desiredState': 'running',

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -1488,7 +1488,7 @@ async def test_deploy_data_app_python_js_skips_storage_config_version_and_passes
         mode='dev',
     )
 
-    keboola_client.data_science_client.deploy_data_app.assert_awaited_once_with('app-1', None, mode='dev', branch=None)
+    keboola_client.data_science_client.deploy_data_app.assert_awaited_once_with('app-1', None, mode='dev')
     keboola_client.storage_client.configuration_version_latest.assert_not_called()
 
 
@@ -1509,9 +1509,7 @@ async def test_deploy_data_app_streamlit_still_passes_config_version(
 
     _ = await deploy_data_app(ctx=mcp_context_client, action='deploy', configuration_id='cfg-streamlit')
 
-    keboola_client.data_science_client.deploy_data_app.assert_awaited_once_with(
-        data_app.data_app_id, '7', mode=None, branch=None
-    )
+    keboola_client.data_science_client.deploy_data_app.assert_awaited_once_with(data_app.data_app_id, '7', mode=None)
 
 
 # ===== Tests for modify_python_js_data_app draft create path =====
@@ -1866,93 +1864,6 @@ async def test_modify_python_js_data_app_create_prod_calls_get_app_git_repo_for_
     # No git block on prod create.
     serialized = create_kwargs['configuration'].model_dump(by_alias=True, exclude_none=True)
     assert 'git' not in serialized['parameters']['dataApp']
-
-
-# ===== Tests for deploy_data_app branch parameter =====
-
-
-@pytest.mark.asyncio
-async def test_deploy_data_app_python_js_with_branch_forwards_to_client(
-    mocker,
-    mcp_context_client: Context,
-) -> None:
-    """For python-js drafts, `branch` must be forwarded to the underlying DSAPI deploy call."""
-    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.data_science_client = mocker.AsyncMock()
-
-    pyjs_app = DataApp(
-        name='twin',
-        component_id=DATA_APP_COMPONENT_ID,
-        configuration_id='cfg-twin',
-        data_app_id='app-twin',
-        project_id='proj-1',
-        branch_id='branch-1',
-        config_version='1',
-        type='python-js',
-        configuration={'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'demo-dev'}}},
-        state='stopped',
-    )
-    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=pyjs_app))
-    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_logs', mocker.AsyncMock(return_value=[]))
-
-    _ = await deploy_data_app(
-        ctx=mcp_context_client,
-        action='deploy',
-        configuration_id='cfg-twin',
-        mode='dev',
-        branch='feature-x',
-    )
-
-    keboola_client.data_science_client.deploy_data_app.assert_awaited_once_with(
-        'app-twin', None, mode='dev', branch='feature-x'
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize('bad_mode', [None, 'production'])
-async def test_deploy_data_app_branch_without_dev_mode_rejected(
-    mcp_context_client: Context,
-    bad_mode,
-) -> None:
-    """`branch` is only meaningful with mode='dev' — anything else must raise."""
-    with pytest.raises(ValueError, match='branch is only meaningful with mode="dev"'):
-        await deploy_data_app(
-            ctx=mcp_context_client,
-            action='deploy',
-            configuration_id='cfg-1',
-            mode=bad_mode,
-            branch='feature-x',
-        )
-
-
-@pytest.mark.asyncio
-async def test_deploy_data_app_streamlit_silently_ignores_branch_param(
-    mocker,
-    mcp_context_client: Context,
-    data_app: DataApp,
-) -> None:
-    """Streamlit apps don't carry a branch on deploy — the `branch` arg is dropped silently."""
-    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
-    keboola_client.data_science_client = mocker.AsyncMock()
-    data_app.state = 'stopped'
-    data_app.type = 'streamlit'
-    data_app.configuration = {'authorization': {'app_proxy': {'auth_providers': [], 'auth_rules': []}}}
-    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=data_app))
-    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_logs', mocker.AsyncMock(return_value=[]))
-    keboola_client.storage_client.configuration_version_latest = mocker.AsyncMock(return_value=7)
-
-    # Streamlit only allows mode='dev' to legitimately pass branch through, but on Streamlit it's a no-op.
-    _ = await deploy_data_app(
-        ctx=mcp_context_client,
-        action='deploy',
-        configuration_id='cfg-streamlit',
-        mode='dev',
-        branch='ignored-on-streamlit',
-    )
-
-    keboola_client.data_science_client.deploy_data_app.assert_awaited_once_with(
-        data_app.data_app_id, '7', mode='dev', branch=None
-    )
 
 
 # ===== Tests for create_python_js_data_app_git_credential =====

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.68.0"
+version = "1.68.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3381](https://linear.app/keboola/issue/AI-3381/remove-dead-branch-argument-from-deploy-data-app-dsapi-ignores-it)

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`deploy_data_app` exposed a `branch` argument (introduced in AI-3005) documented as an escape hatch to override a python-js draft's pinned branch for a single deploy. The MCP server forwarded it as a `branch` field in the `PATCH /apps/{appId}` payload — but DSAPI (sandboxes-service) never implemented that field. Its `UpdateAppPayload` accepts only `desiredState`, `lastRequestTimestamp`, `restartIfRunning`, `configVersion`, `updateDependencies` and `mode`, and the api-bundle request mapper runs with `allowExtraKeys = true`, so the extra key was **silently dropped**. The deploy succeeded but always deployed the branch pinned in the draft's `parameters.dataApp.git.branch` — an agent relying on the override would get a stale preview with no error.

This PR removes the dead parameter:

- `deploy_data_app` tool: dropped the `branch` argument and its `branch`-requires-`mode='dev'` validation; docstring updated.
- `DataScienceClient.deploy_data_app`: dropped the `branch` kwarg and payload field.
- Docs: `TOOLS.md` regenerated; `docs/python-js-data-apps.md` no longer mentions a deploy-time branch override.
- Tests: removed the three tests covering the removed behavior, dropped the `branch` dimension from the deploy payload parametrize.

The pinned-branch mechanism in the draft config (set at create time via `modify_python_js_data_app(branch=...)`) remains the only — and sufficient — way to choose the deployed branch.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable)