### PR TITLE
ci: allow KaiBench evaluation to run on a labelled pull request

### DIFF
--- a/.github/scripts/kaibench-parse-results.py
+++ b/.github/scripts/kaibench-parse-results.py
@@ -32,11 +32,15 @@ status = 'passed' if m['failed'] == 0 and m.get('errors', 0) == 0 and partial_co
 print(f"status={status}")
 
 # Count regressions vs previous run (downloaded into prev-results/)
+# `baseline_run` stays empty when no comparison happened, so callers can tell "0 regressions"
+# apart from "never compared" — the two look identical otherwise.
 regressions = 0
+baseline_run = ''
 prev_runs = sorted(Path('prev-results').glob('run_*'), key=lambda p: p.stat().st_mtime) if Path('prev-results').exists() else []
 if prev_runs:
     prev_file = prev_runs[-1] / 'results.jsonl'
     if prev_file.exists() and results_file.exists():
+        baseline_run = prev_runs[-1].name
         prev_by_qid = {}
         for line in prev_file.read_text().splitlines():
             if line.strip():
@@ -51,3 +55,4 @@ if prev_runs:
                 if prev_by_qid[qid].get('status') == 'passed' and r.get('status') not in ('passed', 'skipped'):
                     regressions += 1
 print(f"regressions={regressions}")
+print(f"baseline_run={baseline_run}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,12 @@ name: CI
 # - For pull requests from branches in this repository, the workflow is skipped to avoid running it twice (once for the
 #   push and once for the PR).
 # - The full workflow (including jobs requiring secrets) runs only on pushes events to branches in this repository
-on: [ push, pull_request ]
+# - KaiBench evaluation is opt-in per pull request: add the `run-kaibench` label. It is the one job that
+#   deliberately runs on `pull_request` (it needs the PR's labels), so it is not double-run by the push event.
+on:
+  push:
+  pull_request:
+    types: [ opened, synchronize, reopened, labeled ]
 concurrency: ci-${{ github.ref }}
 
 permissions:
@@ -17,8 +22,11 @@ permissions:
 jobs:
   build:
     name: Build, test and package
-    # run this job only for push (avoiding pull requests from the same repo) or for pull requests from different repo
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    # run this job only for push (avoiding pull requests from the same repo) or for pull requests from different repo;
+    # `labeled` events carry no code change, so skip them (they exist only to trigger the kaibench job below)
+    if: |
+      github.event.action != 'labeled' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -150,6 +158,60 @@ jobs:
           name: Integration test results (${{ matrix.python-version }})
           path: ./integtest-results.xml
           reporter: 'java-junit'
+
+  kaibench:
+    name: KaiBench Evaluation
+    # Opt-in per PR via the `run-kaibench` label. A full evaluation takes ~30-60 minutes and spends real
+    # Vertex quota, so it must never run unconditionally. Forks are excluded: the evaluation needs secrets.
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-kaibench')
+    # A newer commit on the same PR supersedes an in-flight evaluation rather than queueing behind it
+    concurrency:
+      group: kaibench-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    # the reusable workflow declares these; a caller cannot grant more than it holds itself
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+    uses: ./.github/workflows/kaibench.yml
+    secrets: inherit
+
+  kaibench_gate:
+    name: KaiBench regression gate
+    needs: kaibench
+    if: always() && needs.kaibench.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      # The evaluation suite does not pass 100% of questions, so absolute failures cannot gate a PR.
+      # A regression — a question that passed on the previous run but no longer does — can.
+      - name: Check for regressions
+        env:
+          EVAL_RESULT: ${{ needs.kaibench.result }}
+          REGRESSIONS: ${{ needs.kaibench.outputs.regressions }}
+          BASELINE_RUN: ${{ needs.kaibench.outputs.baseline_run }}
+          PASSED: ${{ needs.kaibench.outputs.passed }}
+          TOTAL: ${{ needs.kaibench.outputs.total }}
+          PASS_RATE: ${{ needs.kaibench.outputs.pass_rate }}
+        run: |
+          set -euo pipefail
+          if [ "$EVAL_RESULT" != "success" ]; then
+            echo "::error::KaiBench evaluation did not complete (job result: $EVAL_RESULT) — check the logs above"
+            exit 1
+          fi
+          echo "Pass rate: ${PASSED:-?}/${TOTAL:-?} (${PASS_RATE:-?}%)"
+          if [ -z "$BASELINE_RUN" ]; then
+            echo "::warning::No baseline artifact available, so no regression comparison was made — this check passing does NOT mean the PR is regression-free"
+            exit 0
+          fi
+          echo "Compared against baseline run: $BASELINE_RUN"
+          if [ "${REGRESSIONS:-0}" -gt 0 ]; then
+            echo "::error::$REGRESSIONS question(s) regressed vs the previous run — see the step summary for details"
+            exit 1
+          fi
+          echo "No regressions."
 
   deploy_to_pypi:
     name: Deploy to pypi.org

--- a/.github/workflows/kaibench.yml
+++ b/.github/workflows/kaibench.yml
@@ -41,6 +41,7 @@ jobs:
       pass_rate: ${{ steps.parse.outputs.pass_rate }}
       duration: ${{ steps.parse.outputs.duration }}
       regressions: ${{ steps.parse.outputs.regressions }}
+      baseline_run: ${{ steps.parse.outputs.baseline_run }}
 
     services:
       postgres:
@@ -218,7 +219,9 @@ jobs:
             CMD_ARGS=(-t "Data Analysis Query" -t "Configuration Reasoning" -t "Storage Object Reasoning" -t "MCP Tool Validation")
           fi
           if [ "${{ inputs.regression_only }}" = "true" ]; then
-            CMD_ARGS+=(--regression-only)
+            # the CLI option is `--regression` (see kaibench/cli.py); `--regression-only` is rejected by
+            # typer as an unknown option, and because this step is continue-on-error it failed silently
+            CMD_ARGS+=(--regression)
           fi
           uv run kaibench run "${CMD_ARGS[@]}"
         continue-on-error: true
@@ -229,7 +232,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PREV_RUN_ID=$(gh run list --workflow kaibench.yml --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          # Locate the baseline by artifact rather than by workflow name: this workflow is always invoked via
+          # `workflow_call` (from release.yml on tags, from ci.yml on labelled PRs), so the run is recorded
+          # under the *calling* workflow and `gh run list --workflow kaibench.yml` finds nothing.
+          # The artifact index is returned newest-first and must be paginated — the repo has thousands of
+          # artifacts, so the KaiBench ones are well past the first page.
+          CANDIDATES=$(gh api "/repos/$GITHUB_REPOSITORY/actions/artifacts" --paginate \
+            --jq '.artifacts[]
+                  | select(.name | startswith("kaibench-results-"))
+                  | select(.expired == false)
+                  | select(.workflow_run.id != '"$GITHUB_RUN_ID"')
+                  | .workflow_run.id' | awk '!seen[$0]++')
+          PREV_RUN_ID=""
+          while IFS= read -r rid; do
+            [ -n "$rid" ] || continue
+            CONCLUSION=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$rid" --jq '.conclusion // empty')
+            if [ "$CONCLUSION" = "success" ]; then
+              PREV_RUN_ID="$rid"
+              echo "Baseline run: $rid"
+              break
+            fi
+            echo "Skipping run $rid (conclusion: ${CONCLUSION:-unknown})"
+          done <<< "$CANDIDATES"
+          if [ -z "$PREV_RUN_ID" ]; then
+            echo "::warning::No usable KaiBench baseline artifact found — regression comparison will be skipped"
+          fi
           echo "run_id=${PREV_RUN_ID}" >> $GITHUB_OUTPUT
 
       - name: Download previous run artifacts

--- a/.github/workflows/kaibench.yml
+++ b/.github/workflows/kaibench.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Checkout KaiBench
         uses: actions/checkout@v7
         with:
-          repository: keboola-rnd/KaiBench
+          # canonical location since the repo moved out of the keboola-rnd org; the old path only worked
+          # by redirect, and `KAIBENCH_REPO_TOKEN` must grant read access to it under this owner
+          repository: keboola/KaiBench
           token: ${{ secrets.KAIBENCH_REPO_TOKEN }}
           path: kaibench
 


### PR DESCRIPTION
## Why

KaiBench could only be evaluated on a release tag (`release.yml` calls `kaibench.yml` on `v*` pushes) or by dispatching `kaibench.yml` by hand. **There was no way to trigger it from a pull request.**

This surfaced while trying to validate #640 against the suite: automation that holds `pull_requests: write` but not `actions: write` gets a 403 on `workflow_dispatch`, so it could not start a run and had to hand the commands to a human.

## What

Labelling a PR **`run-kaibench`** now calls `kaibench.yml` via `workflow_call`.

- **Opt-in, not automatic** — a full run takes ~30–60 min and spends real Vertex quota.
- **Forks excluded** — the evaluation needs secrets.
- **Own concurrency group with `cancel-in-progress`** — a new commit supersedes an in-flight evaluation instead of queueing 45 minutes behind it.
- **Job-level `permissions`** (`contents`/`actions`/`packages: read`), mirroring `release.yml`'s top-level block, so CI's global permissions are untouched.
- `build` now skips `labeled` events, so labelling a fork PR doesn't rerun the 3-version matrix for nothing.

Results are reported through a separate `kaibench_gate` job that **fails on regressions, not on absolute failures** — the suite doesn't pass 100% of its questions, so gating on `failed == 0` would be permanently red. A regression is a question that passed on the baseline run and no longer does.

## Three defects found while wiring this up

1. **The baseline lookup never worked under `workflow_call`.** It used `gh run list --workflow kaibench.yml`, which returns nothing — `kaibench.yml` is always invoked via `workflow_call`, so runs are recorded under the *calling* workflow. Now located through the artifact index. This must be paginated: the repo has ~3,300 artifacts and the KaiBench ones sit well past the first page, so a `per_page=100` lookup silently finds nothing.
2. **"0 regressions" was indistinguishable from "no baseline to compare against."** That would have made the new gate pass silently whenever no baseline existed — the worst failure mode for a merge gate. `kaibench-parse-results.py` now emits `baseline_run`, and the gate warns loudly instead of going quietly green.
3. **`--regression-only` is not a valid CLI option** — it's `--regression` (`kaibench/cli.py`). Typer rejects the unknown option; because the step is `continue-on-error`, the run failed silently. Only reachable via the `regression_only` dispatch input, so default runs were unaffected.

## Verification

- Both workflows parse; `kaibench-parse-results.py` compiles.
- Parse script on a fixture where Q2 went pass→fail and Q3 fail→pass: `regressions=1`, `baseline_run=run_old`. With no baseline: `regressions=0`, `baseline_run=` empty.
- Gate script exercised across all four paths: regression → exit 1; clean → exit 0; no baseline → exit 0 **with a warning**; evaluation didn't complete → exit 1.
- Baseline lookup dry-run against this repo resolves run `28088724816` — the v1.72.6 release evaluation from 2026-06-24, unexpired. So the first labelled PR has a real baseline.
- `--regression-only` rejection reproduced directly: `No such option: --regression-only  Did you mean --regression?`

## Follow-up, deliberately not in scope

Baselines come only from release tags, so a PR is compared against the last release (currently v1.72.6, ~5 weeks old). A scheduled run on `main` would keep the baseline current; a stale baseline still needs solver match and sufficient question overlap to be meaningful.

Requires the `run-kaibench` label to exist on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)