### PR TITLE
fix(query): extend QS client timeout and back off status-poll frequency [AI-3637][AI-2493]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.73.4"
+version = "1.73.5"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/query.py
+++ b/src/keboola_mcp_server/clients/query.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from typing import Any, cast
 
 import httpx
@@ -5,12 +7,22 @@ import httpx
 from keboola_mcp_server.clients import KeboolaServiceClient, RawKeboolaClient
 from keboola_mcp_server.clients.base import JsonDict
 
+LOG = logging.getLogger(__name__)
+
 # Some Query Service calls (e.g. large result fetches) can exceed the base client's default
 # 60s read timeout. Give the MCP server's own HTTP calls to QS more headroom.
 # Note: this does NOT change QS's own ~30s deadline for its internal call to Connection
 # (e.g. workspace credential fetch) - that timeout lives in Query Service, not here.
 # ponytail: fixed 120s bump, revisit with real config if per-deployment tuning is ever needed.
 _QS_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
+
+# submit_job is a POST, so the transport-level retry (base.py, GET/PUT/DELETE/etc only) never
+# applies to it. Job submission can fail with 403 "Failed to get workspace credentials" when QS's
+# own deadline to Connection is shorter than actual credential-provisioning time - a transient
+# failure that happens before any job is created, so it's safe to retry. Scoped to this specific
+# message (not any 403) so a real auth/permission failure isn't masked by pointless retries.
+_SUBMIT_JOB_MAX_ATTEMPTS = 3
+_SUBMIT_JOB_RETRY_DELAY_SECONDS = 1.0
 
 
 class QueryServiceClient(KeboolaServiceClient):
@@ -81,11 +93,25 @@ class QueryServiceClient(KeboolaServiceClient):
             payload['actorType'] = actor_type
         if transactional is not None:
             payload['transactional'] = transactional
-        resp = cast(
-            JsonDict,
-            await self.post(endpoint=f'branches/{self._branch_id}/workspaces/{workspace_id}/queries', data=payload),
-        )
-        return resp['queryJobId']
+
+        endpoint = f'branches/{self._branch_id}/workspaces/{workspace_id}/queries'
+        last_error: httpx.HTTPStatusError | None = None
+        for attempt in range(1, _SUBMIT_JOB_MAX_ATTEMPTS + 1):
+            try:
+                resp = cast(JsonDict, await self.post(endpoint=endpoint, data=payload))
+                return resp['queryJobId']
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code != httpx.codes.FORBIDDEN or 'workspace credentials' not in str(e).lower():
+                    raise
+                last_error = e
+                if attempt < _SUBMIT_JOB_MAX_ATTEMPTS:
+                    LOG.warning(
+                        f'Job submission failed to fetch workspace credentials '
+                        f'(attempt {attempt}/{_SUBMIT_JOB_MAX_ATTEMPTS}), retrying: workspace_id={workspace_id}'
+                    )
+                    await asyncio.sleep(_SUBMIT_JOB_RETRY_DELAY_SECONDS * attempt)
+        assert last_error is not None
+        raise last_error
 
     async def get_job_status(self, job_id: str) -> JsonDict:
         """

--- a/src/keboola_mcp_server/clients/query.py
+++ b/src/keboola_mcp_server/clients/query.py
@@ -106,8 +106,12 @@ class QueryServiceClient(KeboolaServiceClient):
                 if not is_transient_credentials_failure or attempt == _SUBMIT_JOB_MAX_ATTEMPTS:
                     raise
                 LOG.warning(
-                    f'Job submission failed to fetch workspace credentials '
-                    f'(attempt {attempt}/{_SUBMIT_JOB_MAX_ATTEMPTS}), retrying: workspace_id={workspace_id}'
+                    'Job submission failed to fetch workspace credentials '
+                    '(attempt %d/%d), retrying: workspace_id=%s',
+                    attempt,
+                    _SUBMIT_JOB_MAX_ATTEMPTS,
+                    workspace_id,
+                    exc_info=True,
                 )
                 await asyncio.sleep(_SUBMIT_JOB_RETRY_DELAY_SECONDS * attempt)
         raise AssertionError('unreachable: loop always returns or raises')

--- a/src/keboola_mcp_server/clients/query.py
+++ b/src/keboola_mcp_server/clients/query.py
@@ -1,7 +1,16 @@
 from typing import Any, cast
 
+import httpx
+
 from keboola_mcp_server.clients import KeboolaServiceClient, RawKeboolaClient
 from keboola_mcp_server.clients.base import JsonDict
+
+# Some Query Service calls (e.g. large result fetches) can exceed the base client's default
+# 60s read timeout. Give the MCP server's own HTTP calls to QS more headroom.
+# Note: this does NOT change QS's own ~30s deadline for its internal call to Connection
+# (e.g. workspace credential fetch) - that timeout lives in Query Service, not here.
+# ponytail: fixed 120s bump, revisit with real config if per-deployment tuning is ever needed.
+_QS_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
 
 
 class QueryServiceClient(KeboolaServiceClient):
@@ -50,6 +59,7 @@ class QueryServiceClient(KeboolaServiceClient):
                 base_api_url=f'{root_url}/api/{version}',
                 api_token=token,
                 headers=headers,
+                timeout=_QS_TIMEOUT,
             ),
             branch_id=branch_id,
         )

--- a/src/keboola_mcp_server/clients/query.py
+++ b/src/keboola_mcp_server/clients/query.py
@@ -95,23 +95,22 @@ class QueryServiceClient(KeboolaServiceClient):
             payload['transactional'] = transactional
 
         endpoint = f'branches/{self._branch_id}/workspaces/{workspace_id}/queries'
-        last_error: httpx.HTTPStatusError | None = None
         for attempt in range(1, _SUBMIT_JOB_MAX_ATTEMPTS + 1):
             try:
                 resp = cast(JsonDict, await self.post(endpoint=endpoint, data=payload))
                 return resp['queryJobId']
             except httpx.HTTPStatusError as e:
-                if e.response.status_code != httpx.codes.FORBIDDEN or 'workspace credentials' not in str(e).lower():
+                is_transient_credentials_failure = (
+                    e.response.status_code == httpx.codes.FORBIDDEN and 'workspace credentials' in str(e).lower()
+                )
+                if not is_transient_credentials_failure or attempt == _SUBMIT_JOB_MAX_ATTEMPTS:
                     raise
-                last_error = e
-                if attempt < _SUBMIT_JOB_MAX_ATTEMPTS:
-                    LOG.warning(
-                        f'Job submission failed to fetch workspace credentials '
-                        f'(attempt {attempt}/{_SUBMIT_JOB_MAX_ATTEMPTS}), retrying: workspace_id={workspace_id}'
-                    )
-                    await asyncio.sleep(_SUBMIT_JOB_RETRY_DELAY_SECONDS * attempt)
-        assert last_error is not None
-        raise last_error
+                LOG.warning(
+                    f'Job submission failed to fetch workspace credentials '
+                    f'(attempt {attempt}/{_SUBMIT_JOB_MAX_ATTEMPTS}), retrying: workspace_id={workspace_id}'
+                )
+                await asyncio.sleep(_SUBMIT_JOB_RETRY_DELAY_SECONDS * attempt)
+        raise AssertionError('unreachable: loop always returns or raises')
 
     async def get_job_status(self, job_id: str) -> JsonDict:
         """

--- a/src/keboola_mcp_server/clients/query.py
+++ b/src/keboola_mcp_server/clients/query.py
@@ -13,7 +13,7 @@ LOG = logging.getLogger(__name__)
 # 60s read timeout. Give the MCP server's own HTTP calls to QS more headroom.
 # Note: this does NOT change QS's own ~30s deadline for its internal call to Connection
 # (e.g. workspace credential fetch) - that timeout lives in Query Service, not here.
-# ponytail: fixed 120s bump, revisit with real config if per-deployment tuning is ever needed.
+# TODO: fixed 120s bump for now; move to a real config if per-deployment tuning is ever needed.
 _QS_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
 
 # submit_job is a POST, so the transport-level retry (base.py, GET/PUT/DELETE/etc only) never

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -275,8 +275,9 @@ class _Workspace(abc.ABC):
             ]:
                 elapsed_time = time.perf_counter() - ts_start
                 # Back off polling frequency for long-running queries so a multi-minute query
-                # isn't status-checked hundreds of times. Still fits in one last check shortly
-                # before the timeout.
+                # isn't status-checked hundreds of times. Sleep is clamped to the time left so
+                # it never overshoots the timeout, though the last poll before it can still be
+                # up to one full interval (max 20s) earlier than the deadline.
                 remaining = self._QUERY_TIMEOUT - elapsed_time
                 sleep_for = max(min(self._next_poll_interval(elapsed_time), remaining), 0.0)
                 await asyncio.sleep(sleep_for)

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -277,10 +277,8 @@ class _Workspace(abc.ABC):
                 # Back off polling frequency for long-running queries so a multi-minute query
                 # isn't status-checked hundreds of times. Still fits in one last check shortly
                 # before the timeout.
-                sleep_for = self._next_poll_interval(elapsed_time)
                 remaining = self._QUERY_TIMEOUT - elapsed_time
-                if remaining > 0:
-                    sleep_for = min(sleep_for, max(remaining - 5.0, 1.0))
+                sleep_for = max(min(self._next_poll_interval(elapsed_time), remaining), 0.0)
                 await asyncio.sleep(sleep_for)
                 elapsed_time = time.perf_counter() - ts_start
                 if elapsed_time > self._QUERY_TIMEOUT:

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -276,8 +276,8 @@ class _Workspace(abc.ABC):
                 elapsed_time = time.perf_counter() - ts_start
                 # Back off polling frequency for long-running queries so a multi-minute query
                 # isn't status-checked hundreds of times. Sleep is clamped to the time left so
-                # it never overshoots the timeout, though the last poll before it can still be
-                # up to one full interval (max 20s) earlier than the deadline.
+                # it never overshoots the timeout, though the last status check before the
+                # deadline may still land up to one full interval (max 20s) early.
                 remaining = self._QUERY_TIMEOUT - elapsed_time
                 sleep_for = max(min(self._next_poll_interval(elapsed_time), remaining), 0.0)
                 await asyncio.sleep(sleep_for)

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -128,6 +128,17 @@ class _Workspace(abc.ABC):
     _SELECTED_ROWS_MSG = 'Returning {rows} of {total} selected rows.'
     _PAGE_SIZE = 1_000
 
+    @staticmethod
+    def _next_poll_interval(elapsed_seconds: float) -> float:
+        """Job-status polling interval for `execute_query`: fast at first, capped at 20s."""
+        if elapsed_seconds < 10:
+            return 1.0
+        if elapsed_seconds < 30:
+            return 2.0
+        if elapsed_seconds < 120:
+            return 5.0
+        return 20.0
+
     def __init__(self, workspace_id: int, client: KeboolaClient) -> None:
         self._workspace_id = workspace_id
         self._client = client
@@ -262,7 +273,15 @@ class _Workspace(abc.ABC):
                 'canceled',
                 'cancelled',
             ]:
-                await asyncio.sleep(1)
+                elapsed_time = time.perf_counter() - ts_start
+                # Back off polling frequency for long-running queries so a multi-minute query
+                # isn't status-checked hundreds of times. Still fits in one last check shortly
+                # before the timeout.
+                sleep_for = self._next_poll_interval(elapsed_time)
+                remaining = self._QUERY_TIMEOUT - elapsed_time
+                if remaining > 0:
+                    sleep_for = min(sleep_for, max(remaining - 5.0, 1.0))
+                await asyncio.sleep(sleep_for)
                 elapsed_time = time.perf_counter() - ts_start
                 if elapsed_time > self._QUERY_TIMEOUT:
                     # Cancel the query before raising timeout error. Inline the reason (rather than

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10,6 +10,15 @@ from keboola_mcp_server.clients.query import QueryServiceClient
 from keboola_mcp_server.workspace import JobSubmittedInfo, WorkspaceManager, _SnowflakeWorkspace
 
 
+@pytest.mark.parametrize(
+    ('elapsed_seconds', 'expected_interval'),
+    [(0.0, 1.0), (9.99, 1.0), (10.0, 2.0), (29.99, 2.0), (30.0, 5.0), (119.99, 5.0), (120.0, 20.0), (600.0, 20.0)],
+)
+def test_next_poll_interval_backs_off_over_time(elapsed_seconds: float, expected_interval: float) -> None:
+    """Job-status polling interval must back off as the query keeps running."""
+    assert _SnowflakeWorkspace._next_poll_interval(elapsed_seconds) == expected_interval
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ('bearer_token', 'storage_token', 'expected_token'),

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, call
 
+import httpx
 import pytest
 from mcp.server.fastmcp import Context
 from mcp.types import ProgressNotification
@@ -947,6 +948,64 @@ class TestQueryCancellation:
             endpoint='queries/job-abc-123/cancel', data={'reason': 'Test cancellation'}, params=None, timeout=None
         )
         assert result == {'status': 'canceling'}
+
+    @staticmethod
+    def _workspace_credentials_403() -> httpx.HTTPStatusError:
+        request = httpx.Request('POST', 'https://query.example.com/api/v1/branches/1234/workspaces/ws1/queries')
+        response = httpx.Response(403, request=request, text='403 Failed to get workspace credentials')
+        return httpx.HTTPStatusError('403 Failed to get workspace credentials', request=request, response=response)
+
+    @pytest.mark.asyncio
+    async def test_submit_job_retries_on_workspace_credentials_403(self, mocker) -> None:
+        """submit_job retries a transient QS 403 (own deadline shorter than Connection's) up to 3x."""
+        from keboola_mcp_server.clients.base import RawKeboolaClient
+
+        mocker.patch('keboola_mcp_server.clients.query.asyncio.sleep', new=AsyncMock())
+        raw_client = mocker.AsyncMock(RawKeboolaClient)
+        raw_client.post.side_effect = [
+            self._workspace_credentials_403(),
+            self._workspace_credentials_403(),
+            {'queryJobId': 'qs-job-retried'},
+        ]
+
+        qsclient = QueryServiceClient(raw_client=raw_client, branch_id='1234')
+        job_id = await qsclient.submit_job(statements=['SELECT 1'], workspace_id='ws1')
+
+        assert job_id == 'qs-job-retried'
+        assert raw_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_submit_job_raises_after_exhausting_credentials_403_retries(self, mocker) -> None:
+        """submit_job gives up and raises once all retry attempts return the same transient 403."""
+        from keboola_mcp_server.clients.base import RawKeboolaClient
+
+        mocker.patch('keboola_mcp_server.clients.query.asyncio.sleep', new=AsyncMock())
+        raw_client = mocker.AsyncMock(RawKeboolaClient)
+        raw_client.post.side_effect = [self._workspace_credentials_403() for _ in range(3)]
+
+        qsclient = QueryServiceClient(raw_client=raw_client, branch_id='1234')
+        with pytest.raises(httpx.HTTPStatusError, match='workspace credentials'):
+            await qsclient.submit_job(statements=['SELECT 1'], workspace_id='ws1')
+
+        assert raw_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_submit_job_does_not_retry_unrelated_403(self, mocker) -> None:
+        """A 403 unrelated to workspace credentials (e.g. real auth failure) is not retried."""
+        from keboola_mcp_server.clients.base import RawKeboolaClient
+
+        request = httpx.Request('POST', 'https://query.example.com/api/v1/branches/1234/workspaces/ws1/queries')
+        response = httpx.Response(403, request=request, text='403 Forbidden: invalid token')
+        raw_client = mocker.AsyncMock(RawKeboolaClient)
+        raw_client.post.side_effect = httpx.HTTPStatusError(
+            '403 Forbidden: invalid token', request=request, response=response
+        )
+
+        qsclient = QueryServiceClient(raw_client=raw_client, branch_id='1234')
+        with pytest.raises(httpx.HTTPStatusError, match='invalid token'):
+            await qsclient.submit_job(statements=['SELECT 1'], workspace_id='ws1')
+
+        assert raw_client.post.call_count == 1
 
     @pytest.mark.asyncio
     async def test_cancellation_polling_multiple_checks(

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -41,7 +41,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -1141,7 +1141,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1332,7 +1332,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.73.4"
+version = "1.73.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -2509,8 +2509,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Description

**Linear**: AI-3637, AI-2493

### Change Type

- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Three related Query Service client fixes, bundled together at the reporter's request:

1. **AI-3637 (timeout)** — A production incident showed `query_data` on a BigQuery workspace failing with `403 Failed to get workspace credentials`. Root cause: Query Service's own client deadline to Connection (~30s) is shorter than Connection's actual BigQuery credential-provisioning time (~68s observed) — QS gives up and returns 403 before Connection's call even finishes. That timeout mismatch lives in QS/Connection and needs a fix there (tracked as follow-up, see AI-3637 description). As a defensive improvement on this side, the MCP server's own HTTP client timeout for Query Service calls (`clients/query.py`) is bumped from 60s to 120s read, giving headroom for other slow QS responses (e.g. large result fetches). This does **not** fix the 403 itself.
2. **AI-3637 (retry)** — `submit_job` is a POST, so the existing transport-level retry (only GET/PUT/DELETE/etc by default) never covered it. Added a scoped, manual retry (up to 3 attempts) specifically for a 403 whose body mentions "workspace credentials" — the transient case above, which happens before any job is created so it's safe to retry. An unrelated 403 (e.g. a real auth/permission failure) is *not* retried and raises immediately.
3. **AI-2493 (polling)** — QS job-status polling ran every 1s for the entire query duration, so a 4-minute query triggered ~240 status checks. Polling now backs off in steps (1s → 2s → 5s → 20s) as elapsed time grows, while still guaranteeing one last check shortly before the query timeout.

## Testing

- [x] Unit tests added/updated:
  - `tests/test_workspace.py::test_next_poll_interval_backs_off_over_time`
  - `tests/tools/test_sql.py::test_submit_job_retries_on_workspace_credentials_403`
  - `tests/tools/test_sql.py::test_submit_job_raises_after_exhausting_credentials_403_retries`
  - `tests/tools/test_sql.py::test_submit_job_does_not_retry_unrelated_403`
  - Existing timeout/cancellation tests re-verified unaffected (all elapsed times stay under the first 10s polling step)
- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)