### PR TITLE
fix(AI-3438): enforce tool authorization on /preview/configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.72.7"
+version = "1.72.8"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/authorization.py
+++ b/src/keboola_mcp_server/authorization.py
@@ -90,20 +90,40 @@ class ToolAuthorizationMiddleware(fmw.Middleware):
         return allowed_tools, disallowed_tools, read_only_mode
 
     @staticmethod
+    def _is_tool_name_authorized(
+        tool_name: str,
+        is_read_only: bool,
+        allowed_tools: set[str] | None,
+        disallowed_tools: set[str] | None,
+        read_only_mode: bool,
+    ) -> bool:
+        """
+        Header-based (X-Allowed-Tools / X-Disallowed-Tools / X-Read-Only-Mode) authorization decision
+        for a single tool identified by name.
+
+        This is the single source of truth for the header-based gating. :meth:`_is_tool_authorized`
+        uses it for the MCP middleware path; the raw ``/preview/configuration`` Starlette route reuses
+        it (see ``preview.py``) so the preview path enforces exactly the same rules.
+        """
+        # First check if tool is in disallowed list (if any disallow filter is configured)
+        if disallowed_tools and tool_name in disallowed_tools:
+            return False
+        # Check read-only mode - only allow tools with readOnlyHint=True
+        if read_only_mode and not is_read_only:
+            return False
+        # Then check if tool is in allowed list (if specified)
+        if allowed_tools is not None and tool_name not in allowed_tools:
+            return False
+        return True
+
+    @staticmethod
     def _is_tool_authorized(
         tool: Tool, allowed_tools: set[str] | None, disallowed_tools: set[str] | None, read_only_mode: bool
     ) -> bool:
         """Check if a tool is authorized based on allowed/disallowed sets and read-only mode."""
-        # First check if tool is in disallowed list (if any disallow filter is configured)
-        if disallowed_tools and tool.name in disallowed_tools:
-            return False
-        # Check read-only mode - only allow tools with readOnlyHint=True
-        if read_only_mode and not is_read_only_tool(tool):
-            return False
-        # Then check if tool is in allowed list (if specified)
-        if allowed_tools is not None and tool.name not in allowed_tools:
-            return False
-        return True
+        return ToolAuthorizationMiddleware._is_tool_name_authorized(
+            tool.name, is_read_only_tool(tool), allowed_tools, disallowed_tools, read_only_mode
+        )
 
     async def on_list_tools(
         self, context: MiddlewareContext[mt.ListToolsRequest], call_next: CallNext[mt.ListToolsRequest, list[Tool]]

--- a/src/keboola_mcp_server/authorization.py
+++ b/src/keboola_mcp_server/authorization.py
@@ -21,6 +21,7 @@ from fastmcp.server import middleware as fmw
 from fastmcp.server.middleware import CallNext, MiddlewareContext
 from fastmcp.tools import Tool
 from mcp import types as mt
+from starlette.requests import Request
 
 from keboola_mcp_server.mcp import get_http_request_or_none, is_read_only_tool
 
@@ -42,7 +43,9 @@ class ToolAuthorizationMiddleware(fmw.Middleware):
     """
 
     @staticmethod
-    def _get_authorization_config() -> tuple[set[str] | None, set[str] | None, bool]:
+    def _get_authorization_config(
+        http_rq: Request | None = None,
+    ) -> tuple[set[str] | None, set[str] | None, bool]:
         """
         Determines the authorization configuration for the current request based on HTTP headers.
 
@@ -50,8 +53,13 @@ class ToolAuthorizationMiddleware(fmw.Middleware):
         - allowed_tools: Set of allowed tool names, or None if all tools are allowed
         - disallowed_tools: Set of tool names to exclude, or None if no tools are explicitly disallowed
         - read_only_mode: Whether X-Read-Only-Mode header is enabled
+
+        :param http_rq: Explicit request to read headers from. Falls back to the FastMCP request
+            context when omitted. Raw Starlette routes (e.g. /preview/configuration) must pass it
+            explicitly because the FastMCP request contextvar is not populated for them.
         """
-        http_rq = get_http_request_or_none()
+        if http_rq is None:
+            http_rq = get_http_request_or_none()
         if not http_rq:
             # No HTTP request means no authorization headers are present, so we do not apply any filters.
             return None, None, False

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -19,7 +19,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
-from keboola_mcp_server.mcp import ForwardSlashMiddleware, is_read_only_tool
+from keboola_mcp_server.mcp import ForwardSlashMiddleware, is_read_only_tool, is_semantic_tool
 from keboola_mcp_server.server import CustomRoutes, create_server
 
 LOG = logging.getLogger(__name__)
@@ -188,8 +188,10 @@ async def run_server(args: Optional[list[str]] = None) -> None:
             assert isinstance(mcp_server, FastMCP)
             _tools = await mcp_server.list_tools(run_middleware=False)
             app.state.mcp_tools_input_schema = {tool.name: tool.parameters for tool in _tools}
-            # Used by the /preview/configuration authorization check to enforce X-Read-Only-Mode.
+            # Used by the /preview/configuration authorization check to enforce X-Read-Only-Mode
+            # and the ToolsFilteringMiddleware-parity gating (read-only role, semantic feature).
             app.state.mcp_read_only_tools = {tool.name for tool in _tools if is_read_only_tool(tool)}
+            app.state.mcp_semantic_tools = {tool.name for tool in _tools if is_semantic_tool(tool)}
 
             config = uvicorn.Config(
                 app,

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -19,7 +19,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
-from keboola_mcp_server.mcp import ForwardSlashMiddleware
+from keboola_mcp_server.mcp import ForwardSlashMiddleware, is_read_only_tool
 from keboola_mcp_server.server import CustomRoutes, create_server
 
 LOG = logging.getLogger(__name__)
@@ -186,9 +186,10 @@ async def run_server(args: Optional[list[str]] = None) -> None:
             custom_routes.add_to_starlette(app)
 
             assert isinstance(mcp_server, FastMCP)
-            app.state.mcp_tools_input_schema = {
-                tool.name: tool.parameters for tool in await mcp_server.list_tools(run_middleware=False)
-            }
+            _tools = await mcp_server.list_tools(run_middleware=False)
+            app.state.mcp_tools_input_schema = {tool.name: tool.parameters for tool in _tools}
+            # Used by the /preview/configuration authorization check to enforce X-Read-Only-Mode.
+            app.state.mcp_read_only_tools = {tool.name for tool in _tools if is_read_only_tool(tool)}
 
             config = uvicorn.Config(
                 app,

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -392,6 +392,75 @@ class ToolsFilteringMiddleware(fmw.Middleware):
 
         return tools
 
+    @staticmethod
+    def authorize_tool_call(
+        *,
+        tool_name: str,
+        is_read_only: bool,
+        is_semantic: bool,
+        token_role: str,
+        features: set[str],
+        is_oauth: bool,
+        is_main_branch: bool,
+    ) -> str | None:
+        """
+        Decide whether a call to ``tool_name`` is allowed given the project features, the token role,
+        the authentication mode and the branch.
+
+        This is the single source of truth for the project-feature / token-role / branch gating.
+        :meth:`on_call_tool` applies it to MCP tool calls; the raw ``/preview/configuration`` Starlette
+        route reuses it (see ``preview.py``) so the preview path enforces exactly the same rules.
+
+        :return: A denial message if the call is not allowed, or ``None`` if it is allowed.
+        """
+        token_role = token_role.lower()
+
+        if token_role == 'readonly' and not is_read_only:
+            return (
+                f'Access denied: The tool "{tool_name}" requires write permissions. '
+                f'Your current role ({token_role}) only allows read-only operations. '
+                f'Contact your administrator to request write access.'
+            )
+
+        if SEMANTIC_TOOLING_FEATURE not in features and is_semantic:
+            return (
+                f'The tool "{tool_name}" is not available in this project. '
+                'Please ask Keboola support to enable "Semantic Layer Tooling" feature.'
+            )
+
+        if 'hide-conditional-flows' in features:
+            if tool_name == 'create_conditional_flow':
+                return (
+                    'The "create_conditional_flow" tool is not available in this project. '
+                    'Please ask Keboola support to enable "Conditional Flows" feature '
+                    'or use "create_flow" tool instead.'
+                )
+        else:
+            if tool_name == 'create_flow':
+                return (
+                    'The "create_flow" tool is not available in this project. '
+                    'This project uses "Conditional Flows", '
+                    'please use "create_conditional_flow" tool instead.'
+                )
+
+        if token_role in ('admin', 'share') or is_oauth:
+            if tool_name == UPDATE_FLOW_TOOL_NAME:
+                return (
+                    'The "update_flow" tool is not available for admin/OAuth tokens. '
+                    f'Use "{MODIFY_FLOW_TOOL_NAME}" to manage schedules instead.'
+                )
+        else:
+            if tool_name == MODIFY_FLOW_TOOL_NAME:
+                return (
+                    f'The "{MODIFY_FLOW_TOOL_NAME}" tool is not available for this token. '
+                    f'Use "{UPDATE_FLOW_TOOL_NAME}" to update flow configuration instead.'
+                )
+
+        if tool_name in DATA_APP_BRANCH_GATED_TOOLS and not is_main_branch:
+            return 'Data apps are supported only in the main production branch.'
+
+        return None
+
     async def on_call_tool(
         self,
         context: MiddlewareContext[mt.CallToolRequestParams],
@@ -399,56 +468,18 @@ class ToolsFilteringMiddleware(fmw.Middleware):
     ) -> mt.CallToolResult:
         tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
         token_info = await self.get_token_info(context.fastmcp_context)
-        features = self.get_project_features(token_info)
-        token_role = self.get_token_role(token_info).lower()
 
-        if token_role == 'readonly':
-            if not is_read_only_tool(tool):
-                raise ToolError(
-                    f'Access denied: The tool "{tool.name}" requires write permissions. '
-                    f'Your current role ({token_role}) only allows read-only operations. '
-                    f'Contact your administrator to request write access.'
-                )
-
-        if SEMANTIC_TOOLING_FEATURE not in features:
-            if is_semantic_tool(tool):
-                raise ToolError(
-                    f'The tool "{tool.name}" is not available in this project. '
-                    'Please ask Keboola support to enable "Semantic Layer Tooling" feature.'
-                )
-
-        if 'hide-conditional-flows' in features:
-            if tool.name == 'create_conditional_flow':
-                raise ToolError(
-                    'The "create_conditional_flow" tool is not available in this project. '
-                    'Please ask Keboola support to enable "Conditional Flows" feature '
-                    'or use "create_flow" tool instead.'
-                )
-        else:
-            if tool.name == 'create_flow':
-                raise ToolError(
-                    'The "create_flow" tool is not available in this project. '
-                    'This project uses "Conditional Flows", '
-                    'please use"create_conditional_flow" tool instead.'
-                )
-
-        is_oauth = self._is_oauth_authenticated(context.fastmcp_context)
-        if token_role in ('admin', 'share') or is_oauth:
-            if tool.name == UPDATE_FLOW_TOOL_NAME:
-                raise ToolError(
-                    'The "update_flow" tool is not available for admin/OAuth tokens. '
-                    f'Use "{MODIFY_FLOW_TOOL_NAME}" to manage schedules instead.'
-                )
-        else:
-            if tool.name == MODIFY_FLOW_TOOL_NAME:
-                raise ToolError(
-                    f'The "{MODIFY_FLOW_TOOL_NAME}" tool is not available for this token. '
-                    f'Use "{UPDATE_FLOW_TOOL_NAME}" to update flow configuration instead.'
-                )
-
-        if tool.name in DATA_APP_BRANCH_GATED_TOOLS:
-            if not self.is_client_using_main_branch(context.fastmcp_context):
-                raise ToolError('Data apps are supported only in the main production branch.')
+        denial = self.authorize_tool_call(
+            tool_name=tool.name,
+            is_read_only=is_read_only_tool(tool),
+            is_semantic=is_semantic_tool(tool),
+            token_role=self.get_token_role(token_info),
+            features=self.get_project_features(token_info),
+            is_oauth=self._is_oauth_authenticated(context.fastmcp_context),
+            is_main_branch=self.is_client_using_main_branch(context.fastmcp_context),
+        )
+        if denial:
+            raise ToolError(denial)
 
         return await call_next(context)
 

--- a/src/keboola_mcp_server/preview.py
+++ b/src/keboola_mcp_server/preview.py
@@ -13,7 +13,7 @@ from keboola_mcp_server.authorization import ToolAuthorizationMiddleware
 from keboola_mcp_server.clients import KeboolaClient
 from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID, get_metadata_property
 from keboola_mcp_server.config import MetadataField
-from keboola_mcp_server.mcp import ServerState, SessionStateMiddleware
+from keboola_mcp_server.mcp import ServerState, SessionStateMiddleware, ToolsFilteringMiddleware
 from keboola_mcp_server.tools import data_apps as data_app_tools
 from keboola_mcp_server.tools.components import tools as components_tools
 from keboola_mcp_server.tools.components.model import ConfigParamUpdate, TfParamUpdate
@@ -264,29 +264,44 @@ async def preview_config_diff(rq: Request) -> Response:
     # authorization that ToolAuthorizationMiddleware applies to MCP tool calls does not run here.
     # Enforce the same X-Allowed-Tools / X-Disallowed-Tools / X-Read-Only-Mode headers explicitly
     # so a restricted client cannot drive the mutator-preview path for a tool it cannot call.
-    allowed, disallowed, read_only_mode = ToolAuthorizationMiddleware._get_authorization_config(rq)
     read_only_tools = getattr(rq.app.state, 'mcp_read_only_tools', set())
-    if (
-        (disallowed and preview_rq.tool_name in disallowed)
-        or (allowed is not None and preview_rq.tool_name not in allowed)
-        or (read_only_mode and preview_rq.tool_name not in read_only_tools)
+    is_read_only = preview_rq.tool_name in read_only_tools
+    allowed, disallowed, read_only_mode = ToolAuthorizationMiddleware._get_authorization_config(rq)
+    if not ToolAuthorizationMiddleware._is_tool_name_authorized(
+        preview_rq.tool_name, is_read_only, allowed, disallowed, read_only_mode
     ):
-        LOG.info(f'[preview_config_diff] Tool authorization denied: {preview_rq.tool_name}')
+        LOG.info(f'[preview_config_diff] Tool authorization denied (headers): {preview_rq.tool_name}')
         return JSONResponse(
             status_code=403,
             content={'message': f'The tool "{preview_rq.tool_name}" is not authorized for this client.'},
         )
 
-    LOG.info(f'[preview_config_diff] {preview_rq}')
-    LOG.info(f'[preview_config_diff] rq.app={rq.app}')
-    LOG.info(f'[preview_config_diff] rq.app.state={rq.app.state} vars={vars(rq.app.state)}')
-    LOG.info(f'[preview_config_diff] rq.state={rq.state} vars={vars(rq.state)}')
+    # Log only non-sensitive metadata; tool_params can carry user-supplied secrets.
+    LOG.info(f'[preview_config_diff] tool_name={preview_rq.tool_name} param_keys={sorted(preview_rq.tool_params)}')
 
     server_state = ServerState.from_starlette(rq.app)
     config = SessionStateMiddleware.apply_request_config(rq, server_state.config)
     state = await SessionStateMiddleware.create_session_state(config, server_state.runtime_info, readonly=True)
     client = KeboolaClient.from_state(state)
     workspace_manager = WorkspaceManager.from_state(state)
+
+    # Apply the same project-feature / token-role / branch gating that ToolsFilteringMiddleware applies
+    # to MCP tool calls. Header authorization above does not cover these, so without this a caller could
+    # preview e.g. a data-app tool on a non-main branch, or a write tool with a read-only token.
+    semantic_tools = getattr(rq.app.state, 'mcp_semantic_tools', set())
+    token_info = await client.storage_client.verify_token()
+    denial = ToolsFilteringMiddleware.authorize_tool_call(
+        tool_name=preview_rq.tool_name,
+        is_read_only=is_read_only,
+        is_semantic=preview_rq.tool_name in semantic_tools,
+        token_role=ToolsFilteringMiddleware.get_token_role(token_info),
+        features=ToolsFilteringMiddleware.get_project_features(token_info),
+        is_oauth=bool(client.bearer_token),
+        is_main_branch=client.branch_id is None,
+    )
+    if denial:
+        LOG.info(f'[preview_config_diff] Tool authorization denied (project/role/branch): {preview_rq.tool_name}')
+        return JSONResponse(status_code=403, content={'message': denial})
 
     coordinates = await _extract_coordinates(preview_rq.tool_name, preview_rq.tool_params, workspace_manager)
 

--- a/src/keboola_mcp_server/preview.py
+++ b/src/keboola_mcp_server/preview.py
@@ -9,6 +9,7 @@ from pydantic import AliasChoices, BaseModel, Field, TypeAdapter, field_validato
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
+from keboola_mcp_server.authorization import ToolAuthorizationMiddleware
 from keboola_mcp_server.clients import KeboolaClient
 from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID, get_metadata_property
 from keboola_mcp_server.config import MetadataField
@@ -258,6 +259,23 @@ def _prepare_mutator(
 
 async def preview_config_diff(rq: Request) -> Response:
     preview_rq = PreviewConfigDiffRq.model_validate(await rq.json())
+
+    # This route is a raw Starlette route outside the FastMCP middleware chain, so the tool
+    # authorization that ToolAuthorizationMiddleware applies to MCP tool calls does not run here.
+    # Enforce the same X-Allowed-Tools / X-Disallowed-Tools / X-Read-Only-Mode headers explicitly
+    # so a restricted client cannot drive the mutator-preview path for a tool it cannot call.
+    allowed, disallowed, read_only_mode = ToolAuthorizationMiddleware._get_authorization_config(rq)
+    read_only_tools = getattr(rq.app.state, 'mcp_read_only_tools', set())
+    if (
+        (disallowed and preview_rq.tool_name in disallowed)
+        or (allowed is not None and preview_rq.tool_name not in allowed)
+        or (read_only_mode and preview_rq.tool_name not in read_only_tools)
+    ):
+        LOG.info(f'[preview_config_diff] Tool authorization denied: {preview_rq.tool_name}')
+        return JSONResponse(
+            status_code=403,
+            content={'message': f'The tool "{preview_rq.tool_name}" is not authorized for this client.'},
+        )
 
     LOG.info(f'[preview_config_diff] {preview_rq}')
     LOG.info(f'[preview_config_diff] rq.app={rq.app}')

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -10,7 +10,7 @@ from starlette.testclient import TestClient
 from keboola_mcp_server import cli
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
-from keboola_mcp_server.mcp import ServerState
+from keboola_mcp_server.mcp import ServerState, is_read_only_tool
 from keboola_mcp_server.preview import preview_config_diff
 from keboola_mcp_server.server import create_server
 from keboola_mcp_server.tools.components.utils import get_nested, set_nested_value
@@ -30,9 +30,9 @@ async def starlette_app() -> Starlette:
 
     app = Starlette(exception_handlers=cli._exception_handlers)
     app.state.server_state = server_state
-    app.state.mcp_tools_input_schema = {
-        tool.name: tool.parameters for tool in await mcp_server.list_tools(run_middleware=False)
-    }
+    _tools = await mcp_server.list_tools(run_middleware=False)
+    app.state.mcp_tools_input_schema = {tool.name: tool.parameters for tool in _tools}
+    app.state.mcp_read_only_tools = {tool.name for tool in _tools if is_read_only_tool(tool)}
 
     app.add_route('/preview/configuration', preview_config_diff, methods=['POST'])
 
@@ -48,6 +48,62 @@ def test_client(starlette_app: Starlette) -> Generator[TestClient, None, None]:
 
 class TestPreviewConfigDiff:
     """Tests for the POST /preview/configuration endpoint."""
+
+    @pytest.mark.parametrize(
+        ('headers', 'expected_status'),
+        [
+            # No authorization headers -> allowed (reaches the mutator path).
+            ({}, 200),
+            # Tool explicitly allowed.
+            ({'X-Allowed-Tools': 'update_config,get_tables'}, 200),
+            # Tool not in the allow-list -> denied.
+            ({'X-Allowed-Tools': 'get_tables,get_buckets'}, 403),
+            # Tool explicitly disallowed -> denied.
+            ({'X-Disallowed-Tools': 'update_config'}, 403),
+            # Read-only mode denies a mutator preview.
+            ({'X-Read-Only-Mode': 'true'}, 403),
+        ],
+    )
+    def test_preview_tool_authorization(self, test_client: TestClient, mocker, headers, expected_status):
+        """The preview endpoint enforces the same tool-authorization headers as the MCP middleware."""
+        from keboola_mcp_server.clients.storage import ComponentAPIResponse
+
+        async def mock_fetch_component(**kwargs):
+            return ComponentAPIResponse.model_validate(
+                {
+                    'id': 'keboola.ex-test',
+                    'name': 'Test Extractor',
+                    'type': 'extractor',
+                    'configurationSchema': {},
+                    'component_flags': [],
+                }
+            )
+
+        mocker.patch(
+            'keboola_mcp_server.tools.components.tools.fetch_component',
+            side_effect=mock_fetch_component,
+        )
+        mock_client = mocker.AsyncMock(KeboolaClient)
+
+        async def mock_config_detail(**kwargs):
+            return {'id': 'config-123', 'name': 'C', 'configuration': {'parameters': {}}}
+
+        mock_client.storage_client.configuration_detail = mocker.AsyncMock(side_effect=mock_config_detail)
+        mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
+
+        request_payload = {
+            'toolName': 'update_config',
+            'toolParams': {
+                'component_id': 'keboola.ex-test',
+                'configuration_id': 'config-123',
+                'change_description': 'Test change',
+            },
+        }
+
+        response = test_client.post('/preview/configuration', json=request_payload, headers=headers)
+        assert response.status_code == expected_status
+        if expected_status == 403:
+            assert 'not authorized' in response.json()['message']
 
     def test_preview_update_config_success(self, test_client: TestClient, mocker):
         """Test successful preview of update_config tool."""

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -10,7 +10,7 @@ from starlette.testclient import TestClient
 from keboola_mcp_server import cli
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
-from keboola_mcp_server.mcp import ServerState, is_read_only_tool
+from keboola_mcp_server.mcp import ServerState, is_read_only_tool, is_semantic_tool
 from keboola_mcp_server.preview import preview_config_diff
 from keboola_mcp_server.server import create_server
 from keboola_mcp_server.tools.components.utils import get_nested, set_nested_value
@@ -33,10 +33,24 @@ async def starlette_app() -> Starlette:
     _tools = await mcp_server.list_tools(run_middleware=False)
     app.state.mcp_tools_input_schema = {tool.name: tool.parameters for tool in _tools}
     app.state.mcp_read_only_tools = {tool.name for tool in _tools if is_read_only_tool(tool)}
+    app.state.mcp_semantic_tools = {tool.name for tool in _tools if is_semantic_tool(tool)}
 
     app.add_route('/preview/configuration', preview_config_diff, methods=['POST'])
 
     return app
+
+
+def _configure_preview_auth(mock_client, mocker, *, role='admin', features=(), bearer_token=None, branch_id=None):
+    """Configure the auth signals the preview endpoint reads for ToolsFilteringMiddleware-parity gating.
+
+    Defaults to an admin SAPI token on the main/production branch, which clears the project-feature /
+    token-role / branch gates for ordinary write tools.
+    """
+    mock_client.bearer_token = bearer_token
+    mock_client.branch_id = branch_id
+    mock_client.storage_client.verify_token = mocker.AsyncMock(
+        return_value={'owner': {'features': list(features)}, 'admin': {'role': role}}
+    )
 
 
 @pytest.fixture
@@ -84,6 +98,7 @@ class TestPreviewConfigDiff:
             side_effect=mock_fetch_component,
         )
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         async def mock_config_detail(**kwargs):
             return {'id': 'config-123', 'name': 'C', 'configuration': {'parameters': {}}}
@@ -104,6 +119,36 @@ class TestPreviewConfigDiff:
         assert response.status_code == expected_status
         if expected_status == 403:
             assert 'not authorized' in response.json()['message']
+
+    @pytest.mark.parametrize(
+        ('tool_name', 'role', 'branch_id', 'expected_fragment'),
+        [
+            # Read-only token role cannot drive a write tool's preview.
+            ('update_config', 'readOnly', None, 'read-only operations'),
+            # Data app tools are gated to the main/production branch.
+            ('modify_streamlit_data_app', 'admin', 'dev-123', 'main production branch'),
+            # update_flow is not available to admin/OAuth tokens (they use modify_flow).
+            ('update_flow', 'admin', None, 'admin/OAuth'),
+        ],
+    )
+    def test_preview_project_role_branch_authorization(
+        self, test_client: TestClient, mocker, tool_name, role, branch_id, expected_fragment
+    ):
+        """The preview endpoint mirrors ToolsFilteringMiddleware: token-role, feature and branch gating.
+
+        The denial happens before the mutator path runs, so no component/config mocks are needed.
+        """
+        mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
+        _configure_preview_auth(mock_client, mocker, role=role, branch_id=branch_id)
+        mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
+
+        response = test_client.post(
+            '/preview/configuration',
+            json={'toolName': tool_name, 'toolParams': {'configuration_id': 'cfg-1'}},
+        )
+        assert response.status_code == 403
+        assert expected_fragment in response.json()['message']
 
     def test_preview_update_config_success(self, test_client: TestClient, mocker):
         """Test successful preview of update_config tool."""
@@ -141,6 +186,7 @@ class TestPreviewConfigDiff:
 
         # Mock the KeboolaClient.from_state to return a mocked client
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         # Properly mock async method
         async def mock_config_detail(**kwargs):
@@ -208,6 +254,7 @@ class TestPreviewConfigDiff:
         """Test preview with validation error."""
         # Mock the storage client to raise a validation error
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         # Properly mock async method that raises an error
         async def mock_config_detail(**kwargs):
@@ -247,6 +294,7 @@ class TestPreviewConfigDiff:
     def test_preview_invalid_tool_name(self, test_client: TestClient, mocker):
         """Test preview with invalid tool name."""
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
         mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
 
         # Request payload with invalid tool name
@@ -292,6 +340,7 @@ class TestPreviewConfigDiff:
         )
 
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         # Properly mock async method
         async def mock_config_detail(**kwargs):
@@ -361,6 +410,7 @@ class TestPreviewConfigDiff:
 
         # Mock the KeboolaClient
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         # Mock async method for configuration row detail
         async def mock_row_detail(**kwargs):
@@ -448,6 +498,7 @@ class TestPreviewConfigDiff:
 
         # Mock the KeboolaClient
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         async def mock_config_detail(**kwargs):
             return copy.deepcopy(original_config_data)
@@ -540,11 +591,14 @@ class TestPreviewConfigDiff:
 
         # Mock the KeboolaClient
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         async def mock_config_detail(**kwargs):
             return copy.deepcopy(original_config_data)
 
         mock_client.storage_client.configuration_detail = mocker.AsyncMock(side_effect=mock_config_detail)
+        # update_flow is the flow tool exposed to non-admin/non-OAuth tokens, so preview it as one.
+        _configure_preview_auth(mock_client, mocker, role='')
 
         mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
 
@@ -668,9 +722,12 @@ class TestPreviewConfigDiff:
         }
 
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
         mock_client.storage_client.configuration_detail = mocker.AsyncMock(
             side_effect=lambda **_: copy.deepcopy(original_config_data)
         )
+        # modify_flow is the flow tool exposed to admin/OAuth tokens, so preview it as an admin.
+        _configure_preview_auth(mock_client, mocker, role='admin')
         mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
 
         existing_schedules = [
@@ -769,9 +826,12 @@ class TestPreviewConfigDiff:
         }
 
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
         mock_client.storage_client.configuration_detail = mocker.AsyncMock(
             side_effect=lambda **_: copy.deepcopy(original_config_data)
         )
+        # modify_flow is the flow tool exposed to admin/OAuth tokens, so preview it as an admin.
+        _configure_preview_auth(mock_client, mocker, role='admin')
         mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
 
         existing_schedules = [
@@ -831,6 +891,7 @@ class TestPreviewConfigDiff:
 
         # Mock the KeboolaClient
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
         mock_client.token = 'test-token'
         mock_client.storage_api_url = 'https://connection.test.keboola.com'
 
@@ -843,6 +904,8 @@ class TestPreviewConfigDiff:
         mock_client.storage_client.configuration_detail = mocker.AsyncMock(side_effect=mock_config_detail)
         mock_client.storage_client.project_id = mocker.AsyncMock(return_value='test-project')
         mock_client.encryption_client.encrypt = mocker.AsyncMock(side_effect=mock_encrypt)
+        # Data app tools are allowed only on the main/production branch (branch_id=None).
+        _configure_preview_auth(mock_client, mocker, role='admin', branch_id=None)
 
         mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
 
@@ -955,8 +1018,11 @@ class TestPreviewConfigDiff:
         assert len(actual_script) == 1
         assert cast(str, actual_script[0]).endswith('print("Hello World")')
 
-    def test_preview_validation_missing_required_param(self, test_client: TestClient):
+    def test_preview_validation_missing_required_param(self, test_client: TestClient, mocker):
         """Test validation error for missing required parameter."""
+        mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)
+        mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
         # Request missing required 'configuration_id'
         request_payload = {
             'toolName': 'update_config',
@@ -988,6 +1054,9 @@ class TestPreviewConfigDiff:
         Note: Type validation errors at the API level return 400 Bad Request
         rather than 200 with validation errors, as they represent malformed requests.
         """
+        mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)
+        mocker.patch('keboola_mcp_server.preview.KeboolaClient.from_state', return_value=mock_client)
         request_payload = {
             'toolName': 'update_config',
             'toolParams': {
@@ -1047,6 +1116,7 @@ class TestPreviewConfigDiff:
 
         # Mock the KeboolaClient
         mock_client = mocker.AsyncMock(KeboolaClient)
+        _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
 
         async def mock_config_detail(**kwargs):
             return copy.deepcopy(original_config_data)

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.72.7"
+version = "1.72.8"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3438](https://linear.app/keboola/issue/AI-3438/security-previewconfiguration-bypasses-tool-authorization-middleware) — also fixes GH #506

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`POST /preview/configuration` is registered as a raw Starlette route outside the FastMCP middleware chain (`server.py:157`/`server.py:169`), so neither `ToolAuthorizationMiddleware` nor `ToolsFilteringMiddleware` ran for it. A restricted client could drive the mutator-preview path for a tool it is not allowed to call.

These middlewares are FastMCP `Middleware` that hook the MCP JSON-RPC tool-call lifecycle, so they cannot be attached to a raw Starlette route. Instead of reimplementing their logic, the route now reuses the same decision helpers.

Severity is Medium (per the verified Linear verdict): the handler uses a `readonly=True` client and only computes a config diff — **no mutation is persisted to SAPI**. The real issue is an authorization inconsistency / minor info-disclosure, not a write bypass.

Changes:
- Enforce the header gating (`X-Allowed-Tools` / `X-Disallowed-Tools` / `X-Read-Only-Mode`) at the top of `preview_config_diff` via the shared `ToolAuthorizationMiddleware._is_tool_name_authorized`, returning **403** when the tool is disallowed, not in the allow-list, or (read-only mode) not a read-only tool.
- Enforce **`ToolsFilteringMiddleware` parity** via the shared `ToolsFilteringMiddleware.authorize_tool_call`: read-only token role, semantic + conditional-flow feature gating, the `modify_flow`/`update_flow` role split, and dev-branch data-app gating now apply to the preview path too.
- Refactor both middlewares to expose their decision as reusable helpers (`_is_tool_name_authorized`, `authorize_tool_call`) so the preview route and the MCP pipeline share one source of truth.
- `ToolAuthorizationMiddleware._get_authorization_config` accepts an explicit `Request` (the FastMCP `get_http_request()` contextvar is not populated for raw Starlette routes; without it the check would silently no-op).
- Build `app.state.mcp_read_only_tools` and `app.state.mcp_semantic_tools` alongside `mcp_tools_input_schema`, reusing `is_read_only_tool` / `is_semantic_tool` (the GH issue's suggested `READ_ONLY_PREVIEW_TOOLS` constant does not exist and was not used).
- Remove debug logging in `preview_config_diff` that serialized `vars(rq.app.state)` — it included `Config.storage_token`, leaking the SAPI token into logs (flagged by Copilot).

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Automated (`tox`: pytest + black + flake8 green):
- `test_preview_tool_authorization`: header gating — no headers → 200, allowed → 200, not-in-allowlist → 403, disallowed → 403, read-only mutator → 403.
- `test_preview_project_role_branch_authorization`: ToolsFiltering parity — read-only role → 403, data-app tool on dev branch → 403, `update_flow` with admin token → 403.
- Existing `tests/test_preview.py`, `tests/test_authorization.py`, `tests/test_mcp.py` pass.

> ⚠️ **Production prerequisite (infra):** this defense relies on the headers being proxy-injected, not client-set. Before closing the issue, confirm the gateway (1) injects `X-Allowed-Tools`/`X-Disallowed-Tools`/`X-Read-Only-Mode` on `/preview/configuration`, not just `/mcp`, and (2) strips client-supplied copies on that route. No env/flag/Helm changes needed.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)