### PR TITLE
docs(PSGO-261): RFC — PAT/AT token support and PKCE login

### DIFF
--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -6,10 +6,20 @@ Related: [PSGO-263](https://linear.app/keboola/issue/PSGO-263/support-pat-tokens
 
 Reference implementations:
 - Go SDK exchange resolver: [keboola/keboola-sdk-go#90](https://github.com/keboola/keboola-sdk-go/pull/90)
-- Go services consumption (Query/Metastore): [keboola/go-monorepo#540](https://github.com/keboola/go-monorepo#540)
+- Go services consumption (Query/Metastore): [keboola/go-monorepo#540](https://github.com/keboola/go-monorepo/pull/540)
 - UI PKCE login + `/v1/auth/*` client: [keboola/ui#6061](https://github.com/keboola/ui/pull/6061)
 - PHP reference (decentralized exchange): keboola/platform-libraries#507
 - Auth-bridge-proxy RFC: `go-monorepo/docs/rfcs/2026-05-18-auth-bridge-proxy.md`
+
+---
+
+> **As-built status.** This is the original design RFC. During implementation the scope grew
+> beyond Parts A/B: the shipped server adds **multi-project session scope** with per-project
+> fan-out (`get_accessible_projects` / `set_project_scope`), a **scoped-token exchange**
+> (`POST v1/auth/pat/exchange`), and **PAT/MFA leasing** (`v1/auth/sudo`, `v1/auth/pat`, exposed
+> via `login --pat/--totp/--recovery`), plus `logout` and `login --force/--show-token`. The
+> paragraphs below marked _(as-built)_ have been reconciled with the code; the authoritative,
+> fully expanded description lives in the as-built RFC carried by the implementation PR.
 
 ---
 
@@ -63,7 +73,7 @@ Response 200 (AuthBridgeStorageTokenResolveResponse):
 Requirements (from acceptance criteria):
 
 - `Authorization: Bearer kbc_pat_*` **or** `kbc_at_*` + `X-KBC-ProjectId` is accepted wherever a legacy Storage token works today, and resolves to that project's Storage token.
-- Legacy `X-StorageApi-Token` traffic is unaffected.
+- Legacy `X-StorageAPI-Token` traffic is unaffected.
 - The server reads its **own** projected SA JWT from the file path **per request** (kubelet rotation); the SA subject is mapped to `internal:auth-bridge:resolve-storage-token` in kbc-stacks (Part 2, separate repo).
 - Resolver error mapping: `400→400`, `401→401`, `403→403`, `5xx/timeout/network→502`.
 - **No token material** (subject token, resolved Storage token, SA JWT) is ever logged or put in exception messages.
@@ -74,7 +84,7 @@ Requirements (from acceptance criteria):
 For local/stdio use we add a `login` flow that obtains and persists programmatic tokens so the server can run without a hand-pasted Storage token.
 
 ```
-keboola-mcp-server login --storage-api-url https://connection.<stack>.keboola.com
+keboola-mcp-server login --api-url https://connection.<stack>.keboola.com
 ```
 
 1. Generate PKCE verifier/challenge (S256) + `state`; start a loopback listener on `127.0.0.1:<port>/callback`.
@@ -103,21 +113,32 @@ The resulting `accessToken` is then the subject token for the Part A resolver ex
 | HTTP / remote | `Authorization: Bearer kbc_*` per request | exchange per request (Part A); refresh is the client's job, not ours |
 | HTTP OAuth (existing) | `SimpleOAuthProvider` session | unchanged for now (see Scope) |
 
+### Connection endpoints used _(as-built)_
+
+Beyond the resolver and the two PKCE endpoints above, the shipped code also calls:
+
+| Method + path | Purpose |
+| --- | --- |
+| `GET v1/auth/token/introspect` | enumerate the projects a token can reach (drives default multi-project scope) |
+| `POST v1/auth/pat/exchange` | mint a session-scoped child token narrowed to selected project(s) |
+| `POST v1/auth/sudo` | MFA elevation (TOTP / recovery code) ahead of PAT creation |
+| `POST v1/auth/pat` | create a personal access token (`login --pat`) |
+
 ## Resolution Strategy
 
 ### Detection + exchange client (Part A)
 
 - **New** `clients/auth_bridge.py`: `StorageTokenResolver` with `async def resolve(subject_token: str, project_id: int) -> str`. Builds the resolver URL from the stack host suffix (same derivation as `KeboolaClient.__init__`, `clients/client.py:154-166`). Reads the SA JWT from a path env var **per call** (no caching). Redacts all token material from logs/exceptions; maps status codes per the table.
 - **Reuse the existing projected-SA-token mechanism** already added for workspace step-up (commit `b971146f`, workspace provisioning header). Same projected file, same per-request read — factor the file-read into one helper so both call sites share it.
-- **Helper** `is_programmatic_token(token: str) -> bool` (prefix check, `Bearer ` tolerant) in `config.py` or a small `auth.py`.
-- **Wire-in point:** `SessionStateMiddleware.apply_request_config` (`mcp.py:229-245`) and/or `create_session_state` (`mcp.py:248-294`). Today `apply_request_config` pulls `storage_token` from `user.access_token.sapi_token` (OAuth). New branch: if `config.bearer_token` / inbound bearer is programmatic, call the resolver to obtain the Storage token and set `config.storage_token` to the resolved value before `KeboolaClient` is built. Everything downstream (`client.py:169` `bearer_or_sapi_token`, `base.py:38-42` header selection) then uses the legacy Storage token unchanged.
+- **Helper** `is_programmatic_token(token: str) -> bool` (prefix check, `Bearer ` tolerant). _(as-built: lives in `clients/auth_bridge.py`, not `config.py`/`auth.py`.)_
+- **Wire-in point:** `create_session_state` in `mcp.py`. _(as-built: the programmatic token arrives as `config.storage_token`; `create_session_state` branches on `is_programmatic_token(config.storage_token)` — deployed exchanges it via the resolver, local forwards it as a Bearer with `X-KBC-ProjectId`. It is not triggered off `config.bearer_token`.)_ Everything downstream (`client.py:169` `bearer_or_sapi_token`, `base.py:38-42` header selection) then uses the resolved/forwarded token unchanged.
   - Note: with a resolved legacy Storage token we should set `storage_token` and leave `bearer_token` unset, so all service clients (including Queue/AI/sync-actions that don't speak Bearer) work uniformly. The programmatic token never goes downstream.
 - **Project id:** required by the resolver, resolved **per request/session**, not a single static config value. It comes from a session→project mapping injected in middleware (`SessionStateMiddleware`), driven by user/query filtering — the same place that will later host **token-scoping tooling** (issue increasingly tight PATs scoped to a project/session on top of the session mapping). Source order for v1: `X-KBC-ProjectId` header (HTTP) → session mapping → `KBC_PROJECT_ID` env / CLI (stdio) → from `tokenDetail`/login `user` if unambiguous. Add `project_id` to `Config` (`config.py:17-138`, same `KBC_*` / `X-*` resolution pattern) as the plumbing; the mapping/scoping tooling is a follow-up.
 
 ### PKCE login + storage + refresh (Part B)
 
 - **New** `auth_login.py`: PKCE crypto (stdlib `hashlib`, `secrets`, `base64`), loopback `http.server` callback, the two HTTP calls (`/admin/auth/pkce/authorize` open-in-browser, `POST /v1/auth/pkce/token`). Mirror `scripts/auth-demo-cli/pkce.ts` from ui#6061. `clientId` is configurable via env/secret (`KBC_PKCE_CLIENT_ID`), defaulting to the demo value `keboola-cli-demo` for now; tolerate a blank value (injected as a secret later) and swap the real MCP client id when allocated.
-- **New** `credentials.py`: load/save the mode-`600` JSON file; `async def get_access_token()` that refreshes via `POST /v1/auth/token/refresh` when within skew of `expiresAt` and persists the rotated pair. ponytail: file-based store, single-user; no keyring/DB until a real multi-account need appears.
+- **Credential store + refresh:** load/save the mode-`600` JSON file; `async def get_access_token()` that refreshes via `POST /v1/auth/token/refresh` when within skew of `expiresAt` and persists the rotated pair. _(as-built: this lives in `auth_login.py` alongside the PKCE flow — no separate `credentials.py` module.)_ Note: file-based store, single-user; no keyring/DB until a real multi-account need appears.
 - **CLI:** add `login` subcommand in `cli.py` (`parse_args` `cli.py:28-61`, `run_server` dispatch). On normal server start, if no `KBC_STORAGE_TOKEN` and no inbound bearer, load stored creds → refresh-if-needed → feed the access token into the Part A path.
 - Refresh concurrency: guard with an `asyncio.Lock` so concurrent sessions don't double-refresh and invalidate each other's rotated token.
 
@@ -136,12 +157,16 @@ The resulting `accessToken` is then the subject token for the Part A resolver ex
 - `project_id` config plumbing.
 - Unit + integration tests; `TOOLS.md` regen only if tool signatures change (they shouldn't).
 
+**Delivered beyond the original Part A/B design** _(as-built — originally listed out of scope, since built)_
+- Multi-project session scope with per-project fan-out and the `get_accessible_projects` / `set_project_scope` tools.
+- Session-scoped token exchange (`v1/auth/pat/exchange`) for narrowing scope at runtime.
+- MFA / sudo flow (`v1/auth/sudo`) and PAT creation (`v1/auth/pat`) behind `login --pat/--totp/--recovery`.
+
 **Out of scope**
 - kbc-stacks SA-subject → `internal:auth-bridge:resolve-storage-token` mapping and projected-token mount (PSGO-261 Part 2, **separate repo**).
 - Replacing/retiring `SimpleOAuthProvider` OAuth flow.
 - Caching exchange results; keyring/DB credential storage.
-- MFA / sudo / device-code flows, PAT create/list/revoke management endpoints.
-- Multi-project / project-switching UX beyond a single `project_id`.
+- Device-code flow; PAT list/revoke management endpoints.
 
 ## Testing / Verification
 
@@ -154,11 +179,11 @@ The resulting `accessToken` is then the subject token for the Part A resolver ex
 **Integration** (`integtests/`, real stack)
 - Tool call authenticated with a `kbc_pat_*` token + `X-KBC-ProjectId` succeeds and hits the right project.
 - Same with `kbc_at_*`.
-- Legacy `X-StorageApi-Token` path still works (regression).
+- Legacy `X-StorageAPI-Token` path still works (regression).
 - Each resolver error path surfaces the mapped client status.
 
 **Manual**
-- `keboola-mcp-server login --storage-api-url https://connection.<stack>.keboola.com` → browser → tokens stored; start server with no `KBC_STORAGE_TOKEN`; run a tool; let the access token expire and confirm transparent refresh.
+- `keboola-mcp-server login --api-url https://connection.<stack>.keboola.com` → browser → tokens stored; start server with no `KBC_STORAGE_TOKEN`; run a tool; let the access token expire and confirm transparent refresh.
 
 ---
 
@@ -172,8 +197,8 @@ OAuth is **not** removed (the MCP protocol needs it for HTTP transport). The OAu
 
 ## Decisions
 
-1. **`project_id` is explicit session state (D2)** — not derived from the token (a whole-stack PAT has no implicit project; today `StorageClient.project_id()` reads `tokens/verify`, which only works for project-bound legacy tokens). Default from CLI/env (`KBC_PROJECT_ID`) or HTTP `X-KBC-ProjectId`; a new chat may start full-scope and narrow via a **select-project tool** (mirrors the `get_project_info` discovery pattern). Storage-touching tools require a selected project when none is set (clear error, no silent wrong-project resolution).
-1b. **No minting; whole-stack on-disk credential (D1)** — login does not mint a project-scoped PAT. The stored credential is the whole-stack session token; scope narrowing is runtime-only session state. Mitigations: mode-600 file, refresh rotation, never logged.
+1. **`project_id` is explicit session state (D2)** — not derived from the token (a whole-stack PAT has no implicit project; today `StorageClient.project_id()` reads `tokens/verify`, which only works for project-bound legacy tokens). Default from CLI/env (`KBC_PROJECT_ID`) or HTTP `X-KBC-ProjectId`. _(as-built: rather than a single "select-project tool", the server ships two tools — `get_accessible_projects` (introspect-backed discovery) and `set_project_scope` (narrowing) — and, for local programmatic sessions with no explicit project, auto-leases **all** reachable projects as the default scope, gated by an ask-first confirmation.)_
+1b. **Whole-stack on-disk credential; scoped minting at runtime (D1)** — the persisted PKCE credential is the whole-stack session token (mode-600, refresh-rotated, never logged); it is never a project-scoped PAT on disk. _(as-built: `set_project_scope` **does** mint a scoped child token via `v1/auth/pat/exchange`, but only in memory as session state — it is never persisted — and `login --pat` can mint a real PAT on explicit request.)_
 2. **`clientId` for PKCE** — use the demo value `keboola-cli-demo` for now, configurable via `KBC_PKCE_CLIENT_ID` (blank-tolerant, injectable as a secret later); swap the real MCP client id when allocated.
 3. **Refresh token** — treated as an opaque string (no prefix assumptions).
 4. **SA token path env var** — align with the workspace step-up var (`b971146f`) and the Go services' `*_KUBERNETES_TOKEN_PATH` convention; share one file-read helper.

--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -72,7 +72,7 @@ Response 200 (AuthBridgeStorageTokenResolveResponse):
 
 Requirements (from acceptance criteria):
 
-- `Authorization: Bearer kbc_pat_*` **or** `kbc_at_*` + `X-KBC-ProjectId` is accepted wherever a legacy Storage token works today, and resolves to that project's Storage token.
+- A programmatic token — `Authorization: Bearer kbc_pat_*` **or** `kbc_at_*` — **together with** `X-KBC-ProjectId` (both token kinds need it; the resolver body always requires `projectId`) is accepted wherever a legacy Storage token works today, and resolves to that project's Storage token.
 - Legacy `X-StorageAPI-Token` traffic is unaffected.
 - The server reads its **own** projected SA JWT from the file path **per request** (kubelet rotation); the SA subject is mapped to `internal:auth-bridge:resolve-storage-token` in kbc-stacks (Part 2, separate repo).
 - Resolver error mapping: `400→400`, `401→401`, `403→403`, `5xx/timeout/network→502`.
@@ -102,15 +102,15 @@ POST {url}/v1/auth/token/refresh   body { "refreshToken": "<rt>" }
 → { accessToken, refreshToken, expiresIn, sessionId, user }   # rotating refresh — persist both
 ```
 
-The resulting `accessToken` is then the subject token for the Part A resolver exchange. **When the token is dead** (refresh token expired/revoked → refresh returns `invalid_grant`/`401`), the server clears the stored credentials and **enforces re-login** (surfaces a clear "run `login` again" error rather than silently failing).
+The resulting `accessToken` is then the session's programmatic token: on the **deployed** server it is the subject token for the Part A resolver exchange; on the **local** server (no projected SA token) it is forwarded downstream as a Bearer and the Keboola services exchange it — see _Architecture: hybrid (Option C)_. **When the token is dead** (refresh token expired/revoked → refresh returns `invalid_grant`/`401`), the server clears the stored credentials and **enforces re-login** (surfaces a clear "run `login` again" error rather than silently failing).
 
 ### Mode matrix
 
-| Mode | Inbound credential | How token reaches resolver |
+| Mode | Inbound credential | How the token is used |
 | --- | --- | --- |
 | stdio (legacy) | `KBC_STORAGE_TOKEN` | no exchange — used directly (unchanged) |
-| stdio (new) | stored PKCE creds (Part B) | load → refresh-if-needed → exchange (Part A) |
-| HTTP / remote | `Authorization: Bearer kbc_*` per request | exchange per request (Part A); refresh is the client's job, not ours |
+| stdio (new, local) | stored PKCE creds (Part B) | load → refresh-if-needed → forward the bearer downstream + `X-KBC-ProjectId`; services exchange (local has no SA token — see hybrid) |
+| HTTP / remote (deployed) | `Authorization: Bearer kbc_*` per request | exchange per request via the Part A resolver; refresh is the client's job, not ours |
 | HTTP OAuth (existing) | `SimpleOAuthProvider` session | unchanged for now (see Scope) |
 
 ### Connection endpoints used _(as-built)_

--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -1,0 +1,171 @@
+# RFC: PAT / Access Token support and PKCE login for MCP Server
+
+Linear: [PSGO-261](https://linear.app/keboola/issue/PSGO-261/support-pat-tokens-in-mcp-server-mcp-server)
+Parent: [PAT-1838](https://linear.app/keboola/issue/PAT-1838) · Milestone: PAT token support across services
+Related: [PSGO-263](https://linear.app/keboola/issue/PSGO-263/support-pat-tokens-in-stream-keboola-as-code) (stream / keboola-as-code)
+
+Reference implementations:
+- Go SDK exchange resolver: [keboola/keboola-sdk-go#90](https://github.com/keboola/keboola-sdk-go/pull/90)
+- Go services consumption (Query/Metastore): [keboola/go-monorepo#540](https://github.com/keboola/go-monorepo#540)
+- UI PKCE login + `/v1/auth/*` client: [keboola/ui#6061](https://github.com/keboola/ui/pull/6061)
+- PHP reference (decentralized exchange): keboola/platform-libraries#507
+- Auth-bridge-proxy RFC: `go-monorepo/docs/rfcs/2026-05-18-auth-bridge-proxy.md`
+
+---
+
+## Problem
+
+The MCP server authenticates to Keboola exclusively with **legacy Storage API tokens** (`X-StorageAPI-Token`), supplied either as `KBC_STORAGE_TOKEN` (stdio) or minted from an OAuth session (HTTP). Connection is rolling out **programmatic bearer tokens**:
+
+- **Access token** `kbc_at_<uuid>_<random>` — short-lived (`expiresIn`, ~3600s), issued by a login/session flow.
+- **Personal access token** `kbc_pat_<uuid>_<random>` — long-lived, user-created.
+
+These are sent as `Authorization: Bearer <token>` and are **not** Storage tokens — they must be exchanged for a legacy Storage token at Connection before any current Storage-token API will accept them. Today the MCP server has no way to:
+
+1. Accept a `kbc_at_*` / `kbc_pat_*` bearer token and exchange it for a Storage token (PSGO-261 core).
+2. Acquire such a token in the first place for local/stdio use, where there is no browser-driven OAuth — the user must hand-paste a Storage token. We want a **browser PKCE login** that leases an access token + refresh token, stores them, and refreshes the access token until it expires, so `KBC_STORAGE_TOKEN` is no longer the only way in.
+
+**Symptom:** A user presenting a `kbc_pat_*` token gets `401` from every tool. Local users have no login flow and must manually create and paste a Storage token.
+
+## Required Behavior
+
+### Token contract (authoritative, from the three PRs)
+
+| Token | Format | Sent as | Lifetime |
+| --- | --- | --- | --- |
+| Access token | `kbc_at_<uuid>_<random>` | `Authorization: Bearer …` | short (`expiresIn` ≈ 3600s) |
+| Personal access token | `kbc_pat_<uuid>_<random>` | `Authorization: Bearer …` | long |
+| Refresh token | opaque (`kbc_rt_*` per task; **prefix unconfirmed in PRs**) | request body only | long |
+| Legacy Storage token | unchanged | `X-StorageAPI-Token: …` | unchanged |
+
+A token is "programmatic" iff it starts with `kbc_at_` or `kbc_pat_` (case-insensitive `Bearer ` prefix tolerated). This is the **only** trigger for exchange — legacy `X-StorageAPI-Token` traffic is untouched.
+
+### Part A — Accept programmatic tokens and exchange for a Storage token (PSGO-261)
+
+The MCP server is the "service" in the decentralized exchange model. On every request whose inbound credential is a programmatic token, it must:
+
+1. Detect the `kbc_at_` / `kbc_pat_` prefix on the inbound bearer token.
+2. Call the Connection resolver and use the returned legacy Storage token for the rest of the request, exactly as today.
+
+```
+POST {connection}/manage/internal/auth-bridge/resolve-storage-token
+Headers:
+  X-Kubernetes-Authorization: Bearer <MCP server's projected SA JWT, aud=keboola-connection>
+  X-Subject-Token:            Bearer <kbc_at_* | kbc_pat_*>     # the user's token
+  Content-Type: application/json
+Body: { "projectId": <int> }                                   # from X-KBC-ProjectId
+
+Response 200 (AuthBridgeStorageTokenResolveResponse):
+  { "storageToken": "<legacy>", "projectId": <int>, "tokenId": "...",
+    "userId": "...", "expiresAt": "<ISO8601>|null", "tokenDetail": { …tokens/verify payload… } }
+```
+
+Requirements (from acceptance criteria):
+
+- `Authorization: Bearer kbc_pat_*` **or** `kbc_at_*` + `X-KBC-ProjectId` is accepted wherever a legacy Storage token works today, and resolves to that project's Storage token.
+- Legacy `X-StorageApi-Token` traffic is unaffected.
+- The server reads its **own** projected SA JWT from the file path **per request** (kubelet rotation); the SA subject is mapped to `internal:auth-bridge:resolve-storage-token` in kbc-stacks (Part 2, separate repo).
+- Resolver error mapping: `400→400`, `401→401`, `403→403`, `5xx/timeout/network→502`.
+- **No token material** (subject token, resolved Storage token, SA JWT) is ever logged or put in exception messages.
+- **No caching of the exchange result in v1.**
+
+### Part B — PKCE browser login with token storage + auto-refresh (new login)
+
+For local/stdio use we add a `login` flow that obtains and persists programmatic tokens so the server can run without a hand-pasted Storage token.
+
+```
+keboola-mcp-server login --storage-api-url https://connection.<stack>.keboola.com
+```
+
+1. Generate PKCE verifier/challenge (S256) + `state`; start a loopback listener on `127.0.0.1:<port>/callback`.
+2. Open the browser to:
+   `GET {url}/admin/auth/pkce/authorize?responseType=code&clientId=<client>&redirectUri=http://127.0.0.1:<port>/callback&codeChallenge=<c>&codeChallengeMethod=S256&state=<s>`
+3. On callback, verify `state` (constant-time), then exchange:
+   `POST {url}/v1/auth/pkce/token` body `{clientId, code, state, redirectUri, codeVerifier}`
+   → `{accessToken, refreshToken, tokenType:"Bearer", expiresIn, sessionId, user}`.
+4. Persist `{accessToken, refreshToken, expiresAt, sessionId, storageApiUrl}` to a mode-`600` file (default `~/.keboola/mcp/credentials.json`).
+
+Whenever the server holds the credential pair (login flow), it **refreshes during usage**: before each use, if the access token is within a refresh skew (e.g. 60s) of `expiresAt`, refresh first:
+
+```
+POST {url}/v1/auth/token/refresh   body { "refreshToken": "<rt>" }
+→ { accessToken, refreshToken, expiresIn, sessionId, user }   # rotating refresh — persist both
+```
+
+The resulting `accessToken` is then the subject token for the Part A resolver exchange. **When the token is dead** (refresh token expired/revoked → refresh returns `invalid_grant`/`401`), the server clears the stored credentials and **enforces re-login** (surfaces a clear "run `login` again" error rather than silently failing).
+
+### Mode matrix
+
+| Mode | Inbound credential | How token reaches resolver |
+| --- | --- | --- |
+| stdio (legacy) | `KBC_STORAGE_TOKEN` | no exchange — used directly (unchanged) |
+| stdio (new) | stored PKCE creds (Part B) | load → refresh-if-needed → exchange (Part A) |
+| HTTP / remote | `Authorization: Bearer kbc_*` per request | exchange per request (Part A); refresh is the client's job, not ours |
+| HTTP OAuth (existing) | `SimpleOAuthProvider` session | unchanged for now (see Scope) |
+
+## Resolution Strategy
+
+### Detection + exchange client (Part A)
+
+- **New** `clients/auth_bridge.py`: `StorageTokenResolver` with `async def resolve(subject_token: str, project_id: int) -> str`. Builds the resolver URL from the stack host suffix (same derivation as `KeboolaClient.__init__`, `clients/client.py:154-166`). Reads the SA JWT from a path env var **per call** (no caching). Redacts all token material from logs/exceptions; maps status codes per the table.
+- **Reuse the existing projected-SA-token mechanism** already added for workspace step-up (commit `b971146f`, workspace provisioning header). Same projected file, same per-request read — factor the file-read into one helper so both call sites share it.
+- **Helper** `is_programmatic_token(token: str) -> bool` (prefix check, `Bearer ` tolerant) in `config.py` or a small `auth.py`.
+- **Wire-in point:** `SessionStateMiddleware.apply_request_config` (`mcp.py:229-245`) and/or `create_session_state` (`mcp.py:248-294`). Today `apply_request_config` pulls `storage_token` from `user.access_token.sapi_token` (OAuth). New branch: if `config.bearer_token` / inbound bearer is programmatic, call the resolver to obtain the Storage token and set `config.storage_token` to the resolved value before `KeboolaClient` is built. Everything downstream (`client.py:169` `bearer_or_sapi_token`, `base.py:38-42` header selection) then uses the legacy Storage token unchanged.
+  - Note: with a resolved legacy Storage token we should set `storage_token` and leave `bearer_token` unset, so all service clients (including Queue/AI/sync-actions that don't speak Bearer) work uniformly. The programmatic token never goes downstream.
+- **Project id:** required by the resolver, resolved **per request/session**, not a single static config value. It comes from a session→project mapping injected in middleware (`SessionStateMiddleware`), driven by user/query filtering — the same place that will later host **token-scoping tooling** (issue increasingly tight PATs scoped to a project/session on top of the session mapping). Source order for v1: `X-KBC-ProjectId` header (HTTP) → session mapping → `KBC_PROJECT_ID` env / CLI (stdio) → from `tokenDetail`/login `user` if unambiguous. Add `project_id` to `Config` (`config.py:17-138`, same `KBC_*` / `X-*` resolution pattern) as the plumbing; the mapping/scoping tooling is a follow-up.
+
+### PKCE login + storage + refresh (Part B)
+
+- **New** `auth_login.py`: PKCE crypto (stdlib `hashlib`, `secrets`, `base64`), loopback `http.server` callback, the two HTTP calls (`/admin/auth/pkce/authorize` open-in-browser, `POST /v1/auth/pkce/token`). Mirror `scripts/auth-demo-cli/pkce.ts` from ui#6061. `clientId` is configurable via env/secret (`KBC_PKCE_CLIENT_ID`), defaulting to the demo value `keboola-cli-demo` for now; tolerate a blank value (injected as a secret later) and swap the real MCP client id when allocated.
+- **New** `credentials.py`: load/save the mode-`600` JSON file; `async def get_access_token()` that refreshes via `POST /v1/auth/token/refresh` when within skew of `expiresAt` and persists the rotated pair. ponytail: file-based store, single-user; no keyring/DB until a real multi-account need appears.
+- **CLI:** add `login` subcommand in `cli.py` (`parse_args` `cli.py:28-61`, `run_server` dispatch). On normal server start, if no `KBC_STORAGE_TOKEN` and no inbound bearer, load stored creds → refresh-if-needed → feed the access token into the Part A path.
+- Refresh concurrency: guard with an `asyncio.Lock` so concurrent sessions don't double-refresh and invalidate each other's rotated token.
+
+### Non-obvious trade-offs
+
+- **One exchange per request, no cache (v1):** matches the issue's explicit "no caching" and the SA-token-per-request rotation requirement. The resolver round-trip adds latency to every tool call; v2 may cache keyed by `(subject_token, project_id)` until `expiresAt`. Flag, don't build.
+- **Resolved token replaces bearer downstream:** simpler and uniform across all service clients vs. teaching every client to forward the programmatic bearer (Queue/AI/sync-actions don't accept Bearer today).
+- **Existing OAuth (`SimpleOAuthProvider`) left intact:** it already mints a SAPI token. Folding it into the resolver path is a follow-up, not this RFC.
+
+## Scope
+
+**In scope**
+- Detect `kbc_at_*` / `kbc_pat_*` inbound tokens and exchange them via the Connection resolver (Part A), in both stdio and HTTP modes.
+- Per-request SA-JWT read; resolver error mapping; no token logging; no exchange caching.
+- PKCE `login` command, credential storage, and access-token auto-refresh (Part B).
+- `project_id` config plumbing.
+- Unit + integration tests; `TOOLS.md` regen only if tool signatures change (they shouldn't).
+
+**Out of scope**
+- kbc-stacks SA-subject → `internal:auth-bridge:resolve-storage-token` mapping and projected-token mount (PSGO-261 Part 2, **separate repo**).
+- Replacing/retiring `SimpleOAuthProvider` OAuth flow.
+- Caching exchange results; keyring/DB credential storage.
+- MFA / sudo / device-code flows, PAT create/list/revoke management endpoints.
+- Multi-project / project-switching UX beyond a single `project_id`.
+
+## Testing / Verification
+
+**Unit**
+- `is_programmatic_token`: `kbc_at_*`, `kbc_pat_*`, `Bearer ` prefix, legacy token, empty → correct boolean.
+- `StorageTokenResolver`: success returns `storageToken`; resolver `400/401/403` pass through, `5xx/timeout/network → 502`; assert no token material in log records or exception strings (capture logs, assert redaction); assert SA file is read on each call.
+- PKCE: verifier charset/length, `codeChallenge == base64url(sha256(verifier))`, `state` constant-time compare.
+- Credentials: refresh triggered within skew, rotated pair persisted, file mode `600`, concurrent refresh serialized by the lock.
+
+**Integration** (`integtests/`, real stack)
+- Tool call authenticated with a `kbc_pat_*` token + `X-KBC-ProjectId` succeeds and hits the right project.
+- Same with `kbc_at_*`.
+- Legacy `X-StorageApi-Token` path still works (regression).
+- Each resolver error path surfaces the mapped client status.
+
+**Manual**
+- `keboola-mcp-server login --storage-api-url https://connection.<stack>.keboola.com` → browser → tokens stored; start server with no `KBC_STORAGE_TOKEN`; run a tool; let the access token expire and confirm transparent refresh.
+
+---
+
+## Decisions
+
+1. **`project_id`** — resolved per request/session from a middleware session→project mapping driven by user/query filtering, not a single static value. v1 ships the `Config` plumbing + header/env fallback; the mapping and token-scoping tooling (progressively tighter PATs scoped on top of the session) is a follow-up.
+2. **`clientId` for PKCE** — use the demo value `keboola-cli-demo` for now, configurable via `KBC_PKCE_CLIENT_ID` (blank-tolerant, injectable as a secret later); swap the real MCP client id when allocated.
+3. **Refresh token** — treated as an opaque string (no prefix assumptions).
+4. **SA token path env var** — align with the workspace step-up var (`b971146f`) and the Go services' `*_KUBERNETES_TOKEN_PATH` convention; share one file-read helper.
+5. **Refresh + dead token** — the server **always refreshes during usage** when it holds the token pair; when the token is dead (refresh fails), it clears stored credentials and **enforces re-login**.

--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -126,6 +126,9 @@ Beyond the resolver and the two PKCE endpoints above, the shipped code also call
 
 ## Resolution Strategy
 
+> Code `file:line` references below are relative to `src/keboola_mcp_server/` (e.g.
+> `clients/client.py` is `src/keboola_mcp_server/clients/client.py`).
+
 ### Detection + exchange client (Part A)
 
 - **New** `clients/auth_bridge.py`: `StorageTokenResolver` with `async def resolve(subject_token: str, project_id: int) -> str`. Builds the resolver URL from the stack host suffix (same derivation as `KeboolaClient.__init__`, `clients/client.py:154-166`). Reads the SA JWT from a path env var **per call** (no caching). Redacts all token material from logs/exceptions; maps status codes per the table.

--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -8,7 +8,7 @@ Reference implementations:
 - Go SDK exchange resolver: [keboola/keboola-sdk-go#90](https://github.com/keboola/keboola-sdk-go/pull/90)
 - Go services consumption (Query/Metastore): [keboola/go-monorepo#540](https://github.com/keboola/go-monorepo/pull/540)
 - UI PKCE login + `/v1/auth/*` client: [keboola/ui#6061](https://github.com/keboola/ui/pull/6061)
-- PHP reference (decentralized exchange): keboola/platform-libraries#507
+- PHP reference (decentralized exchange): [keboola/platform-libraries#507](https://github.com/keboola/platform-libraries/pull/507)
 - Auth-bridge-proxy RFC: `go-monorepo/docs/rfcs/2026-05-18-auth-bridge-proxy.md`
 
 ---

--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -162,9 +162,18 @@ The resulting `accessToken` is then the subject token for the Part A resolver ex
 
 ---
 
+## Architecture: hybrid (Option C) — see brainstorm.md
+
+Two token paths, one per environment:
+- **Deployed mcp-server (in-k8s):** detect `kbc_at_*`/`kbc_pat_*`, exchange via the resolver using the projected SA JWT → legacy Storage token → used for all downstream clients (Part A; PSGO-261 AC).
+- **Local stdio:** PKCE `login` (stack URL only) leases a whole-stack session token, stored + auto-refreshed; MCP **forwards the bearer** + `X-KBC-ProjectId` downstream and the services exchange (no SA token exists locally).
+
+OAuth is **not** removed (the MCP protocol needs it for HTTP transport). The OAuth→PAT exchange is a **separate PR**; until it lands, the public mcp-server keeps its current OAuth→SAPI-mint path (interim divergence, stated intentionally).
+
 ## Decisions
 
-1. **`project_id`** — resolved per request/session from a middleware session→project mapping driven by user/query filtering, not a single static value. v1 ships the `Config` plumbing + header/env fallback; the mapping and token-scoping tooling (progressively tighter PATs scoped on top of the session) is a follow-up.
+1. **`project_id` is explicit session state (D2)** — not derived from the token (a whole-stack PAT has no implicit project; today `StorageClient.project_id()` reads `tokens/verify`, which only works for project-bound legacy tokens). Default from CLI/env (`KBC_PROJECT_ID`) or HTTP `X-KBC-ProjectId`; a new chat may start full-scope and narrow via a **select-project tool** (mirrors the `get_project_info` discovery pattern). Storage-touching tools require a selected project when none is set (clear error, no silent wrong-project resolution).
+1b. **No minting; whole-stack on-disk credential (D1)** — login does not mint a project-scoped PAT. The stored credential is the whole-stack session token; scope narrowing is runtime-only session state. Mitigations: mode-600 file, refresh rotation, never logged.
 2. **`clientId` for PKCE** — use the demo value `keboola-cli-demo` for now, configurable via `KBC_PKCE_CLIENT_ID` (blank-tolerant, injectable as a secret later); swap the real MCP client id when allocated.
 3. **Refresh token** — treated as an opaque string (no prefix assumptions).
 4. **SA token path env var** — align with the workspace step-up var (`b971146f`) and the Go services' `*_KUBERNETES_TOKEN_PATH` convention; share one file-read helper.

--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -16,7 +16,7 @@ Reference implementations:
 > **As-built status.** This is the original design RFC. During implementation the scope grew
 > beyond Parts A/B: the shipped server adds **multi-project session scope** with per-project
 > fan-out (`get_accessible_projects` / `set_project_scope`), a **scoped-token exchange**
-> (`POST v1/auth/pat/exchange`), and **PAT/MFA leasing** (`v1/auth/sudo`, `v1/auth/pat`, exposed
+> (`POST /v1/auth/pat/exchange`), and **PAT/MFA leasing** (`/v1/auth/sudo`, `/v1/auth/pat`, exposed
 > via `login --pat/--totp/--recovery`), plus `logout` and `login --force/--show-token`. The
 > paragraphs below marked _(as-built)_ have been reconciled with the code; the authoritative,
 > fully expanded description lives in the as-built RFC carried by the implementation PR.
@@ -119,10 +119,10 @@ Beyond the resolver and the two PKCE endpoints above, the shipped code also call
 
 | Method + path | Purpose |
 | --- | --- |
-| `GET v1/auth/token/introspect` | enumerate the projects a token can reach (drives default multi-project scope) |
-| `POST v1/auth/pat/exchange` | mint a session-scoped child token narrowed to selected project(s) |
-| `POST v1/auth/sudo` | MFA elevation (TOTP / recovery code) ahead of PAT creation |
-| `POST v1/auth/pat` | create a personal access token (`login --pat`) |
+| `GET /v1/auth/token/introspect` | enumerate the projects a token can reach (drives default multi-project scope) |
+| `POST /v1/auth/pat/exchange` | mint a session-scoped child token narrowed to selected project(s) |
+| `POST /v1/auth/sudo` | MFA elevation (TOTP / recovery code) ahead of PAT creation |
+| `POST /v1/auth/pat` | create a personal access token (`login --pat`) |
 
 ## Resolution Strategy
 
@@ -159,8 +159,8 @@ Beyond the resolver and the two PKCE endpoints above, the shipped code also call
 
 **Delivered beyond the original Part A/B design** _(as-built — originally listed out of scope, since built)_
 - Multi-project session scope with per-project fan-out and the `get_accessible_projects` / `set_project_scope` tools.
-- Session-scoped token exchange (`v1/auth/pat/exchange`) for narrowing scope at runtime.
-- MFA / sudo flow (`v1/auth/sudo`) and PAT creation (`v1/auth/pat`) behind `login --pat/--totp/--recovery`.
+- Session-scoped token exchange (`/v1/auth/pat/exchange`) for narrowing scope at runtime.
+- MFA / sudo flow (`/v1/auth/sudo`) and PAT creation (`/v1/auth/pat`) behind `login --pat/--totp/--recovery`.
 
 **Out of scope**
 - kbc-stacks SA-subject → `internal:auth-bridge:resolve-storage-token` mapping and projected-token mount (PSGO-261 Part 2, **separate repo**).
@@ -198,7 +198,7 @@ OAuth is **not** removed (the MCP protocol needs it for HTTP transport). The OAu
 ## Decisions
 
 1. **`project_id` is explicit session state (D2)** — not derived from the token (a whole-stack PAT has no implicit project; today `StorageClient.project_id()` reads `tokens/verify`, which only works for project-bound legacy tokens). Default from CLI/env (`KBC_PROJECT_ID`) or HTTP `X-KBC-ProjectId`. _(as-built: rather than a single "select-project tool", the server ships two tools — `get_accessible_projects` (introspect-backed discovery) and `set_project_scope` (narrowing) — and, for local programmatic sessions with no explicit project, auto-leases **all** reachable projects as the default scope, gated by an ask-first confirmation.)_
-1b. **Whole-stack on-disk credential; scoped minting at runtime (D1)** — the persisted PKCE credential is the whole-stack session token (mode-600, refresh-rotated, never logged); it is never a project-scoped PAT on disk. _(as-built: `set_project_scope` **does** mint a scoped child token via `v1/auth/pat/exchange`, but only in memory as session state — it is never persisted — and `login --pat` can mint a real PAT on explicit request.)_
+1b. **Whole-stack on-disk credential; scoped minting at runtime (D1)** — the persisted PKCE credential is the whole-stack session token (mode-600, refresh-rotated, never logged); it is never a project-scoped PAT on disk. _(as-built: `set_project_scope` **does** mint a scoped child token via `/v1/auth/pat/exchange`, but only in memory as session state — it is never persisted — and `login --pat` can mint a real PAT on explicit request.)_
 2. **`clientId` for PKCE** — use the demo value `keboola-cli-demo` for now, configurable via `KBC_PKCE_CLIENT_ID` (blank-tolerant, injectable as a secret later); swap the real MCP client id when allocated.
 3. **Refresh token** — treated as an opaque string (no prefix assumptions).
 4. **SA token path env var** — align with the workspace step-up var (`b971146f`) and the Go services' `*_KUBERNETES_TOKEN_PATH` convention; share one file-read helper.

--- a/feature_spec/pat_token_support/brainstorm.md
+++ b/feature_spec/pat_token_support/brainstorm.md
@@ -48,10 +48,10 @@ Implications:
 - Soft dependencies that gate the production rollout (not local dev): kbc-stacks must map `mcp-server`'s SA subject to `internal:auth-bridge:resolve-storage-token` and mount the projected token (PSGO-261 Part 2); the Connection resolver and `/admin/auth/pkce/authorize` must be enabled on the target production stacks.
 
 ### Prior art
-- **`auth-demo-cli/pkce.ts` (ui#6061)** — the reference PKCE client to mirror for the new local `login` command.
+- **`auth-demo-cli/pkce.ts` ([ui#6061](https://github.com/keboola/ui/pull/6061))** — the reference PKCE client to mirror for the new local `login` command.
 - **`SimpleOAuthProvider` (`oauth.py`)** — existing PKCE + SAPI-mint patterns to follow for token handling/storage.
 - **k8s SA step-up header (`b971146f`)** — the projected-SA-token mechanism; it is the mechanism the resolver's `X-Kubernetes-Authorization` exchange must reuse on the **deployed** mcp-server (in-k8s only).
-- **platform-libraries#507** — PHP decentralized-exchange reference for exchange + error mapping.
+- **[platform-libraries#507](https://github.com/keboola/platform-libraries/pull/507)** — PHP decentralized-exchange reference for exchange + error mapping.
 
 ### Scope split (user-stated, verbatim)
 > "I think we cannot get rid of OAuth because it's MCP protocol build on top of it. We can have login separate when not having oauth — instead of passing headers just stack is enough. The OAuth exchange will be done separately as separate PR."

--- a/feature_spec/pat_token_support/brainstorm.md
+++ b/feature_spec/pat_token_support/brainstorm.md
@@ -124,7 +124,7 @@ Core question: how does MCP turn an inbound `kbc_at_*` / `kbc_pat_*` into authen
 ### Cross-cutting checklist (mcp-server)
 | Dimension | Touched? | Detail |
 |---|---|---|
-| Transports (stdio / streamable-http) | Yes | stdio gets login path; http/OAuth path unchanged this PR |
+| Transports (stdio / streamable-http) | Yes | stdio gets login path; http/OAuth path unchanged by the implementation |
 | OAuth provider (`SimpleOAuthProvider`) | No | left intact; OAuth→PAT exchange is a separate PR |
 | Both deployments (mcp-server + mcp-server-agent) | Yes | one image; agent's direct-Storage-token path must not regress |
 | Legacy `X-StorageAPI-Token` path | No (must stay) | only `kbc_at_`/`kbc_pat_` prefixes trigger new behavior |
@@ -132,7 +132,7 @@ Core question: how does MCP turn an inbound `kbc_at_*` / `kbc_pat_*` into authen
 | `TOOLS.md` / tool signatures | No | no tool signature change expected |
 | Config / env vars | Yes | `project_id`, `KBC_PKCE_CLIENT_ID`, SA-token path var |
 | Unit + integration tests | Yes | new resolver, login, refresh, regression for legacy token |
-| Version bump + `uv.lock` | Yes | minor (new capability) |
+| Version bump + `uv.lock` | Yes | implementation PR: minor (new capability); this docs PR: patch, to merge cleanly ahead of it |
 
 ## 6. Security pass
 

--- a/feature_spec/pat_token_support/brainstorm.md
+++ b/feature_spec/pat_token_support/brainstorm.md
@@ -98,7 +98,7 @@ Core question: how does MCP turn an inbound `kbc_at_*` / `kbc_pat_*` into authen
 
 ## 5. Impact analysis
 
-> Adapted to `keboola-mcp-server` (Python). The skill's connection/platform-wiki checklist (Doctrine, Zend, storage-driver protobuf) does not apply here; the cross-cutting table below is the mcp-server equivalent. File:line refs verified against current `main`.
+> Adapted to `keboola-mcp-server` (Python). The skill's connection/platform-wiki checklist (Doctrine, Zend, storage-driver protobuf) does not apply here; the cross-cutting table below is the mcp-server equivalent. File:line refs are relative to `src/keboola_mcp_server/` and were verified against current `main`.
 
 ### Files / symbols touched
 | File / symbol | Change |

--- a/feature_spec/pat_token_support/brainstorm.md
+++ b/feature_spec/pat_token_support/brainstorm.md
@@ -1,0 +1,185 @@
+---
+slug: pat_token_support
+status: ready-for-rfc
+author: Martin Vaško
+created: 2026-06-24
+linear: PSGO-261
+---
+
+# Brainstorm: PAT / Access Token support and PKCE login for MCP Server
+
+> This document is the discovery artifact that precedes the formal RFC at `./RFC.md`. Anything in the RFC must be traceable to a decision recorded here.
+
+## 1. Problem framing
+
+### Trigger
+Three reinforcing drivers landed together:
+1. **Platform PAT rollout (PAT-1838).** Connection is shipping programmatic tokens (`kbc_at_*`, `kbc_pat_*`) and every service must accept them; MCP server is explicitly on the list as PSGO-261.
+2. **Kill storage-token login.** We want to stop requiring a hand-pasted `KBC_STORAGE_TOKEN` for local/stdio use and replace it with a browser PKCE login that leases and refreshes tokens.
+3. **Multi-project / Kai.** PSGO-261 sits under Kai Multi-Project Support; PATs scoped per project/session are the enabler for multi-project agent workflows.
+
+### Pain
+- **Kai multi-project agents** can't act across projects today: one Storage token is bound to one project.
+- **Platform / security team** carry the standing risk of long-lived Storage tokens living in user and agent configs with no refresh or revocation.
+- **Local / CLI users** must manually create and paste a long-lived Storage token to run MCP over stdio.
+
+### Cost of inaction (6-month horizon)
+- MCP server becomes the lone holdout requiring legacy Storage tokens, **blocking deprecation of Storage-token auth** platform-wide.
+- **Kai multi-project workflows stall** because per-project Storage tokens are a hard ceiling.
+- Long-lived Storage tokens keep accumulating in user/agent configs with no rotation or session revocation — **ongoing leak exposure**.
+
+## 2. Constraints
+
+### Hard constraints (can't change)
+- **Resolver contract is fixed.** Exchange must go through Connection `POST /manage/internal/auth-bridge/resolve-storage-token`, authenticated with the server's projected SA JWT (`X-Kubernetes-Authorization`). No new exchange API.
+- **One image, both deployments.** `mcp-server` (public, OAuth) and `mcp-server-agent` (direct Storage token) share the image and the `KeboolaClient` auth path; the change must cover both.
+- **Legacy token keeps working unchanged** (PSGO-261 AC). Only the `kbc_at_` / `kbc_pat_` prefixes trigger an exchange; `X-StorageAPI-Token` traffic is untouched.
+- **No token material in logs or exceptions** (PSGO-261 AC): subject token, resolved Storage token, SA JWT.
+
+### Login / scoping model (user-stated, verbatim)
+> "The OAuth does typically exchange to JWT token that is connected to PAT token. For regular MCP locally, we should provide only stack, it should login us and provide us whole stack access, then in the chat we will be narrowing down the scope."
+
+Implications:
+- **Local/stdio:** the user supplies only the **stack URL**. Login (PKCE) grants **whole-stack access** (a broad session/PAT). The **scope is then narrowed in-chat** per project/session via the middleware mapping (the future token-scoping tooling).
+- **OAuth (public mcp-server):** the OAuth session yields a JWT bound to an underlying PAT; same downstream exchange path.
+
+### Deadlines and dependencies
+- **No hard external date.** Approach: land as a **draft PR**, verify end-to-end against a **dev stack** where the resolver + PKCE already work, then roll out to production "any day we need to."
+- Soft dependencies that gate the production rollout (not local dev): kbc-stacks must map `mcp-server`'s SA subject to `internal:auth-bridge:resolve-storage-token` and mount the projected token (PSGO-261 Part 2); the Connection resolver and `/admin/auth/pkce/authorize` must be enabled on the target production stacks.
+
+### Prior art
+- **`auth-demo-cli/pkce.ts` (ui#6061)** — the reference PKCE client to mirror for the new local `login` command.
+- **`SimpleOAuthProvider` (`oauth.py`)** — existing PKCE + SAPI-mint patterns to follow for token handling/storage.
+- **k8s SA step-up header (`b971146f`)** — the projected-SA-token mechanism; it is the mechanism the resolver's `X-Kubernetes-Authorization` exchange must reuse on the **deployed** mcp-server (in-k8s only).
+- **platform-libraries#507** — PHP decentralized-exchange reference for exchange + error mapping.
+
+### Scope split (user-stated, verbatim)
+> "I think we cannot get rid of OAuth because it's MCP protocol build on top of it. We can have login separate when not having oauth — instead of passing headers just stack is enough. The OAuth exchange will be done separately as separate PR."
+
+Therefore:
+- **OAuth is NOT removed.** It is part of the MCP protocol for the public/HTTP transport.
+- **This work = the non-OAuth local path:** supply only the stack URL → PKCE login → whole-stack access → narrow scope in-chat. No header passing required locally.
+- **OAuth → PAT exchange is a separate PR** and out of scope here.
+- Open design point (carry to Phase 4): the deployed mcp-server has a projected SA token and can call the resolver; **local stdio has no SA token**, so locally MCP likely forwards the `kbc_at_*` bearer downstream and lets the services exchange (per go-monorepo#540). The two paths differ — nail this in Alternatives.
+
+## 3. Stakeholders
+
+| Bucket | Person / team | Concern |
+|---|---|---|
+| Approver | PSGO tech lead (Martin Zajic, issue creator) | MCP-side design sign-off |
+| Approver | Connection / auth team (PAT-1838, connection#7403) | Resolver + `/v1/auth` PKCE contract; SA scope grant |
+| Approver | Security `?` | Token handling, no-logging, scope-narrowing model |
+| Approver | kbc-stacks owner `?` | Per-stack SA-subject → `internal:auth-bridge:resolve-storage-token` mapping (Part 2) |
+| Implementer | Martin Vaško (PSGO) | MCP server Python change |
+| Affected (not in room) | mcp-server-agent operators | Same image/auth path; must not regress direct-Storage-token use |
+| Affected (not in room) | Local MCP users / Kai agents | New login UX; in-chat scope narrowing |
+
+## 4. Alternatives considered
+
+Core question: how does MCP turn an inbound `kbc_at_*` / `kbc_pat_*` into authenticated downstream calls, given local (no SA token) and deployed (has SA token) differ?
+
+### Option A: Forward bearer downstream (no MCP-side exchange)
+- **Solves:** Local works with no SA token; trivial — attach `Authorization: Bearer kbc_*` + `X-KBC-ProjectId` to service clients and let each service exchange (go-monorepo#540).
+- **Costs:** Only Query/Metastore accept programmatic tokens today; Storage/Queue/AI/sync-actions/data-science/scheduler must all add support first.
+- **Risks:** Broken tools until every downstream service accepts PATs; does not meet PSGO-261 AC ("the service authenticates to the resolver with its own SA JWT").
+
+### Option B: MCP-side resolver exchange (PSGO-261 core)
+- **Solves:** Meets the AC exactly; one exchange → legacy Storage token works with all services unchanged.
+- **Costs:** Requires the projected SA token → only the **deployed/in-k8s** mcp-server can do it.
+- **Risks:** No local-stdio story; doesn't address "kill storage-token login" on its own.
+
+### Option C: Hybrid (recommended)
+- **Solves:** Deployed mcp-server does Option B (resolver exchange via SA JWT); local stdio does the PKCE login + Option A (forward bearer, services exchange). Each path is the only viable one for its environment; covers both deployments from one image.
+- **Costs:** Two auth code paths to maintain and test; local path inherits Option A's "services must accept PATs" dependency.
+- **Risks:** Local tools that hit a service not yet PAT-aware fail until that service ships support — must be surfaced clearly (see stress-test).
+
+### Recommendation
+**Option C.** It is the only option that satisfies the PSGO-261 AC on the deployed service *and* delivers the stack-only local login the user wants, without removing OAuth. The accepted tradeoff: two distinct token paths (resolver-exchange in k8s, forward-bearer locally), and the local path depends on downstream services accepting programmatic tokens. OAuth→PAT exchange remains a separate PR.
+
+## 5. Impact analysis
+
+> Adapted to `keboola-mcp-server` (Python). The skill's connection/platform-wiki checklist (Doctrine, Zend, storage-driver protobuf) does not apply here; the cross-cutting table below is the mcp-server equivalent. File:line refs verified against current `main`.
+
+### Files / symbols touched
+| File / symbol | Change |
+|---|---|
+| `config.py` `Config` (17-138) | add `project_id` field (same `KBC_*`/`X-*` resolution); add `is_programmatic_token()` helper |
+| `clients/auth_bridge.py` (new) | `StorageTokenResolver.resolve(subject_token, project_id)` → resolver call, per-request SA read, error mapping, token redaction |
+| `mcp.py` `apply_request_config` (229-245) / `create_session_state` (248-294) | branch on programmatic token: deployed → resolve to Storage token; local → forward bearer |
+| `clients/client.py` `__init__` (125-216) | no contract change — `bearer_or_sapi_token` (169) already routes Bearer vs SAPI |
+| `clients/base.py` `RawKeboolaClient.__init__` (38-42) | no change — already picks `Authorization: Bearer` vs `X-StorageAPI-Token` by prefix |
+| `auth_login.py` (new) | PKCE crypto + loopback callback + `/admin/auth/pkce/authorize` + `POST /v1/auth/pkce/token` |
+| `credentials.py` (new) | mode-600 token store + auto-refresh via `POST /v1/auth/token/refresh` + dead-token → relogin |
+| `cli.py` `parse_args`/`run_server` (28-207) | `login` subcommand; stack-only startup that loads stored creds |
+| `workspace.py` (b971146f) | share one SA-token-file read helper with the resolver client |
+
+### Services / APIs touched (all outbound from MCP)
+| Surface | Impact |
+|---|---|
+| Connection `POST /manage/internal/auth-bridge/resolve-storage-token` | **New** outbound call (deployed only); needs SA JWT + scope grant |
+| Connection `/admin/auth/pkce/authorize`, `POST /v1/auth/pkce/token` | **New** outbound (local login) |
+| Connection `POST /v1/auth/token/refresh` | **New** outbound (token refresh during usage) |
+| Storage / Queue / AI / data-science / scheduler / sync-actions / metastore clients | Contract unchanged; **token source** changes (resolved Storage token deployed, forwarded bearer local) |
+
+### Cross-cutting checklist (mcp-server)
+| Dimension | Touched? | Detail |
+|---|---|---|
+| Transports (stdio / streamable-http) | Yes | stdio gets login path; http/OAuth path unchanged this PR |
+| OAuth provider (`SimpleOAuthProvider`) | No | left intact; OAuth→PAT exchange is a separate PR |
+| Both deployments (mcp-server + mcp-server-agent) | Yes | one image; agent's direct-Storage-token path must not regress |
+| Legacy `X-StorageAPI-Token` path | No (must stay) | only `kbc_at_`/`kbc_pat_` prefixes trigger new behavior |
+| k8s projected SA token | Yes | reuse b971146f mechanism for resolver auth |
+| `TOOLS.md` / tool signatures | No | no tool signature change expected |
+| Config / env vars | Yes | `project_id`, `KBC_PKCE_CLIENT_ID`, SA-token path var |
+| Unit + integration tests | Yes | new resolver, login, refresh, regression for legacy token |
+| Version bump + `uv.lock` | Yes | minor (new capability) |
+
+## 6. Security pass
+
+| Dimension | Assessment |
+|---|---|
+| Authentication boundary | **Yes.** Adds a programmatic-token (`kbc_at_`/`kbc_pat_`) acceptance path, a resolver exchange, and a PKCE login. Does not weaken auth — all paths still require Connection-issued credentials; legacy token path unchanged. |
+| Authorization / role check | **Yes.** The PAT/AT carries its own scope; the resolver validates the subject token's access to the requested `projectId`. MCP must pass the correct `project_id` and must not elevate scope. In-chat narrowing can only *reduce* scope, never widen it. |
+| Tenant isolation (cross-project / cross-org) | **Critical — Yes.** A token scoped to project A must never resolve a project-B Storage token. Resolver enforces; MCP must never reuse/cache a resolved token across projects or sessions. v1 has **no caching**, which preserves isolation by construction. |
+| Data exposure (responses / logs / events / exports) | **Yes.** Token material (subject token, resolved Storage token, SA JWT, refresh token) must never appear in logs or exception messages (AC). Tested by asserting redaction in captured logs. |
+| Encryption at rest / in transit | **Partial.** In transit: TLS to Connection. At rest: **local creds file holds access + refresh tokens in plaintext** (mode 600). No KMS locally — accepted for a single-user dev machine; flagged. |
+| External egress (3rd-party APIs, service accounts) | **No new third party.** New egress is to Connection only. Deployed path uses the projected SA service account (scope `internal:auth-bridge:resolve-storage-token`). |
+| Audit trail (event emitted, visible to support) | **Connection-side.** Login, refresh, and exchange are audited by Connection; sessions are listable/revocable via `/v1/auth/sessions`. MCP emits no new audit events. |
+| Abuse / DoS / rate limiting | **Yes — design concern.** Refresh-during-usage + no caching = one resolver round-trip per request → load on the resolver. A dead token must trigger relogin, **not** an infinite refresh loop. Needs bounded retry / backoff. |
+| Multi-tenant blast radius | **Yes.** The deployed SA token can resolve Storage tokens for valid subject tokens; if it leaks, blast radius is broad. Mitigated by narrow resolver scope + per-request file read (no long-lived in-memory copy) + never logging it. |
+| SOX / compliance (HIPAA, GDPR, SOC2) | **No direct change.** No change to SOX-protected branch workflows. GDPR: see PII row. |
+| Secrets handling (KMS, encryption-service, logs) | **Yes.** SA token read from projected file **per request** (no cache, handles rotation). `KBC_PKCE_CLIENT_ID` may be injected as a secret (blank-tolerant). Creds file mode 600. |
+| PII (collection, retention, deletion) | **Minor.** PKCE token response includes `user{id,email,name}`; persisted in the local creds file. Deleting the file removes it. No server-side PII added. |
+
+## 6.5. Stress-test findings
+
+- `[failure-mode]` **Rotating refresh + concurrent clients = logout storm.** `/v1/auth/token/refresh` rotates the refresh token, so the old one dies. An in-process `asyncio.Lock` stops one process double-refreshing, but **two MCP processes sharing the same creds file** (user runs two clients, or agent + CLI) will rotate each other out → random mid-session logouts. Ask the author: is the creds file single-writer? Do we need file locking or a per-client token?
+- `[second-order]` **"Narrow scope in chat" is advisory, not enforced on the stored credential.** Login grants whole-stack access and that whole-stack token sits on disk; in-chat narrowing is a runtime construct. A stolen creds file = whole-stack access. **Resolved (D1):** accepted by design — no minting; mitigate with mode-600 + rotation + no-logging, not credential scoping.
+- `[foot-gun]` **`project_id` ambiguity resolves the *wrong* project silently.** The resolver needs one `projectId`; a stale per-call source returns a valid token for the wrong project with no error. **Resolved (D2):** `project_id` is explicit session state (CLI/env default + select-project tool), never silently derived; storage-touching tools require a selected project when none is set.
+- `[adoption]` **The hybrid split gives identical-looking failures.** Locally (forward-bearer), a tool can fail because (a) that service doesn't accept PATs yet, (b) wrong `project_id`, or (c) expired token — all surface as a raw downstream 401. First adopters can't self-diagnose. Need an explicit error taxonomy / preflight check that says which of the three it is.
+- `[user-mentioned]` **Interim divergence while OAuth exchange is a separate PR.** Until the deferred OAuth→PAT PR lands, the public mcp-server keeps minting a SAPI token from OAuth while local uses the new PAT path — the same image runs two different auth models. State this interim state explicitly so reviewers don't assume parity.
+
+## Decisions from review (2026-06-24)
+
+**D1 — No minting; the on-disk credential stays whole-stack.** We will not mint project-scoped PATs at login. We don't know upfront what the user will access (complex/multi-project work is expected), so login leases the whole-stack session token (access + refresh) and stores it. Scope narrowing is **runtime-only session state**, never a property of the stored credential. Accepted tradeoff: a stolen creds file grants whole-stack access — mitigated by mode-600 storage + refresh rotation + no logging, not by credential scoping.
+
+**D2 — `project_id` is explicit session state, not derived from the token.** With a whole-stack PAT there is no implicit project (today `StorageClient.project_id()` reads it from `tokens/verify`, storage.py:1079 — that only works because the legacy token is project-bound). So:
+- `project_id` becomes optional session state, defaulting from CLI/env (`KBC_PROJECT_ID`) and overridable in HTTP via `X-KBC-ProjectId`. We do **not** know project ids upfront.
+- A new chat can **start full-scope** (no project selected). Storage-touching tools then either use the default or require a project to be selected first (clear error, see error-taxonomy finding).
+- Narrowing happens via a **tool** that sets the active project into session state (mirrors the `get_project_info` discovery pattern: a stack-level "list accessible projects" step, then a "select project" step). Once set, the resolver uses it and `project_id()` returns it directly without `tokens/verify`.
+- Restrictions can also be pre-seeded from CLI/env (a project allow-list on the session) when known.
+
+Open implementation detail (non-blocking for the RFC's shape): the exact stack-level endpoint to enumerate PAT-accessible projects, and whether selection is a dedicated tool vs. a parameter on existing tools.
+
+## 7. Open questions
+- [ ] **Concurrent-client creds-file handling.** Single-writer assumption, file locking, or per-client token to avoid rotating-refresh logout storms? Owner: Martin Vaško. Needed by: before implementation.
+- [ ] **Hybrid-failure error taxonomy.** How does a local user distinguish "service not PAT-aware" vs "wrong project_id" vs "expired token"? Owner: Martin Vaško. Needed by: before implementation.
+- [ ] **PKCE `clientId` allocation + `/admin/auth/pkce/authorize` prod GA.** Owner: Connection auth. Needed by: before production rollout (not local dev).
+- [ ] **Exact SA-token path env var** — align with b971146f and the Go `*_KUBERNETES_TOKEN_PATH` convention. Owner: Martin Vaško. Needed by: before implementation.
+- [ ] **Approver names** for Security and kbc-stacks buckets. Owner: PSGO lead. Needed by: before RFC sign-off.
+
+## 8. Next step
+
+`ready-for-rfc`. Recommended approach (Option C hybrid) is locked, security pass is complete, the two design-blocking questions are resolved (D1 no-minting / whole-stack credential; D2 explicit-session-state `project_id` + select-project tool), and there are 5 stress-test findings. Remaining open questions are implementation details that do not change the RFC's shape.
+
+Next: update `RFC.md` to the hybrid (Option C) model — add the local PKCE-login path, the explicit `project_id` session state + select-project tool, and fold in the five stress-test findings. Then proceed via the `rfc-write` flow / review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.75.2"
+version = "1.75.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.75.2"
+version = "1.75.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [PSGO-261](https://linear.app/keboola/issue/PSGO-261/support-pat-tokens-in-mcp-server-mcp-server) (parent [PAT-1838](https://linear.app/keboola/issue/PAT-1838))

Adds `feature_spec/pat_token_support/RFC.md` and `brainstorm.md` for review/agreement. Also bumps the project version to 1.73.5 (+ `uv.lock`) so the docs PR merges cleanly ahead of the stacked implementation PR.

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (docs only — RFC design document, no behavior change)

### Summary

Design for adding Connection **programmatic token** support to the MCP server, in two parts:

- **Part A (PSGO-261 core)** — accept `kbc_at_*` / `kbc_pat_*` bearer tokens and exchange them for a legacy Storage token via `POST /manage/internal/auth-bridge/resolve-storage-token`, authenticating with the server's own projected k8s SA JWT (`X-Kubernetes-Authorization`) — reusing the workspace step-up mechanism from `b971146f`. Legacy `X-StorageAPI-Token` traffic is untouched; per-request SA read, no caching, resolver error mapping (400/401/403 pass-through, 5xx/network → 502), no token logging.
- **Part B (new login)** — a PKCE browser `login` command that leases an access + refresh token, stores them (mode-600 file), and **refreshes the access token during usage**; a dead token enforces re-login.

Token contract verified against the three reference PRs (keboola-sdk-go#90, go-monorepo#540, ui#6061).

Resolved design decisions (in the RFC): `project_id` resolved per session via middleware mapping with future token-scoping tooling; PKCE `clientId` configurable (`KBC_PKCE_CLIENT_ID`, defaults to demo `keboola-cli-demo`); refresh token treated as opaque; SA-token path aligned with the workspace step-up var.

Still open (deferred, non-blocking for Part A): whether `/admin/auth/pkce/authorize` is GA on production stacks; the real MCP-allocated `clientId`; exact SA-token env var name; session→project mapping / token-scoping tooling design.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

N/A — documentation-only PR. Testing requirements are specified inside the RFC for the implementation PR that follows.

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable) — none; RFC only
- [ ] Integration tests added/updated (if applicable) — none; RFC only
- [x] Project version bumped (→ 1.73.5, patch) + `uv.lock`
- [x] Documentation updated (RFC added)

[PSGO-261]: https://keboola.atlassian.net/browse/PSGO-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
