### PR TITLE
AI-3135: fix: don't persist empty data-app storage that breaks Writable Tables UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.72.5"
+version = "1.72.6"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -92,7 +92,10 @@ class DataAppConfig(BaseModel):
 
     parameters: Parameters = Field(description='The parameters of the data app')
     authorization: Authorization = Field(description='The authorization of the data app')
-    storage: dict[str, Any] = Field(description='The storage of the data app', default_factory=dict)
+    # Optional with a None default so an app without storage mappings omits the key entirely. An
+    # empty object would be serialized as `[]` by the backend and break the Writable Tables editor
+    # (AI-3135); see `_prune_empty_storage_objects` in tools/data_apps.py.
+    storage: dict[str, Any] | None = Field(description='The storage of the data app', default=None)
 
 
 class CodeDataAppConfig(BaseModel):

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -225,7 +225,7 @@ class AppRunInfo(BaseModel):
         startup_logs = (run.startup_logs or '').strip().rsplit('\n', _APP_RUN_LOG_LINES)[-_APP_RUN_LOG_LINES:]
         failure_message = run.failure_reason.message if run.failure_reason else None
         if failure_message and len(failure_message) > _APP_RUN_MESSAGE_LIMIT:
-            failure_message = '…' + failure_message[-(_APP_RUN_MESSAGE_LIMIT - 1):]
+            failure_message = '…' + failure_message[-(_APP_RUN_MESSAGE_LIMIT - 1) :]
         return cls(
             state=run.state,
             created_at=run.created_at,
@@ -1176,7 +1176,9 @@ async def modify_python_js_data_app(
                 else None
             ),
             authorization=authorization_model,
-            storage=validated_storage,
+            # An empty (or all-empty) storage block prunes to `{}`; omit it entirely rather than
+            # persisting an empty object that the backend would store as `[]` (AI-3135).
+            storage=validated_storage or None,
         )
         if git_block is not None:
             # The git block's `#password` is plaintext at this point; the encryption service walks
@@ -1358,6 +1360,47 @@ def _build_authenticated_clone_url(https_url: str, secret: str) -> str:
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
+def _prune_empty_storage_objects(value: Any) -> Any:
+    """Recursively drop empty-object (``{}``) values from a data-app ``storage`` block.
+
+    The Keboola backend (PHP/SAPI) cannot tell an empty JSON object from an empty array and
+    serializes ``{}`` as ``[]``. The UI's Input/Output Mapping editor (Writable Tables) then
+    silently refuses to add or save entries when ``storage`` — or one of its ``input``/``output``
+    containers — is an array instead of an object (AI-3135). We therefore never persist an empty
+    object inside the storage block; the platform recreates a correctly shaped one when the user
+    adds the first mapping. Empty *arrays* (e.g. the canonical ``{"output": {"tables": []}}``) are
+    intentionally preserved.
+    """
+    if isinstance(value, dict):
+        pruned: dict[str, Any] = {}
+        for key, sub_value in value.items():
+            pruned_sub = _prune_empty_storage_objects(sub_value)
+            if isinstance(pruned_sub, dict) and not pruned_sub:
+                continue
+            pruned[key] = pruned_sub
+        return pruned
+    if isinstance(value, list):
+        return [_prune_empty_storage_objects(item) for item in value]
+    return value
+
+
+def _normalize_config_storage(config: dict[str, Any]) -> None:
+    """Normalize the ``storage`` block of a data-app config dict in place before persisting.
+
+    Drops empty mapping containers and removes the ``storage`` key entirely when it carries no
+    mappings (or is a non-object leftover such as ``[]``), so the broken array shape that breaks
+    the Writable Tables editor is never written or left behind (AI-3135).
+    """
+    if 'storage' not in config:
+        return
+    storage = config['storage']
+    pruned = _prune_empty_storage_objects(storage) if isinstance(storage, dict) else None
+    if pruned:
+        config['storage'] = pruned
+    else:
+        config.pop('storage', None)
+
+
 def _validate_data_app_storage(
     storage: Optional[dict[str, Any]],
     *,
@@ -1387,7 +1430,10 @@ def _validate_data_app_storage(
         initial_message='The "storage" field is not valid.',
         validation_context=validation_context,
     )
-    return cast(dict[str, Any], validated['storage'])
+    # Strip empty mapping containers so we never persist an empty object that the backend would
+    # serialize as `[]`, which silently breaks the Writable Tables editor (AI-3135). An all-empty
+    # block prunes down to `{}` (treated as a wipe by the callers).
+    return cast(dict[str, Any], _prune_empty_storage_objects(validated['storage']))
 
 
 def _update_existing_code_data_app_config(
@@ -1408,7 +1454,9 @@ def _update_existing_code_data_app_config(
     keys already present. Used on projects without the `data-apps-storage-workspace` feature to
     inject WORKSPACE_ID; on projects with the feature, pass None.
     `storage` replaces the entire `storage` block when provided (None preserves the existing one;
-    an empty dict is an explicit wipe).
+    an empty dict — or one that prunes down to nothing — is an explicit wipe that removes the
+    `storage` key entirely). Whatever storage ends up in the config is normalized so empty mapping
+    containers never persist as `[]` and break the Writable Tables editor (AI-3135).
     """
     new_config = cast(dict[str, Any], copy.deepcopy(existing_config))
     new_config.setdefault('parameters', {})
@@ -1424,6 +1472,7 @@ def _update_existing_code_data_app_config(
         data_app['secrets'] = updated_secrets
     if storage is not None:
         new_config['storage'] = storage
+    _normalize_config_storage(new_config)
     return new_config
 
 
@@ -1715,6 +1764,9 @@ def _update_existing_data_app_config(
 
     if authentication_type != 'default':
         new_config['authorization'] = _get_authorization(authentication_type == 'basic-auth')
+    # Clean up any empty/array-shaped storage left behind by earlier MCP/CLI/KAI writes so the
+    # Writable Tables editor keeps working after a re-save (AI-3135).
+    _normalize_config_storage(new_config)
     return new_config
 
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -889,7 +889,8 @@ class TestPreviewConfigDiff:
                     'packages': ['httpx', 'pandas', 'streamlit'],
                 },
                 'authorization': {},
-                'storage': {},
+                # The empty `storage: {}` from the original config is pruned on re-save so it is
+                # never persisted as `[]` (which breaks the Writable Tables editor, AI-3135).
             },
         }
         # check the script

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import DATA_APP_COMPONENT_ID, KeboolaClient
-from keboola_mcp_server.clients.data_science import AppRunResponse, DataAppResponse
+from keboola_mcp_server.clients.data_science import AppRunResponse, DataAppConfig, DataAppResponse
 from keboola_mcp_server.config import MetadataField
 from keboola_mcp_server.links import Link
 from keboola_mcp_server.tools.data_apps import (
@@ -29,6 +29,7 @@ from keboola_mcp_server.tools.data_apps import (
     _get_query_function_code,
     _get_secrets,
     _inject_query_to_source_code,
+    _prune_empty_storage_objects,
     _update_existing_data_app_config,
     _uses_basic_authentication,
     deploy_data_app,
@@ -320,6 +321,43 @@ def test_build_data_app_config_merges_defaults_and_secrets():
     assert config['authorization'] == _get_authorization(True)
 
 
+@pytest.mark.parametrize(
+    ('block', 'expected'),
+    [
+        # An empty storage block collapses to empty so the caller omits the `storage` key.
+        ({}, {}),
+        # Empty `input`/`output` objects are dropped — PHP would serialize them as `[]` and the
+        # mapping editor (Writable Tables) then silently fails to add entries (AI-3135).
+        ({'input': {}, 'output': {}}, {}),
+        # The canonical empty state uses empty *arrays*, which must be preserved verbatim.
+        ({'output': {'tables': []}}, {'output': {'tables': []}}),
+        # Mixed: drop the empty `input`, keep the populated `output`.
+        (
+            {
+                'input': {},
+                'output': {'tables': [{'destination': 'in.c-main.t', 'unload_strategy': 'direct-grant'}]},
+            },
+            {'output': {'tables': [{'destination': 'in.c-main.t', 'unload_strategy': 'direct-grant'}]}},
+        ),
+        # Nested empty objects inside a table entry are pruned; scalars and arrays survive.
+        (
+            {'output': {'tables': [{'destination': 'in.c-main.t', 'table_metadata': {}}]}},
+            {'output': {'tables': [{'destination': 'in.c-main.t'}]}},
+        ),
+    ],
+)
+def test_prune_empty_storage_objects(block, expected) -> None:
+    """Empty objects are stripped (they collapse to `[]` server-side); empty arrays are kept."""
+    assert _prune_empty_storage_objects(block) == expected
+
+
+def test_build_data_app_config_create_omits_empty_storage() -> None:
+    """Streamlit create must not persist an empty `storage` object (it becomes `[]` server-side, AI-3135)."""
+    config = _build_data_app_config('My App', "print('hi')", [], 'no-auth', {}, 'snowflake')
+    serialized = DataAppConfig.model_validate(config).model_dump(by_alias=True, exclude_none=True)
+    assert 'storage' not in serialized
+
+
 def test_update_existing_data_app_config():
     existing = {
         'parameters': {
@@ -438,6 +476,45 @@ def test_update_existing_data_app_config_keeps_previous_properties_when_undefine
     assert 'numpy' in new['parameters']['packages']
     assert 'httpx' in new['parameters']['packages']
     assert new['parameters']['dataApp']['secrets']['KEEP'] == 'secret'
+
+
+@pytest.mark.parametrize(
+    ('existing_storage', 'storage_key_present', 'expected_storage'),
+    [
+        # Leftover empty object (serialized as `[]` server-side) is removed on re-save (AI-3135).
+        ({}, False, None),
+        # Leftover array-shaped storage is removed.
+        ([], False, None),
+        # Empty `input`/`output` containers are pruned away to nothing -> key removed.
+        ({'input': {}, 'output': {}}, False, None),
+        # A valid storage block is preserved untouched.
+        (
+            {'output': {'tables': [{'destination': 'in.c-main.t', 'unload_strategy': 'direct-grant'}]}},
+            True,
+            {'output': {'tables': [{'destination': 'in.c-main.t', 'unload_strategy': 'direct-grant'}]}},
+        ),
+    ],
+)
+def test_update_existing_data_app_config_normalizes_storage(
+    existing_storage, storage_key_present, expected_storage
+) -> None:
+    """Streamlit re-save repairs a broken/empty leftover `storage` shape instead of preserving it."""
+    existing = {
+        'parameters': {'dataApp': {'slug': 'x', 'secrets': {}}, 'script': ['old'], 'packages': []},
+        'storage': existing_storage,
+    }
+    new = _update_existing_data_app_config(
+        existing_config=existing,
+        name='',
+        source_code='',
+        packages=[],
+        authentication_type='default',
+        secrets={},
+        sql_dialect='snowflake',
+    )
+    assert ('storage' in new) is storage_key_present
+    if storage_key_present:
+        assert new['storage'] == expected_storage
 
 
 def test_update_existing_data_app_config_no_authorization_key():
@@ -1477,6 +1554,46 @@ async def test_modify_python_js_data_app_create_passes_storage_through(
     assert serialized['storage'] == storage
 
 
+@pytest.mark.parametrize('passed_storage', [{}, {'input': {}, 'output': {}}], ids=['empty', 'all_empty_objects'])
+@pytest.mark.asyncio
+async def test_modify_python_js_data_app_create_omits_empty_storage(
+    mocker,
+    mcp_context_client: Context,
+    workspace_manager,
+    passed_storage,
+) -> None:
+    """Create path never persists an empty `storage` block (it collapses to `[]` server-side, AI-3135)."""
+    keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
+    keboola_client.data_science_client = mocker.AsyncMock()
+
+    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+
+    app_response = _make_python_js_data_app_response()
+    keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=app_response)
+    keboola_client.data_science_client.get_app_git_repo = mocker.AsyncMock(
+        return_value=AppGitRepoResponse(
+            ssh_url='git@managed.repo:org/app.git',
+            https_url='https://managed.repo/org/app.git',
+            is_managed_git_repo=True,
+        )
+    )
+    mocker.patch('keboola_mcp_server.tools.data_apps.set_cfg_creation_metadata', mocker.AsyncMock())
+    mocker.patch('keboola_mcp_server.tools.data_apps.apply_folder_metadata', mocker.AsyncMock(return_value=None))
+
+    _ = await modify_python_js_data_app(
+        ctx=mcp_context_client,
+        name='My App',
+        description='desc',
+        slug='my-app',
+        storage=passed_storage,
+    )
+
+    serialized = keboola_client.data_science_client.create_data_app.await_args.kwargs['configuration'].model_dump(
+        by_alias=True, exclude_none=True
+    )
+    assert 'storage' not in serialized
+
+
 @pytest.mark.asyncio
 async def test_modify_python_js_data_app_update_replaces_storage(
     mocker,
@@ -1650,11 +1767,23 @@ def test_update_existing_code_data_app_config_no_auth_overwrites() -> None:
     [
         # None preserves the existing storage block untouched
         (None, True, {'input': {'tables': [{'source': 'in.c-main.kept', 'destination': 'kept.csv'}]}}),
-        # Empty dict is an explicit wipe
-        ({}, True, {}),
-        # Non-empty dict replaces the existing block wholesale
+        # Empty dict is an explicit wipe — the `storage` key is removed entirely (never persisted as
+        # `{}`, which the backend collapses to `[]` and breaks the mapping editor, AI-3135).
+        ({}, False, None),
+        # A block that prunes down to nothing (only empty objects) is treated like a wipe.
+        ({'input': {}, 'output': {}}, False, None),
+        # Non-empty dict replaces the existing block wholesale.
         (
             {'output': {'tables': [{'destination': 'in.c-main.new', 'unload_strategy': 'direct-grant'}]}},
+            True,
+            {'output': {'tables': [{'destination': 'in.c-main.new', 'unload_strategy': 'direct-grant'}]}},
+        ),
+        # Empty mapping containers are pruned from an otherwise-populated block.
+        (
+            {
+                'input': {},
+                'output': {'tables': [{'destination': 'in.c-main.new', 'unload_strategy': 'direct-grant'}]},
+            },
             True,
             {'output': {'tables': [{'destination': 'in.c-main.new', 'unload_strategy': 'direct-grant'}]}},
         ),
@@ -1663,7 +1792,8 @@ def test_update_existing_code_data_app_config_no_auth_overwrites() -> None:
 def test_update_existing_code_data_app_config_storage_semantics(
     passed_storage, expected_storage_key_present, expected_storage
 ) -> None:
-    """`storage=None` preserves; `storage={}` wipes; a non-empty dict replaces wholesale."""
+    """`storage=None` preserves; an empty/all-empty block wipes (removes the key); a non-empty dict
+    replaces wholesale (with empty mapping containers pruned)."""
     existing = {
         'parameters': {'autoSuspendAfterSeconds': 900, 'dataApp': {'slug': 'x'}},
         'storage': {'input': {'tables': [{'source': 'in.c-main.kept', 'destination': 'kept.csv'}]}},
@@ -1674,7 +1804,8 @@ def test_update_existing_code_data_app_config_storage_semantics(
         storage=passed_storage,
     )
     assert ('storage' in new) is expected_storage_key_present
-    assert new['storage'] == expected_storage
+    if expected_storage_key_present:
+        assert new['storage'] == expected_storage
 
 
 # ===== Tests for deploy_data_app with mode and python-js =====

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.72.5"
+version = "1.72.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3135](https://linear.app/keboola/issue/AI-3135/writable-tables-ui-does-not-persist-configuration)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Data apps generated via MCP/KAI/CLI could leave an **empty `storage` block** in the configuration. The Keboola backend (PHP/SAPI) cannot distinguish an empty JSON object from an empty array and serializes `{}` as `[]`, so `storage` (or its `input`/`output` containers) ended up stored as an **array**. The UI's Input/Output Mapping (**Writable Tables**) editor then silently fails to add or save entries — the reported bug.

Root cause was confirmed both in code and in the Linear/Slack thread (Jakub Kotek: *"MCP/CLI left an empty storage and it got saved as an array instead of an object, and then nothing could be added… better to delete it"*).

**What changed** (`tools/data_apps.py`, `clients/data_science.py`):
- `_prune_empty_storage_objects` — recursively strips empty objects (`{}`) from a storage block while **preserving empty arrays** (the canonical `{"output": {"tables": []}}` is left intact).
- `_normalize_config_storage` — removes the `storage` key entirely when it prunes to nothing (or is a leftover `[]`).
- Wired into **all four data-app write paths**: streamlit create (`DataAppConfig.storage` now defaults to `None` so it's omitted), streamlit update, python-js create (`storage=validated_storage or None`), and python-js update. The update builders also **repair** a broken/empty storage shape left by earlier writes when the config is re-saved through MCP.

**Behavior change:** the python-js storage wipe (`storage={}`) now removes the `storage` key entirely instead of persisting an empty object.

**Out of scope:** the separate "Insufficient privileges" symptom for `direct-grant` writable tables is a platform-side grant issue, not an MCP write-shape problem.

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Regression tests added/updated: prune-helper unit cases, both create paths omitting empty storage, the wipe/prune semantics for the python-js update builder, and the streamlit re-save repair. Full unit suite green (1553 passed); `black`/`isort`/`flake8`/`check-tools-docs` all pass.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)