### PR TITLE
fix(storage): prefer KBC metadata over legacy description for buckets/tables [AI-3423]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.72.2"
+version = "1.72.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/storage/tools.py
+++ b/src/keboola_mcp_server/tools/storage/tools.py
@@ -213,12 +213,15 @@ class BucketDetail(BaseModel):
     @model_validator(mode='before')
     @classmethod
     def set_description(cls, values: dict[str, Any]) -> dict[str, Any]:
-        description = values.get('description')
+        # KBC metadata holds the curated, user-editable description (update_descriptions writes here).
+        # The legacy top-level `description` field is auto-generated (e.g. "Bucket created by
+        # Transformation API") and stale for linked/shared buckets, so metadata must take precedence.
         metadata = values.get('metadata', [])
-        if not description:
-            description = get_metadata_property(metadata, MetadataField.SHARED_DESCRIPTION)
-        if not description:
-            description = get_metadata_property(metadata, MetadataField.DESCRIPTION)
+        description = (
+            get_metadata_property(metadata, MetadataField.SHARED_DESCRIPTION)
+            or get_metadata_property(metadata, MetadataField.DESCRIPTION)
+            or values.get('description')
+        )
         values['description'] = description or None
         return values
 
@@ -346,13 +349,13 @@ class TableSummary(BaseModel):
     @model_validator(mode='before')
     @classmethod
     def set_description(cls, values: dict[str, Any]) -> dict[str, Any]:
-        description = values.get('description')
-        if not description:
-            metadata = values.get('metadata', [])
-            description = get_metadata_property(metadata, MetadataField.DESCRIPTION)
-        if not description:
-            metadata = get_nested(values, 'sourceTable.metadata', default=[])
-            description = get_metadata_property(metadata, MetadataField.DESCRIPTION)
+        # KBC.description metadata holds the curated, user-editable description and must win over the
+        # legacy top-level `description` field, which is auto-generated and stale for linked tables.
+        description = (
+            get_metadata_property(values.get('metadata', []), MetadataField.DESCRIPTION)
+            or get_metadata_property(get_nested(values, 'sourceTable.metadata', default=[]), MetadataField.DESCRIPTION)
+            or values.get('description')
+        )
         values['description'] = description or None
         return values
 

--- a/tests/tools/storage/test_tools.py
+++ b/tests/tools/storage/test_tools.py
@@ -1178,15 +1178,28 @@ async def test_get_tables(
 @pytest.mark.parametrize(
     ('raw_data', 'expected_description'),
     [
-        # direct description field takes priority over all metadata
+        # AI-3423: curated KBC metadata wins over the stale legacy `description` field
         (
             {
-                'description': 'Direct desc',
+                'description': 'Bucket created by Transformation API',
                 'metadata': [
                     {'key': 'KBC.sharedDescription', 'value': 'Shared desc'},
                     {'key': 'KBC.description', 'value': 'Meta desc'},
                 ],
             },
+            'Shared desc',
+        ),
+        # KBC.description wins over the legacy `description` field (no sharedDescription)
+        (
+            {
+                'description': 'Bucket created by Transformation API',
+                'metadata': [{'key': 'KBC.description', 'value': 'Meta desc'}],
+            },
+            'Meta desc',
+        ),
+        # legacy `description` field used only when no KBC metadata is present
+        (
+            {'description': 'Direct desc', 'metadata': []},
             'Direct desc',
         ),
         # KBC.sharedDescription is preferred over KBC.description
@@ -1232,13 +1245,18 @@ def test_bucket_detail_description_fallback(raw_data: dict[str, Any], expected_d
 @pytest.mark.parametrize(
     ('raw_data', 'expected_description'),
     [
-        # direct description field takes priority
+        # AI-3423: curated KBC.description wins over the stale legacy `description` field
         (
             {
-                'description': 'Direct desc',
+                'description': 'Table created by Transformation API',
                 'metadata': [{'key': 'KBC.description', 'value': 'Meta desc'}],
                 'sourceTable': {'metadata': [{'key': 'KBC.description', 'value': 'Source desc'}]},
             },
+            'Meta desc',
+        ),
+        # legacy `description` field used only when no KBC metadata is present
+        (
+            {'description': 'Direct desc', 'metadata': []},
             'Direct desc',
         ),
         # own KBC.description is preferred over sourceTable metadata

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.72.2"
+version = "1.72.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3423](https://linear.app/keboola/issue/AI-3423/get-buckets-returns-legacy-bucket-description-instead-of)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`get_buckets` (and `get_tables`) returned the stale legacy top-level `description`
field — auto-generated text like `"Bucket created by Transformation API"` — instead
of the curated `KBC.description` / `KBC.sharedDescription` value stored in bucket/table
metadata. For linked and shared buckets the legacy field is always non-empty, so the
priority logic in `set_description` never reached the metadata fallback.

`update_descriptions` writes the user's description to `KBC.description` **metadata**
(not the legacy field), so metadata is the source of truth. This PR inverts the
priority in both `BucketDetail.set_description` and `TableDetail.set_description`:

- Buckets: `KBC.sharedDescription` → `KBC.description` → legacy `description`
- Tables: own `KBC.description` → `sourceTable` `KBC.description` → legacy `description`

The legacy field is now only used as a last resort when no KBC metadata is present.

## Testing

- [ ] Tested with Cursor AI desktop (\`Streamable-HTTP\` transports)

Unit tests: updated the parametrized description-resolution suites for both
`BucketDetail` and `TableDetail` to assert metadata wins over the stale legacy field
(the exact AI-3423 scenario), plus a case confirming the legacy field is still used
when no metadata exists. All 57 storage tests pass; black + flake8 clean.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)