### PR TITLE
fix: send OAuth bearer token to data-science for app git credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.72.0"
+version = "1.72.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/client.py
+++ b/src/keboola_mcp_server/clients/client.py
@@ -185,9 +185,14 @@ class KeboolaClient:
         self._ai_service_client = AIServiceClient.create(
             root_url=ai_service_api_url, token=self._token, headers=self._headers, readonly=readonly
         )
+        # Data-science (sandboxes-service) git-repo credential endpoints require an admin-context
+        # token (CanManageAppRepoCredentials -> StorageApiToken::isAdminToken()). The OAuth bearer
+        # token carries admin context; the SAPI token minted for OAuth sessions does not. Pass the
+        # bearer token when available so credential minting works for OAuth clients (falls back to
+        # the SAPI token otherwise). See AI-3398.
         self._data_science_client = DataScienceClient.create(
             root_url=data_science_api_url,
-            token=self._token,
+            token=bearer_or_sapi_token,
             branch_id=branch_id,
             headers=self._headers,
             readonly=readonly,

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -481,6 +481,41 @@ class TestKeboolaClient:
             assert metastore_headers['X-StorageAPI-Token'] == expected_metastore_token
             assert 'Authorization' not in metastore_headers
 
+    @pytest.mark.parametrize(
+        ('bearer_token', 'storage_token', 'expected_data_science_token'),
+        [
+            ('oauth_bearer_123', 'sapi_token_456', 'Bearer oauth_bearer_123'),
+            (None, 'sapi_token_456', 'sapi_token_456'),
+            ('', 'sapi_token_456', 'sapi_token_456'),
+        ],
+        ids=['with_bearer_token', 'without_bearer_token', 'empty_bearer_token'],
+    )
+    def test_data_science_client_token_selection(
+        self, bearer_token: str | None, storage_token: str, expected_data_science_token: str
+    ):
+        """DataScienceClient uses the bearer token when available, falls back to the storage token.
+
+        The sandboxes-service git-repo credential endpoints require an admin-context token
+        (CanManageAppRepoCredentials -> isAdminToken()); the OAuth bearer token carries it while the
+        minted SAPI token does not (AI-3398).
+        """
+        client = KeboolaClient(
+            storage_api_url='https://connection.keboola.com',
+            storage_api_token=storage_token,
+            bearer_token=bearer_token,
+        )
+
+        data_science_headers = client.data_science_client.raw_client.headers
+
+        if expected_data_science_token.startswith('Bearer '):
+            assert 'Authorization' in data_science_headers
+            assert data_science_headers['Authorization'] == expected_data_science_token
+            assert 'X-StorageAPI-Token' not in data_science_headers
+        else:
+            assert 'X-StorageAPI-Token' in data_science_headers
+            assert data_science_headers['X-StorageAPI-Token'] == expected_data_science_token
+            assert 'Authorization' not in data_science_headers
+
 
 def test_flow_schema_cache_roundtrip():
     client = KeboolaClient(

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.72.0"
+version = "1.72.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3398](https://linear.app/keboola/issue/AI-3398)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Deploying/iterating python-js managed-git data apps via MCP failed for OAuth clients with:

> Token is not authorized to manage credentials of app 'X', admin context is required

**Root cause.** The data-science (sandboxes-service) git-repo credential endpoints
(`POST /apps/{id}/git-repo/credentials`, used by `create_python_js_data_app_git_credential` and the
draft-create path of `modify_python_js_data_app`) are guarded by `CanManageAppRepoCredentials`, which
requires `StorageApiToken::isAdminToken()`. The MCP passed `self._token` to the data-science client; in
OAuth sessions that is a SAPI token minted via `POST /v2/storage/tokens`, which has no `admin` context,
so the check failed. (Local/CLI sessions only worked when `KBC_STORAGE_TOKEN` happened to be an
admin-context token.)

**Fix.** Route the data-science client through `bearer_or_sapi_token` — the same pattern already used
for `storage` / `scheduler` / `metastore`. In OAuth mode the data-science client now sends
`Authorization: Bearer <oauth>` (which carries admin context); SAPI-token sessions are unchanged (still
`X-StorageAPI-Token`). One line in `clients/client.py` plus a unit test.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Verified directly instead:

- **End-to-end on `canary-orion` via the normal OAuth authorization-code flow** — obtained a real OAuth
  access token through browser login, routed it through the patched client, and `create_app_git_credential`
  succeeded with `owner_admin_id` set (the exact call that returns `admin context is required` on `main`).
- **Regression** — SAPI-token sessions still send `X-StorageAPI-Token` and mint successfully (no change).
- **Unit** — `test_data_science_client_token_selection` (bearer present → `Authorization: Bearer`;
  absent/empty → `X-StorageAPI-Token`). Full suite green except the known-local `test_json_logging`
  flake (needs `:8000`; passes in CI). `black` / `isort` / `flake8` / `check-tools-docs` clean.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated — N/A: the OAuth-bearer path needs an OAuth session in CI; existing integtests run with SAPI tokens
- [x] Project version bumped according to the change type (1.71.0 → 1.71.1)
- [ ] Documentation updated — N/A: no tool signature / docstring / `TOOLS.md` change
