### PR TITLE
feat: expose AppRun failureReason in get_data_apps deployment info

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2122,6 +2122,10 @@ Considerations:
 - If no configuration_ids are provided, the tool will list all data apps in the project given the limit and offset.
 - Data App detail contains configuration, metadata, source code, links, and deployment info along with the latest
 data app logs to investigate in-app errors. The logs may be updated after opening the data app URL.
+- `deployment_info.last_run` carries the outcome of the most recent deployment attempt. For an app
+  that fails to start, check its `failure_reason`/`failure_message` FIRST — they cover setup-phase
+  failures (e.g. invalid secrets, git clone errors, failing setup scripts) that happen before the
+  container starts and therefore never appear in the regular logs.
 - `repo_url` (managed git repo URL for python-js apps) is ONLY populated on the detail path
   (when `configuration_ids` is provided). The inventory list always returns `repo_url=None`,
   even for python-js apps with a managed repo — to retrieve the URL, call this tool again

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.70.1"
+version = "1.71.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -298,6 +298,64 @@ class AppGitRepoResponse(BaseModel):
     )
 
 
+class AppRunFailureReason(BaseModel):
+    """Machine-readable failure info attached by the platform to an unsuccessful AppRun."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    reason: str | None = Field(
+        default=None,
+        description=(
+            'Machine-readable code identifying the kind of failure, '
+            'e.g. "ConfigDecryptionFailed" or "StartupProbeFailed".'
+        ),
+    )
+    message: str | None = Field(default=None, description='Human-readable explanation of the failure.')
+
+
+class AppRunResponse(BaseModel):
+    """Response model for a single AppRun — one deployment attempt of a data app."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(description='The ID of the app run.')
+    app_id: str | None = Field(
+        validation_alias=AliasChoices('appId', 'app_id'),
+        default=None,
+        description='The ID of the data app this run belongs to.',
+    )
+    state: str = Field(description='The state of the run: "starting", "running", "finished" or "failed".')
+    created_at: str | None = Field(
+        validation_alias=AliasChoices('createdAt', 'created_at'),
+        default=None,
+        description='The timestamp when the run was created.',
+    )
+    started_at: str | None = Field(
+        validation_alias=AliasChoices('startedAt', 'started_at'),
+        default=None,
+        description='The timestamp when the app became ready, or `null` if it never started.',
+    )
+    stopped_at: str | None = Field(
+        validation_alias=AliasChoices('stoppedAt', 'stopped_at'),
+        default=None,
+        description='The timestamp when the run stopped, or `null` while it is still active.',
+    )
+    startup_logs: str | None = Field(
+        validation_alias=AliasChoices('startupLogs', 'startup_logs'),
+        default=None,
+        description='Output of the startup phase (entrypoint log), when available.',
+    )
+    failure_reason: AppRunFailureReason | None = Field(
+        validation_alias=AliasChoices('failureReason', 'failure_reason'),
+        default=None,
+        description=(
+            'Why the run was not successful. Populated by the platform for failed runs, including '
+            'setup-phase failures (e.g. invalid secrets) that produce no container logs.'
+        ),
+    )
+    mode: str | None = Field(default=None, description='The mode of the run, e.g. "prod" or "dev".')
+
+
 class DataScienceClient(KeboolaServiceClient):
 
     def __init__(self, raw_client: RawKeboolaClient, branch_id: str | None = None) -> None:
@@ -465,6 +523,19 @@ class DataScienceClient(KeboolaServiceClient):
         """
         response = await self.get(endpoint=f'apps/{data_app_id}/git-repo')
         return AppGitRepoResponse.model_validate(response)
+
+    async def list_app_runs(self, data_app_id: str, *, limit: int = 5, offset: int = 0) -> list[AppRunResponse]:
+        """
+        List runs (deployment attempts) of a data app, newest first.
+
+        :param data_app_id: The ID of the data app
+        :param limit: Maximum number of runs to return
+        :param offset: Number of runs to skip
+        :return: The app runs, including `failure_reason` for unsuccessful ones.
+        """
+        response = await self.get(endpoint=f'apps/{data_app_id}/runs', params={'limit': limit, 'offset': offset})
+        assert isinstance(response, list)
+        return [AppRunResponse.model_validate(run) for run in response]
 
     async def delete_data_app(self, data_app_id: str) -> None:
         """

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -222,10 +222,10 @@ class AppRunInfo(BaseModel):
 
     @classmethod
     def from_api_response(cls, run: AppRunResponse) -> 'AppRunInfo':
-        startup_logs = (run.startup_logs or '').strip().split('\n')[-_APP_RUN_LOG_LINES:]
+        startup_logs = (run.startup_logs or '').strip().rsplit('\n', _APP_RUN_LOG_LINES)[-_APP_RUN_LOG_LINES:]
         failure_message = run.failure_reason.message if run.failure_reason else None
         if failure_message and len(failure_message) > _APP_RUN_MESSAGE_LIMIT:
-            failure_message = '…' + failure_message[-_APP_RUN_MESSAGE_LIMIT:]
+            failure_message = '…' + failure_message[-(_APP_RUN_MESSAGE_LIMIT - 1):]
         return cls(
             state=run.state,
             created_at=run.created_at,

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -13,7 +13,12 @@ from pydantic import BaseModel, Field
 
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID, KeboolaClient, get_metadata_property
-from keboola_mcp_server.clients.data_science import CodeDataAppConfig, DataAppConfig, DataAppResponse
+from keboola_mcp_server.clients.data_science import (
+    AppRunResponse,
+    CodeDataAppConfig,
+    DataAppConfig,
+    DataAppResponse,
+)
 from keboola_mcp_server.clients.storage import ConfigurationAPIResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.errors import tool_errors
@@ -118,6 +123,12 @@ _MANAGED_GIT_REPO_USERNAME = 'kai'
 # will see the error from its own `git push` or from `deploy_data_app`.
 _DEFAULT_DRAFT_BRANCH = 'init'
 
+# How much of an AppRun's diagnostics is surfaced in tool output. `failure_message` can embed the
+# entire startup log (StartupProbeFailed duplicates it verbatim), so both are trimmed to keep the
+# tool output bounded while preserving the error tail, which is where the actionable line lives.
+_APP_RUN_LOG_LINES = 30
+_APP_RUN_MESSAGE_LIMIT = 3000
+
 
 INJECTED_BLOCK_RE = re.compile(
     r'(?P<before>.*?)#\s###\sINJECTED_CODE\s####.*?#\s###\sEND_OF_INJECTED_CODE\s####(?P<after>.*)',
@@ -186,6 +197,45 @@ class DataAppSummary(BaseModel):
         )
 
 
+class AppRunInfo(BaseModel):
+    """Outcome of a single deployment attempt (AppRun) of a data app."""
+
+    state: str = Field(description='The state of the run: "starting", "running", "finished" or "failed".')
+    created_at: Optional[str] = Field(description='The timestamp when the run was created.', default=None)
+    stopped_at: Optional[str] = Field(
+        description='The timestamp when the run stopped, or `null` while it is still active.', default=None
+    )
+    failure_reason: Optional[str] = Field(
+        description=(
+            'Machine-readable code identifying why the run failed, e.g. "ConfigDecryptionFailed" '
+            'or "StartupProbeFailed". `null` for successful runs.'
+        ),
+        default=None,
+    )
+    failure_message: Optional[str] = Field(
+        description='Detailed explanation of the failure, when the platform provides one.', default=None
+    )
+    startup_logs: list[str] = Field(
+        description='The last lines of the run\'s startup (entrypoint) log, when available.',
+        default_factory=list,
+    )
+
+    @classmethod
+    def from_api_response(cls, run: AppRunResponse) -> 'AppRunInfo':
+        startup_logs = (run.startup_logs or '').strip().split('\n')[-_APP_RUN_LOG_LINES:]
+        failure_message = run.failure_reason.message if run.failure_reason else None
+        if failure_message and len(failure_message) > _APP_RUN_MESSAGE_LIMIT:
+            failure_message = '…' + failure_message[-_APP_RUN_MESSAGE_LIMIT:]
+        return cls(
+            state=run.state,
+            created_at=run.created_at,
+            stopped_at=run.stopped_at,
+            failure_reason=run.failure_reason.reason if run.failure_reason else None,
+            failure_message=failure_message,
+            startup_logs=[line for line in startup_logs if line],
+        )
+
+
 class DeploymentInfo(BaseModel):
     """Deployment information of a data app."""
 
@@ -200,6 +250,15 @@ class DeploymentInfo(BaseModel):
     )
     logs: list[str] = Field(
         description='The latest 20 log lines reported in the data app deployment.', default_factory=list
+    )
+    last_run: Optional[AppRunInfo] = Field(
+        description=(
+            'The most recent deployment attempt (AppRun). When the app failed to start, its '
+            '`failure_reason`/`failure_message` explain why — including setup-phase failures '
+            '(e.g. invalid secrets) that happen before the container starts and so produce no '
+            'container logs at all. Check this FIRST when diagnosing an app that does not start.'
+        ),
+        default=None,
     )
 
 
@@ -291,10 +350,11 @@ class DataApp(BaseModel):
         self.links = links
         return self
 
-    def with_deployment_info(self, logs: list[str]) -> 'DataApp':
+    def with_deployment_info(self, logs: list[str], last_run: Optional[AppRunInfo] = None) -> 'DataApp':
         """Adds deployment info to the data app.
 
         :param logs: The logs of the data app deployment.
+        :param last_run: The most recent deployment attempt (AppRun), when available.
         :return: The data app with the deployment info.
         """
         self.deployment_info = DeploymentInfo(
@@ -302,6 +362,7 @@ class DataApp(BaseModel):
             state=self.state,
             url=self.deployment_url or 'deployment link not available yet',
             logs=logs,
+            last_run=last_run,
         )
         return self
 
@@ -1229,6 +1290,10 @@ async def get_data_apps(
     - If no configuration_ids are provided, the tool will list all data apps in the project given the limit and offset.
     - Data App detail contains configuration, metadata, source code, links, and deployment info along with the latest
     data app logs to investigate in-app errors. The logs may be updated after opening the data app URL.
+    - `deployment_info.last_run` carries the outcome of the most recent deployment attempt. For an app
+      that fails to start, check its `failure_reason`/`failure_message` FIRST — they cover setup-phase
+      failures (e.g. invalid secrets, git clone errors, failing setup scripts) that happen before the
+      container starts and therefore never appear in the regular logs.
     - `repo_url` (managed git repo URL for python-js apps) is ONLY populated on the detail path
       (when `configuration_ids` is provided). The inventory list always returns `repo_url=None`,
       even for python-js apps with a managed repo — to retrieve the URL, call this tool again
@@ -1333,7 +1398,10 @@ async def deploy_data_app(
             mode=mode,
         )
         data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
-        data_app = data_app.with_deployment_info(await _fetch_logs(client, data_app.data_app_id))
+        data_app = data_app.with_deployment_info(
+            await _fetch_logs(client, data_app.data_app_id),
+            last_run=await _fetch_latest_run(client, data_app.data_app_id),
+        )
         links = links_manager.get_data_app_links(
             configuration_id=data_app.configuration_id,
             configuration_name=data_app.name,
@@ -1576,7 +1644,8 @@ async def _fetch_data_app_details_task(
             uses_basic_authentication=_uses_basic_authentication(data_app.configuration.get('authorization') or {}),
         )
         logs = await _fetch_logs(client, data_app.data_app_id)
-        data_app = data_app.with_links(links).with_deployment_info(logs)
+        last_run = await _fetch_latest_run(client, data_app.data_app_id)
+        data_app = data_app.with_links(links).with_deployment_info(logs, last_run=last_run)
         # Drafts of a python-js prod are surfaced inline so the agent can find them in one round-trip
         # — see Scenario C in `modify_python_js_data_app`. Skip for drafts themselves and for Streamlit
         # (neither has children).
@@ -1654,6 +1723,22 @@ async def _fetch_logs(client: KeboolaClient, data_app_id: str) -> list[str]:
     except httpx.HTTPStatusError:
         # The data app is not running, return empty list
         return []
+
+
+async def _fetch_latest_run(client: KeboolaClient, data_app_id: str) -> Optional[AppRunInfo]:
+    """Fetches the most recent run (deployment attempt) of a data app, or None when there is none.
+
+    Diagnostics must not break the detail fetch: any error (e.g. an older DSAPI without the
+    runs endpoint) is logged and reported as "no run info" rather than raised.
+    """
+    try:
+        runs = await client.data_science_client.list_app_runs(data_app_id, limit=1)
+        if not runs:
+            return None
+        return AppRunInfo.from_api_response(runs[0])
+    except Exception:
+        LOG.exception(f'Failed to fetch app runs for data app: {data_app_id}')
+        return None
 
 
 def _get_authorization(auth_with_password: bool) -> dict[str, Any]:

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -216,7 +216,7 @@ class AppRunInfo(BaseModel):
         description='Detailed explanation of the failure, when the platform provides one.', default=None
     )
     startup_logs: list[str] = Field(
-        description='The last lines of the run\'s startup (entrypoint) log, when available.',
+        description="The last lines of the run's startup (entrypoint) log, when available.",
         default_factory=list,
     )
 

--- a/tests/clients/test_data_science.py
+++ b/tests/clients/test_data_science.py
@@ -7,6 +7,7 @@ import pytest
 
 from keboola_mcp_server.clients.data_science import (
     AppGitRepoResponse,
+    AppRunResponse,
     CodeDataAppConfig,
     CreatedGitCredentialResponse,
     DataScienceClient,
@@ -237,3 +238,50 @@ def test_code_data_app_config_serializes_to_expected_shape() -> None:
         },
         'runtime': {'image': {'version': 'dev-1.0.0'}},
     }
+
+
+@pytest.mark.asyncio
+async def test_list_app_runs_gets_expected_endpoint_and_parses_failure_reason() -> None:
+    client = DataScienceClient.create('https://api.example.com', token=None)
+    client.get = AsyncMock(  # type: ignore[assignment]
+        return_value=[
+            {
+                'id': 'run-2',
+                'appId': 'app-123',
+                'state': 'failed',
+                'createdAt': '2026-06-12T10:36:20+00:00',
+                'startedAt': None,
+                'stoppedAt': '2026-06-12T10:36:21+00:00',
+                'startupLogs': None,
+                'failureReason': {
+                    'reason': 'ConfigDecryptionFailed',
+                    'message': 'failed to decrypt key "#API_KEY"',
+                },
+                'mode': 'prod',
+            },
+            {
+                'id': 'run-1',
+                'appId': 'app-123',
+                'state': 'finished',
+                'createdAt': '2026-06-12T09:00:00+00:00',
+                'startedAt': '2026-06-12T09:00:05+00:00',
+                'stoppedAt': '2026-06-12T09:30:00+00:00',
+                'startupLogs': 'booting\nready',
+                'failureReason': None,
+                'mode': 'prod',
+            },
+        ]
+    )
+
+    runs = await client.list_app_runs('app-123', limit=2)
+
+    client.get.assert_awaited_once_with(endpoint='apps/app-123/runs', params={'limit': 2, 'offset': 0})
+    assert len(runs) == 2
+    assert all(isinstance(run, AppRunResponse) for run in runs)
+    assert runs[0].state == 'failed'
+    assert runs[0].started_at is None
+    assert runs[0].failure_reason is not None
+    assert runs[0].failure_reason.reason == 'ConfigDecryptionFailed'
+    assert runs[0].failure_reason.message == 'failed to decrypt key "#API_KEY"'
+    assert runs[1].failure_reason is None
+    assert runs[1].startup_logs == 'booting\nready'

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -2493,7 +2493,7 @@ def test_app_run_info_truncates_long_logs_and_message() -> None:
     )
     # The error tail is what matters: keep the LAST lines/chars, marking message truncation with an ellipsis.
     assert info.startup_logs == [f'line-{i}' for i in range(100 - _APP_RUN_LOG_LINES, 100)]
-    assert len(info.failure_message) == _APP_RUN_MESSAGE_LIMIT + 1
+    assert len(info.failure_message) == _APP_RUN_MESSAGE_LIMIT
     assert info.failure_message.startswith('…')
 
 

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -7,19 +7,23 @@ from fastmcp import Context
 
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID, KeboolaClient
-from keboola_mcp_server.clients.data_science import DataAppResponse
+from keboola_mcp_server.clients.data_science import AppRunResponse, DataAppResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.data_apps import (
+    _APP_RUN_LOG_LINES,
+    _APP_RUN_MESSAGE_LIMIT,
     _QUERY_SERVICE_QUERY_DATA_FUNCTION_CODE,
     _STORAGE_QUERY_DATA_FUNCTION_CODE,
     MAX_DNS_LABEL_LENGTH,
+    AppRunInfo,
     DataApp,
     DataAppSlugTooLongError,
     DataAppSummary,
     ModifiedDataAppOutput,
     _build_data_app_config,
     _fetch_data_app,
+    _fetch_latest_run,
     _get_authorization,
     _get_data_app_slug,
     _get_query_function_code,
@@ -2438,3 +2442,110 @@ async def test_delete_python_js_data_app_draft_refuses_streamlit(
 
     keboola_client.data_science_client.delete_data_app.assert_not_called()
     keboola_client.storage_client.configuration_delete.assert_not_called()
+
+
+def _make_failed_app_run(**overrides) -> AppRunResponse:
+    payload = {
+        'id': 'run-1',
+        'appId': 'app-prod-1',
+        'state': 'failed',
+        'createdAt': '2026-06-12T10:36:20+00:00',
+        'startedAt': None,
+        'stoppedAt': '2026-06-12T10:36:21+00:00',
+        'startupLogs': None,
+        'failureReason': {
+            'reason': 'ConfigDecryptionFailed',
+            'message': 'failed to decrypt key "#API_KEY"',
+        },
+        'mode': 'prod',
+    }
+    payload.update(overrides)
+    return AppRunResponse.model_validate(payload)
+
+
+def test_app_run_info_flattens_failure_reason() -> None:
+    info = AppRunInfo.from_api_response(_make_failed_app_run())
+    assert info.state == 'failed'
+    assert info.created_at == '2026-06-12T10:36:20+00:00'
+    assert info.stopped_at == '2026-06-12T10:36:21+00:00'
+    assert info.failure_reason == 'ConfigDecryptionFailed'
+    assert info.failure_message == 'failed to decrypt key "#API_KEY"'
+    assert info.startup_logs == []
+
+
+def test_app_run_info_handles_successful_run_without_failure_reason() -> None:
+    info = AppRunInfo.from_api_response(
+        _make_failed_app_run(state='finished', failureReason=None, startupLogs='booting\nready')
+    )
+    assert info.failure_reason is None
+    assert info.failure_message is None
+    assert info.startup_logs == ['booting', 'ready']
+
+
+def test_app_run_info_truncates_long_logs_and_message() -> None:
+    long_logs = '\n'.join(f'line-{i}' for i in range(100))
+    long_message = 'x' * (_APP_RUN_MESSAGE_LIMIT + 1000)
+    info = AppRunInfo.from_api_response(
+        _make_failed_app_run(
+            startupLogs=long_logs,
+            failureReason={'reason': 'StartupProbeFailed', 'message': long_message},
+        )
+    )
+    # The error tail is what matters: keep the LAST lines/chars, marking message truncation with an ellipsis.
+    assert info.startup_logs == [f'line-{i}' for i in range(100 - _APP_RUN_LOG_LINES, 100)]
+    assert len(info.failure_message) == _APP_RUN_MESSAGE_LIMIT + 1
+    assert info.failure_message.startswith('…')
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_run_returns_newest_run_info(mocker, mcp_context_client: Context) -> None:
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.data_science_client.list_app_runs = mocker.AsyncMock(return_value=[_make_failed_app_run()])
+
+    info = await _fetch_latest_run(keboola_client, 'app-prod-1')
+
+    keboola_client.data_science_client.list_app_runs.assert_awaited_once_with('app-prod-1', limit=1)
+    assert info is not None
+    assert info.failure_reason == 'ConfigDecryptionFailed'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('list_app_runs_behavior', ['empty', 'raises'])
+async def test_fetch_latest_run_degrades_to_none(
+    mocker, mcp_context_client: Context, list_app_runs_behavior: str
+) -> None:
+    """Diagnostics must not break the detail fetch: no runs (brand-new app) and a failing runs
+    endpoint (older DSAPI) both surface as `None` rather than an error."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    if list_app_runs_behavior == 'empty':
+        mock = mocker.AsyncMock(return_value=[])
+    else:
+        mock = mocker.AsyncMock(side_effect=RuntimeError('404 Not Found'))
+    keboola_client.data_science_client.list_app_runs = mock
+
+    assert await _fetch_latest_run(keboola_client, 'app-prod-1') is None
+
+
+@pytest.mark.asyncio
+async def test_get_data_apps_detail_includes_last_run_failure(mocker, mcp_context_client: Context) -> None:
+    """The detail path must surface the latest AppRun's failure so agents can diagnose apps whose
+    setup-phase failures (e.g. invalid secrets) produce no container logs at all."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    prod_cfg_id = 'cfg-prod-1'
+    prod = _make_python_js_prod_data_app(configuration_id=prod_cfg_id, state='stopped')
+    keboola_client.storage_client.configuration_list = mocker.AsyncMock(return_value=[])
+    keboola_client.data_science_client.list_app_runs = mocker.AsyncMock(return_value=[_make_failed_app_run()])
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=prod))
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_logs', mocker.AsyncMock(return_value=[]))
+
+    result = await get_data_apps(ctx=mcp_context_client, configuration_ids=[prod_cfg_id])
+
+    assert len(result.data_apps) == 1
+    detail = result.data_apps[0]
+    assert isinstance(detail, DataApp)
+    assert detail.deployment_info is not None
+    last_run = detail.deployment_info.last_run
+    assert last_run is not None
+    assert last_run.state == 'failed'
+    assert last_run.failure_reason == 'ConfigDecryptionFailed'
+    assert last_run.failure_message == 'failed to decrypt key "#API_KEY"'

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.70.1"
+version = "1.71.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: AI-3377

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

The data-science API now attaches `failureReason: {reason, message}` to unsuccessful AppRuns. This PR surfaces the latest run in data-app tool outputs so agents can diagnose startup failures — notably setup-phase failures (invalid secrets, git clone errors) that happen before the container starts and therefore produce no container logs at all.

- `clients/data_science.py`: new `AppRunResponse` + `AppRunFailureReason` models and `DataScienceClient.list_app_runs()` (`GET apps/{id}/runs`).
- `tools/data_apps.py`: new `DeploymentInfo.last_run` (state, timestamps, `failure_reason`, `failure_message` capped at 3000 chars, `startup_logs` trimmed to the last 30 lines), populated on the `get_data_apps` detail path and in `deploy_data_app` output. Run-fetch failures degrade to `last_run: null` so older DSAPIs without the runs endpoint keep working.
- `get_data_apps` docstring tells the agent to check `last_run` first when an app does not start.

Why it matters — verified on `canary-orion` with the In Platform Agent (Kai) against an app whose secret had a realistically corrupted cipher (`ConfigDecryptionFailed`, zero logs):

- **Before**: Kai misdiagnosed it as "the app has never been deployed" and recommended deploying it again.
- **After**: Kai answered directly from `last_run`: corrupted `#API_KEY` secret, failed in <1 s before container start, fix = re-save the secret.

Full experiment write-up (failure scenario matrix, latencies, operator feedback) is on AI-3377.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [x] Tested with In Platform Agent on `canary-orion` (local kai-agent → docker-compose MCP server → canary DSAPI)
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable) — new coverage for `list_app_runs` (endpoint/params, `failureReason` parsing), `AppRunInfo` flattening + truncation, `_fetch_latest_run` graceful degradation, and `last_run` propagation on the `get_data_apps` detail path (122 tests pass)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable) — tool docstring
