### PR TITLE
chore: allow model invocation for release-notes skill

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: release-notes
 description: Prepares release notes and tags for a new Keboola MCP Server version. Use when the user asks to prepare a release, create release notes, or tag a new version.
-disable-model-invocation: true
 ---
 
 **Before doing anything**, ask the user three questions in a single prompt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.72.6"
+version = "1.72.7"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.72.6"
+version = "1.72.7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: N/A

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Removes `disable-model-invocation: true` from the `release-notes` skill frontmatter
(`.claude/skills/release-notes/SKILL.md`). With the field omitted, the skill reverts
to the default of allowing model invocation, so it can be triggered automatically when
a user asks to "prepare a release", "create release notes", or "tag a new version" —
instead of requiring an explicit invocation.

Version bumped 1.72.6 → 1.72.7 (patch; tooling/chore change, no functional code change).

## Testing

Not applicable — this only changes Claude skill metadata. No server/runtime behavior is
affected. Local `tox` passes (`black`, `isort`, `flake8`, `check-tools-docs`, pytest);
the single `test_json_logging` failure is the known local-only port-8000 conflict that
passes in CI.

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)
