### PR TITLE
chore(ci): auto-generate release notes and notify PRs on vX.Y.Z tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,11 +159,24 @@ jobs:
           fetch-depth: 0
 
       - name: Create GitHub Release with generated notes
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Idempotent: a re-run (or partial retry) must not fail just because the
+          # release already exists — and must not re-comment on the PRs either.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            gh release create "$TAG" --verify-tag --generate-notes
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Comment on PRs included in the release
+        if: steps.release.outputs.created == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,44 @@ jobs:
           image-tag: dev-${{ github.sha }}
           github-app-private-key: ${{ secrets.GITOPS_KBC_STACKS_TRIGGER_APP_PVK }}
 
+  # Only for production MCP-server releases (vX.Y.Z): create a GitHub Release with
+  # auto-generated notes (all PRs merged since the previous tag), then comment on
+  # each referenced PR that it shipped in this release. The `startsWith(refs/tags/v)`
+  # guard excludes agent-v*, canary-orion-*, and dev-* tags.
+  release-notes:
+    name: Release notes
+    needs: build-and-push
+    if: needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # create the GitHub Release
+      pull-requests: write   # comment on referenced PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+
+      - name: Comment on PRs included in the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          notes=$(gh release view "$TAG" --json body -q .body)
+          # Auto-generated notes reference each PR as ".../pull/123" (and sometimes #123).
+          prs=$(printf '%s\n' "$notes" | grep -oE '(/pull/|#)[0-9]+' | grep -oE '[0-9]+' | sort -un) || true
+          for pr in $prs; do
+            gh pr comment "$pr" \
+              --body "🚀 Shipped in release [\`$TAG\`](https://github.com/$REPO/releases/tag/$TAG)."
+          done
+
   kaibench:
     name: KaiBench Evaluation
     needs: build-and-push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.73.3"
+version = "1.73.4"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1332,7 +1332,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.73.3"
+version = "1.73.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: N/A (CI/CD chore)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Adds a `release-notes` job to `release.yml` that runs after `build-and-push` **only for production MCP-server tags (`vX.Y.Z`)** — the `startsWith(refs/tags/v)` guard excludes `agent-v*`, `canary-orion-*`, and `dev-*` tags.

The job:
1. Creates a GitHub Release with auto-generated notes (`gh release create --generate-notes`), covering every PR merged since the previous tag.
2. Parses the PR references out of those notes and posts a comment on each one confirming it shipped in the release.

Both steps use `github.token`; the job requests `contents: write` (release) and `pull-requests: write` (comments). All external values are passed via `env:` and quoted in the script — no untrusted interpolation.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

CI-only change; validated locally: workflow YAML parses, and the PR-number extraction (`/pull/N` and `#N` forms, ignoring the compare URL) was verified against sample release notes.

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)