### PR TITLE
ST-4159: stop forwarding deprecated automerge to update-image-tag

### DIFF
--- a/.github/actions/trigger-image-tag-update/action.yaml
+++ b/.github/actions/trigger-image-tag-update/action.yaml
@@ -7,10 +7,6 @@ inputs:
   image-tag:
     description: "The image tag to update to"
     required: true
-  automerge:
-    description: "Automatically merge PRs"
-    required: false
-    default: "true"
   dry-run:
     description: "Do a dry run"
     required: false
@@ -64,7 +60,6 @@ runs:
         -r main \
         -f helm-chart=${{ inputs.helm-chart }} \
         -f image-tag=${{ inputs.image-tag }} \
-        -f automerge=${{ inputs.automerge }} \
         -f dry-run=${{ inputs.dry-run }} \
         -f commit-sha=${{ inputs.commit-sha }} \
         -f metadata="$ENCODED_METADATA"


### PR DESCRIPTION
## What
Remove the deprecated `automerge` input (its declaration in `inputs:` and the `-f automerge=...` line in the `gh workflow run` call) from this repo's local `.github/actions/trigger-image-tag-update` action, which dispatches `keboola/kbc-stacks` `update-image-tag.yaml`.

## Why
helm-image-updater **v0.23.0** (released) no longer reads `automerge` — auto-merge is decided from the image **tag class + target stacks** (production is always release-promoter-managed). Part of the org-wide **ST-4159** dispatcher cleanup: every dispatcher must stop sending `automerge`/`multi-stage` before the `workflow_dispatch` input declarations can be removed from kbc-stacks.

## Safety
No behavior change — the `automerge` input is still **declared** on the kbc-stacks workflow, so the dispatch keeps working; this just stops sending a value ignored downstream.

Linear: [ST-4159](https://linear.app/keboola/issue/ST-4159/helm-image-updater-legacy-deploy-cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
