### PR TITLE
feat(search): adopt server-side Storage search endpoints [AI-3393]

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3481,6 +3481,8 @@ This tool supports two complementary search types:
 
 1) textual
 - Searches items by name, server-side (fast, independent of project size).
+- Full-text (fuzzy) matching: tokenized and typo/similarity tolerant — pass the name as the user said it; do
+NOT "fix" spelling or build regex. It is NOT substring matching and does NOT support regex.
 - Prefers the current branch context; when nothing is found there, automatically widens the search to all
 branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
 
@@ -3509,11 +3511,13 @@ data-apps, flows, or transformations
 
 HOW IT WORKS:
 - Supports two types:
-  - search_type="textual": searches item names server-side; names only — descriptions, column names and
-  configuration contents are NOT searched (use config-based search for configuration contents)
+  - search_type="textual": full-text (fuzzy) name search, server-side. Names only — descriptions, column names
+  and configuration contents are NOT searched (use config-based search for configuration contents). Matching is
+  tokenized and typo/similarity tolerant, so approximate names still match; it is not substring matching.
   - search_type="config-based": matches inside configuration JSON objects, optionally narrowed by JSON path `scopes`
 - case-insensitive search
-- mode for pattern search: `literal` (default); `regex` is supported for config-based search only
+- mode for pattern search: applies to config-based only — `literal` (default) or `regex`. Textual search ignores
+  `mode` (always full-text) and rejects `regex`.
 - Multiple patterns work as OR condition - matches items containing ANY of the patterns
 - Each result includes the item's ID, name, creation date, and relevant metadata; the response also carries
 `total` and `by_type` counts and the `branch_scope` the hits come from
@@ -3648,7 +3652,7 @@ scopes=["storage"]
     },
     "mode": {
       "default": "literal",
-      "description": "How to interpret patterns: \"regex\" for regular expressions or \"literal\" for exact text (default: \"literal\"). Regex is only supported for config-based search.",
+      "description": "How to interpret patterns. Applies to config-based search only: \"regex\" for regular expressions or \"literal\" for exact text (default: \"literal\"). Ignored by textual search, which is always a full-text (fuzzy) query and rejects \"regex\".",
       "enum": [
         "regex",
         "literal"

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3480,8 +3480,9 @@ in the current project and returns matching ID + metadata.
 This tool supports two complementary search types:
 
 1) textual
-- Searches item metadata fields by matching patterns against id, name, displayName, and description.
-- For tables, also searches column names and column descriptions.
+- Searches items by name, server-side (fast, independent of project size).
+- Prefers the current branch context; when nothing is found there, automatically widens the search to all
+branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
 
 2) config-based
 - Searches item configurations (JSON objects) by matching patterns against the configuration values ​​converted
@@ -3508,13 +3509,16 @@ data-apps, flows, or transformations
 
 HOW IT WORKS:
 - Supports two types:
-  - search_type="textual": matches against id, name, displayName, and description, for tables also column names
-  and column descriptions
+  - search_type="textual": searches item names server-side; names only — descriptions, column names and
+  configuration contents are NOT searched (use config-based search for configuration contents)
   - search_type="config-based": matches inside configuration JSON objects, optionally narrowed by JSON path `scopes`
 - case-insensitive search
-- mode for pattern search: `literal` (default) or `regex`
+- mode for pattern search: `literal` (default); `regex` is supported for config-based search only
 - Multiple patterns work as OR condition - matches items containing ANY of the patterns
-- Each result includes the item's ID, name, creation date, and relevant metadata
+- Each result includes the item's ID, name, creation date, and relevant metadata; the response also carries
+`total` and `by_type` counts and the `branch_scope` the hits come from
+- textual search prefers the current branch; on zero hits it automatically retries across all branches of the
+project and marks the response with branch_scope="all-branches"
 - scopes (config-based) narrow matching to specific JSONPath areas within configurations; matching is performed
 against the stringified JSON node content in those areas.
 - config-based always returns all matched paths per item in `match_scopes` (including matched patterns)
@@ -3522,9 +3526,11 @@ against the stringified JSON node content in those areas.
 IMPORTANT:
 - Always use this tool when the user mentions a name but you don't have the exact ID
 - The search returns IDs that you can use with other tools (e.g., get_tables, get_configs, get_flows)
-- Results are ordered by update time. The most recently updated items are returned first.
-- Fill `item_types` to make the search more efficient when you know the item type; scanning buckets and tables can
-be expensive
+- Results are ordered by the `updated` field, most recent first. `updated` is the item's last update time
+when available, or its creation time otherwise (textual/global-search hits expose only the creation time).
+- Textual search matches names only, with fuzzy full-text matching (typo/similarity tolerant; no regex). To find
+items by description or by table column, use get_tables or config-based search; to find items by configuration
+content, use config-based search.
 - For exact ID lookups, use specific tools like get_tables, get_configs, get_flows instead
 - Use specific `scopes` only when you know the config structure (schema or real example); otherwise run config-based
 search without scopes.
@@ -3535,23 +3541,19 @@ USAGE EXAMPLES:
 1) textual search examples:
 - user_input: "Find all tables with 'customer' in the name"
     → patterns=["customer"], item_types=["table"]
-    → Returns all tables whose id, name, displayName, or description contains "customer"
-
-- user_input: "Find tables with 'email' column"
-    → patterns=["email"], item_types=["table"]
-    → Returns all tables that have a column named "email" or with "email" in column description
+    → Returns all tables whose name matches "customer"
 
 - user_input: "Search for the sales transformation"
     → patterns=["sales"], item_types=["transformation"]
-    → Returns transformations with "sales" in any searchable field
+    → Returns transformations with "sales" in the name
 
 - user_input: "Find items named 'daily report' or 'weekly summary'"
-    → patterns=["daily.*report", "weekly.*summary"], item_types=[], mode="regex"
+    → patterns=["daily report", "weekly summary"], item_types=[]
     → Returns all items matching any of these patterns
 
 - user_input: "Show me all configurations related to Google Analytics"
-    → patterns=["google.*analytics"], item_types=["configuration"], mode="regex"
-    → Returns configurations with matching patterns
+    → patterns=["google analytics"], item_types=["configuration"]
+    → Returns configurations with matching names
 
 2) config-based search examples:
 - user_input: "Find transformations/configs/components referencing table in.c-prod.customers"
@@ -3646,7 +3648,7 @@ scopes=["storage"]
     },
     "mode": {
       "default": "literal",
-      "description": "How to interpret patterns: \"regex\" for regular expressions or \"literal\" for exact text (default: \"literal\").",
+      "description": "How to interpret patterns: \"regex\" for regular expressions or \"literal\" for exact text (default: \"literal\"). Regex is only supported for config-based search.",
       "enum": [
         "regex",
         "literal"

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3481,14 +3481,14 @@ This tool supports two complementary search types:
 
 1) textual
 - Searches items by name, server-side (fast, independent of project size).
-- Full-text (fuzzy) matching: tokenized and typo/similarity tolerant — pass the name as the user said it; do
-NOT "fix" spelling or build regex. It is NOT substring matching and does NOT support regex.
+- Full-text (fuzzy) matching: tokenized and typo/similarity tolerant — pass the name as the user said it;
+  do NOT "fix" spelling or build regex. It is NOT substring matching and does NOT support regex.
 - Prefers the current branch context; when nothing is found there, automatically widens the search to all
-branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
+  branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
 
 2) config-based
 - Searches item configurations (JSON objects) by matching patterns against the configuration values ​​converted
-to a string, optionally narrowed by JSON path `scopes`.
+  to a string, optionally narrowed by JSON path `scopes`.
 - Returns also `match_scopes` with JSON paths and matched patterns per scope.
 
 THIS IS THE PRIMARY DISCOVERY TOOL. Always use it BEFORE any get_* tool when you need to find items
@@ -3512,19 +3512,19 @@ data-apps, flows, or transformations
 HOW IT WORKS:
 - Supports two types:
   - search_type="textual": full-text (fuzzy) name search, server-side. Names only — descriptions, column names
-  and configuration contents are NOT searched (use config-based search for configuration contents). Matching is
-  tokenized and typo/similarity tolerant, so approximate names still match; it is not substring matching.
+    and configuration contents are NOT searched (use config-based search for configuration contents). Matching
+    is tokenized and typo/similarity tolerant, so approximate names still match; it is not substring matching.
   - search_type="config-based": matches inside configuration JSON objects, optionally narrowed by JSON path `scopes`
 - case-insensitive search
 - mode for pattern search: applies to config-based only — `literal` (default) or `regex`. Textual search ignores
   `mode` (always full-text) and rejects `regex`.
 - Multiple patterns work as OR condition - matches items containing ANY of the patterns
 - Each result includes the item's ID, name, creation date, and relevant metadata; the response also carries
-`total` and `by_type` counts and the `branch_scope` the hits come from
+  `total` and `by_type` counts and the `branch_scope` the hits come from
 - textual search prefers the current branch; on zero hits it automatically retries across all branches of the
-project and marks the response with branch_scope="all-branches"
+  project and marks the response with branch_scope="all-branches"
 - scopes (config-based) narrow matching to specific JSONPath areas within configurations; matching is performed
-against the stringified JSON node content in those areas.
+  against the stringified JSON node content in those areas.
 - config-based always returns all matched paths per item in `match_scopes` (including matched patterns)
 
 IMPORTANT:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3531,13 +3531,13 @@ IMPORTANT:
 - Always use this tool when the user mentions a name but you don't have the exact ID
 - The search returns IDs that you can use with other tools (e.g., get_tables, get_configs, get_flows)
 - Results are ordered by the `updated` field, most recent first. `updated` is the item's last update time
-when available, or its creation time otherwise (textual/global-search hits expose only the creation time).
+  when available, or its creation time otherwise (textual/global-search hits expose only the creation time).
 - Textual search matches names only, with fuzzy full-text matching (typo/similarity tolerant; no regex). To find
-items by description or by table column, use get_tables or config-based search; to find items by configuration
-content, use config-based search.
+  items by description or by table column, use get_tables or config-based search; to find items by configuration
+  content, use config-based search.
 - For exact ID lookups, use specific tools like get_tables, get_configs, get_flows instead
 - Use specific `scopes` only when you know the config structure (schema or real example); otherwise run config-based
-search without scopes.
+  search without scopes.
 - Use find_component_id and get_configs tools to find configurations related to a specific component
 - If results are too numerous or empty, ask the user to refine their query rather than enumerating all items.
 

--- a/feature_spec/global_search_adoption/RFC.md
+++ b/feature_spec/global_search_adoption/RFC.md
@@ -168,6 +168,37 @@ These must be stated in the tool docstring so agents adapt:
 In exchange: single-digit API calls per search, server-side pagination, true total
 counts, and results independent of project size.
 
+### Validation prompt samples
+
+Concrete user prompts to verify the routing manually (local MCP / canary). The "Gap #"
+column references the regression list above where applicable.
+
+**Prompts that MUST use global search (textual, server-side):**
+
+| Sample prompt | Expected `search` call | What it proves |
+| --- | --- | --- |
+| "Find all tables with 'customer' in the name" | `patterns=["customer"], item_types=["table"]` | name search hits `global-search` with `types=[table]`, single-digit API calls |
+| "Search for the sales transformation" | `patterns=["sales"], item_types=["transformation"]` | `transformation` type mapping |
+| "Find the flow named 'Daily ETL'" | `patterns=["Daily ETL"], item_types=["flow"]` | flow re-typing by component ID (orchestrator / conditional flow) |
+| "Find the data app called 'Churn dashboard'" | `patterns=["Churn dashboard"], item_types=["data-app"]` | `configuration` over-fetch + client-side narrowing to `data-app` |
+| "Find items named 'daily report' or 'weekly summary'" | `patterns=["daily report", "weekly summary"]` | one request per pattern, OR-merge + dedupe |
+| "Is there a bucket called 'marketing'?" | `patterns=["marketing"], item_types=["bucket"]` | bucket type mapping |
+| (on a dev branch) "Find the table 'orders_final'" where it exists only in production | `patterns=["orders_final"], item_types=["table"]` | zero hits in current branch → automatic all-branches retry; hit carries `branch_id`/`branch_name`, response `branch_scope="all-branches"` |
+
+**Prompts that must NOT use global search (config-based, legacy fallback or other tools):**
+
+| Sample prompt | Expected routing | Gap # |
+| --- | --- | --- |
+| "Find transformations referencing table in.c-prod.customers" | `search_type="config-based"` (client-side enumeration of configurations) | 1-like: config JSON content is not indexed |
+| "Which flows use configuration ID 01k9cz233cvd1rga3zzx40g8qj?" | `search_type="config-based"`, `scopes=["tasks", "phases"]` | config JSON content |
+| "Where is my_bucket used in input or output mappings?" | `search_type="config-based"`, `scopes=["storage.input", "storage.output"]` | config JSON content |
+| "Find tables that have an 'email' column" | `get_tables` (column listing), NOT textual search | 2 |
+| "Find tables whose description mentions GDPR" | `get_tables` + descriptions (or future `tables_search` by metadata); textual search will NOT match | 1, 2 |
+| "Find items matching regex 'daily.*report'" | textual + `mode="regex"` → tool error; agent retries with literal patterns or config-based regex | 3 |
+| "Show me table in.c-main.orders" | exact ID → `get_tables` directly, no search at all | 4 |
+| "I need a Salesforce extractor" | `find_component_id` (AI service suggestion), not `search` | — |
+| Any textual search in a project without the `global-search` feature | same `search` call, legacy client-side enumeration path (transparent fallback) | — |
+
 ## Resolution Strategy
 
 ### `clients/storage.py`

--- a/feature_spec/global_search_adoption/RFC.md
+++ b/feature_spec/global_search_adoption/RFC.md
@@ -1,0 +1,296 @@
+# RFC: Adopt server-side Storage search endpoints in the `search` tool
+
+Linear: [AI-3393](https://linear.app/keboola/issue/AI-3393/adopt-server-side-storage-search-endpoints-in-the-mcp-search-tool)
+
+## Problem
+
+The `search` tool (`src/keboola_mcp_server/tools/search.py`) implements **client-side
+search by full enumeration**. On every textual search call it:
+
+1. Lists all buckets — `merged_bucket_list()` (1–2 API calls, prod + branch).
+2. Lists tables **per bucket** with `include=columns,columnMetadata` — N API calls for
+   N buckets (`_fetch_tables`).
+3. Lists all components with `include=configuration,rows` per component type —
+   up to 4 API calls (`_fetch_configs`).
+4. Regex/literal-matches everything in Python, sorts, and paginates client-side.
+
+Visible symptoms:
+
+- **Latency** scales with project size (a project with hundreds of buckets fires
+  hundreds of sequential table-list calls per search).
+- **SAPI load**: every agent search downloads the entire project inventory, including
+  full configuration JSON bodies even for textual searches that never look at them.
+- Pagination (`limit`/`offset`) is cosmetic — the full dataset is fetched regardless.
+
+Storage API now provides server-side search endpoints that eliminate the enumeration:
+
+| Endpoint | Capability |
+| --- | --- |
+| `GET /v2/storage/global-search` | Full-text **name** search across item types, filterable by `projectIds`, `types`, `branchTypes`, `branchIds`; native `limit`/`offset` and total count |
+| `GET /v2/storage/search/tables` | Exact-match table search by `metadataKey` / `metadataValue` / `metadataProvider` |
+| `GET /v2/storage/branch/{branchId}/search/component-configurations` | Configuration search by `componentId`, `configurationId`, `metadataKeys` |
+
+Two of the three are already partially wired in `clients/storage.py`:
+`global_search()` (`storage.py:842`, currently used only by integtests) and
+`component_configurations_search()` (`storage.py:614`, used only for data-app folder
+lookups). `search/tables` is not wired at all.
+
+### Prior art (why this is a round trip)
+
+The `search` tool was originally global-search based (AI-1172) and was then rewritten
+to client-side enumeration in AI-1838. The driver was capability coverage: global
+search indexes **names only**, is gated by the `global-search` project feature, and
+cannot serve config-content search. This RFC re-adopts global search for what it is
+good at (textual discovery) while explicitly keeping what it cannot do (config-content
+search) on the existing client-side path, and defines a feature-flag fallback so we do
+not regress projects where global search is unavailable.
+
+## Required Behavior
+
+### 1. Textual search goes server-side
+
+`search(search_type='textual')` must call `GET /v2/storage/global-search` instead of
+enumerating buckets/tables/configurations. Scope is always the **current project**:
+`projectIds=[<project id from tokens/verify>]`.
+
+Tool signature stays compatible:
+
+| Parameter | Behavior after change |
+| --- | --- |
+| `patterns: list[str]` | Kept. One global-search request per pattern, issued concurrently; results OR-merged and deduplicated by `(type, id)`. |
+| `item_types` | Kept. Mapped to the API `types[]` parameter (mapping below). |
+| `search_type` | Kept. `textual` → global-search; `config-based` → existing client-side path (unchanged). |
+| `scopes` | Kept, config-based only (unchanged). |
+| `mode` | **Deprecated for textual search.** Global search is a full-text index; `regex` cannot be honored server-side. `mode='regex'` + `search_type='textual'` returns a clear tool error instructing to use a plain query (or config-based search). `mode` remains honored for config-based search. |
+| `limit` / `offset` | Kept, passed natively to the API. With multiple patterns, each request uses the caller's `limit` and merged results are re-sorted and truncated to `limit` (documented approximation). |
+
+`item_types` → API `types[]` mapping (`SearchItemType` → `ItemType` in
+`clients/storage.py:25`):
+
+| Tool `item_types` value | API `types[]` | Post-filter |
+| --- | --- | --- |
+| `bucket`, `table`, `transformation`, `configuration`, `configuration-row`, `workspace`, `flow` | same value | — |
+| `data-app` | `configuration` | keep only `componentId == DATA_APP_COMPONENT_ID` |
+| `component` | `configuration`, `configuration-row` | — (mirrors current `_validate_item_types` expansion) |
+| empty | omitted (all types) | — |
+
+### 2. Branch-aware search with project-wide fallback
+
+The search must prefer the branch the MCP session is operating on, then widen:
+
+1. **Primary query — current branch context:**
+   - On the default branch (`client.branch_id is None` / storage client
+     `_branch_id == 'default'`): `branchTypes[]=production`, no `branchIds`.
+   - On a dev branch: `branchTypes[]=development`, `branchIds[]=<current branch id>`.
+
+   (This is exactly what `global_search()` does today — the logic moves to an explicit
+   parameter so the tool controls it; see Resolution Strategy.)
+
+2. **Fallback query — whole project, any branch:** executed only when the primary
+   query returns **zero hits across all patterns**. Same `query`/`types`/`projectIds`,
+   but **no `branchTypes` and no `branchIds`** — so items living in other dev branches
+   (or in production, when searching from a dev branch) are found.
+
+3. Hits returned from the fallback must be **clearly attributed to their branch** so
+   the agent does not mistake another branch's item for one in its own context. The
+   API's `fullPath.branch` provides id/name; surface it on the hit (new fields, see
+   below).
+
+### 3. Result shape
+
+`SearchHit` is kept as the output model, populated from `GlobalSearchResponse.Item`:
+
+| `SearchHit` field | Source |
+| --- | --- |
+| `bucket_id` / `table_id` / `component_id` / `configuration_id` / `configuration_row_id` | `item.id`, `item.component_id`, and `item.full_path` (bucket/configuration parents), keyed by `item.type` |
+| `item_type` | `item.type` (+ `data-app` re-typing by component id, mirroring `_fetch_configs`) |
+| `name` | `item.name` |
+| `updated` | `item.created` (the index does not expose update time; rename or document) |
+| `display_name`, `description` | **No longer populated** for textual search — not in the index. Fields stay on the model (config-based path and compatibility). |
+| `matches` | Empty for textual search (no per-field match attribution from the API). |
+| `links` | Unchanged (`ProjectLinksManager`). |
+
+New fields on `SearchHit`:
+
+- `branch_id: str | None`, `branch_name: str | None` — populated from
+  `fullPath.branch` when present; lets the agent see fallback hits live elsewhere.
+
+New top-level information: the API returns `all` (total count) and `byType`. Return
+hits wrapped in a small output model (`SearchOutput(hits=..., total=..., by_type=...)`)
+— this resolves the existing `TODO: Should we report the total number of hits?` at
+`search.py:805`. (Tool output shape change → minor version bump, TOOLS.md regen.)
+
+### 4. Feature flag handling
+
+`global-search` is a project feature (`ProjectFeature` literal, checked via
+`AsyncStorageClient.is_enabled()`).
+
+- If enabled → server-side path.
+- If **not** enabled → fall back to the **legacy client-side textual search**
+  (current code, kept in a clearly named module/function), and log a warning.
+- The legacy path is removed in a follow-up PR once the feature is confirmed GA on all
+  production stacks (tracked as a separate Linear issue). The RFC explicitly does
+  **not** gamble on availability — that is what caused the AI-1838 reversal.
+
+### 5. Config-based search is unchanged
+
+`search_type='config-based'` keeps the existing client-side implementation
+(`fetch_configurations` / `SearchSpec.match_configuration_scopes`). Global search
+indexes names only — there is no server-side substitute for searching configuration
+JSON content. Importantly, the config-based path **never enumerates buckets/tables**,
+so the expensive part of today's tool is fully covered by the textual migration.
+
+### 6. Adopt the two metadata search endpoints in the client layer
+
+- `search/tables`: new `AsyncStorageClient.tables_search(metadata_key=None,
+  metadata_value=None, metadata_provider=None, include=None)` client method. First
+  consumer: none in the `search` tool (it is exact-match metadata lookup, not
+  free-text); it is groundwork for metadata-driven discovery (e.g. find tables
+  carrying a given `KBC.*` key) and for replacing ad-hoc enumeration elsewhere.
+- `search/component-configurations`: extend the existing
+  `component_configurations_search()` to pass `componentId` (and optionally
+  `configurationId`, `include`) **server-side** instead of the current client-side
+  post-filter (`storage.py:634-636`).
+
+### Accepted capability regressions (textual search)
+
+These must be stated in the tool docstring so agents adapt:
+
+1. **Descriptions are not searched** (item descriptions, bucket/table descriptions).
+2. **Table column names / column descriptions are not searched** (today's
+   `_check_column_match`). Mitigation: agents use `get_tables` for column-level
+   detail, or config-based search for mappings.
+3. **Regex mode is not supported** for textual search.
+4. **ID-substring matching is not guaranteed** — the index matches names; searching
+   for `in.c-prod.customers` may not hit by ID. Mitigation: docstring directs exact-ID
+   lookups to `get_*` tools (it already does).
+
+In exchange: single-digit API calls per search, server-side pagination, true total
+counts, and results independent of project size.
+
+## Resolution Strategy
+
+### `clients/storage.py`
+
+1. Refactor `global_search()` (`storage.py:842`): extract the hard-coded branch logic
+   into an explicit parameter, e.g.
+   `branch_scope: Literal['current', 'all'] = 'current'`:
+   - `'current'` → today's behavior (`branchTypes` / `branchIds` from `_branch_id`),
+   - `'all'` → no branch filters.
+   Keep `projectIds=[await self.project_id()]` inside the method (single-project
+   invariant of the MCP server).
+2. Add `tables_search()` calling `GET search/tables` (note: **not** branch-prefixed).
+3. Extend `component_configurations_search()` with server-side `componentId` /
+   `configurationId` / `include` params; keep the signature backward-compatible for
+   the existing caller (`tools/components/utils.py:433`).
+4. Extend `GlobalSearchResponse.Item` with typed access to `fullPath` branch info
+   (`branch_id` / `branch_name` properties or a small `FullPath` model).
+
+### `tools/search.py`
+
+1. Split `search()` by `search_type`:
+   - `config-based` → existing flow, untouched.
+   - `textual` → new `_global_search_textual(client, spec, limit, offset)`:
+     a. `await client.storage_client.is_enabled('global-search')`; if false →
+        `_legacy_textual_search(...)` (today's `_fetch_buckets` / `_fetch_tables` /
+        `fetch_configurations` textual flow, moved as-is).
+     b. Map `item_types` → API `types` (table above).
+     c. `asyncio.gather` one `global_search(query=pattern, types=..., limit=...,
+        offset=..., branch_scope='current')` per pattern.
+     d. If all responses have `all == 0` → repeat with `branch_scope='all'`.
+     e. Merge, dedupe by `(type, id)`, map to `SearchHit` (+ branch fields), sort by
+        `created` desc, truncate to `limit`, attach links.
+2. Reject `mode='regex'` + `search_type='textual'` with a `tool_errors` message.
+3. Update the tool docstring: new semantics, regressions list, fallback-to-all-branches
+   behavior, total-count field.
+4. Keep `SearchSpec` for the config-based path; the textual path no longer needs it
+   (no client-side matching).
+
+### Non-obvious trade-offs
+
+- **Per-pattern requests vs. one joined query:** global search treats a multi-word
+  query as one full-text query; joining patterns with spaces would change semantics
+  (AND-ish vs. the tool's documented OR). One request per pattern preserves OR
+  semantics at the cost of ≤ len(patterns) requests — still orders of magnitude
+  cheaper than enumeration.
+- **Fallback only on zero hits** (not always-merge): merging both scopes on every call
+  would double request count and bury current-branch hits among other branches'
+  items. Zero-hit fallback matches the agent intent: "prefer my branch, widen only if
+  nothing found".
+- **Keeping the legacy path temporarily** doubles textual-search code for one release
+  cycle. Accepted: it is the safety net the AI-1838 reversal proved necessary, and it
+  is deleted by a scheduled follow-up.
+- **`updated` semantics change** (index exposes `created` only). Kept under the same
+  field name to avoid breaking consumers; documented in the field description.
+
+## Scope
+
+In scope:
+
+- `clients/storage.py`: `global_search()` refactor (+ branch scope param),
+  `tables_search()`, server-side params for `component_configurations_search()`,
+  `GlobalSearchResponse` branch-info typing.
+- `tools/search.py`: textual path switched to global search with feature-flag fallback
+  and zero-hit branch widening; `SearchHit.branch_id`/`branch_name`; `SearchOutput`
+  with total/by-type counts; docstring rewrite.
+- Tests (see below), TOOLS.md regen (`tox -e check-tools-docs`), minor version bump in
+  `pyproject.toml` + `uv lock`.
+
+Out of scope:
+
+- Removing the legacy client-side textual search (follow-up issue, after GA
+  verification on all stacks).
+- Any change to `search_type='config-based'` behavior.
+- A new tool exposing `tables_search` to agents (client-layer groundwork only).
+- `find_component_id` (AI service based, unrelated).
+- Cross-project search (`projectIds` stays pinned to the current project).
+
+## Testing / Verification
+
+Unit tests (`tests/tools/test_search.py`, `tests/clients/`):
+
+- Parametrize the existing textual-search tests on the new axis
+  `global_search_enabled` (True/False) — False must exercise the legacy path
+  unchanged; True mocks `global_search()` responses.
+- Branch widening: primary returns 0 hits → assert second call with
+  `branch_scope='all'`; primary returns hits → assert no second call; fallback hits
+  carry `branch_id`/`branch_name`.
+- `item_types` mapping incl. `data-app` post-filter and `component` expansion.
+- Multi-pattern OR-merge + dedupe by `(type, id)`.
+- `mode='regex'` + textual → tool error.
+- Client: `tables_search` and `component_configurations_search` build correct query
+  params (`metadataKeys[i]`, `componentId`, includes).
+
+Integration tests (`integtests/`):
+
+- Extend `integtests/clients/test_client.py` global-search tests for
+  `branch_scope='all'` and `tables_search`.
+- `integtests/tools/test_search.py`: textual search via global search finds a table
+  created by the test fixture (skip when `global-search` feature is off, mirroring
+  `test_global_search_with_results`).
+
+Manual verification (local MCP via `.mcp.json`):
+
+1. Default branch: search a known table name → found via 1 API call path; verify hit
+   links and total count.
+2. Dev branch (`KBC_BRANCH_ID` set): search an item that exists only in production →
+   primary query empty, fallback finds it, hit shows production branch attribution.
+3. Project without `global-search` feature: tool behaves exactly as today (legacy
+   path), warning logged.
+4. `tox` — pytest, black, flake8, check-tools-docs all exit 0.
+
+## Open Questions (verify before/while implementing)
+
+1. **Index coverage:** does global search match `displayName` and ID substrings, or
+   names only? Determines the final wording of the "accepted regressions" docstring
+   section. (Verify empirically against a real stack.)
+2. **Match style:** prefix vs. substring vs. tokenized full-text — affects guidance on
+   multi-word patterns in the docstring.
+3. **`types` support:** confirm `rows`/`state`/`shared-code` behave as expected when
+   requested explicitly (they are in `ItemType` but not in the tool's
+   `SearchItemType` mapping today).
+4. **`search/tables` matching semantics:** exact-match only or partial on
+   `metadataValue`? Determines whether it could later serve description search
+   (`KBC.description`) as a follow-up.
+5. **Multi-pattern + offset:** with >1 patterns, offset-based pagination over a merged
+   list is approximate. Acceptable, or should multi-pattern searches cap at one page?

--- a/feature_spec/global_search_adoption/RFC.md
+++ b/feature_spec/global_search_adoption/RFC.md
@@ -165,8 +165,15 @@ These must be stated in the tool docstring so agents adapt:
    for `in.c-prod.customers` may not hit by ID. Mitigation: docstring directs exact-ID
    lookups to `get_*` tools (it already does).
 
+Note that global search is **full-text**, not literal substring matching:
+it is tokenized, case-insensitive and typo/similarity tolerant. This is an upside
+(approximate names still match — "marketng" finds "marketing"), but it means the
+`mode` parameter has **no effect on textual search** (it is honored only for
+config-based search), and exact-substring expectations do not hold. The docstring tells
+agents to pass the plain name and not to pre-correct spelling or build regex.
+
 In exchange: single-digit API calls per search, server-side pagination, true total
-counts, and results independent of project size.
+counts, fuzzy/typo-tolerant matching, and results independent of project size.
 
 ### Validation prompt samples
 
@@ -183,6 +190,7 @@ column references the regression list above where applicable.
 | "Find the data app called 'Churn dashboard'" | `patterns=["Churn dashboard"], item_types=["data-app"]` | `configuration` over-fetch + client-side narrowing to `data-app` |
 | "Find items named 'daily report' or 'weekly summary'" | `patterns=["daily report", "weekly summary"]` | one request per pattern, OR-merge + dedupe |
 | "Is there a bucket called 'marketing'?" | `patterns=["marketing"], item_types=["bucket"]` | bucket type mapping |
+| "Find the bucket 'marketng'" (typo) | `patterns=["marketng"], item_types=["bucket"]` | fuzzy full-text matching still finds "marketing" — proves textual search is full-text, not substring |
 | (on a dev branch) "Find the table 'orders_final'" where it exists only in production | `patterns=["orders_final"], item_types=["table"]` | zero hits in current branch → automatic all-branches retry; hit carries `branch_id`/`branch_name`, response `branch_scope="all-branches"` |
 
 **Prompts that must NOT use global search (config-based, legacy fallback or other tools):**
@@ -315,8 +323,11 @@ Manual verification (local MCP via `.mcp.json`):
 1. **Index coverage:** does global search match `displayName` and ID substrings, or
    names only? Determines the final wording of the "accepted regressions" docstring
    section. (Verify empirically against a real stack.)
-2. **Match style:** prefix vs. substring vs. tokenized full-text — affects guidance on
-   multi-word patterns in the docstring.
+2. **Match style:** ~~prefix vs. substring vs. tokenized full-text~~ — **resolved:**
+   global search is tokenized full-text, typo/similarity tolerant (not substring, not
+   regex). The docstring and `mode` parameter reflect this; `mode` is honored only for
+   config-based search. Still worth confirming the exact fuzziness / multi-word (AND vs
+   OR within a single pattern) behavior empirically.
 3. **`types` support:** confirm `rows`/`state`/`shared-code` behave as expected when
    requested explicitly (they are in `ItemType` but not in the tool's
    `SearchItemType` mapping today).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.69.2"
+version = "1.70.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -872,9 +872,8 @@ class AsyncStorageClient(KeboolaServiceClient):
         branch_scope: Literal['current', 'all'] = 'current',
     ) -> GlobalSearchResponse:
         """
-        Searches for items in the storage. It allows you to search for entities by name across all projects within an
-        organization, even those you do not have direct access to. The search is conducted only through entity names to
-        ensure confidentiality. The search is always restricted to the current project.
+        Searches for items in the storage by name. The search is conducted only through entity names to ensure
+        confidentiality. The request is always scoped to the current project via `projectIds[]`.
 
         :param query: The query to search for.
         :param limit: The maximum number of items to return.

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -62,6 +62,22 @@ class GlobalSearchResponse(BaseModel):
         project_name: str = Field(description='The name of the project the item belongs to.', alias='projectName')
         created: datetime = Field(description='The date and time the item was created in ISO format.')
 
+        @property
+        def branch_id(self) -> str | None:
+            """The id of the branch the item belongs to, extracted from the full path."""
+            branch = self.full_path.get('branch')
+            if isinstance(branch, dict) and branch.get('id') is not None:
+                return str(branch['id'])
+            return None
+
+        @property
+        def branch_name(self) -> str | None:
+            """The name of the branch the item belongs to, extracted from the full path."""
+            branch = self.full_path.get('branch')
+            if isinstance(branch, dict) and branch.get('name'):
+                return str(branch['name'])
+            return None
+
     all: int = Field(description='Total number of found results.')
     items: list[Item] = Field(description='List of search results of the GlobalSearchType.')
     by_type: dict[str, int] = Field(
@@ -614,26 +630,34 @@ class AsyncStorageClient(KeboolaServiceClient):
     async def component_configurations_search(
         self,
         component_id: str | None = None,
+        configuration_id: str | None = None,
         metadata_keys: list[str] | None = None,
+        include: list[str] | None = None,
     ) -> list[JsonDict]:
         """
-        Searches component configurations by metadata keys.
+        Searches component configurations by component, configuration and metadata keys.
+        All filters are applied server-side by the SAPI search endpoint.
 
         :param component_id: Optional component ID to filter results.
+        :param configuration_id: Optional configuration ID to filter results.
         :param metadata_keys: List of metadata keys to filter by — returns only configurations
             that have at least one of the specified metadata keys set.
+        :param include: Additional fields to include in the response (e.g. 'filteredMetadata').
         :return: List of matching configurations as dictionaries.
         """
-        if not metadata_keys:
+        if not (component_id or configuration_id or metadata_keys):
             return []
         endpoint = f'branch/{self._branch_id}/search/component-configurations'
         params: dict[str, Any] = {}
-        for i, key in enumerate(metadata_keys):
-            params[f'metadataKeys[{i}]'] = key
-        results = cast(list[JsonDict], await self.get(endpoint=endpoint, params=params))
         if component_id:
-            results = [r for r in results if r.get('componentId') == component_id]
-        return results
+            params['componentId'] = component_id
+        if configuration_id:
+            params['configurationId'] = configuration_id
+        for i, key in enumerate(metadata_keys or []):
+            params[f'metadataKeys[{i}]'] = key
+        if include:
+            params['include'] = ','.join(include)
+        return cast(list[JsonDict], await self.get(endpoint=endpoint, params=params))
 
     async def configuration_metadata_get(self, component_id: str, configuration_id: str) -> list[JsonDict]:
         """
@@ -845,16 +869,20 @@ class AsyncStorageClient(KeboolaServiceClient):
         limit: int = 100,
         offset: int = 0,
         types: Sequence[ItemType] = tuple(),
+        branch_scope: Literal['current', 'all'] = 'current',
     ) -> GlobalSearchResponse:
         """
         Searches for items in the storage. It allows you to search for entities by name across all projects within an
         organization, even those you do not have direct access to. The search is conducted only through entity names to
-        ensure confidentiality. We restrict the search to the project and branch production type of the user.
+        ensure confidentiality. The search is always restricted to the current project.
 
         :param query: The query to search for.
         :param limit: The maximum number of items to return.
         :param offset: The offset to start from, pagination parameter.
         :param types: The types of items to search for.
+        :param branch_scope: 'current' restricts the search to the branch this client operates on
+            (production branches on the default branch, the specific dev branch otherwise);
+            'all' searches the whole project across all branches.
         """
         params: dict[str, Any] = {
             'query': query,
@@ -863,11 +891,12 @@ class AsyncStorageClient(KeboolaServiceClient):
             'limit': limit,
             'offset': offset,
         }
-        if self._branch_id == 'default':
-            params['branchTypes[]'] = 'production'
-        else:
-            params['branchTypes[]'] = 'development'
-            params['branchIds[]'] = self._branch_id
+        if branch_scope == 'current':
+            if self._branch_id == 'default':
+                params['branchTypes[]'] = 'production'
+            else:
+                params['branchTypes[]'] = 'development'
+                params['branchIds[]'] = self._branch_id
         params = {k: v for k, v in params.items() if v}
         raw_resp = await self.get(endpoint='global-search', params=params)
         return GlobalSearchResponse.model_validate(raw_resp)
@@ -931,6 +960,36 @@ class AsyncStorageClient(KeboolaServiceClient):
             payload['columnsMetadata'] = columns_metadata
 
         return cast(JsonDict, await self.post(endpoint=f'tables/{table_id}/metadata', data=payload))
+
+    async def tables_search(
+        self,
+        metadata_key: str | None = None,
+        metadata_value: str | None = None,
+        metadata_provider: str | None = None,
+        include: list[str] | None = None,
+    ) -> list[JsonDict]:
+        """
+        Searches tables by their metadata using the SAPI search endpoint. All filters are exact-match
+        and applied server-side; at least one of the metadata filters must be provided.
+
+        :param metadata_key: The metadata key to filter by (e.g. 'KBC.description').
+        :param metadata_value: The metadata value to filter by.
+        :param metadata_provider: The provider of the metadata (e.g. 'user').
+        :param include: Additional fields to include in the response (e.g. 'columns').
+        :return: List of matching tables as dictionaries.
+        """
+        if not (metadata_key or metadata_value or metadata_provider):
+            return []
+        params: dict[str, Any] = {}
+        if metadata_key:
+            params['metadataKey'] = metadata_key
+        if metadata_value:
+            params['metadataValue'] = metadata_value
+        if metadata_provider:
+            params['metadataProvider'] = metadata_provider
+        if include:
+            params['include'] = ','.join(include)
+        return cast(list[JsonDict], await self.get(endpoint='search/tables', params=params))
 
     # TODO: no branch support
     async def trigger_event(

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -790,8 +790,9 @@ async def search(
     mode: Annotated[
         SearchPatternMode,
         Field(
-            description='How to interpret patterns: "regex" for regular expressions or "literal" for exact text '
-            '(default: "literal"). Regex is only supported for config-based search.'
+            description='How to interpret patterns. Applies to config-based search only: "regex" for regular '
+            'expressions or "literal" for exact text (default: "literal"). Ignored by textual search, which is '
+            'always a full-text (fuzzy) query and rejects "regex".'
         ),
     ] = 'literal',
     limit: Annotated[
@@ -811,6 +812,8 @@ async def search(
 
     1) textual
     - Searches items by name, server-side (fast, independent of project size).
+    - Full-text (fuzzy) matching: tokenized and typo/similarity tolerant — pass the name as the user said it; do
+    NOT "fix" spelling or build regex. It is NOT substring matching and does NOT support regex.
     - Prefers the current branch context; when nothing is found there, automatically widens the search to all
     branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
 
@@ -839,11 +842,13 @@ async def search(
 
     HOW IT WORKS:
     - Supports two types:
-      - search_type="textual": searches item names server-side; names only — descriptions, column names and
-      configuration contents are NOT searched (use config-based search for configuration contents)
+      - search_type="textual": full-text (fuzzy) name search, server-side. Names only — descriptions, column names
+      and configuration contents are NOT searched (use config-based search for configuration contents). Matching is
+      tokenized and typo/similarity tolerant, so approximate names still match; it is not substring matching.
       - search_type="config-based": matches inside configuration JSON objects, optionally narrowed by JSON path `scopes`
     - case-insensitive search
-    - mode for pattern search: `literal` (default); `regex` is supported for config-based search only
+    - mode for pattern search: applies to config-based only — `literal` (default) or `regex`. Textual search ignores
+      `mode` (always full-text) and rejects `regex`.
     - Multiple patterns work as OR condition - matches items containing ANY of the patterns
     - Each result includes the item's ID, name, creation date, and relevant metadata; the response also carries
     `total` and `by_type` counts and the `branch_scope` the hits come from
@@ -947,8 +952,9 @@ async def search(
     if search_type == 'textual' and await client.storage_client.is_enabled(GLOBAL_SEARCH_FEATURE):
         if mode == 'regex':
             raise ToolError(
-                'Regex patterns are not supported for textual search. Use literal patterns, or use '
-                'search_type="config-based" for regex matching inside configurations.'
+                'Regex patterns are not supported for textual search — it is a full-text (fuzzy) name search. '
+                'Pass the plain name as the pattern, or use search_type="config-based" for regex matching inside '
+                'configurations.'
             )
         output = await _global_textual_search(client, spec, limit=limit, offset=offset)
     else:

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -862,13 +862,13 @@ async def search(
     - Always use this tool when the user mentions a name but you don't have the exact ID
     - The search returns IDs that you can use with other tools (e.g., get_tables, get_configs, get_flows)
     - Results are ordered by the `updated` field, most recent first. `updated` is the item's last update time
-    when available, or its creation time otherwise (textual/global-search hits expose only the creation time).
+      when available, or its creation time otherwise (textual/global-search hits expose only the creation time).
     - Textual search matches names only, with fuzzy full-text matching (typo/similarity tolerant; no regex). To find
-    items by description or by table column, use get_tables or config-based search; to find items by configuration
-    content, use config-based search.
+      items by description or by table column, use get_tables or config-based search; to find items by configuration
+      content, use config-based search.
     - For exact ID lookups, use specific tools like get_tables, get_configs, get_flows instead
     - Use specific `scopes` only when you know the config structure (schema or real example); otherwise run config-based
-    search without scopes.
+      search without scopes.
     - Use find_component_id and get_configs tools to find configurations related to a specific component
     - If results are too numerous or empty, ask the user to refine their query rather than enumerating all items.
 
@@ -1020,6 +1020,11 @@ async def _enumeration_search(client: KeboolaClient, spec: SearchSpec, limit: in
             continue
         else:
             all_hits.extend(result)
+
+    # The configuration endpoint returns every config type at once, so narrow to the requested types to match
+    # the global-search path (e.g. item_types=['configuration-row'] must not leak 'configuration' hits).
+    if types_to_fetch:
+        all_hits = [hit for hit in all_hits if hit.item_type in types_to_fetch]
 
     # TODO: Should we sort by the item type too?
     all_hits.sort(

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -3,10 +3,11 @@ import json
 import logging
 import re
 from collections import defaultdict
-from typing import Annotated, Any, AsyncGenerator, Iterable, Literal, Mapping, Sequence
+from typing import Annotated, Any, AsyncGenerator, Iterable, Literal, Mapping, Sequence, cast
 
 import jsonpath_ng
 from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
 from fastmcp.tools import FunctionTool
 from jsonpath_ng.jsonpath import JSONPath
 from mcp.types import ToolAnnotations
@@ -20,6 +21,8 @@ from keboola_mcp_server.clients.client import (
     KeboolaClient,
     get_metadata_property,
 )
+from keboola_mcp_server.clients.storage import GlobalSearchResponse
+from keboola_mcp_server.clients.storage import ItemType as ApiItemType
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.errors import tool_errors
 from keboola_mcp_server.links import Link, ProjectLinksManager
@@ -70,8 +73,30 @@ SEARCH_ITEM_TYPE_TO_COMPONENT_TYPES: Mapping[SearchItemType, Sequence[str]] = {
     'workspace': ['other'],
 }
 
+GLOBAL_SEARCH_FEATURE = 'global-search'
+WORKSPACE_COMPONENT_ID = 'keboola.sandboxes'
+
+# Maps the tool's item types to the API types requested from the global-search endpoint. Some tool
+# types (data-app, flow, workspace) exist server-side as 'configuration' items distinguished only
+# by their component ID, so 'configuration' is over-fetched and narrowed client-side after re-typing.
+SEARCH_ITEM_TYPE_TO_API_TYPES: Mapping[SearchItemType, Sequence[ApiItemType]] = {
+    'bucket': ('bucket',),
+    'table': ('table',),
+    'transformation': ('transformation',),
+    'configuration': ('configuration',),
+    'configuration-row': ('configuration-row',),
+    'component': ('configuration', 'configuration-row'),
+    'flow': ('flow', 'configuration'),
+    'data-app': ('configuration',),
+    'workspace': ('workspace', 'configuration'),
+    'shared-code': ('shared-code',),
+    'rows': ('rows',),
+    'state': ('state',),
+}
+
 SearchType = Literal['textual', 'config-based']
 SearchPatternMode = Literal['regex', 'literal']
+SearchBranchScope = Literal['current-branch', 'all-branches']
 
 
 def add_search_tools(mcp: FastMCP) -> None:
@@ -113,11 +138,20 @@ class SearchHit(BaseModel):
     configuration_row_id: str | None = Field(default=None, description='The ID of the configuration row.')
 
     item_type: SearchItemType = Field(description='The type of the item (e.g. table, bucket, configuration, etc.).')
-    updated: str = Field(description='The date and time the item was created in ISO 8601 format.')
+    updated: str = Field(
+        description='The date and time the item was last updated (or created, when the update time is not '
+        'available) in ISO 8601 format.'
+    )
 
     name: str | None = Field(default=None, description='Name of the item.')
     display_name: str | None = Field(default=None, description='Display name of the item.')
     description: str | None = Field(default=None, description='Description of the item.')
+    branch_id: str | None = Field(
+        default=None, description='ID of the branch the item belongs to, when reported by the search backend.'
+    )
+    branch_name: str | None = Field(
+        default=None, description='Name of the branch the item belongs to, when reported by the search backend.'
+    )
     matches: list[PatternMatch] = Field(
         default_factory=list,
         description='Most specific JSONPath scopes with grouped matched patterns (config-based search only).',
@@ -173,6 +207,28 @@ class SearchHit(BaseModel):
             PatternMatch(scope=scope, patterns=list(patterns_by_scope[scope])) for scope in most_specific_scopes
         ]
         return self
+
+
+class SearchOutput(BaseModel):
+    """Paginated search results with total counts."""
+
+    hits: list[SearchHit] = Field(description='The matching items (paginated).')
+    total: int = Field(
+        description='Approximate total number of matching items before pagination; treat it as an upper bound on '
+        'the items reachable via pagination. With multiple patterns, an item matching more than one pattern is '
+        'counted once per pattern; for textual search the count may also include items later removed by client-side '
+        'type narrowing (e.g. configurations re-typed to data-apps/flows/workspaces).'
+    )
+    by_type: dict[str, int] = Field(
+        default_factory=dict,
+        description='Number of matching items per item type (before pagination and client-side narrowing).',
+    )
+    branch_scope: SearchBranchScope = Field(
+        default='current-branch',
+        description="Branch scope the hits come from. 'all-branches' means nothing was found in the current "
+        "branch context and the search was widened to the whole project; check each hit's branch_id/branch_name "
+        'to see where it lives.',
+    )
 
 
 class SearchSpec(BaseModel):
@@ -474,7 +530,7 @@ async def _fetch_configs(
             item_type: SearchItemType = 'transformation'
             if not allowed_transformations:
                 continue
-        elif component_id == 'keboola.sandboxes':
+        elif component_id == WORKSPACE_COMPONENT_ID:
             item_type: SearchItemType = 'workspace'
             if not allowed_workspaces:
                 continue
@@ -550,6 +606,149 @@ async def _fetch_configs(
                         ).set_matches(matches)
 
 
+def _api_types_for(item_types: Sequence[SearchItemType]) -> list[ApiItemType]:
+    """Maps the tool's item types to a deduplicated list of API types for the global-search endpoint."""
+    api_types: list[ApiItemType] = []
+    for item_type in item_types:
+        for api_type in SEARCH_ITEM_TYPE_TO_API_TYPES.get(item_type, ()):
+            if api_type not in api_types:
+                api_types.append(api_type)
+    return api_types
+
+
+def _retype_configuration(component_id: str | None) -> SearchItemType:
+    """Maps a 'configuration' global-search item to the tool's more specific item type by its component."""
+    if component_id in (ORCHESTRATOR_COMPONENT_ID, CONDITIONAL_FLOW_COMPONENT_ID):
+        return 'flow'
+    if component_id == DATA_APP_COMPONENT_ID:
+        return 'data-app'
+    if component_id == WORKSPACE_COMPONENT_ID:
+        return 'workspace'
+    return 'configuration'
+
+
+def _global_search_hit(item: GlobalSearchResponse.Item) -> SearchHit | None:
+    """Maps a global-search item to a SearchHit; returns None for items that cannot be mapped."""
+    common: dict[str, Any] = {
+        'updated': item.created.isoformat(),
+        'name': item.name,
+        'branch_id': item.branch_id,
+        'branch_name': item.branch_name,
+    }
+
+    if item.type == 'bucket':
+        return SearchHit(bucket_id=item.id, item_type='bucket', **common)
+
+    if item.type == 'table':
+        bucket = item.full_path.get('bucket')
+        bucket_id = str(bucket['id']) if isinstance(bucket, dict) and bucket.get('id') else None
+        return SearchHit(table_id=item.id, bucket_id=bucket_id, item_type='table', **common)
+
+    if item.type in ('configuration-row', 'rows'):
+        configuration = item.full_path.get('configuration')
+        configuration_id = (
+            str(configuration['id']) if isinstance(configuration, dict) and configuration.get('id') else None
+        )
+        if not (item.component_id and configuration_id):
+            LOG.warning(f'Skipping global-search row hit with no parent configuration in fullPath: {item.id}')
+            return None
+        return SearchHit(
+            component_id=item.component_id,
+            configuration_id=configuration_id,
+            configuration_row_id=item.id,
+            item_type='configuration-row',
+            **common,
+        )
+
+    # The remaining types (configuration, transformation, flow, workspace, shared-code, state) are all
+    # configuration-like items whose id is the configuration ID.
+    component_id = item.component_id or (WORKSPACE_COMPONENT_ID if item.type == 'workspace' else None)
+    if not component_id:
+        LOG.warning(f'Skipping global-search hit with no component id: {item.type} {item.id}')
+        return None
+    item_type = _retype_configuration(component_id) if item.type == 'configuration' else cast(SearchItemType, item.type)
+    return SearchHit(component_id=component_id, configuration_id=item.id, item_type=item_type, **common)
+
+
+async def _global_textual_search(
+    client: KeboolaClient,
+    spec: SearchSpec,
+    limit: int,
+    offset: int,
+) -> SearchOutput:
+    """
+    Searches item names server-side via the SAPI global-search endpoint, scoped to the current project.
+
+    Runs one request per pattern (patterns are OR-ed, mirroring the legacy behavior) against the current
+    branch context first; when nothing is found, widens the search to the whole project (all branches).
+    """
+    api_types = _api_types_for(spec.item_types)
+    # 'rows' hits are reported as 'configuration-row' and 'component' expands to configuration (rows);
+    # normalize the requested types accordingly for the client-side narrowing.
+    requested_types = {'configuration-row' if t == 'rows' else t for t in spec.item_types if t != 'component'}
+
+    # The 'configuration' API type is lossy: a single server-side 'configuration' item may re-type to
+    # configuration/data-app/flow/workspace, so when the caller filters by type the server can fill a page
+    # with items that are dropped during client-side narrowing, under-filling the page. Over-fetch up to the
+    # server max in that case so the narrowed page is more likely to reach `limit`. Deep pagination (large
+    # offset) remains approximate because the server paginates in un-narrowed space.
+    needs_overfetch = bool(requested_types) and 'configuration' in api_types
+    fetch_limit = MAX_GLOBAL_SEARCH_LIMIT if needs_overfetch else limit
+
+    async def query(branch_scope: Literal['current', 'all']) -> list[GlobalSearchResponse]:
+        return list(
+            await asyncio.gather(
+                *(
+                    client.storage_client.global_search(
+                        query=pattern, types=api_types, limit=fetch_limit, offset=offset, branch_scope=branch_scope
+                    )
+                    for pattern in spec.patterns
+                )
+            )
+        )
+
+    def collect(responses: list[GlobalSearchResponse]) -> list[SearchHit]:
+        hits_by_key: dict[tuple[str, str], SearchHit] = {}
+        for response in responses:
+            for item in response.items:
+                if (hit := _global_search_hit(item)) is None:
+                    continue
+                if requested_types and hit.item_type not in requested_types:
+                    continue
+                hits_by_key.setdefault((item.type, item.id), hit)
+        return list(hits_by_key.values())
+
+    branch_scope: Literal['current', 'all'] = 'current'
+    responses = await query(branch_scope)
+    hits = collect(responses)
+    if not hits and offset == 0:
+        # Nothing in the current branch context — widen to the whole project so that items living
+        # in other branches can be discovered. Hits carry branch_id/branch_name for attribution.
+        branch_scope = 'all'
+        responses = await query(branch_scope)
+        hits = collect(responses)
+
+    hits.sort(
+        key=lambda x: (
+            x.updated,
+            x.bucket_id or x.table_id or x.component_id or x.configuration_id or x.configuration_row_id,
+        ),
+        reverse=True,
+    )
+
+    by_type: dict[str, int] = defaultdict(int)
+    for response in responses:
+        for type_name, count in response.by_type.items():
+            by_type[type_name] += count
+
+    return SearchOutput(
+        hits=hits[:limit],
+        total=sum(response.all for response in responses),
+        by_type=dict(by_type),
+        branch_scope='current-branch' if branch_scope == 'current' else 'all-branches',
+    )
+
+
 @tool_errors()
 async def search(
     ctx: Context,
@@ -592,7 +791,7 @@ async def search(
         SearchPatternMode,
         Field(
             description='How to interpret patterns: "regex" for regular expressions or "literal" for exact text '
-            '(default: "literal").'
+            '(default: "literal"). Regex is only supported for config-based search.'
         ),
     ] = 'literal',
     limit: Annotated[
@@ -603,7 +802,7 @@ async def search(
         ),
     ] = DEFAULT_GLOBAL_SEARCH_LIMIT,
     offset: Annotated[int, Field(description='Number of matching items to skip for pagination (default: 0).')] = 0,
-) -> list[SearchHit]:
+) -> SearchOutput:
     """
     Searches for Keboola items (tables, buckets, components, configurations, transformations, flows, data-apps, etc.)
     in the current project and returns matching ID + metadata.
@@ -611,8 +810,9 @@ async def search(
     This tool supports two complementary search types:
 
     1) textual
-    - Searches item metadata fields by matching patterns against id, name, displayName, and description.
-    - For tables, also searches column names and column descriptions.
+    - Searches items by name, server-side (fast, independent of project size).
+    - Prefers the current branch context; when nothing is found there, automatically widens the search to all
+    branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
 
     2) config-based
     - Searches item configurations (JSON objects) by matching patterns against the configuration values ​​converted
@@ -639,13 +839,16 @@ async def search(
 
     HOW IT WORKS:
     - Supports two types:
-      - search_type="textual": matches against id, name, displayName, and description, for tables also column names
-      and column descriptions
+      - search_type="textual": searches item names server-side; names only — descriptions, column names and
+      configuration contents are NOT searched (use config-based search for configuration contents)
       - search_type="config-based": matches inside configuration JSON objects, optionally narrowed by JSON path `scopes`
     - case-insensitive search
-    - mode for pattern search: `literal` (default) or `regex`
+    - mode for pattern search: `literal` (default); `regex` is supported for config-based search only
     - Multiple patterns work as OR condition - matches items containing ANY of the patterns
-    - Each result includes the item's ID, name, creation date, and relevant metadata
+    - Each result includes the item's ID, name, creation date, and relevant metadata; the response also carries
+    `total` and `by_type` counts and the `branch_scope` the hits come from
+    - textual search prefers the current branch; on zero hits it automatically retries across all branches of the
+    project and marks the response with branch_scope="all-branches"
     - scopes (config-based) narrow matching to specific JSONPath areas within configurations; matching is performed
     against the stringified JSON node content in those areas.
     - config-based always returns all matched paths per item in `match_scopes` (including matched patterns)
@@ -653,9 +856,11 @@ async def search(
     IMPORTANT:
     - Always use this tool when the user mentions a name but you don't have the exact ID
     - The search returns IDs that you can use with other tools (e.g., get_tables, get_configs, get_flows)
-    - Results are ordered by update time. The most recently updated items are returned first.
-    - Fill `item_types` to make the search more efficient when you know the item type; scanning buckets and tables can
-    be expensive
+    - Results are ordered by the `updated` field, most recent first. `updated` is the item's last update time
+    when available, or its creation time otherwise (textual/global-search hits expose only the creation time).
+    - Textual search matches names only, with fuzzy full-text matching (typo/similarity tolerant; no regex). To find
+    items by description or by table column, use get_tables or config-based search; to find items by configuration
+    content, use config-based search.
     - For exact ID lookups, use specific tools like get_tables, get_configs, get_flows instead
     - Use specific `scopes` only when you know the config structure (schema or real example); otherwise run config-based
     search without scopes.
@@ -666,23 +871,19 @@ async def search(
     1) textual search examples:
     - user_input: "Find all tables with 'customer' in the name"
         → patterns=["customer"], item_types=["table"]
-        → Returns all tables whose id, name, displayName, or description contains "customer"
-
-    - user_input: "Find tables with 'email' column"
-        → patterns=["email"], item_types=["table"]
-        → Returns all tables that have a column named "email" or with "email" in column description
+        → Returns all tables whose name matches "customer"
 
     - user_input: "Search for the sales transformation"
         → patterns=["sales"], item_types=["transformation"]
-        → Returns transformations with "sales" in any searchable field
+        → Returns transformations with "sales" in the name
 
     - user_input: "Find items named 'daily report' or 'weekly summary'"
-        → patterns=["daily.*report", "weekly.*summary"], item_types=[], mode="regex"
+        → patterns=["daily report", "weekly summary"], item_types=[]
         → Returns all items matching any of these patterns
 
     - user_input: "Show me all configurations related to Google Analytics"
-        → patterns=["google.*analytics"], item_types=["configuration"], mode="regex"
-        → Returns configurations with matching patterns
+        → patterns=["google analytics"], item_types=["configuration"]
+        → Returns configurations with matching names
 
     2) config-based search examples:
     - user_input: "Find transformations/configs/components referencing table in.c-prod.customers"
@@ -741,13 +942,48 @@ async def search(
         )
         limit = DEFAULT_GLOBAL_SEARCH_LIMIT
 
+    client = KeboolaClient.from_state(ctx.session.state)
+
+    if search_type == 'textual' and await client.storage_client.is_enabled(GLOBAL_SEARCH_FEATURE):
+        if mode == 'regex':
+            raise ToolError(
+                'Regex patterns are not supported for textual search. Use literal patterns, or use '
+                'search_type="config-based" for regex matching inside configurations.'
+            )
+        output = await _global_textual_search(client, spec, limit=limit, offset=offset)
+    else:
+        # Projects without the global-search feature fall back to the legacy client-side enumeration;
+        # config-based search has no server-side equivalent and always runs client-side.
+        output = await _enumeration_search(client, spec, limit=limit, offset=offset)
+
+    # Get links for the hits
+    links_manager = await ProjectLinksManager.from_client(client)
+    for hit in output.hits:
+        hit.links.extend(
+            links_manager.get_links(
+                bucket_id=hit.bucket_id,
+                table_id=hit.table_id,
+                component_id=hit.component_id,
+                configuration_id=hit.configuration_id,
+                name=hit.name,
+            )
+        )
+
+    return output
+
+
+async def _enumeration_search(client: KeboolaClient, spec: SearchSpec, limit: int, offset: int) -> SearchOutput:
+    """
+    Searches by enumerating the project's items client-side. Used for config-based search (which has no
+    server-side equivalent) and as the legacy fallback for textual search in projects without the
+    global-search feature.
+    """
     # Determine which types to fetch
     types_to_fetch = set(spec.item_types) if spec.item_types else set()
 
     # Fetch items concurrently based on requested types
     tasks = []
     all_hits: list[SearchHit] = []
-    client = KeboolaClient.from_state(ctx.session.state)
 
     if not types_to_fetch or 'bucket' in types_to_fetch:
         tasks.append(_fetch_buckets(client, spec))
@@ -787,23 +1023,17 @@ async def search(
         ),
         reverse=True,
     )
-    paginated_hits = all_hits[offset : offset + limit]
 
-    # Get links for the hits
-    links_manager = await ProjectLinksManager.from_client(client)
-    for hit in paginated_hits:
-        hit.links.extend(
-            links_manager.get_links(
-                bucket_id=hit.bucket_id,
-                table_id=hit.table_id,
-                component_id=hit.component_id,
-                configuration_id=hit.configuration_id,
-                name=hit.name,
-            )
-        )
+    by_type: dict[str, int] = defaultdict(int)
+    for hit in all_hits:
+        by_type[hit.item_type] += 1
 
-    # TODO: Should we report the total number of hits?
-    return paginated_hits
+    return SearchOutput(
+        hits=all_hits[offset : offset + limit],
+        total=len(all_hits),
+        by_type=dict(by_type),
+        branch_scope='current-branch',
+    )
 
 
 class SuggestedComponentOutput(BaseModel):

--- a/src/keboola_mcp_server/tools/search.py
+++ b/src/keboola_mcp_server/tools/search.py
@@ -812,14 +812,14 @@ async def search(
 
     1) textual
     - Searches items by name, server-side (fast, independent of project size).
-    - Full-text (fuzzy) matching: tokenized and typo/similarity tolerant — pass the name as the user said it; do
-    NOT "fix" spelling or build regex. It is NOT substring matching and does NOT support regex.
+    - Full-text (fuzzy) matching: tokenized and typo/similarity tolerant — pass the name as the user said it;
+      do NOT "fix" spelling or build regex. It is NOT substring matching and does NOT support regex.
     - Prefers the current branch context; when nothing is found there, automatically widens the search to all
-    branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
+      branches of the project — such hits carry `branch_id`/`branch_name` so you can tell where they live.
 
     2) config-based
     - Searches item configurations (JSON objects) by matching patterns against the configuration values ​​converted
-    to a string, optionally narrowed by JSON path `scopes`.
+      to a string, optionally narrowed by JSON path `scopes`.
     - Returns also `match_scopes` with JSON paths and matched patterns per scope.
 
     THIS IS THE PRIMARY DISCOVERY TOOL. Always use it BEFORE any get_* tool when you need to find items
@@ -843,19 +843,19 @@ async def search(
     HOW IT WORKS:
     - Supports two types:
       - search_type="textual": full-text (fuzzy) name search, server-side. Names only — descriptions, column names
-      and configuration contents are NOT searched (use config-based search for configuration contents). Matching is
-      tokenized and typo/similarity tolerant, so approximate names still match; it is not substring matching.
+        and configuration contents are NOT searched (use config-based search for configuration contents). Matching
+        is tokenized and typo/similarity tolerant, so approximate names still match; it is not substring matching.
       - search_type="config-based": matches inside configuration JSON objects, optionally narrowed by JSON path `scopes`
     - case-insensitive search
     - mode for pattern search: applies to config-based only — `literal` (default) or `regex`. Textual search ignores
       `mode` (always full-text) and rejects `regex`.
     - Multiple patterns work as OR condition - matches items containing ANY of the patterns
     - Each result includes the item's ID, name, creation date, and relevant metadata; the response also carries
-    `total` and `by_type` counts and the `branch_scope` the hits come from
+      `total` and `by_type` counts and the `branch_scope` the hits come from
     - textual search prefers the current branch; on zero hits it automatically retries across all branches of the
-    project and marks the response with branch_scope="all-branches"
+      project and marks the response with branch_scope="all-branches"
     - scopes (config-based) narrow matching to specific JSONPath areas within configurations; matching is performed
-    against the stringified JSON node content in those areas.
+      against the stringified JSON node content in those areas.
     - config-based always returns all matched paths per item in `match_scopes` (including matched patterns)
 
     IMPORTANT:

--- a/tests/clients/test_storage.py
+++ b/tests/clients/test_storage.py
@@ -135,3 +135,98 @@ class TestConfigurationWriteEncryption:
             await _create_config(client, {'parameters': {'#password': 'plain-secret'}})
 
         raw_client.post.assert_not_called()
+
+
+class TestSearchEndpoints:
+    """The storage client must build correct query parameters for the SAPI search endpoints."""
+
+    @pytest.mark.parametrize(
+        ('branch_id', 'branch_scope', 'expected_branch_params'),
+        [
+            (None, 'current', {'branchTypes[]': 'production'}),
+            ('123', 'current', {'branchTypes[]': 'development', 'branchIds[]': '123'}),
+            (None, 'all', {}),
+            ('123', 'all', {}),
+        ],
+        ids=['default_branch_current', 'dev_branch_current', 'default_branch_all', 'dev_branch_all'],
+    )
+    @pytest.mark.asyncio
+    async def test_global_search_branch_scope(
+        self,
+        raw_client: RawKeboolaClient,
+        branch_id: str | None,
+        branch_scope: str,
+        expected_branch_params: dict[str, Any],
+    ) -> None:
+        async def get_side_effect(endpoint: str, params: dict[str, Any] | None = None, **kwargs: Any) -> JsonDict:
+            if endpoint == 'tokens/verify':
+                return {'owner': {'id': 4214}}
+            assert endpoint == 'global-search'
+            return {'all': 0, 'items': [], 'byType': {}, 'byProject': {}}
+
+        raw_client.get.side_effect = get_side_effect
+        client = AsyncStorageClient(raw_client=raw_client, branch_id=branch_id)
+
+        await client.global_search('foo', limit=10, offset=5, branch_scope=branch_scope)
+
+        params = raw_client.get.call_args.kwargs['params']
+        assert params == {'query': 'foo', 'projectIds[]': ['4214'], 'limit': 10, 'offset': 5, **expected_branch_params}
+
+    @pytest.mark.asyncio
+    async def test_tables_search_params(self, raw_client: RawKeboolaClient) -> None:
+        raw_client.get.return_value = [{'id': 'in.c-bucket.table'}]
+        client = AsyncStorageClient(raw_client=raw_client)
+
+        result = await client.tables_search(
+            metadata_key='KBC.description',
+            metadata_value='foo',
+            metadata_provider='user',
+            include=['columns', 'buckets'],
+        )
+
+        raw_client.get.assert_called_once_with(
+            endpoint='search/tables',
+            params={
+                'metadataKey': 'KBC.description',
+                'metadataValue': 'foo',
+                'metadataProvider': 'user',
+                'include': 'columns,buckets',
+            },
+        )
+        assert result == [{'id': 'in.c-bucket.table'}]
+
+    @pytest.mark.asyncio
+    async def test_tables_search_requires_filter(self, raw_client: RawKeboolaClient) -> None:
+        client = AsyncStorageClient(raw_client=raw_client)
+        assert await client.tables_search() == []
+        raw_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_component_configurations_search_params(self, raw_client: RawKeboolaClient) -> None:
+        raw_client.get.return_value = [{'id': 'config-1', 'componentId': 'keboola.ex-test'}]
+        client = AsyncStorageClient(raw_client=raw_client, branch_id='123')
+
+        result = await client.component_configurations_search(
+            component_id='keboola.ex-test',
+            configuration_id='config-1',
+            metadata_keys=['KBC.configuration.folderName', 'KBC.other'],
+            include=['filteredMetadata'],
+        )
+
+        raw_client.get.assert_called_once_with(
+            endpoint='branch/123/search/component-configurations',
+            params={
+                'componentId': 'keboola.ex-test',
+                'configurationId': 'config-1',
+                'metadataKeys[0]': 'KBC.configuration.folderName',
+                'metadataKeys[1]': 'KBC.other',
+                'include': 'filteredMetadata',
+            },
+        )
+        assert result == [{'id': 'config-1', 'componentId': 'keboola.ex-test'}]
+
+    @pytest.mark.asyncio
+    async def test_component_configurations_search_requires_filter(self, raw_client: RawKeboolaClient) -> None:
+        client = AsyncStorageClient(raw_client=raw_client)
+        assert await client.component_configurations_search() == []
+        raw_client.get.assert_not_called()

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -137,6 +137,47 @@ class TestSearch:
         ]
 
     @pytest.mark.asyncio
+    async def test_enumeration_filters_to_requested_item_types(
+        self, mocker: MockerFixture, mcp_context_client: Context
+    ):
+        """The legacy enumeration path must not leak configuration hits when only configuration-row is requested."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+
+        keboola_client.storage_client.bucket_list = mocker.AsyncMock(return_value=[])
+        keboola_client.storage_client.bucket_table_list = mocker.AsyncMock(return_value=[])
+        keboola_client.storage_client.workspace_list = mocker.AsyncMock(return_value=[])
+
+        def component_list_side_effect(component_type, include=None):
+            if component_type == 'extractor':
+                return [
+                    {
+                        'id': 'keboola.ex-db-mysql',
+                        'name': 'MySQL Extractor',
+                        'configurations': [
+                            {
+                                'id': 'test-config',
+                                'name': 'test config',
+                                'created': '2024-01-02T00:00:00Z',
+                                'rows': [{'id': 'test-row', 'name': 'test row', 'created': '2024-01-03T00:00:00Z'}],
+                            }
+                        ],
+                    }
+                ]
+            return []
+
+        keboola_client.storage_client.component_list = mocker.AsyncMock(side_effect=component_list_side_effect)
+
+        result = await search(
+            ctx=mcp_context_client,
+            patterns=['test'],
+            item_types=(cast(SearchItemType, 'configuration-row'),),
+        )
+
+        assert {hit.item_type for hit in result.hits} == {'configuration-row'}
+        assert result.total == 1
+        assert result.by_type == {'configuration-row': 1}
+
+    @pytest.mark.asyncio
     async def test_search_with_regex_pattern(self, mocker: MockerFixture, mcp_context_client: Context):
         """Test search with regex patterns."""
         keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -8,12 +8,14 @@ from pytest_mock import MockerFixture
 
 from keboola_mcp_server.clients.ai_service import ComponentSuggestionResponse, SuggestedComponent
 from keboola_mcp_server.clients.base import JsonDict
-from keboola_mcp_server.clients.client import KeboolaClient
+from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID, KeboolaClient
+from keboola_mcp_server.clients.storage import GlobalSearchResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.search import (
     SearchHit,
     SearchItemType,
+    SearchOutput,
     SearchSpec,
     SuggestedComponentOutput,
     find_component_id,
@@ -25,10 +27,11 @@ class TestSearch:
     """Test cases for the search tool function."""
 
     @pytest.fixture(autouse=True)
-    def _mock_has_feature(self, mocker: MockerFixture, mcp_context_client: Context):
-        """Disable storage-branches feature for all search tests (no dual-fetch needed)."""
+    def _mock_features(self, mocker: MockerFixture, mcp_context_client: Context):
+        """Disable storage-branches (no dual-fetch) and global-search (legacy textual path) features."""
         keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
         keboola_client.has_feature = mocker.AsyncMock(return_value=False)
+        keboola_client.storage_client.is_enabled = mocker.AsyncMock(return_value=False)
 
     @pytest.mark.asyncio
     async def test_search_no_patterns(self, mcp_context_client: Context):
@@ -94,8 +97,10 @@ class TestSearch:
             offset=0,
         )
 
-        assert isinstance(result, list)
-        assert result == [
+        assert isinstance(result, SearchOutput)
+        assert result.total == 2
+        assert result.branch_scope == 'current-branch'
+        assert result.hits == [
             SearchHit(
                 component_id='keboola.ex-db-mysql',
                 configuration_id='test-config',
@@ -157,8 +162,7 @@ class TestSearch:
             mode='regex',
         )
 
-        assert isinstance(result, list)
-        assert result == [
+        assert result.hits == [
             SearchHit(
                 bucket_id='in.c-customer-data',
                 item_type='bucket',
@@ -203,11 +207,11 @@ class TestSearch:
         # Call without specifying limit, offset, or item_types
         result = await search(ctx=mcp_context_client, patterns=['test'])
 
-        assert isinstance(result, list)
         # Should return exactly 50 items (default limit), not all 60
-        assert len(result) == 50, f'Expected default limit of 50, got {len(result)}'
+        assert len(result.hits) == 50, f'Expected default limit of 50, got {len(result.hits)}'
+        assert result.total == 60
         # The first item should be the most recently updated
-        assert result[0].bucket_id == 'in.c-test-bucket-059'
+        assert result.hits[0].bucket_id == 'in.c-test-bucket-059'
 
     @pytest.mark.asyncio
     async def test_search_limit_out_of_range(self, mocker: MockerFixture, mcp_context_client: Context):
@@ -234,19 +238,16 @@ class TestSearch:
 
         # Test with limit too high (> MAX_GLOBAL_SEARCH_LIMIT = 100)
         result = await search(ctx=mcp_context_client, patterns=['test'], limit=200)
-        assert isinstance(result, list)
         # Should be overridden to DEFAULT_GLOBAL_SEARCH_LIMIT = 50
-        assert len(result) == 50, f'Expected limit to be overridden to 50, got {len(result)}'
+        assert len(result.hits) == 50, f'Expected limit to be overridden to 50, got {len(result.hits)}'
 
         # Test with limit too low (<= 0)
         result = await search(ctx=mcp_context_client, patterns=['test'], limit=0)
-        assert isinstance(result, list)
-        assert len(result) == 50, f'Expected limit to be overridden to 50, got {len(result)}'
+        assert len(result.hits) == 50, f'Expected limit to be overridden to 50, got {len(result.hits)}'
 
         # Test with negative limit
         result = await search(ctx=mcp_context_client, patterns=['test'], limit=-5)
-        assert isinstance(result, list)
-        assert len(result) == 50, f'Expected limit to be overridden to 50, got {len(result)}'
+        assert len(result.hits) == 50, f'Expected limit to be overridden to 50, got {len(result.hits)}'
 
     @pytest.mark.asyncio
     async def test_search_negative_offset(self, mocker: MockerFixture, mcp_context_client: Context):
@@ -273,11 +274,10 @@ class TestSearch:
 
         # Test with negative offset
         result = await search(ctx=mcp_context_client, patterns=['test'], offset=-10, limit=5)
-        assert isinstance(result, list)
         # Should be overridden to offset=0, returning first 5 items
-        assert len(result) == 5
+        assert len(result.hits) == 5
         # First item should be the most recently updated (bucket-009)
-        assert result[0].bucket_id == 'in.c-test-bucket-009'
+        assert result.hits[0].bucket_id == 'in.c-test-bucket-009'
 
         # Verify it matches the result with offset=0
         result_with_zero_offset = await search(ctx=mcp_context_client, patterns=['test'], offset=0, limit=5)
@@ -303,7 +303,7 @@ class TestSearch:
 
         # Test pagination
         result = await search(ctx=mcp_context_client, patterns=['test'], limit=2, offset=0)
-        assert result == [
+        assert result.hits == [
             SearchHit(
                 bucket_id='in.c-bucket-10',
                 item_type='bucket',
@@ -333,7 +333,7 @@ class TestSearch:
         ]
 
         result = await search(ctx=mcp_context_client, patterns=['test'], limit=1, offset=2)
-        assert result == [
+        assert result.hits == [
             SearchHit(
                 bucket_id='in.c-bucket-8',
                 item_type='bucket',
@@ -374,8 +374,7 @@ class TestSearch:
 
         result = await search(ctx=mcp_context_client, patterns=['test'], item_types=(cast(SearchItemType, 'bucket'),))
 
-        assert isinstance(result, list)
-        assert result == [
+        assert result.hits == [
             SearchHit(
                 bucket_id='in.c-my-bucket',
                 item_type='bucket',
@@ -465,8 +464,7 @@ class TestSearch:
 
         result = await search(ctx=mcp_context_client, patterns=['test'], limit=20, offset=0)
 
-        assert isinstance(result, list)
-        assert result == [
+        assert result.hits == [
             SearchHit(
                 component_id='keboola.ex-db-mysql',
                 configuration_id='test-config-b',
@@ -697,10 +695,9 @@ class TestSearch:
             ctx=mcp_context_client, patterns=[search_pattern], item_types=(cast(SearchItemType, 'table'),)
         )
 
-        assert isinstance(result, list)
-        assert len(result) == expected_count
+        assert len(result.hits) == expected_count
         if expected_count > 0:
-            assert result[0].table_id == expected_first_table_id
+            assert result.hits[0].table_id == expected_first_table_id
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -914,7 +911,7 @@ class TestSearch:
                     key=lambda x: x['scope'] or '',
                 ),
             )
-            for hit in result
+            for hit in result.hits
         ]
         normalized_expected = [
             (
@@ -927,6 +924,293 @@ class TestSearch:
             for config_id, matches in expected_hits
         ]
         assert normalized_actual == normalized_expected
+
+
+def _global_search_item(
+    item_id: str,
+    name: str,
+    item_type: str,
+    *,
+    component_id: str | None = None,
+    full_path: dict[str, Any] | None = None,
+    created: str = '2024-01-01T00:00:00+00:00',
+) -> JsonDict:
+    return {
+        'id': item_id,
+        'name': name,
+        'type': item_type,
+        'fullPath': full_path or {},
+        'componentId': component_id,
+        'organizationId': 1,
+        'projectId': 69420,
+        'projectName': 'Test Project',
+        'created': created,
+    }
+
+
+def _global_search_response(*items: JsonDict) -> GlobalSearchResponse:
+    by_type: dict[str, int] = {}
+    for item in items:
+        item_type = cast(str, item['type'])
+        by_type[item_type] = by_type.get(item_type, 0) + 1
+    return GlobalSearchResponse.model_validate(
+        {'all': len(items), 'items': list(items), 'byType': by_type, 'byProject': {'69420': 'Test Project'}}
+    )
+
+
+class TestGlobalTextualSearch:
+    """Test cases for the textual search backed by the SAPI global-search endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_global_search(self, mocker: MockerFixture, mcp_context_client: Context):
+        """Enable the global-search feature so that textual search uses the server-side endpoint."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        keboola_client.storage_client.is_enabled = mocker.AsyncMock(return_value=True)
+
+    @pytest.mark.asyncio
+    async def test_search_maps_global_search_items(self, mocker: MockerFixture, mcp_context_client: Context):
+        """Items are mapped to SearchHits with IDs, branch info, re-typed flows and links."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        project_id = await keboola_client.storage_client.project_id()
+
+        response = _global_search_response(
+            _global_search_item(
+                'in.c-test-bucket.users',
+                'users',
+                'table',
+                full_path={'bucket': {'id': 'in.c-test-bucket'}, 'branch': {'id': 7, 'name': 'Main'}},
+                created='2024-01-03T00:00:00+00:00',
+            ),
+            _global_search_item(
+                'cfg-1',
+                'Test MySQL Config',
+                'configuration',
+                component_id='keboola.ex-db-mysql',
+                created='2024-01-02T00:00:00+00:00',
+            ),
+            _global_search_item(
+                'flow-1',
+                'My Flow',
+                'configuration',
+                component_id='keboola.orchestrator',
+                created='2024-01-01T00:00:00+00:00',
+            ),
+        )
+        keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=response)
+
+        result = await search(ctx=mcp_context_client, patterns=['test'])
+
+        keboola_client.storage_client.global_search.assert_called_once_with(
+            query='test', types=[], limit=50, offset=0, branch_scope='current'
+        )
+        assert isinstance(result, SearchOutput)
+        assert result.branch_scope == 'current-branch'
+        assert result.total == 3
+        assert result.by_type == {'table': 1, 'configuration': 2}
+        assert result.hits == [
+            SearchHit(
+                table_id='in.c-test-bucket.users',
+                bucket_id='in.c-test-bucket',
+                item_type='table',
+                updated='2024-01-03T00:00:00+00:00',
+                name='users',
+                branch_id='7',
+                branch_name='Main',
+                links=[
+                    Link(
+                        type='ui-detail',
+                        title='Table: users',
+                        url=(
+                            f'https://connection.test.keboola.com/admin/projects/{project_id}'
+                            '/storage/in.c-test-bucket/table/users'
+                        ),
+                    )
+                ],
+            ),
+            SearchHit(
+                component_id='keboola.ex-db-mysql',
+                configuration_id='cfg-1',
+                item_type='configuration',
+                updated='2024-01-02T00:00:00+00:00',
+                name='Test MySQL Config',
+                links=[
+                    Link(
+                        type='ui-detail',
+                        title='Configuration: Test MySQL Config',
+                        url=(
+                            f'https://connection.test.keboola.com/admin/projects/{project_id}'
+                            '/components/keboola.ex-db-mysql/cfg-1'
+                        ),
+                    )
+                ],
+            ),
+            SearchHit(
+                component_id='keboola.orchestrator',
+                configuration_id='flow-1',
+                item_type='flow',
+                updated='2024-01-01T00:00:00+00:00',
+                name='My Flow',
+                links=[
+                    Link(
+                        type='ui-detail',
+                        title='Flow: My Flow',
+                        url=(f'https://connection.test.keboola.com/admin/projects/{project_id}' '/flows/flow-1'),
+                    )
+                ],
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_search_widens_to_all_branches_on_zero_hits(self, mocker: MockerFixture, mcp_context_client: Context):
+        """When the current branch context has no hits, the search retries across all branches."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        dev_branch_hit = _global_search_response(
+            _global_search_item(
+                'in.c-dev-bucket.users',
+                'users',
+                'table',
+                full_path={'branch': {'id': 123, 'name': 'my-dev-branch'}},
+            ),
+        )
+        keboola_client.storage_client.global_search = mocker.AsyncMock(
+            side_effect=[_global_search_response(), dev_branch_hit]
+        )
+
+        result = await search(ctx=mcp_context_client, patterns=['users'], item_types=('table',))
+
+        assert keboola_client.storage_client.global_search.call_args_list == [
+            call(query='users', types=['table'], limit=50, offset=0, branch_scope='current'),
+            call(query='users', types=['table'], limit=50, offset=0, branch_scope='all'),
+        ]
+        assert result.branch_scope == 'all-branches'
+        assert len(result.hits) == 1
+        assert result.hits[0].table_id == 'in.c-dev-bucket.users'
+        assert result.hits[0].branch_id == '123'
+        assert result.hits[0].branch_name == 'my-dev-branch'
+
+    @pytest.mark.asyncio
+    async def test_search_does_not_widen_when_paginating(self, mocker: MockerFixture, mcp_context_client: Context):
+        """An empty page with non-zero offset must not trigger the all-branches retry."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=_global_search_response())
+
+        result = await search(ctx=mcp_context_client, patterns=['users'], offset=10)
+
+        keboola_client.storage_client.global_search.assert_called_once_with(
+            query='users', types=[], limit=50, offset=10, branch_scope='current'
+        )
+        assert result.hits == []
+        assert result.branch_scope == 'current-branch'
+
+    @pytest.mark.asyncio
+    async def test_search_multiple_patterns_merge_and_dedupe(self, mocker: MockerFixture, mcp_context_client: Context):
+        """Each pattern issues its own request; results are OR-merged and deduplicated by item."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        shared_item = _global_search_item('cfg-1', 'Shared Config', 'configuration', component_id='keboola.ex-db-mysql')
+        unique_item = _global_search_item('cfg-2', 'Unique Config', 'configuration', component_id='keboola.ex-db-mysql')
+        keboola_client.storage_client.global_search = mocker.AsyncMock(
+            side_effect=[
+                _global_search_response(shared_item, unique_item),
+                _global_search_response(shared_item),
+            ]
+        )
+
+        result = await search(ctx=mcp_context_client, patterns=['shared', 'config'])
+
+        assert keboola_client.storage_client.global_search.call_count == 2
+        assert sorted(hit.configuration_id for hit in result.hits) == ['cfg-1', 'cfg-2']
+        # The shared item is counted once per pattern in the server-side totals.
+        assert result.total == 3
+
+    @pytest.mark.asyncio
+    async def test_search_data_app_narrowing(self, mocker: MockerFixture, mcp_context_client: Context):
+        """Searching for data-apps over-fetches configurations and narrows them by component ID."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        response = _global_search_response(
+            _global_search_item('app-1', 'My Data App', 'configuration', component_id=DATA_APP_COMPONENT_ID),
+            _global_search_item('cfg-1', 'Regular Config', 'configuration', component_id='keboola.ex-db-mysql'),
+        )
+        keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=response)
+
+        result = await search(ctx=mcp_context_client, patterns=['app'], item_types=('data-app',))
+
+        # Narrowing 'configuration' to data-apps is lossy, so the page is over-fetched up to the server max
+        # to avoid under-filling once the non-matching configurations are dropped client-side.
+        keboola_client.storage_client.global_search.assert_called_once_with(
+            query='app', types=['configuration'], limit=100, offset=0, branch_scope='current'
+        )
+        assert len(result.hits) == 1
+        assert result.hits[0].configuration_id == 'app-1'
+        assert result.hits[0].item_type == 'data-app'
+
+    @pytest.mark.asyncio
+    async def test_search_overfetch_fills_page_after_narrowing(
+        self, mocker: MockerFixture, mcp_context_client: Context
+    ):
+        """A small user limit still over-fetches to the server max, then caps the narrowed page to that limit.
+
+        Regular configurations preceding the data-apps would under-fill the page if the user limit were sent
+        verbatim; over-fetching ensures the page reaches the requested limit when enough data-apps exist.
+        """
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        items = [
+            _global_search_item('cfg-1', 'Regular One', 'configuration', component_id='keboola.ex-db-mysql'),
+            _global_search_item('cfg-2', 'Regular Two', 'configuration', component_id='keboola.ex-db-mysql'),
+            _global_search_item('app-1', 'Data App One', 'configuration', component_id=DATA_APP_COMPONENT_ID),
+            _global_search_item('app-2', 'Data App Two', 'configuration', component_id=DATA_APP_COMPONENT_ID),
+            _global_search_item('app-3', 'Data App Three', 'configuration', component_id=DATA_APP_COMPONENT_ID),
+        ]
+        keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=_global_search_response(*items))
+
+        result = await search(ctx=mcp_context_client, patterns=['app'], item_types=('data-app',), limit=2)
+
+        # The user limit (2) is below the server max, so the request over-fetches up to 100...
+        keboola_client.storage_client.global_search.assert_called_once_with(
+            query='app', types=['configuration'], limit=100, offset=0, branch_scope='current'
+        )
+        # ...and the narrowed page is capped to the user limit, containing only data-apps.
+        assert len(result.hits) == 2
+        assert all(hit.item_type == 'data-app' for hit in result.hits)
+
+    @pytest.mark.asyncio
+    async def test_search_configuration_row_mapping(self, mocker: MockerFixture, mcp_context_client: Context):
+        """Row hits resolve their parent configuration from fullPath; unresolvable rows are skipped."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        response = _global_search_response(
+            _global_search_item(
+                'row-1',
+                'My Row',
+                'configuration-row',
+                component_id='keboola.ex-db-mysql',
+                full_path={'configuration': {'id': 'cfg-1', 'name': 'Parent Config'}},
+            ),
+            _global_search_item('row-2', 'Orphan Row', 'configuration-row', component_id='keboola.ex-db-mysql'),
+        )
+        keboola_client.storage_client.global_search = mocker.AsyncMock(return_value=response)
+
+        result = await search(ctx=mcp_context_client, patterns=['row'], item_types=('configuration-row',))
+
+        assert len(result.hits) == 1
+        assert result.hits[0] == SearchHit(
+            component_id='keboola.ex-db-mysql',
+            configuration_id='cfg-1',
+            configuration_row_id='row-1',
+            item_type='configuration-row',
+            updated='2024-01-01T00:00:00+00:00',
+            name='My Row',
+            links=result.hits[0].links,
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_regex_mode_rejected(self, mocker: MockerFixture, mcp_context_client: Context):
+        """Regex patterns are not supported by the server-side textual search."""
+        keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+        keboola_client.storage_client.global_search = mocker.AsyncMock()
+
+        with pytest.raises(ToolError, match='Regex patterns are not supported for textual search'):
+            await search(ctx=mcp_context_client, patterns=['customer.*'], mode='regex')
+
+        keboola_client.storage_client.global_search.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1322,7 +1322,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.69.2"
+version = "1.70.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3393](https://linear.app/keboola/issue/AI-3393/adopt-server-side-storage-search-endpoints-in-the-mcp-search-tool)

RFC: [`feature_spec/global_search_adoption/RFC.md`](feature_spec/global_search_adoption/RFC.md)

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

The `search` tool's textual mode previously enumerated the whole project client-side (all buckets, all tables per bucket with columns, all components with full configurations + rows) and regex-matched in Python — latency and SAPI load scaled with project size, and pagination was cosmetic.

Textual search now uses the SAPI **global-search** endpoint, always scoped to the current project:

- One concurrent request per pattern; results OR-merged and deduplicated, preserving the documented multi-pattern semantics.
- **Branch strategy:** the current branch context is searched first (production branch types on default, `branchIds=[current]` on a dev branch); on zero hits the search automatically widens to all branches of the project. Widened hits carry new `branch_id`/`branch_name` fields and the response is marked `branch_scope="all-branches"`.
- **Feature-flag fallback:** projects without the `global-search` feature transparently fall back to the legacy client-side enumeration (kept for one release cycle; removal is a follow-up).
- `search_type="config-based"` is unchanged — global search indexes names only, so there is no server-side substitute for searching configuration JSON.
- The tool returns a new `SearchOutput` envelope with `hits`, `total` and `by_type` counts.
- Regex mode is rejected for textual search with a clear tool error (the index does not support it); it remains supported for config-based search.

Client layer:

- `global_search()` gains a `branch_scope: 'current' | 'all'` parameter.
- New `tables_search()` wraps `GET /v2/storage/search/tables` (metadata key/value/provider).
- `component_configurations_search()` now filters by `componentId`/`configurationId`/`include` server-side instead of post-filtering client-side.

Known capability gaps of global search (documented in the tool docstring): descriptions, column names/descriptions and item-ID substrings are not searched textually; agents are directed to `get_tables` or config-based search for those.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Unit tests: legacy enumeration tests now pin the `global-search` feature off and keep covering the fallback path; new `TestGlobalTextualSearch` covers item mapping (incl. flow/data-app/workspace re-typing and row `fullPath` resolution), branch widening on zero hits, no widening during pagination, multi-pattern merge + dedupe, data-app narrowing and regex rejection. Client tests cover query-param construction for all three search endpoints. Full suite: 1505 passed; all tox envs green (pytest, black, isort, flake8, check-tools-docs).

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)