### PR TITLE
ci: deploy dev-<sha> tags to testing stacks and split canary triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,15 @@ name: Build and Push Docker Image
 on:
   push:
     tags:
-      - 'v*'
-      - 'agent-v*'
+      # Production releases (deployed to production stacks).
+      - 'v*'         # MCP server, e.g. v1.70.0
+      - 'agent-v*'   # In Platform Agent, e.g. agent-v1.70.0
+      # Canary releases (deployed to canary-orion stacks).
+      - 'canary-orion-v*'      # MCP server canary, e.g. canary-orion-v1.70.0-dev.1
+      - 'canary-orion-agent*'  # In Platform Agent canary, e.g. canary-orion-agent-v1.70.0-dev.1
+      # Dev releases (deployed to testing stacks).
+      - 'dev-v*'       # MCP server dev, e.g. dev-v1.70.0-dev.1
+      - 'dev-agent*'   # In Platform Agent dev, e.g. dev-agent-v1.70.0-dev.1
 
 permissions:
   contents: read
@@ -36,9 +43,13 @@ jobs:
             ${{ env.SERVICE_IMAGE_NAME }}
           tags: |
             type=sha,format=long
+            # Production: clean v* / agent-v* tags -> production stacks.
             type=raw,value=production-${{ github.sha }},enable=${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/agent-v')) && !contains(github.ref, '-dev.') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
-            type=raw,value=canary-orion-${{ github.sha }},enable=${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/agent-v')) && contains(github.ref, '-dev.') }}
+            # Canary: canary-orion-v* / canary-orion-agent* tags -> canary-orion stacks.
+            type=raw,value=canary-orion-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/canary-orion-') }}
+            # Dev: dev-v* / dev-agent* tags -> testing stacks.
+            type=raw,value=dev-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/dev-') }}
 
       - name: Docker login
         uses: docker/login-action@v4
@@ -83,7 +94,7 @@ jobs:
 
       - name: Trigger image tag update for canary-orion
         uses: ./.github/actions/trigger-image-tag-update
-        if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-dev.')
+        if: startsWith(github.ref, 'refs/tags/canary-orion-v')
         with:
           helm-chart: "mcp-server"
           image-tag: canary-orion-${{ github.sha }}
@@ -97,9 +108,17 @@ jobs:
           image-tag: production-${{ github.sha }}
           github-app-private-key: ${{ secrets.GITOPS_KBC_STACKS_TRIGGER_APP_PVK }}
 
+      - name: Trigger image tag update for testing (dev)
+        uses: ./.github/actions/trigger-image-tag-update
+        if: startsWith(github.ref, 'refs/tags/dev-v')
+        with:
+          helm-chart: "mcp-server"
+          image-tag: dev-${{ github.sha }}
+          github-app-private-key: ${{ secrets.GITOPS_KBC_STACKS_TRIGGER_APP_PVK }}
+
       - name: Trigger image tag update for canary-orion (agent)
         uses: ./.github/actions/trigger-image-tag-update
-        if: startsWith(github.ref, 'refs/tags/agent-v') && contains(github.ref, '-dev.')
+        if: startsWith(github.ref, 'refs/tags/canary-orion-agent')
         with:
           helm-chart: "mcp-server-agent"
           image-tag: canary-orion-${{ github.sha }}
@@ -111,6 +130,14 @@ jobs:
         with:
           helm-chart: "mcp-server-agent"
           image-tag: production-${{ github.sha }}
+          github-app-private-key: ${{ secrets.GITOPS_KBC_STACKS_TRIGGER_APP_PVK }}
+
+      - name: Trigger image tag update for testing (agent dev)
+        uses: ./.github/actions/trigger-image-tag-update
+        if: startsWith(github.ref, 'refs/tags/dev-agent')
+        with:
+          helm-chart: "mcp-server-agent"
+          image-tag: dev-${{ github.sha }}
           github-app-private-key: ${{ secrets.GITOPS_KBC_STACKS_TRIGGER_APP_PVK }}
 
   kaibench:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The rules in this file (git workflow, versioning, venv setup) complement `CONTRI
 
 ## Mapping a Docker Image Tag to a Version
 
-Production/canary images on Docker Hub (`keboola/mcp-server`) are tagged `production-<full-git-sha>` (or `canary-orion-<sha>`, etc.). To resolve a tag to a release version and check whether it's the latest deployed image, don't guess — run:
+Images on Docker Hub (`keboola/mcp-server`) are tagged `production-<full-git-sha>` (or `canary-orion-<sha>`, `dev-<sha>`, etc.) depending on which git tag triggered the build — see [Releasing](#releasing) for the tag → stack mapping. To resolve a tag to a release version and check whether it's the latest deployed image, don't guess — run:
 
 ```bash
 # 1. Which commit + version is in the image? (sha = part after "production-")
@@ -134,7 +134,21 @@ server always reflecting your latest code changes:
   - `vX.Y.Z` — MCP server release (always)
   - `agent-vX.Y.Z` — In Platform Agent release (only when releasing the agent as well)
 - Either tag triggers `release.yml` CI (builds/publishes the Docker image). KaiBench runs only on
-  production `vX.Y.Z` tags — not `agent-vX.Y.Z`, and not `-dev.` prereleases.
+  production `vX.Y.Z` tags — not `agent-vX.Y.Z`, and not the canary/dev tags below.
+- `release.yml` maps git tags to image tags and deployment stacks as follows:
+
+  | Git tag pushed | Image tag built | Helm chart | Deployed to |
+  |---|---|---|---|
+  | `vX.Y.Z` | `production-<sha>` (+ `latest`) | `mcp-server` | production stacks |
+  | `agent-vX.Y.Z` | `production-<sha>` | `mcp-server-agent` | production stacks |
+  | `canary-orion-vX.Y.Z-dev.N` | `canary-orion-<sha>` | `mcp-server` | canary-orion stacks |
+  | `canary-orion-agent-vX.Y.Z-dev.N` | `canary-orion-<sha>` | `mcp-server-agent` | canary-orion stacks |
+  | `dev-vX.Y.Z-dev.N` | `dev-<sha>` | `mcp-server` | testing stacks |
+  | `dev-agent-vX.Y.Z-dev.N` | `dev-<sha>` | `mcp-server-agent` | testing stacks |
+
+  The stack routing (which physical stacks a `canary-orion-`/`dev-`/`production-` image tag lands on)
+  is configured on the `keboola/kbc-stacks` side; this repo only builds the image and triggers the
+  tag update.
 - Use the **`release-notes` skill** to prepare a release — it generates the release notes, opens
   the draft `release/vX.Y.Z` PR, and walks through tagging both `vX.Y.Z` and `agent-vX.Y.Z`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.69.4"
+version = "1.69.5"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1322,7 +1322,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.69.4"
+version = "1.69.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: N/A (CI/infra change — no Linear issue)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Restructures `release.yml`'s git-tag → image-tag → Helm-chart → stack mapping:

- **New dev/testing path** — pushing `dev-v*` (server) or `dev-agent*` (agent) tags builds a `dev-<sha>` image and triggers a deployment to the **testing stacks**, mirroring exactly how `canary-orion-*` tags deploy to canary stacks (same charts, same `trigger-image-tag-update` action; the stack routing for the `dev-` prefix lives in `keboola/kbc-stacks`).
- **Canary trigger split** — canary no longer rides on the `v*`/`agent-v*` + `-dev.` heuristic. It now triggers on explicit tags:
  - `canary-orion-v*` → `mcp-server` chart
  - `canary-orion-agent*` → `mcp-server-agent` chart
  - both still publish the `canary-orion-<sha>` image.
- **Production unchanged** — `v*` / `agent-v*` (without `-dev.`) still build `production-<sha>` (+ `latest` for `v*`) and deploy to production. KaiBench still runs only on production `v*` tags.
- **Docs** — the full tag → image-tag → chart → stack mapping is documented in `CLAUDE.md` (Releasing section).

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

This is a CI-only change (no server/runtime code touched). Verified:
- `release.yml` parses as valid YAML and the six `on.push.tags` globs resolve as intended (`v*`, `agent-v*`, `canary-orion-v*`, `canary-orion-agent*`, `dev-v*`, `dev-agent*`).
- Each deploy step's `if:` is mutually exclusive across the tag families (e.g. `dev-v*` does not match `refs/tags/v`, `canary-orion-agent*` does not match `agent-v`).
- `tox -e black,isort,flake8,check-tools-docs` all pass.

> Note: real end-to-end validation requires pushing the new tags and confirming the `keboola/kbc-stacks` side has matching routing for the `dev-` image-tag prefix — that routing config is out of this repo's scope and should be confirmed before the first `dev-*` tag is pushed.

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable) — N/A (CI workflow change)
- [ ] Integration tests added/updated (if applicable) — N/A
- [x] Project version bumped according to the change type (1.69.4 → 1.69.5)
- [x] Documentation updated (CLAUDE.md release/tag scheme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)