### PR TITLE
feat: cancel running query when the MCP client disconnects mid-query_data (AI-3204)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.69.5"
+version = "1.70.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -108,9 +108,12 @@ async def _execute_watching_disconnect(
     # query either way, but keep the log honest so a watcher bug isn't disguised as a disconnect.
     watcher_exc = disconnect_task.exception()
     if watcher_exc is not None:
+        # Pass an explicit (type, exc, tb) tuple: stdlib logging treats a truthy non-tuple
+        # `exc_info` as True and falls back to sys.exc_info(), which is empty here, so the
+        # watcher's traceback would otherwise be lost.
         LOG.warning(
             f'HTTP disconnect watcher for query_data "{query_name}" failed; cancelling underlying query',
-            exc_info=watcher_exc,
+            exc_info=(type(watcher_exc), watcher_exc, watcher_exc.__traceback__),
         )
     else:
         LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -3,10 +3,9 @@ import contextlib
 import csv
 import logging
 from io import StringIO
-from typing import Annotated
+from typing import Annotated, Awaitable
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.dependencies import get_http_request
 from fastmcp.tools import FunctionTool
 from mcp.types import (
     ProgressNotification,
@@ -16,9 +15,11 @@ from mcp.types import (
     ToolAnnotations,
 )
 from pydantic import BaseModel, Field
+from starlette.requests import Request
 
 from keboola_mcp_server.errors import tool_errors
-from keboola_mcp_server.workspace import JobSubmittedInfo, SqlSelectData, WorkspaceManager
+from keboola_mcp_server.mcp import get_http_request_or_none
+from keboola_mcp_server.workspace import JobSubmittedInfo, QueryResult, SqlSelectData, WorkspaceManager
 
 LOG = logging.getLogger(__name__)
 
@@ -26,12 +27,12 @@ SQL_TOOLS_TAG = 'sql'
 MAX_ROWS = 1_000
 MAX_CHARS = 50_000
 # How often to check whether the HTTP client has disconnected during a long query.
-# Mirrors the 1 s job-poll cadence in `_SnowflakeWorkspace.execute_query`.
+# Mirrors the 1 s job-poll cadence in `_Workspace.execute_query`.
 _DISCONNECT_POLL_INTERVAL = 1.0
 
 
-async def _watch_for_http_disconnect(poll_interval: float = _DISCONNECT_POLL_INTERVAL) -> None:
-    """Return when the underlying HTTP request is torn down, or block forever otherwise.
+async def _watch_for_http_disconnect(request: Request, poll_interval: float | None = None) -> None:
+    """Return when the underlying HTTP `request` is torn down.
 
     In stateless streamable-HTTP mode (`stateless_http=True` in `cli.py`), the MCP
     `notifications/cancelled` payload arrives on a fresh transport instance and cannot
@@ -41,27 +42,102 @@ async def _watch_for_http_disconnect(poll_interval: float = _DISCONNECT_POLL_INT
     hit "stop" in Kai, lost network) and trigger the same cancellation path we
     already have for SDK-driven cancels.
 
-    Returns silently when disconnect is detected. Blocks forever if there is no HTTP
-    request bound (e.g. stdio transport, background workers) — in that case the caller
-    will only stop on normal task completion or its own cancellation.
+    Only started when there is an HTTP request bound (see `query_data`); on stdio /
+    background workers there is nothing to watch, so the caller skips the race entirely.
 
     Any error from `is_disconnected()` is treated as "still connected" so a transient
     ASGI hiccup never cancels an otherwise-working query.
-    """
-    try:
-        request = get_http_request()
-    except RuntimeError:
-        # No HTTP request context — never fire (e.g. stdio transport).
-        await asyncio.Event().wait()
-        return  # unreachable; satisfies the type checker
 
+    `poll_interval` is resolved at call time (not bound as a default) so tests can
+    patch `_DISCONNECT_POLL_INTERVAL` and have it take effect here.
+    """
+    interval = poll_interval if poll_interval is not None else _DISCONNECT_POLL_INTERVAL
     while True:
         try:
             if await request.is_disconnected():
                 return
         except Exception:
             LOG.debug('HTTP is_disconnected() check failed; treating as still-connected', exc_info=True)
-        await asyncio.sleep(poll_interval)
+        await asyncio.sleep(interval)
+
+
+async def _drain(*tasks: asyncio.Task) -> None:
+    """Cancel and drain `tasks` under a shield so their cancellation cleanup — notably the
+    backend `cancel_job` in `_Workspace.execute_query` — finishes even when `query_data` is
+    itself being torn down.
+
+    The shield protects the in-flight cleanup, but the `await` here is deliberately NOT
+    protected: if `query_data` is cancelled at this boundary, the `CancelledError` propagates
+    out (the caller's cancellation must win — we must not go on to return a result or raise a
+    synthetic error as if nothing happened) while the drain runs to completion in the background.
+    """
+    await asyncio.shield(asyncio.gather(*(_cancel_and_drain(t) for t in tasks)))
+
+
+async def _execute_watching_disconnect(
+    query_coro: Awaitable[QueryResult], request: Request, query_name: str
+) -> QueryResult:
+    """Run `query_coro`, cancelling it — and thus the backend job, via `execute_query`'s
+    `CancelledError` handler — if the HTTP client disconnects first.
+
+    Returns the query result when the query wins the race. Raises `ValueError('Query was
+    cancelled')` if the client disconnected (or the disconnect watcher itself failed) before the
+    query finished: a plain `ValueError` keeps the cancelled call on the normal `@tool_errors`
+    path, so it is logged as an error (not a success) and the client still gets a response — a
+    raised `CancelledError` would be a `BaseException` that bypasses the decorator entirely.
+    """
+    query_task = asyncio.create_task(query_coro)
+    disconnect_task = asyncio.create_task(_watch_for_http_disconnect(request))
+    try:
+        done, _pending = await asyncio.wait([query_task, disconnect_task], return_when=asyncio.FIRST_COMPLETED)
+    except BaseException:
+        # `query_data` itself was cancelled (e.g. SDK-driven MCP cancellation on a non-stateless
+        # transport). Drain both tasks so `execute_query`'s CancelledError handler runs long enough
+        # to propagate `cancel_job` and neither task leaks as pending; suppress the drain's own
+        # CancelledError so the original exception propagates via `raise`.
+        with contextlib.suppress(asyncio.CancelledError):
+            await _drain(query_task, disconnect_task)
+        raise
+
+    if query_task in done:
+        # The query won; the watcher is still pending, so drain it.
+        await _drain(disconnect_task)
+        return query_task.result()
+
+    # The watcher won: either the client disconnected, or the watcher itself raised. Cancel the
+    # query either way, but keep the log honest so a watcher bug isn't disguised as a disconnect.
+    watcher_exc = disconnect_task.exception()
+    if watcher_exc is not None:
+        LOG.warning(
+            f'HTTP disconnect watcher for query_data "{query_name}" failed; cancelling underlying query',
+            exc_info=watcher_exc,
+        )
+    else:
+        LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')
+    await _drain(query_task)
+    raise ValueError('Query was cancelled')
+
+
+async def _cancel_and_drain(task: asyncio.Task) -> None:
+    """Cancel a task and await its unwind, suppressing the resulting error.
+
+    Draining (rather than fire-and-forget `task.cancel()`) lets any shielded
+    cleanup the task runs on cancellation — notably the backend `cancel_job` in
+    `_Workspace.execute_query` — finish before we move on. `KeyboardInterrupt` /
+    `SystemExit` are intentionally NOT suppressed.
+
+    Only the expected `CancelledError` is swallowed. Any other exception raised
+    while the task unwinds is a real bug in the cancellation cleanup path (e.g. the
+    shielded backend cancel) — log it with a traceback rather than silently dropping
+    it, but still don't re-raise so draining stays best-effort.
+    """
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        LOG.warning('Unexpected error while draining cancelled task', exc_info=True)
 
 
 def _client_progress_token(ctx: Context) -> ProgressToken | None:
@@ -215,43 +291,20 @@ async def query_data(
     async def _on_job_submitted(info: JobSubmittedInfo) -> None:
         await _emit_job_submitted_progress(ctx, progress_token, info)
 
-    # Race the query against the HTTP client disconnecting. If the client gives up
-    # before the query finishes (Kai kills the sandbox SDK process on STOP, which drops
-    # the proxied tools/call socket), cancelling `query_task` triggers the CancelledError
-    # branch inside `_Workspace.execute_query`, which fires `cancel_job` on the backend
-    # so the scan stops. Needed because in stateless HTTP mode the MCP cancel
-    # notification cannot reach this running request — see `_watch_for_http_disconnect`.
-    query_task = asyncio.create_task(
-        workspace_manager.execute_query(
-            sql_query,
-            max_rows=MAX_ROWS,
-            max_chars=MAX_CHARS,
-            on_job_submitted=_on_job_submitted if progress_token is not None else None,
-        )
+    query_coro = workspace_manager.execute_query(
+        sql_query,
+        max_rows=MAX_ROWS,
+        max_chars=MAX_CHARS,
+        on_job_submitted=_on_job_submitted if progress_token is not None else None,
     )
-    disconnect_task = asyncio.create_task(_watch_for_http_disconnect())
-    try:
-        done, _pending = await asyncio.wait(
-            [query_task, disconnect_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-    except BaseException:
-        query_task.cancel()
-        disconnect_task.cancel()
-        raise
-
-    if query_task not in done:
-        LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')
-        query_task.cancel()
-        with contextlib.suppress(BaseException):
-            await query_task
-        raise asyncio.CancelledError(f'HTTP client disconnected during query_data "{query_name}"')
-
-    disconnect_task.cancel()
-    with contextlib.suppress(BaseException):
-        await disconnect_task
-
-    result = query_task.result()
+    # The disconnect race only buys us anything on the HTTP path, where the client can actually
+    # drop the socket (Kai kills the sandbox SDK process on STOP). With no HTTP request bound
+    # (stdio / background workers) nothing can disconnect, so run the query directly.
+    request = get_http_request_or_none()
+    if request is None:
+        result = await query_coro
+    else:
+        result = await _execute_watching_disconnect(query_coro, request, query_name)
     if result.is_ok:
         LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
         if result.data:

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -1,9 +1,12 @@
+import asyncio
+import contextlib
 import csv
 import logging
 from io import StringIO
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
+from fastmcp.server.dependencies import get_http_request
 from fastmcp.tools import FunctionTool
 from mcp.types import (
     ProgressNotification,
@@ -22,6 +25,43 @@ LOG = logging.getLogger(__name__)
 SQL_TOOLS_TAG = 'sql'
 MAX_ROWS = 1_000
 MAX_CHARS = 50_000
+# How often to check whether the HTTP client has disconnected during a long query.
+# Mirrors the 1 s job-poll cadence in `_SnowflakeWorkspace.execute_query`.
+_DISCONNECT_POLL_INTERVAL = 1.0
+
+
+async def _watch_for_http_disconnect(poll_interval: float = _DISCONNECT_POLL_INTERVAL) -> None:
+    """Return when the underlying HTTP request is torn down, or block forever otherwise.
+
+    In stateless streamable-HTTP mode (`stateless_http=True` in `cli.py`), the MCP
+    `notifications/cancelled` payload arrives on a fresh transport instance and cannot
+    reach the in-flight tool call's session — so `asyncio.CancelledError` is never
+    raised inside the running tool. Watching the underlying ASGI request for an
+    `http.disconnect` event lets us notice when the client gave up (closed the tab,
+    hit "stop" in Kai, lost network) and trigger the same cancellation path we
+    already have for SDK-driven cancels.
+
+    Returns silently when disconnect is detected. Blocks forever if there is no HTTP
+    request bound (e.g. stdio transport, background workers) — in that case the caller
+    will only stop on normal task completion or its own cancellation.
+
+    Any error from `is_disconnected()` is treated as "still connected" so a transient
+    ASGI hiccup never cancels an otherwise-working query.
+    """
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        # No HTTP request context — never fire (e.g. stdio transport).
+        await asyncio.Event().wait()
+        return  # unreachable; satisfies the type checker
+
+    while True:
+        try:
+            if await request.is_disconnected():
+                return
+        except Exception:
+            LOG.debug('HTTP is_disconnected() check failed; treating as still-connected', exc_info=True)
+        await asyncio.sleep(poll_interval)
 
 
 def _client_progress_token(ctx: Context) -> ProgressToken | None:
@@ -175,12 +215,43 @@ async def query_data(
     async def _on_job_submitted(info: JobSubmittedInfo) -> None:
         await _emit_job_submitted_progress(ctx, progress_token, info)
 
-    result = await workspace_manager.execute_query(
-        sql_query,
-        max_rows=MAX_ROWS,
-        max_chars=MAX_CHARS,
-        on_job_submitted=_on_job_submitted if progress_token is not None else None,
+    # Race the query against the HTTP client disconnecting. If the client gives up
+    # before the query finishes (Kai kills the sandbox SDK process on STOP, which drops
+    # the proxied tools/call socket), cancelling `query_task` triggers the CancelledError
+    # branch inside `_Workspace.execute_query`, which fires `cancel_job` on the backend
+    # so the scan stops. Needed because in stateless HTTP mode the MCP cancel
+    # notification cannot reach this running request — see `_watch_for_http_disconnect`.
+    query_task = asyncio.create_task(
+        workspace_manager.execute_query(
+            sql_query,
+            max_rows=MAX_ROWS,
+            max_chars=MAX_CHARS,
+            on_job_submitted=_on_job_submitted if progress_token is not None else None,
+        )
     )
+    disconnect_task = asyncio.create_task(_watch_for_http_disconnect())
+    try:
+        done, _pending = await asyncio.wait(
+            [query_task, disconnect_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    except BaseException:
+        query_task.cancel()
+        disconnect_task.cancel()
+        raise
+
+    if query_task not in done:
+        LOG.info(f'HTTP client disconnected during query_data "{query_name}"; cancelling underlying query')
+        query_task.cancel()
+        with contextlib.suppress(BaseException):
+            await query_task
+        raise asyncio.CancelledError(f'HTTP client disconnected during query_data "{query_name}"')
+
+    disconnect_task.cancel()
+    with contextlib.suppress(BaseException):
+        await disconnect_task
+
+    result = query_task.result()
     if result.is_ok:
         LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
         if result.data:

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -232,55 +232,77 @@ class _Workspace(abc.ABC):
 
         ts_start = time.perf_counter()
         job_id = await self._qsclient.submit_job(statements=[sql_query], workspace_id=str(self.id))
-        if on_job_submitted is not None:
-            info = JobSubmittedInfo(
-                job_id=job_id,
-                cancellation_url=self._qsclient.build_cancel_url(job_id),
-                backend=self.get_sql_dialect().lower(),
-            )
-            # Best-effort: a failed progress notification must not kill the running query.
-            # CancelledError is `BaseException` since Python 3.8, so `except Exception` already
-            # lets it propagate on the supported Python (>=3.10). The explicit branch below
-            # documents intent and guards against a future refactor that might widen the catch
-            # to `BaseException` and silently swallow cancellation.
+        # The job is now registered with Query Service, so everything from here on must run under
+        # the CancelledError handler below: if the client cancels while we are still in the
+        # `on_job_submitted` callback (e.g. emitting the progress notification), we must still
+        # propagate the cancel to the backend rather than leak a running QS job.
+        try:
+            if on_job_submitted is not None:
+                info = JobSubmittedInfo(
+                    job_id=job_id,
+                    cancellation_url=self._qsclient.build_cancel_url(job_id),
+                    backend=self.get_sql_dialect().lower(),
+                )
+                # Best-effort: a failed progress notification must not kill the running query.
+                # CancelledError is `BaseException` since Python 3.8, so `except Exception` already
+                # lets it propagate on the supported Python (>=3.10). The explicit branch below
+                # documents intent and re-raises so the outer CancelledError handler can cancel the
+                # backend job; it also guards against a future refactor that might widen the catch
+                # to `BaseException` and silently swallow cancellation.
+                try:
+                    await on_job_submitted(info)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    LOG.warning(f'on_job_submitted callback raised for job_id={job_id}: {exc!r} — continuing')
+            while (job_status := await self._qsclient.get_job_status(job_id)) and job_status['status'] not in [
+                'completed',
+                'failed',
+                'canceled',
+                'cancelled',
+            ]:
+                await asyncio.sleep(1)
+                elapsed_time = time.perf_counter() - ts_start
+                if elapsed_time > self._QUERY_TIMEOUT:
+                    # Cancel the query before raising timeout error. Inline the reason (rather than
+                    # binding a `reason` local) so it can't be mistaken for an in-scope variable by
+                    # the `except asyncio.CancelledError` handler below, which uses its own reason.
+                    cancellation_confirmed, query_completed = await self._cancel_job_with_timeout(
+                        job_id, f'Query timeout exceeded after {elapsed_time:.2f} seconds'
+                    )
+
+                    # If query completed during cancellation, fetch and return results
+                    if query_completed:
+                        LOG.info(f'Query completed during cancellation polling, returning results: job_id={job_id}')
+                        # Break out of the polling loop to fetch results below
+                        job_status = await self._qsclient.get_job_status(job_id)
+                        break
+
+                    # Query did not complete - raise timeout error
+                    if cancellation_confirmed:
+                        raise RuntimeError(
+                            f'Query execution timed out after {elapsed_time:.2f} seconds. '
+                            f'The query has been cancelled: job_id={job_id}'
+                        )
+                    else:
+                        raise RuntimeError(
+                            f'Query execution timed out after {elapsed_time:.2f} seconds. '
+                            f'Cancellation was attempted but could not be confirmed. '
+                            f'The query may still be running on the server: job_id={job_id}'
+                        )
+        except asyncio.CancelledError:
+            # Client (e.g. MCP `notifications/cancelled`) cancelled the in-flight tool call.
+            # Propagate the cancel to the backend so the query doesn't keep scanning data.
+            # `asyncio.shield` keeps the cancel HTTP call alive even though our own task
+            # is being cancelled; without it the request would be torn down immediately.
+            LOG.info(f'Query cancelled by client: job_id={job_id}')
             try:
-                await on_job_submitted(info)
+                await asyncio.shield(self._cancel_job_with_timeout(job_id, reason='Client cancelled the request'))
             except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                LOG.warning(f'on_job_submitted callback raised for job_id={job_id}: {exc!r} — continuing')
-        while (job_status := await self._qsclient.get_job_status(job_id)) and job_status['status'] not in [
-            'completed',
-            'failed',
-            'canceled',
-            'cancelled',
-        ]:
-            await asyncio.sleep(1)
-            elapsed_time = time.perf_counter() - ts_start
-            if elapsed_time > self._QUERY_TIMEOUT:
-                # Cancel the query before raising timeout error
-                reason = f'Query timeout exceeded after {elapsed_time:.2f} seconds'
-                cancellation_confirmed, query_completed = await self._cancel_job_with_timeout(job_id, reason)
-
-                # If query completed during cancellation, fetch and return results
-                if query_completed:
-                    LOG.info(f'Query completed during cancellation polling, returning results: job_id={job_id}')
-                    # Break out of the polling loop to fetch results below
-                    job_status = await self._qsclient.get_job_status(job_id)
-                    break
-
-                # Query did not complete - raise timeout error
-                if cancellation_confirmed:
-                    raise RuntimeError(
-                        f'Query execution timed out after {elapsed_time:.2f} seconds. '
-                        f'The query has been cancelled: job_id={job_id}'
-                    )
-                else:
-                    raise RuntimeError(
-                        f'Query execution timed out after {elapsed_time:.2f} seconds. '
-                        f'Cancellation was attempted but could not be confirmed. '
-                        f'The query may still be running on the server: job_id={job_id}'
-                    )
+                # Outer scope was cancelled again while the shielded cancel was still running;
+                # we did our best — let the original CancelledError propagate below.
+                pass
+            raise
 
         # Short-circuit when the poll loop exited because the job was cancelled out-of-band
         # (e.g. the user clicked STOP and the kai-agent backend POSTed

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import urlparse
 
@@ -309,6 +310,27 @@ async def test_execute_query_swallows_callback_exception_and_completes_query():
     qs_mock.get_job_results.assert_awaited()
 
 
+@pytest.mark.asyncio
+async def test_execute_query_cancels_backend_when_cancelled_during_callback():
+    """If the in-flight task is cancelled while awaiting `on_job_submitted` (the job is already
+    submitted by then), the backend job must still be cancelled rather than left running."""
+    workspace, qs_mock = _make_snowflake_workspace_with_mocked_qs(job_id='job-cb-cancel')
+    # Make QS report the job as cancelled so `_cancel_job_with_timeout` confirms immediately.
+    qs_mock.get_job_status.return_value = {'status': 'cancelled', 'statements': [{'id': 'stmt-1'}]}
+
+    async def cancel_during_callback(info: JobSubmittedInfo) -> None:
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await workspace.execute_query('SELECT 1', on_job_submitted=cancel_during_callback)
+
+    # The backend cancel must have been issued for the already-submitted job.
+    qs_mock.cancel_job.assert_awaited_once()
+    assert qs_mock.cancel_job.await_args.args[0] == 'job-cb-cancel'
+    # The cancellation short-circuits before any results fetch.
+    qs_mock.get_job_results.assert_not_awaited()
+
+
 def test_build_cancel_url_uses_raw_client_base_api_url():
     """build_cancel_url must produce an absolute URL clients can POST to without further assembly."""
     qs = QueryServiceClient.create(
@@ -360,3 +382,67 @@ async def test_workspace_manager_create_skips_feature_lookup_on_default_branch()
     await WorkspaceManager.create(input_client)
 
     input_client.has_feature.assert_not_called()
+
+
+def _make_cancel_test_workspace(*, cancel_job_side_effect=None) -> tuple[_SnowflakeWorkspace, AsyncMock, dict]:
+    """Build a `_SnowflakeWorkspace` whose `_qsclient` simulates a long-running query.
+
+    The mocked `get_job_status` returns ``running`` until `cancel_job` is invoked,
+    after which it returns ``canceled`` (mimicking Query Service confirming the cancel).
+    The ``state`` dict lets the caller inspect whether cancellation was issued.
+    """
+    workspace = _SnowflakeWorkspace(workspace_id=1, schema='test_schema', client=Mock(spec=KeboolaClient))
+    mock_qs = AsyncMock(spec=QueryServiceClient)
+    workspace._qsclient = mock_qs
+
+    mock_qs.submit_job.return_value = 'job-abc-123'
+
+    state = {'cancelled': False}
+
+    async def get_status(job_id: str):
+        return {'status': 'canceled' if state['cancelled'] else 'running'}
+
+    async def default_cancel(job_id: str, reason: str):
+        state['cancelled'] = True
+        return {}
+
+    mock_qs.get_job_status.side_effect = get_status
+    mock_qs.cancel_job.side_effect = cancel_job_side_effect or default_cancel
+    return workspace, mock_qs, state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('cancel_job_side_effect_factory', 'expect_cancel_call'),
+    [
+        (None, True),
+        (
+            lambda: HTTPStatusError(
+                'cancel failed',
+                request=Mock(spec=Request),
+                response=Mock(spec=Response, status_code=500, text='boom'),
+            ),
+            True,
+        ),
+    ],
+    ids=['backend_cancel_succeeds', 'backend_cancel_fails'],
+)
+async def test_execute_query_cancellation_propagates_to_backend(
+    cancel_job_side_effect_factory, expect_cancel_call: bool
+):
+    """Client cancellation (MCP `notifications/cancelled`) must trigger `cancel_job` on
+    the Snowflake side. If the backend cancel itself fails, the original CancelledError
+    must still propagate so the SDK can finalize the request cleanly."""
+    side_effect = cancel_job_side_effect_factory() if cancel_job_side_effect_factory else None
+    workspace, mock_qs, _state = _make_cancel_test_workspace(cancel_job_side_effect=side_effect)
+
+    task = asyncio.create_task(workspace.execute_query('SELECT 1'))
+    # Yield to let the task enter the poll loop and issue at least one get_job_status.
+    await asyncio.sleep(0.05)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    if expect_cancel_call:
+        mock_qs.cancel_job.assert_called_once_with('job-abc-123', reason='Client cancelled the request')

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -1,6 +1,7 @@
+import asyncio
 import json
 from typing import Any
-from unittest.mock import AsyncMock, Mock, call
+from unittest.mock import AsyncMock, MagicMock, Mock, call
 
 import pytest
 from mcp.server.fastmcp import Context
@@ -8,7 +9,7 @@ from mcp.types import ProgressNotification
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
-from keboola_mcp_server.tools.sql import QueryDataOutput, query_data
+from keboola_mcp_server.tools.sql import QueryDataOutput, _watch_for_http_disconnect, query_data
 from keboola_mcp_server.workspace import (
     JobSubmittedInfo,
     QueryResult,
@@ -1141,6 +1142,64 @@ class TestQueryCancellation:
 
         # Verify cancellation was attempted
         qsclient.cancel_job.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_query_data_cancels_on_http_disconnect(self, mcp_context_client: Context, mocker) -> None:
+        """When the underlying HTTP request disconnects mid-flight, `query_data` must
+        cancel the workspace task so its CancelledError branch can fire `cancel_job`."""
+
+        # Workspace task that never completes — simulates a long-running query.
+        async def never_returns(*_a, **_kw):
+            await asyncio.Event().wait()
+
+        manager = AsyncMock(WorkspaceManager)
+        manager.execute_query.side_effect = never_returns
+        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+        # Fake HTTP request: not disconnected for the first poll, then disconnected.
+        fake_request = MagicMock()
+        disconnect_states = iter([False, True])
+        fake_request.is_disconnected = AsyncMock(side_effect=lambda: next(disconnect_states))
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
+        # Speed the poll up so the test doesn't have to wait a full second.
+        mocker.patch('keboola_mcp_server.tools.sql._DISCONNECT_POLL_INTERVAL', 0.01)
+
+        with pytest.raises(asyncio.CancelledError):
+            await query_data('SELECT 1', 'test', mcp_context_client)
+
+        manager.execute_query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_query_data_no_disconnect_watcher_in_stdio_mode(self, mcp_context_client: Context, mocker) -> None:
+        """When there is no HTTP request bound (stdio transport), the watcher must
+        block forever and the query must complete normally."""
+        manager = AsyncMock(WorkspaceManager)
+        manager.execute_query.return_value = QueryResult(
+            status='ok',
+            data=SqlSelectData(columns=['a'], rows=[{'a': 1}]),
+            message=None,
+        )
+        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+        mocker.patch(
+            'keboola_mcp_server.tools.sql.get_http_request',
+            side_effect=RuntimeError('No active HTTP request found.'),
+        )
+
+        result = await query_data('SELECT 1', 'test', mcp_context_client)
+        assert isinstance(result, QueryDataOutput)
+        assert result.csv_data == 'a\r\n1\r\n'
+
+    @pytest.mark.asyncio
+    async def test_watch_for_http_disconnect_treats_errors_as_connected(self, mocker) -> None:
+        """A transient is_disconnected() failure must not be treated as a disconnect."""
+        fake_request = MagicMock()
+        # First call errors (still treated as connected); second call signals disconnect.
+        fake_request.is_disconnected = AsyncMock(side_effect=[RuntimeError('asgi hiccup'), True])
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
+
+        await asyncio.wait_for(_watch_for_http_disconnect(poll_interval=0.01), timeout=1.0)
+        assert fake_request.is_disconnected.await_count == 2
 
     @pytest.mark.asyncio
     async def test_query_completes_just_before_timeout(

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, call
@@ -1160,19 +1161,96 @@ class TestQueryCancellation:
         fake_request = MagicMock()
         disconnect_states = iter([False, True])
         fake_request.is_disconnected = AsyncMock(side_effect=lambda: next(disconnect_states))
-        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request_or_none', return_value=fake_request)
         # Speed the poll up so the test doesn't have to wait a full second.
         mocker.patch('keboola_mcp_server.tools.sql._DISCONNECT_POLL_INTERVAL', 0.01)
 
-        with pytest.raises(asyncio.CancelledError):
+        # A disconnect surfaces as a plain ValueError (not CancelledError) so it stays on the
+        # `@tool_errors` path — logged as an error, not a success, and a response reaches the client.
+        with pytest.raises(ValueError, match='Query was cancelled'):
             await query_data('SELECT 1', 'test', mcp_context_client)
 
         manager.execute_query.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_query_data_logs_when_disconnect_watcher_raises(
+        self, mcp_context_client: Context, mocker, caplog
+    ) -> None:
+        """If the disconnect watcher finishes with an exception (rather than returning on a
+        detected disconnect), `query_data` must still cancel the query and surface the watcher
+        error in the logs — never leak a "Task exception was never retrieved" warning."""
+
+        async def never_returns(*_a, **_kw):
+            await asyncio.Event().wait()
+
+        manager = AsyncMock(WorkspaceManager)
+        manager.execute_query.side_effect = never_returns
+        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+
+        async def boom(*_a, **_kw):
+            raise RuntimeError('watcher blew up')
+
+        # An HTTP request must be bound for the watcher race to run at all.
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request_or_none', return_value=MagicMock())
+        mocker.patch('keboola_mcp_server.tools.sql._watch_for_http_disconnect', side_effect=boom)
+
+        with caplog.at_level('WARNING'), pytest.raises(ValueError, match='Query was cancelled'):
+            await query_data('SELECT 1', 'test', mcp_context_client)
+
+        manager.execute_query.assert_called_once()
+        assert any('disconnect watcher' in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_query_data_propagates_cancel_during_post_query_drain(
+        self, mcp_context_client: Context, mocker
+    ) -> None:
+        """If `query_data` is cancelled while draining the disconnect watcher after the query
+        completed, the `CancelledError` must propagate (not be swallowed by `_cancel_and_drain`
+        and cause a result to be returned), while the shielded drain still runs to completion."""
+        manager = AsyncMock(WorkspaceManager)
+        manager.execute_query.return_value = QueryResult(
+            status='ok',
+            data=SqlSelectData(columns=['a'], rows=[{'a': 1}]),
+            message=None,
+        )
+        mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+        # HTTP mode with a request that never disconnects: the query wins the race, leaving the
+        # disconnect watcher as the pending task drained once the query completes.
+        fake_request = MagicMock()
+        fake_request.is_disconnected = AsyncMock(return_value=False)
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request_or_none', return_value=fake_request)
+
+        drain_started = asyncio.Event()
+        drain_finished = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_drain(task: asyncio.Task) -> None:
+            task.cancel()
+            drain_started.set()
+            await release.wait()
+            # Mirror the real `_cancel_and_drain`: actually await the cancelled task so it does
+            # not linger as a pending task and emit "Task exception was never retrieved" warnings.
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            drain_finished.set()
+
+        mocker.patch('keboola_mcp_server.tools.sql._cancel_and_drain', side_effect=slow_drain)
+
+        task = asyncio.create_task(query_data('SELECT 1', 'test', mcp_context_client))
+        # Wait until query_data reaches the shielded post-query drain, then cancel it there.
+        await asyncio.wait_for(drain_started.wait(), timeout=1.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # The shield kept the drain alive: let it complete and confirm it finished despite the
+        # outer cancellation that already propagated out of query_data.
+        release.set()
+        await asyncio.wait_for(drain_finished.wait(), timeout=1.0)
+
+    @pytest.mark.asyncio
     async def test_query_data_no_disconnect_watcher_in_stdio_mode(self, mcp_context_client: Context, mocker) -> None:
-        """When there is no HTTP request bound (stdio transport), the watcher must
-        block forever and the query must complete normally."""
+        """When there is no HTTP request bound (stdio transport), the disconnect race is skipped
+        entirely and the query runs directly to completion."""
         manager = AsyncMock(WorkspaceManager)
         manager.execute_query.return_value = QueryResult(
             status='ok',
@@ -1181,10 +1259,7 @@ class TestQueryCancellation:
         )
         mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
 
-        mocker.patch(
-            'keboola_mcp_server.tools.sql.get_http_request',
-            side_effect=RuntimeError('No active HTTP request found.'),
-        )
+        mocker.patch('keboola_mcp_server.tools.sql.get_http_request_or_none', return_value=None)
 
         result = await query_data('SELECT 1', 'test', mcp_context_client)
         assert isinstance(result, QueryDataOutput)
@@ -1196,9 +1271,8 @@ class TestQueryCancellation:
         fake_request = MagicMock()
         # First call errors (still treated as connected); second call signals disconnect.
         fake_request.is_disconnected = AsyncMock(side_effect=[RuntimeError('asgi hiccup'), True])
-        mocker.patch('keboola_mcp_server.tools.sql.get_http_request', return_value=fake_request)
 
-        await asyncio.wait_for(_watch_for_http_disconnect(poll_interval=0.01), timeout=1.0)
+        await asyncio.wait_for(_watch_for_http_disconnect(fake_request, poll_interval=0.01), timeout=1.0)
         assert fake_request.is_disconnected.await_count == 2
 
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,15 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version >= '3.11' and python_full_version < '3.13'",
     "python_full_version < '3.11'",
 ]
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "aiofile"
@@ -98,7 +102,7 @@ wheels = [
 
 [[package]]
 name = "azure-storage-blob"
-version = "12.30.0"
+version = "12.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -106,9 +110,9 @@ dependencies = [
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz", hash = "sha256:2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657", size = 611359, upload-time = "2026-05-15T03:34:59.865Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/2c/6ddee6a3e42d0236ba9259e4df7fa97fdc415ff0802b736c634baaf4b285/azure_storage_blob-12.29.0-py3-none-any.whl", hash = "sha256:ccf8a1bcd5e49df83ab85aab793b579e5ba2eeea2ad8900b2f62ca3a37dc391f", size = 434823, upload-time = "2026-05-15T03:35:01.837Z" },
 ]
 
 [[package]]
@@ -184,30 +188,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.26"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/6a/fede22427b4e8e56bae102de50351f1a02519be86f8c8dd5347c377cfceb/boto3-1.43.26.tar.gz", hash = "sha256:33f027b7911dffe84f4896b66024c228eb856f4cf8c1ff3465be0eae1f413731", size = 113143, upload-time = "2026-06-09T19:34:20.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/31/32388d5ec332ffe81d8f3650860f94b66294009172d188c390cad58c6f5f/boto3-1.43.22.tar.gz", hash = "sha256:2a7fe12d8e0731bb8aa7c1e59b4ccc770fda031b8659c2f6f497393bdcec3051", size = 113203, upload-time = "2026-06-03T19:33:13.39Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/39/06d683934d94972c070179952746a57adff5c1851e2396d505a9b8cd9754/boto3-1.43.26-py3-none-any.whl", hash = "sha256:7c88bfbde6abcf062d04ac410a1cf4eaf8675f025f35f3ad9accc9b0224ce6b9", size = 140537, upload-time = "2026-06-09T19:34:17.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/6b/c2fb3b91e849882df5426e68cc15eb2b5ba6ac28325ab2aa3a1065da5884/boto3-1.43.22-py3-none-any.whl", hash = "sha256:0597fb9fe1613e636ac55219a5a54ad0fcb7c15e6be32c799301f7fb53ff04e1", size = 140536, upload-time = "2026-06-03T19:33:10.939Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.26"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/ba/aa37cd4e72aa8b70fdb93f47129ef3b79887edcfb343bd41df2783a72f12/botocore-1.43.26.tar.gz", hash = "sha256:fd9280ac868194afcee59c7def62e0031fb4b599f7ef85360d30c7e42357c1dc", size = 15497173, upload-time = "2026-06-09T19:34:07.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/cf/840f1b8db16d45e3807c23d1ea779723eed1cd9cf3b6c49e16f372d2a777/botocore-1.43.22.tar.gz", hash = "sha256:b00de525e538289ed4a7a85263f1be4e47473c124cec87be6b23be49356bf745", size = 15458781, upload-time = "2026-06-03T19:33:02.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/e6/5a5ec1033613e7812e5b19ec8c2a1889834fde336d8812d53019eac6e04a/botocore-1.43.26-py3-none-any.whl", hash = "sha256:eeb92265bae289555182a46341c998a656ab49c0dbdb762c65b30fe354fcc9e8", size = 15183593, upload-time = "2026-06-09T19:34:03.012Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6b/576a1b0f915871e35f14a33104f2bcae635f19c6a72486ba639db0d1fc70/botocore-1.43.22-py3-none-any.whl", hash = "sha256:ceec9f81d0891abe7b28ca2b2ee47e32de7b3360ad11e80d351470f015217379", size = 15141375, upload-time = "2026-06-03T19:32:58.324Z" },
 ]
 
 [[package]]
@@ -628,67 +632,67 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "48.0.1"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
-    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
-    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
-    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
-    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
-    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
-    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
-    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
-    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/d3/eb4e394e587341fdad09a09101fa76478ead3a78b0ad63e55c22f0d75c02/cryptography-48.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:08a597acce1ff37f347400087776599e2348a3a8bc53b44120e463cd274efe4a", size = 3951747, upload-time = "2026-06-09T22:31:23.871Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/4a/3f43451b4f858bfceaaaffc649e6e787e8d4fb332a1d443af39ab02cc8f1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:735824ec41b7f74a7c45fb1591349333e4c696cb6c044e5f46356e560143e4cd", size = 4641226, upload-time = "2026-06-09T22:31:02.532Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4e/855584c2c23b09e4ce2d3b9c30e983e679cd60b068c513c6bbdb91e11782/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:92a46e1d638daa264ba2971c0b0489c9409787943efae4d60ffda3d091ef832c", size = 4668958, upload-time = "2026-06-09T22:32:06.213Z" },
-    { url = "https://files.pythonhosted.org/packages/42/3b/d35750e41d803d1e516fd6d6011f065424924da7af1748cef4cc9cb3ede1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:7e234ac052af99f2700826a5c29ea99d9c1b1f80341cde62d11c8154dc8e0bd9", size = 4640793, upload-time = "2026-06-09T22:32:26.331Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/aa/cdb7181fe865285e87e96825aaab239400f1de0c3bfba9bd9769b79f1a92/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:33842cf0888951cef5bc7ac724ab844a42044c1727b967b7f8997289a0464f92", size = 4668505, upload-time = "2026-06-09T22:31:27.534Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8c/ce3823c06c2804f194f9e64f0d67fa3f4094a39f2bb1a990cd03603af8fc/cryptography-48.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a", size = 3742204, upload-time = "2026-06-09T22:31:34.773Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
 name = "cyclopts"
-version = "4.17.0"
+version = "4.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -698,18 +702,18 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/b7/2e64e26e7189c2f0f88cea467d068ec968f2fa24628b0ffb93132a0f2b14/cyclopts-4.17.0.tar.gz", hash = "sha256:6b3231f18b404879e978214ef26fa174e8b505bd0f2117290b4135560666004b", size = 181338, upload-time = "2026-06-09T13:41:26.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/07/bf61d13de86d96a4c46aff00c9ca0eced44bcc8c3e16280605c1253e5720/cyclopts-4.16.1.tar.gz", hash = "sha256:8aa47bf92a5fb33abca5af05e576eecdb0d2f79893ad29238046df78370fc4a8", size = 181196, upload-time = "2026-05-25T15:29:08.518Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/26/1614f15b8ea89ee201a2484ea5bede7319a2b07c796c321ffdadd705559e/cyclopts-4.17.0-py3-none-any.whl", hash = "sha256:6ee947c9f3bbe9679b9fa9cea1bb327298db80b302df62d7f1d1bd82726508e0", size = 219147, upload-time = "2026-06-09T13:41:24.97Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8d/7f362c2fb8ef4decd2160bc24d4292c6ca658cc6d9a161b89ca5122bbdbf/cyclopts-4.16.1-py3-none-any.whl", hash = "sha256:617795392c4113a2c2cc7af716f20244900e87f23daa05442d1268d81472a592", size = 219020, upload-time = "2026-05-25T15:29:09.646Z" },
 ]
 
 [[package]]
 name = "distlib"
-version = "0.4.2"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/8d/873e9252ea2c0e0c857884e0a2899ec43ade132345df1925ef24cbe64f18/distlib-0.4.2.tar.gz", hash = "sha256:baeb401c90f27acd15c4861ae0847d1e731c27ac3dbf4210643ba61fa1e813db", size = 614914, upload-time = "2026-06-08T16:24:15.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/aa891c893821d4d127292ed66c6940d1d715894bd5a0ce048056bc641773/distlib-0.4.2-py2.py3-none-any.whl", hash = "sha256:ca4cb11e5d746b5ec13c199cbf19ae27a241f89702b54e153a74332955446067", size = 470510, upload-time = "2026-06-08T16:24:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
 ]
 
 [[package]]
@@ -1221,24 +1225,21 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.7.1"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/2f590052b55cbdd0ace470ee7ee1f685f6882051be93a9374891005623e2/joserfc-1.7.0.tar.gz", hash = "sha256:4aced6ab0c47846f0a531402aec2419a874b91e918df9c4c9da8a82fb559d6c4", size = 232967, upload-time = "2026-06-02T09:59:34.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/83/b6b62a66a06ce872d9429a5eb5ee20b2002fd9c331b953c94381c1f7c9f9/joserfc-1.7.0-py3-none-any.whl", hash = "sha256:17e5d7a5a35e65442b05efc435a3d5d46696ffa2c8a2ed0eea6f63fc268e3224", size = 70387, upload-time = "2026-06-02T09:59:33.264Z" },
 ]
 
 [[package]]
 name = "json-log-formatter"
-version = "1.2.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/eb/caf193a5c77e3d9c1604dfa86fe87d9096e014303497134f23f6196a7685/json_log_formatter-1.2.1.tar.gz", hash = "sha256:1d4fd14495ad7e694aa576259ba81acaa69e6945d9d780f32ed25373d7d5ae93", size = 5936, upload-time = "2026-06-08T16:32:55.855Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/a1/b11bca303b81d07d5a686254ecbee35771d6fd050bdf0524a0003aeca306/json_log_formatter-1.2.1-py3-none-any.whl", hash = "sha256:1e40432466c911ba2d106a302314b1c3b0019de44c762bef94e8f23138a415a7", size = 6591, upload-time = "2026-06-08T16:32:54.614Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ef/324f4a28ed0152a32b80685b26316b604218e4ac77487ea82719c3c28bc6/json_log_formatter-1.1.1.tar.gz", hash = "sha256:0815e3b4469e5c79cf3f6dc8a0613ba6601f4a7464f85ba03655cfa6e3e17d10", size = 5896, upload-time = "2025-02-27T22:56:15.643Z" }
 
 [[package]]
 name = "jsonpath-ng"
@@ -1322,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.69.5"
+version = "1.70.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1987,11 +1988,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.32"
+version = "0.0.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/7e/9b35ad8f3d9ca680f7c87a88f19612fdd8da9796c4d3b46e560ac79dcc4a/python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680", size = 46689, upload-time = "2026-06-04T08:27:49.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/7f7f299527a5a8ad90acd5f2f78dfa6c8495c6301a3205106ea68a84de96/python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28", size = 29996, upload-time = "2026-06-04T08:27:47.804Z" },
 ]
 
 [[package]]
@@ -2524,11 +2525,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "30.10.0"
+version = "30.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/23/68932577cac288a0b7267ab8cea3e0e8a90809ed52a37b8514a795ea0433/sqlglot-30.10.0.tar.gz", hash = "sha256:be915f765813ba7ec7c6037732a738cb36811737b5ea6258ba99268043ef74a6", size = 5888815, upload-time = "2026-06-09T10:10:05.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/64/89299aefc6ebdf4fc899f5dc14c7fcb7eb9da9290a2b4d615ae7ab884b17/sqlglot-30.8.0.tar.gz", hash = "sha256:1c5f93fb742dd9aaa75eee6bb33a637794a858b9a86375fac23a2dc0f7bc127e", size = 5869750, upload-time = "2026-05-13T09:04:38.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/09/4f82db061c866e1bc3b620f852a1516881683ffce76c33180a5b6a0a6a34/sqlglot-30.10.0-py3-none-any.whl", hash = "sha256:540e5dfee4c6b65a3b5d93517a2573bb7546681e95d530d0e4e1702415d8835e", size = 696535, upload-time = "2026-06-09T10:10:03.437Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4e/80705091aaf9c95e125d243f0aa871bc9f3670b4c9d963e6bad3b3dce8ff/sqlglot-30.8.0-py3-none-any.whl", hash = "sha256:af903378c331d5b72277a1b41118f07bc3e50cf4478e2d47eed12c96ee6a22a4", size = 687831, upload-time = "2026-05-13T09:04:36.336Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

**Linear**: [AI-3204](https://linear.app/keboola/issue/AI-3204/cancel-query-data-queries-when-chat-is-stopped)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Stopping a Kai chat during `query_data` did not cancel the underlying Query Service job — long scans (a reported 400GB case) kept running with no way to stop them from the UI.

This PR makes the dropped HTTP connection itself the cancellation signal:

1. **`_Workspace.execute_query`** wraps the job-status polling loop in an `asyncio.CancelledError` handler: on cancellation it fires `cancel_job` on the Query Service inside `asyncio.shield(...)`, so the backend cancel survives the task teardown. Since polling is now unified in the base class, this covers Snowflake and BigQuery alike.
2. **`query_data`** races the query task against `_watch_for_http_disconnect()`, which polls the underlying ASGI request's `is_disconnected()`. When the client tears down its `tools/call` connection (Kai kills the sandbox SDK process on STOP; the kai-agent proxy now propagates the abort upstream — see companion PR keboola/ui#6349), the query task is cancelled, tripping the handler from (1).

Why disconnect and not MCP `notifications/cancelled`: the server runs streamable-HTTP in **stateless** mode (`stateless_http=True`), so the cancel notification arrives on a fresh transport instance and never reaches the in-flight tool call. The connection drop is the only signal that reliably reaches the running request. An earlier attempt at this watcher (on the abandoned `martinvasko-ai-3204-cancel-query_data-queries-when-chat-is-stopped` branch) "never fired" only because the kai-agent proxy held its upstream socket open after the sandbox died — that is fixed on the Kai side now.

Safety net: the existing 5-minute `_QUERY_TIMEOUT` in `execute_query` still hard-cancels the QS job (via `_cancel_job_with_timeout`) even if disconnect detection never fires, so an orphaned query can never run longer than 5 minutes.

The `notifications/progress` emission with `_meta.keboola.queryJobId` / `cancellationUrl` stays: it is informational for other MCP clients and keeps the SSE stream non-idle (which helps disconnect detection through load balancers). It is no longer load-bearing for Kai cancellation.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
