### PR TITLE
AJDA-2852: fix: don't report modify_streamlit_data_app failure after a committed write

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.72.1"
+version = "1.72.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -551,8 +551,14 @@ async def modify_streamlit_data_app(
     )
 
     if configuration_id:
-        # Update existing data app
-        data_app, updated_config, _ = await modify_streamlit_data_app_internal(
+        # Update existing data app.
+        #
+        # `configuration_update` below is the ONLY step allowed to fail the whole tool: if it raises, nothing
+        # was committed and a ToolError truthfully reports the failure. Everything after it merely enriches the
+        # response (re-fetch, metadata, folder, links) and must NEVER turn a committed write into a reported
+        # failure -- otherwise the agent, seeing an error, retries and re-applies the change, producing the
+        # v27->v29 double-write that deployed broken code (AJDA-2852). Hence the best-effort block below.
+        data_app_pre, updated_config, _ = await modify_streamlit_data_app_internal(
             client=client,
             workspace_manager=workspace_manager,
             name=name,
@@ -563,43 +569,64 @@ async def modify_streamlit_data_app(
             configuration_id=configuration_id,
             change_description=change_description,
         )
-        await client.storage_client.configuration_update(
+        update_resp = await client.storage_client.configuration_update(
             component_id=DATA_APP_COMPONENT_ID,
             configuration_id=configuration_id,
             configuration=updated_config,
             change_description=change_description or 'Change Data App',
-            updated_name=name or data_app.name,
-            updated_description=description or data_app.description,
+            updated_name=name or data_app_pre.name,
+            updated_description=description or data_app_pre.description,
         )
-        data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
-        await set_cfg_update_metadata(
-            client=client,
-            component_id=DATA_APP_COMPONENT_ID,
-            configuration_id=configuration_id,
-            configuration_version=int(data_app.config_version),
-        )
-        folder_hint = await apply_folder_metadata(
-            client, DATA_APP_COMPONENT_ID, configuration_id, folder, 'data apps', 'modify_streamlit_data_app'
-        )
-        links = links_manager.get_data_app_links(
-            configuration_id=data_app.configuration_id,
-            configuration_name=name,
-            deployment_link=data_app.deployment_url,
-            uses_basic_authentication=_uses_basic_authentication(data_app.configuration.get('authorization') or {}),
-        )
-        response = (
-            'updated (redeploy required to apply changes in the running app)'
-            if data_app.state in ('running', 'starting')
-            else 'updated'
-        )
-        return ModifiedDataAppOutput(
-            response=response,
-            change_summary=folder_hint,
-            data_app=DataAppSummary.model_validate(data_app.model_dump()),
-            links=links,
-        )
+        # --- write committed past this point; response building is strictly best-effort ---
+        # The new version comes straight from the PUT response, so it is known even if the re-fetch below fails.
+        new_version = str(update_resp.get('version') or '')
+        try:
+            await set_cfg_update_metadata(
+                client=client,
+                component_id=DATA_APP_COMPONENT_ID,
+                configuration_id=configuration_id,
+                configuration_version=int(new_version) if new_version.isdigit() else int(data_app_pre.config_version),
+            )
+            folder_hint = await apply_folder_metadata(
+                client, DATA_APP_COMPONENT_ID, configuration_id, folder, 'data apps', 'modify_streamlit_data_app'
+            )
+            data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
+            links = links_manager.get_data_app_links(
+                configuration_id=data_app.configuration_id,
+                configuration_name=name,
+                deployment_link=data_app.deployment_url,
+                uses_basic_authentication=_uses_basic_authentication(data_app.configuration.get('authorization') or {}),
+            )
+            response = (
+                'updated (redeploy required to apply changes in the running app)'
+                if data_app.state in ('running', 'starting')
+                else 'updated'
+            )
+            return ModifiedDataAppOutput(
+                response=response,
+                change_summary=folder_hint,
+                data_app=DataAppSummary.model_validate(data_app.model_dump()),
+                links=links,
+            )
+        except Exception as exc:
+            LOG.exception(
+                'Data app configuration %s was updated (version %s) but building the response failed; '
+                'returning a partial success so the change is not retried.',
+                configuration_id,
+                new_version or '?',
+            )
+            return _partial_update_output(
+                data_app_pre=data_app_pre,
+                links_manager=links_manager,
+                configuration_id=configuration_id,
+                name=name,
+                new_version=new_version,
+                error=exc,
+            )
     else:
-        # Create new data app
+        # Create new data app. As with the update path, `create_data_app` is the committing write; the
+        # metadata/folder/links steps after it are best-effort and must not fail the tool once the app exists,
+        # so a failed retry cannot create a duplicate app (AJDA-2852).
         config = _build_data_app_config(name, source_code, packages, authentication_type, secrets, sql_dialect)
         config = await client.encryption_client.encrypt(
             config, component_id=DATA_APP_COMPONENT_ID, project_id=project_id
@@ -608,32 +635,48 @@ async def modify_streamlit_data_app(
         data_app_resp = await client.data_science_client.create_data_app(
             name, description, configuration=validated_config
         )
-        await set_cfg_creation_metadata(
-            client=client,
-            component_id=DATA_APP_COMPONENT_ID,
-            configuration_id=data_app_resp.config_id,
-        )
-        folder_hint = await apply_folder_metadata(
-            client,
-            DATA_APP_COMPONENT_ID,
-            data_app_resp.config_id,
-            folder,
-            'data apps',
-            'modify_streamlit_data_app',
-            is_new=True,
-        )
-        links = links_manager.get_data_app_links(
-            configuration_id=data_app_resp.config_id,
-            configuration_name=name,
-            deployment_link=data_app_resp.url,
-            uses_basic_authentication=_uses_basic_authentication(validated_config.authorization),
-        )
-        return ModifiedDataAppOutput(
-            response='created',
-            change_summary=folder_hint,
-            data_app=DataAppSummary.from_api_response(data_app_resp),
-            links=links,
-        )
+        # --- app created past this point; response building is strictly best-effort ---
+        try:
+            await set_cfg_creation_metadata(
+                client=client,
+                component_id=DATA_APP_COMPONENT_ID,
+                configuration_id=data_app_resp.config_id,
+            )
+            folder_hint = await apply_folder_metadata(
+                client,
+                DATA_APP_COMPONENT_ID,
+                data_app_resp.config_id,
+                folder,
+                'data apps',
+                'modify_streamlit_data_app',
+                is_new=True,
+            )
+            links = links_manager.get_data_app_links(
+                configuration_id=data_app_resp.config_id,
+                configuration_name=name,
+                deployment_link=data_app_resp.url,
+                uses_basic_authentication=_uses_basic_authentication(validated_config.authorization),
+            )
+            return ModifiedDataAppOutput(
+                response='created',
+                change_summary=folder_hint,
+                data_app=DataAppSummary.from_api_response(data_app_resp),
+                links=links,
+            )
+        except Exception as exc:
+            LOG.exception(
+                'Data app %s was created (configuration %s) but building the response failed; '
+                'returning a partial success so creation is not retried.',
+                data_app_resp.id,
+                data_app_resp.config_id,
+            )
+            return _partial_create_output(
+                data_app_resp=data_app_resp,
+                links_manager=links_manager,
+                validated_config=validated_config,
+                name=name,
+                error=exc,
+            )
 
 
 async def modify_streamlit_data_app_internal(
@@ -698,6 +741,115 @@ async def modify_streamlit_data_app_internal(
             )
 
     return data_app, updated_config, folder_preview
+
+
+def _partial_update_output(
+    *,
+    data_app_pre: DataApp,
+    links_manager: ProjectLinksManager,
+    configuration_id: str,
+    name: str,
+    new_version: str,
+    error: Exception,
+) -> ModifiedDataAppOutput:
+    """Build a truthful partial-success response after a committed Streamlit update whose response building failed.
+
+    The configuration write already landed, so this MUST NOT raise -- it is built entirely from the pre-update
+    data app (fetched before the write) plus the new version from the update response. The ``change_summary``
+    tells the agent the change IS applied and must not be retried, preventing the duplicate-write loop.
+    """
+    try:
+        summary = DataAppSummary.model_validate(data_app_pre.model_dump())
+        summary.config_version = new_version or summary.config_version
+    except Exception:
+        # Defensive: this helper must never raise (the write already committed). SafeState/SafeType accept any
+        # string, so building from the pre-update primitives cannot fail even if the schema is later tightened.
+        summary = DataAppSummary(
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=configuration_id,
+            data_app_id=getattr(data_app_pre, 'data_app_id', '') or '',
+            project_id=getattr(data_app_pre, 'project_id', '') or '',
+            branch_id=getattr(data_app_pre, 'branch_id', '') or '',
+            config_version=new_version or getattr(data_app_pre, 'config_version', '') or '',
+            state=getattr(data_app_pre, 'state', 'unknown') or 'unknown',
+            type=getattr(data_app_pre, 'type', 'streamlit') or 'streamlit',
+        )
+    try:
+        links = links_manager.get_data_app_links(
+            configuration_id=configuration_id,
+            configuration_name=name or data_app_pre.name,
+            deployment_link=data_app_pre.deployment_url,
+            uses_basic_authentication=_uses_basic_authentication(data_app_pre.configuration.get('authorization') or {}),
+        )
+    except Exception:
+        links = []
+    # Mirror the success-path wording: the redeploy hint only applies to a running/starting app. The pre-update
+    # state is a faithful proxy here -- a config write does not change deployment state on its own.
+    response = (
+        'updated (redeploy required to apply changes in the running app)'
+        if data_app_pre.state in ('running', 'starting')
+        else 'updated'
+    )
+    return ModifiedDataAppOutput(
+        response=response,
+        change_summary=(
+            f'The configuration WAS updated (version {new_version or "unknown"}), but loading the full app '
+            f'details failed, so this response is partial: {error}. Do NOT retry the update -- the change is '
+            f'already applied. Call deploy_data_app to apply it to the running app.'
+        ),
+        data_app=summary,
+        links=links,
+    )
+
+
+def _partial_create_output(
+    *,
+    data_app_resp: DataAppResponse,
+    links_manager: ProjectLinksManager,
+    validated_config: DataAppConfig,
+    name: str,
+    error: Exception,
+) -> ModifiedDataAppOutput:
+    """Build a truthful partial-success response after a committed Streamlit create whose response building failed.
+
+    The app already exists, so this MUST NOT raise -- it is built from the create response the API already
+    returned. The ``change_summary`` tells the agent the app IS created and must not be retried, preventing a
+    duplicate app.
+    """
+    try:
+        summary = DataAppSummary.from_api_response(data_app_resp)
+    except Exception:
+        # Defensive: this helper must never raise (the app already exists). SafeState/SafeType accept any
+        # string, so building from the create-response primitives cannot fail even if the schema is tightened.
+        summary = DataAppSummary(
+            component_id=getattr(data_app_resp, 'component_id', DATA_APP_COMPONENT_ID) or DATA_APP_COMPONENT_ID,
+            configuration_id=getattr(data_app_resp, 'config_id', '') or '',
+            data_app_id=getattr(data_app_resp, 'id', '') or '',
+            project_id=getattr(data_app_resp, 'project_id', '') or '',
+            branch_id=getattr(data_app_resp, 'branch_id', '') or '',
+            config_version=getattr(data_app_resp, 'config_version', '') or '',
+            state=getattr(data_app_resp, 'state', 'unknown') or 'unknown',
+            type=getattr(data_app_resp, 'type', 'streamlit') or 'streamlit',
+        )
+    try:
+        links = links_manager.get_data_app_links(
+            configuration_id=data_app_resp.config_id,
+            configuration_name=name,
+            deployment_link=data_app_resp.url,
+            uses_basic_authentication=_uses_basic_authentication(validated_config.authorization),
+        )
+    except Exception:
+        links = []
+    return ModifiedDataAppOutput(
+        response='created',
+        change_summary=(
+            f'The data app WAS created (configuration {data_app_resp.config_id}), but building the full response '
+            f'failed, so this response is partial: {error}. Do NOT retry creation -- it would create a duplicate. '
+            f'Call deploy_data_app to start the app.'
+        ),
+        data_app=summary,
+        links=links,
+    )
 
 
 @tool_errors()

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -579,14 +579,20 @@ async def modify_streamlit_data_app(
         )
         # --- write committed past this point; response building is strictly best-effort ---
         # The new version comes straight from the PUT response, so it is known even if the re-fetch below fails.
-        new_version = str(update_resp.get('version') or '')
+        # Read it defensively: this runs after the committing write and must not raise (a non-dict response would
+        # otherwise turn the committed write into a ToolError -- the very failure mode this block guards against).
+        new_version = str(update_resp.get('version') or '') if isinstance(update_resp, dict) else ''
         try:
-            await set_cfg_update_metadata(
-                client=client,
-                component_id=DATA_APP_COMPONENT_ID,
-                configuration_id=configuration_id,
-                configuration_version=int(new_version) if new_version.isdigit() else int(data_app_pre.config_version),
-            )
+            # Only stamp the UPDATED_BY_MCP version when the new version is actually known. Falling back to the
+            # pre-update version would record a misleading version (the write did increment it), so skip the
+            # metadata write when the response carried no numeric version.
+            if new_version.isdigit():
+                await set_cfg_update_metadata(
+                    client=client,
+                    component_id=DATA_APP_COMPONENT_ID,
+                    configuration_id=configuration_id,
+                    configuration_version=int(new_version),
+                )
             folder_hint = await apply_folder_metadata(
                 client, DATA_APP_COMPONENT_ID, configuration_id, folder, 'data apps', 'modify_streamlit_data_app'
             )
@@ -608,7 +614,7 @@ async def modify_streamlit_data_app(
                 data_app=DataAppSummary.model_validate(data_app.model_dump()),
                 links=links,
             )
-        except Exception as exc:
+        except Exception:
             LOG.exception(
                 'Data app configuration %s was updated (version %s) but building the response failed; '
                 'returning a partial success so the change is not retried.',
@@ -621,7 +627,6 @@ async def modify_streamlit_data_app(
                 configuration_id=configuration_id,
                 name=name,
                 new_version=new_version,
-                error=exc,
             )
     else:
         # Create new data app. As with the update path, `create_data_app` is the committing write; the
@@ -663,7 +668,7 @@ async def modify_streamlit_data_app(
                 data_app=DataAppSummary.from_api_response(data_app_resp),
                 links=links,
             )
-        except Exception as exc:
+        except Exception:
             LOG.exception(
                 'Data app %s was created (configuration %s) but building the response failed; '
                 'returning a partial success so creation is not retried.',
@@ -675,7 +680,6 @@ async def modify_streamlit_data_app(
                 links_manager=links_manager,
                 validated_config=validated_config,
                 name=name,
-                error=exc,
             )
 
 
@@ -750,13 +754,14 @@ def _partial_update_output(
     configuration_id: str,
     name: str,
     new_version: str,
-    error: Exception,
 ) -> ModifiedDataAppOutput:
     """Build a truthful partial-success response after a committed Streamlit update whose response building failed.
 
     The configuration write already landed, so this MUST NOT raise -- it is built entirely from the pre-update
     data app (fetched before the write) plus the new version from the update response. The ``change_summary``
-    tells the agent the change IS applied and must not be retried, preventing the duplicate-write loop.
+    tells the agent the change IS applied and must not be retried, preventing the duplicate-write loop. The
+    underlying exception is intentionally not surfaced to the caller (it is logged at the call site) -- the
+    agent-facing message stays stable and free of internal detail.
     """
     try:
         summary = DataAppSummary.model_validate(data_app_pre.model_dump())
@@ -794,8 +799,8 @@ def _partial_update_output(
         response=response,
         change_summary=(
             f'The configuration WAS updated (version {new_version or "unknown"}), but loading the full app '
-            f'details failed, so this response is partial: {error}. Do NOT retry the update -- the change is '
-            f'already applied. Call deploy_data_app to apply it to the running app.'
+            f'details failed, so this response is partial. Do NOT retry the update -- the change is already '
+            f'applied. Call deploy_data_app to apply it to the running app.'
         ),
         data_app=summary,
         links=links,
@@ -808,13 +813,13 @@ def _partial_create_output(
     links_manager: ProjectLinksManager,
     validated_config: DataAppConfig,
     name: str,
-    error: Exception,
 ) -> ModifiedDataAppOutput:
     """Build a truthful partial-success response after a committed Streamlit create whose response building failed.
 
     The app already exists, so this MUST NOT raise -- it is built from the create response the API already
     returned. The ``change_summary`` tells the agent the app IS created and must not be retried, preventing a
-    duplicate app.
+    duplicate app. The underlying exception is intentionally not surfaced to the caller (it is logged at the
+    call site) -- the agent-facing message stays stable and free of internal detail.
     """
     try:
         summary = DataAppSummary.from_api_response(data_app_resp)
@@ -844,7 +849,7 @@ def _partial_create_output(
         response='created',
         change_summary=(
             f'The data app WAS created (configuration {data_app_resp.config_id}), but building the full response '
-            f'failed, so this response is partial: {error}. Do NOT retry creation -- it would create a duplicate. '
+            f'failed, so this response is partial. Do NOT retry creation -- it would create a duplicate. '
             f'Call deploy_data_app to start the app.'
         ),
         data_app=summary,

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -968,7 +968,6 @@ async def test_partial_output_helpers_never_raise_when_summary_construction_fail
         configuration_id='cfg-1',
         name='My App',
         new_version='28',
-        error=RuntimeError('enrichment boom'),
     )
     assert isinstance(update_out, ModifiedDataAppOutput)
     assert update_out.data_app.configuration_id == 'cfg-1'
@@ -984,12 +983,76 @@ async def test_partial_output_helpers_never_raise_when_summary_construction_fail
         links_manager=links_manager,
         validated_config=mocker.MagicMock(authorization={}),
         name='My App',
-        error=RuntimeError('enrichment boom'),
     )
     assert isinstance(create_out, ModifiedDataAppOutput)
     assert create_out.data_app.configuration_id == 'new-cfg-1'
     assert create_out.data_app.data_app_id == 'app-2'
     assert 'WAS created' in (create_out.change_summary or '')
+
+
+@pytest.mark.asyncio
+async def test_modify_streamlit_data_app_update_skips_metadata_when_version_missing(
+    mocker,
+    mcp_context_client: Context,
+    workspace_manager,
+) -> None:
+    """When the update response carries no numeric version, set_cfg_update_metadata must be SKIPPED rather than
+    stamped with the (now-stale) pre-update version, which would record a misleading UPDATED_BY_MCP version
+    (review hardening on AJDA-2852). The tool still returns a normal success."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+
+    workspace_manager.get_workspace_id = mocker.AsyncMock(return_value=1)
+    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
+    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='default')
+    keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
+
+    encrypted_config = {
+        'parameters': {'script': ['SELECT 1']},
+        'storage': {},
+        'authorization': {'app_proxy': {'auth_providers': [], 'auth_rules': []}},
+    }
+    keboola_client.encryption_client = mocker.AsyncMock()
+    keboola_client.encryption_client.encrypt = mocker.AsyncMock(return_value=encrypted_config)
+
+    existing_data_app = DataApp(
+        name='My App',
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id='cfg-1',
+        data_app_id='app-1',
+        project_id='proj-1',
+        branch_id='default',
+        config_version='27',
+        type='streamlit',
+        auto_suspend_after_seconds=900,
+        configuration=encrypted_config,
+        state='stopped',
+    )
+    mocker.patch(
+        'keboola_mcp_server.tools.data_apps.modify_streamlit_data_app_internal',
+        mocker.AsyncMock(return_value=(existing_data_app, encrypted_config, None)),
+    )
+    # Committing write succeeds but the response carries no version.
+    keboola_client.storage_client.configuration_update = mocker.AsyncMock(return_value={})
+    # Let the rest of the (best-effort) response building succeed.
+    set_meta = mocker.patch('keboola_mcp_server.tools.data_apps.set_cfg_update_metadata', mocker.AsyncMock())
+    mocker.patch('keboola_mcp_server.tools.data_apps.apply_folder_metadata', mocker.AsyncMock(return_value=None))
+    mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=existing_data_app))
+
+    result = await modify_streamlit_data_app(
+        ctx=mcp_context_client,
+        name='My App',
+        description='desc',
+        source_code='import streamlit as st\n{QUERY_DATA_FUNCTION}\nst.write("hello")',
+        packages=['pandas'],
+        authentication_type='no-auth',
+        configuration_id='cfg-1',
+        change_description='test',
+    )
+
+    assert isinstance(result, ModifiedDataAppOutput)
+    assert result.response == 'updated'
+    # The misleading pre-update-version stamp must NOT happen when the new version is unknown.
+    set_meta.assert_not_awaited()
 
 
 # ===== Tests for modify_python_js_data_app =====

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -830,6 +830,168 @@ async def test_modify_streamlit_data_app_folder(
         assert result.change_summary is None
 
 
+@pytest.mark.parametrize(
+    ('configuration_id', 'fail_at', 'state', 'expected_response'),
+    [
+        # Update: failure at the re-fetch step, running app keeps the "redeploy required" hint.
+        ('cfg-1', '_fetch_data_app', 'running', 'updated (redeploy required to apply changes in the running app)'),
+        # Update: failure at the FIRST post-write step (metadata) on a stopped app -> still partial, no redeploy hint.
+        ('cfg-1', 'set_cfg_update_metadata', 'stopped', 'updated'),
+        # Create: failure at a post-write step.
+        ('', 'set_cfg_creation_metadata', None, 'created'),
+    ],
+    ids=['update_refetch_running', 'update_metadata_stopped', 'create_metadata'],
+)
+@pytest.mark.asyncio
+async def test_modify_streamlit_data_app_partial_success_when_response_building_fails(
+    mocker,
+    mcp_context_client: Context,
+    workspace_manager,
+    configuration_id: str,
+    fail_at: str,
+    state: str | None,
+    expected_response: str,
+) -> None:
+    """Regression for AJDA-2852: when the API write commits but a post-write response-building step raises,
+    the tool must return a truthful partial success (not a ToolError) so the agent does not retry and
+    double-apply the change. Parametrized over which post-write step fails to prove the partial path is reached
+    regardless of failure point, and that the response wording still reflects the app state."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+
+    workspace_manager.get_workspace_id = mocker.AsyncMock(return_value=1)
+    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
+    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='default')
+    keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
+
+    encrypted_config = {
+        'parameters': {'script': ['SELECT 1']},
+        'storage': {},
+        'authorization': {'app_proxy': {'auth_providers': [], 'auth_rules': []}},
+    }
+    keboola_client.encryption_client = mocker.AsyncMock()
+    keboola_client.encryption_client.encrypt = mocker.AsyncMock(return_value=encrypted_config)
+
+    boom = RuntimeError('boom while building response')
+
+    if configuration_id:
+        existing_data_app = DataApp(
+            name='My App',
+            component_id=DATA_APP_COMPONENT_ID,
+            configuration_id=configuration_id,
+            data_app_id='app-1',
+            project_id='proj-1',
+            branch_id='default',
+            config_version='27',
+            type='streamlit',
+            auto_suspend_after_seconds=900,
+            configuration=encrypted_config,
+            state=state,
+        )
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps.modify_streamlit_data_app_internal',
+            mocker.AsyncMock(return_value=(existing_data_app, encrypted_config, None)),
+        )
+        # The write commits and returns the new version...
+        keboola_client.storage_client.configuration_update = mocker.AsyncMock(return_value={'version': 28})
+        # ...but a post-write enrichment step blows up.
+        mocker.patch(f'keboola_mcp_server.tools.data_apps.{fail_at}', side_effect=boom)
+        committing_mock = keboola_client.storage_client.configuration_update
+    else:
+        mocker.patch(
+            'keboola_mcp_server.tools.data_apps.DataAppConfig.model_validate',
+            return_value=mocker.MagicMock(authorization={'app_proxy': {'auth_providers': [], 'auth_rules': []}}),
+        )
+        keboola_client.data_science_client = mocker.AsyncMock()
+        keboola_client.data_science_client.create_data_app = mocker.AsyncMock(
+            return_value=_make_data_app_response(config_id='new-cfg-1')
+        )
+        # The app is created, but a post-write enrichment step blows up.
+        mocker.patch(f'keboola_mcp_server.tools.data_apps.{fail_at}', side_effect=boom)
+        committing_mock = keboola_client.data_science_client.create_data_app
+
+    # Must NOT raise (no ToolError) even though a post-write step failed.
+    result = await modify_streamlit_data_app(
+        ctx=mcp_context_client,
+        name='My App',
+        description='desc',
+        source_code='import streamlit as st\n{QUERY_DATA_FUNCTION}\nst.write("hello")',
+        packages=['pandas'],
+        authentication_type='no-auth',
+        configuration_id=configuration_id,
+        change_description='test',
+    )
+
+    assert isinstance(result, ModifiedDataAppOutput)
+    # The committing write happened exactly once and is never retried within the call.
+    committing_mock.assert_awaited_once()
+    assert result.change_summary is not None
+    # The response truthfully reports the change landed and warns against retrying.
+    assert 'do not retry' in result.change_summary.lower()
+    # Response wording mirrors the success path (redeploy hint only for running/starting apps).
+    assert result.response == expected_response
+    if configuration_id:
+        assert 'WAS updated' in result.change_summary
+        # New version surfaced from the write response despite the failed re-fetch.
+        assert '28' in result.change_summary
+        assert result.data_app.config_version == '28'
+    else:
+        assert 'WAS created' in result.change_summary
+
+
+@pytest.mark.asyncio
+async def test_partial_output_helpers_never_raise_when_summary_construction_fails(mocker) -> None:
+    """The partial-output helpers promise 'MUST NOT raise' even if the primary DataAppSummary construction
+    fails -- they must fall back to a summary built from primitives instead of letting a committed write
+    surface as a ToolError (AJDA-2852)."""
+    from keboola_mcp_server.tools.data_apps import _partial_create_output, _partial_update_output
+
+    links_manager = mocker.MagicMock()
+    links_manager.get_data_app_links.return_value = []
+
+    # --- update helper: force the primary model_validate to raise ---
+    data_app_pre = DataApp(
+        name='My App',
+        component_id=DATA_APP_COMPONENT_ID,
+        configuration_id='cfg-1',
+        data_app_id='app-1',
+        project_id='proj-1',
+        branch_id='default',
+        config_version='27',
+        type='streamlit',
+        configuration={'authorization': {}},
+        state='running',
+    )
+    mocker.patch.object(DataAppSummary, 'model_validate', side_effect=RuntimeError('validate boom'))
+    update_out = _partial_update_output(
+        data_app_pre=data_app_pre,
+        links_manager=links_manager,
+        configuration_id='cfg-1',
+        name='My App',
+        new_version='28',
+        error=RuntimeError('enrichment boom'),
+    )
+    assert isinstance(update_out, ModifiedDataAppOutput)
+    assert update_out.data_app.configuration_id == 'cfg-1'
+    assert update_out.data_app.data_app_id == 'app-1'
+    assert update_out.data_app.config_version == '28'  # falls back to the new version from the write response
+    assert update_out.response == 'updated (redeploy required to apply changes in the running app)'
+
+    # --- create helper: force the primary from_api_response to raise ---
+    data_app_resp = _make_data_app_response(config_id='new-cfg-1', data_app_id='app-2')
+    mocker.patch.object(DataAppSummary, 'from_api_response', side_effect=RuntimeError('from_api boom'))
+    create_out = _partial_create_output(
+        data_app_resp=data_app_resp,
+        links_manager=links_manager,
+        validated_config=mocker.MagicMock(authorization={}),
+        name='My App',
+        error=RuntimeError('enrichment boom'),
+    )
+    assert isinstance(create_out, ModifiedDataAppOutput)
+    assert create_out.data_app.configuration_id == 'new-cfg-1'
+    assert create_out.data_app.data_app_id == 'app-2'
+    assert 'WAS created' in (create_out.change_summary or '')
+
+
 # ===== Tests for modify_python_js_data_app =====
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.72.1"
+version = "1.72.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
[link to issue](https://linear.app/keboola/issue/AJDA-2852/fix-mcp-for-streamlit-and-cc)

## Description

Fixes point 2 of AJDA-2852 (from a customer support request): `modify_streamlit_data_app` could silently apply changes while still reporting an error. The tool performed the API write (`configuration_update` on the update path, `create_data_app` on the create path) and then built its response (re-fetch, metadata, folder, links, model validation). Any failure in a post-write step was wrapped by the `@tool_errors` decorator into a `ToolError`, so the tool reported **failure** even though the write had already committed. Agents then retried and re-applied the change — observed as a config version jumping v27 → v29 and deploying broken code (wrong packages), with no way to tell from the error whether the write had landed.

Changes in `src/keboola_mcp_server/tools/data_apps.py`:

- **Hard split between the committing write and response building.** In both branches the write (`configuration_update` / `create_data_app`) is now the only step allowed to fail the whole tool — if it raises, nothing was committed and the `ToolError` is truthful. Everything after it is wrapped in a best-effort `try/except`.
- **Truthful partial-success on post-write failure.** New helpers `_partial_update_output` / `_partial_create_output` return a `ModifiedDataAppOutput` whose `change_summary` states the change WAS applied (with the new version) and that the agent must **NOT** retry, pointing it to `deploy_data_app`. This breaks the retry/double-write loop.
- **Version known without the re-fetch.** The new config version is read directly from the `configuration_update` response (`update_resp.get('version')`), so it is reported even when the re-fetch fails. The partial-update response mirrors the success-path "redeploy required" wording based on the pre-update app state.
- **Metadata stamp reordered.** On the update path, `set_cfg_update_metadata` now runs *before* `_fetch_data_app` (previously after). This is intentional — the metadata version now comes from the write response rather than the re-fetch — and harmless, but flagged here for reviewers as the ordering changed.
- **Helpers never raise.** Both fall back to a `DataAppSummary` built from primitives (`SafeState`/`SafeType` accept any string), so a committed write can never surface as a `ToolError` even if `DataAppSummary` construction fails.

Review hardening (follow-up commit):

- The new-version read is now defensive (`isinstance(update_resp, dict)`), so a non-dict response can't raise after the committing write and reintroduce the bug.
- `set_cfg_update_metadata` is skipped when the update response carries no numeric version, instead of stamping the stale pre-update version (which would record a misleading `UPDATED_BY_MCP` version). Covered by a new regression test.
- The raw exception is no longer interpolated into the agent-facing `change_summary` (it is already logged at the call site), keeping the message stable and free of internal detail.

Tests (`tests/tools/test_data_apps.py`):

- `test_modify_streamlit_data_app_partial_success_when_response_building_fails` — parametrized over update/create and over which post-write step fails; asserts no `ToolError`, success response with state-correct wording, the new version surfaced, "do not retry" guidance, and that the committing write ran exactly once.
- `test_partial_output_helpers_never_raise_when_summary_construction_fails` — forces the primary `DataAppSummary` construction to raise and asserts the helpers still return a sane fallback.
- `test_modify_streamlit_data_app_update_skips_metadata_when_version_missing` — asserts `set_cfg_update_metadata` is skipped when the update response carries no numeric version.

Patch version bump `1.72.1` → `1.72.2`.

## Release Notes

- **Justification**
    - A committed data-app change must never be reported as a failure. The old behavior made agents believe the write had failed, so they retried and applied the change twice — bumping the config version and deploying broken code with no signal that anything had landed.
    - For a non-developer: when the assistant updates or creates a Streamlit data app, it now always tells you truthfully whether the change was saved — even if it couldn't load all the follow-up details — instead of showing a confusing error that hides the fact the change already happened.
- **Plans for Customer Communication**
    - No customer communication needed. This is a reliability fix to an MCP tool's error reporting; no API surface, parameters, or success behavior change.
- **Impact Analysis**
    - Scope is limited to `modify_streamlit_data_app`. The success path is unchanged. The only behavioral change is on post-write failure: the tool now returns a partial-success result instead of raising. No effect on other tools; not single-tenant-specific.
    - Not behind a feature flag.
- **Deployment Plan**
    - Continuous deployment with the regular MCP server release; no stack-by-stack rollout required.
- **Rollback Plan**
    - Fully reversible by reverting this commit and redeploying. Not a one-way-door change.
- **Post-Release Support Plan**
    - No special monitoring required. If desired, the `change_summary` "partial success" wording can be watched in tool events to confirm the degraded path behaves as expected. Support team notification not needed.

