### PR TITLE
ci: exclude measured-unstable questions from the KaiBench regression gate

### DIFF
--- a/.github/kaibench-flaky-questions.txt
+++ b/.github/kaibench-flaky-questions.txt
@@ -1,0 +1,19 @@
+# Questions excluded from the KaiBench regression gate.
+#
+# A question belongs here only when it has been MEASURED as unstable against an unmodified
+# server — not merely observed failing once. The gate compares a single trial per question,
+# so a question with a base pass rate meaningfully below 100% produces phantom regressions
+# at that rate and trains reviewers to ignore the check.
+#
+# Exclusions are reported as warnings on every gated run, so coverage lost here stays
+# visible rather than silently narrowing. Remove an entry once the underlying question is
+# made deterministic.
+#
+# Format: one question ID per line. Blank lines and #-comments ignored.
+
+# ~50% pass rate on unmodified main (6/10 vs 4/10 on a branch, Fisher exact p=0.66 — the
+# instability is the question's own, not any PR's). Six-value all-or-nothing set_comparison
+# over an underspecified multi-source join: date-overlap semantics, weekday/weekend boundary,
+# and aggregation grain are all undefined. Tracked in keboola/KaiBench#80 as the reference
+# case for the semantic layer; remove this entry once those definitions are modelled.
+12

--- a/.github/scripts/kaibench-parse-results.py
+++ b/.github/scripts/kaibench-parse-results.py
@@ -50,6 +50,12 @@ regressed_qids = []
 flaky_regressions = 0
 flaky_regressed_qids = []
 baseline_run = ''
+# Share of this run's questions the baseline actually covers. A targeted run (say a single
+# question dispatched with --questions) produces a perfectly valid artifact that nonetheless
+# makes a near-empty baseline, which would otherwise yield "0 regressions" and a green check
+# while verifying almost nothing.
+baseline_overlap = 0
+baseline_shared = 0
 prev_runs = sorted(Path('prev-results').glob('run_*'), key=lambda p: p.stat().st_mtime) if Path('prev-results').exists() else []
 if prev_runs:
     prev_file = prev_runs[-1] / 'results.jsonl'
@@ -63,6 +69,10 @@ if prev_runs:
                 except json.JSONDecodeError:
                     continue
                 prev_by_qid[str(pr.get('question_id', ''))] = pr
+        candidate_qids = {str(r.get('question_id', '')) for r in evaluated}
+        baseline_shared = len(candidate_qids & set(prev_by_qid))
+        if candidate_qids:
+            baseline_overlap = round(100 * baseline_shared / len(candidate_qids))
         for r in evaluated:
             qid = str(r.get('question_id', ''))
             if qid in prev_by_qid:
@@ -77,4 +87,6 @@ print(f"regressions={regressions}")
 print(f"regressed_qids={','.join(sorted(regressed_qids))}")
 print(f"flaky_regressions={flaky_regressions}")
 print(f"flaky_regressed_qids={','.join(sorted(flaky_regressed_qids))}")
+print(f"baseline_overlap={baseline_overlap}")
+print(f"baseline_shared={baseline_shared}")
 print(f"baseline_run={baseline_run}")

--- a/.github/scripts/kaibench-parse-results.py
+++ b/.github/scripts/kaibench-parse-results.py
@@ -31,10 +31,24 @@ print(f"duration={m['duration_seconds']:.0f}")
 status = 'passed' if m['failed'] == 0 and m.get('errors', 0) == 0 and partial_count == 0 else 'failed'
 print(f"status={status}")
 
+# Questions measured as unstable against an unmodified server. A single-trial comparison on a
+# question whose base pass rate is well under 100% produces phantom regressions at that rate, so
+# these are counted separately instead of failing the gate. Reported, never silently dropped.
+flaky_path = Path(__file__).parent.parent / 'kaibench-flaky-questions.txt'
+flaky_qids = set()
+if flaky_path.exists():
+    for raw in flaky_path.read_text().splitlines():
+        entry = raw.split('#', 1)[0].strip()
+        if entry:
+            flaky_qids.add(entry)
+
 # Count regressions vs previous run (downloaded into prev-results/)
 # `baseline_run` stays empty when no comparison happened, so callers can tell "0 regressions"
 # apart from "never compared" — the two look identical otherwise.
 regressions = 0
+regressed_qids = []
+flaky_regressions = 0
+flaky_regressed_qids = []
 baseline_run = ''
 prev_runs = sorted(Path('prev-results').glob('run_*'), key=lambda p: p.stat().st_mtime) if Path('prev-results').exists() else []
 if prev_runs:
@@ -53,6 +67,14 @@ if prev_runs:
             qid = str(r.get('question_id', ''))
             if qid in prev_by_qid:
                 if prev_by_qid[qid].get('status') == 'passed' and r.get('status') not in ('passed', 'skipped'):
-                    regressions += 1
+                    if qid in flaky_qids:
+                        flaky_regressions += 1
+                        flaky_regressed_qids.append(qid)
+                    else:
+                        regressions += 1
+                        regressed_qids.append(qid)
 print(f"regressions={regressions}")
+print(f"regressed_qids={','.join(sorted(regressed_qids))}")
+print(f"flaky_regressions={flaky_regressions}")
+print(f"flaky_regressed_qids={','.join(sorted(flaky_regressed_qids))}")
 print(f"baseline_run={baseline_run}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,8 @@ jobs:
           FLAKY_REGRESSIONS: ${{ needs.kaibench.outputs.flaky_regressions }}
           FLAKY_REGRESSED_QIDS: ${{ needs.kaibench.outputs.flaky_regressed_qids }}
           BASELINE_RUN: ${{ needs.kaibench.outputs.baseline_run }}
+          BASELINE_OVERLAP: ${{ needs.kaibench.outputs.baseline_overlap }}
+          BASELINE_SHARED: ${{ needs.kaibench.outputs.baseline_shared }}
           PASSED: ${{ needs.kaibench.outputs.passed }}
           TOTAL: ${{ needs.kaibench.outputs.total }}
           PASS_RATE: ${{ needs.kaibench.outputs.pass_rate }}
@@ -209,7 +211,13 @@ jobs:
             echo "::warning::No baseline artifact available, so no regression comparison was made — this check passing does NOT mean the PR is regression-free"
             exit 0
           fi
-          echo "Compared against baseline run: $BASELINE_RUN"
+          echo "Compared against baseline run: $BASELINE_RUN (covers ${BASELINE_SHARED:-?} of $TOTAL questions, ${BASELINE_OVERLAP:-?}%)"
+          # A targeted run (dispatched with `questions`) yields a valid artifact that is nonetheless a
+          # near-empty baseline. Real regressions inside a thin overlap are still worth failing on, but a
+          # pass must not read as full coverage.
+          if [ "${BASELINE_OVERLAP:-0}" -lt 50 ]; then
+            echo "::warning::Baseline covers only ${BASELINE_OVERLAP:-0}% of this run's questions (${BASELINE_SHARED:-0}/$TOTAL) — most questions were NOT compared against anything. Treat a pass here as unverified; run the full suite on main to establish a comparable baseline."
+          fi
           # Surface excluded questions every time, so coverage given up here stays visible
           # instead of quietly shrinking what this check actually verifies.
           if [ "${FLAKY_REGRESSIONS:-0}" -gt 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,9 @@ jobs:
         env:
           EVAL_RESULT: ${{ needs.kaibench.result }}
           REGRESSIONS: ${{ needs.kaibench.outputs.regressions }}
+          REGRESSED_QIDS: ${{ needs.kaibench.outputs.regressed_qids }}
+          FLAKY_REGRESSIONS: ${{ needs.kaibench.outputs.flaky_regressions }}
+          FLAKY_REGRESSED_QIDS: ${{ needs.kaibench.outputs.flaky_regressed_qids }}
           BASELINE_RUN: ${{ needs.kaibench.outputs.baseline_run }}
           PASSED: ${{ needs.kaibench.outputs.passed }}
           TOTAL: ${{ needs.kaibench.outputs.total }}
@@ -207,8 +210,13 @@ jobs:
             exit 0
           fi
           echo "Compared against baseline run: $BASELINE_RUN"
+          # Surface excluded questions every time, so coverage given up here stays visible
+          # instead of quietly shrinking what this check actually verifies.
+          if [ "${FLAKY_REGRESSIONS:-0}" -gt 0 ]; then
+            echo "::warning::Ignored $FLAKY_REGRESSIONS regression(s) on known-unstable question(s): ${FLAKY_REGRESSED_QIDS} — these are excluded via .github/kaibench-flaky-questions.txt and are NOT verified by this check"
+          fi
           if [ "${REGRESSIONS:-0}" -gt 0 ]; then
-            echo "::error::$REGRESSIONS question(s) regressed vs the previous run — see the step summary for details"
+            echo "::error::$REGRESSIONS question(s) regressed vs the previous run: ${REGRESSED_QIDS} — see the step summary for details"
             exit 1
           fi
           echo "No regressions."

--- a/.github/workflows/kaibench.yml
+++ b/.github/workflows/kaibench.yml
@@ -41,6 +41,9 @@ jobs:
       pass_rate: ${{ steps.parse.outputs.pass_rate }}
       duration: ${{ steps.parse.outputs.duration }}
       regressions: ${{ steps.parse.outputs.regressions }}
+      regressed_qids: ${{ steps.parse.outputs.regressed_qids }}
+      flaky_regressions: ${{ steps.parse.outputs.flaky_regressions }}
+      flaky_regressed_qids: ${{ steps.parse.outputs.flaky_regressed_qids }}
       baseline_run: ${{ steps.parse.outputs.baseline_run }}
 
     services:

--- a/.github/workflows/kaibench.yml
+++ b/.github/workflows/kaibench.yml
@@ -25,13 +25,23 @@ on:
         required: false
         type: string
         default: ''
+      questions:
+        description: 'Specific question IDs (comma-separated). Intersects with the other filters.'
+        required: false
+        type: string
+        default: ''
+      repeat:
+        description: 'Trials per question, for consistency/noise measurement (default 1)'
+        required: false
+        type: string
+        default: ''
   workflow_call:
 
 jobs:
   evaluate:
     name: Run KaiBench evaluation
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     continue-on-error: ${{ github.event_name == 'workflow_call' }}
     outputs:
       status: ${{ steps.parse.outputs.status }}
@@ -45,6 +55,8 @@ jobs:
       flaky_regressions: ${{ steps.parse.outputs.flaky_regressions }}
       flaky_regressed_qids: ${{ steps.parse.outputs.flaky_regressed_qids }}
       baseline_run: ${{ steps.parse.outputs.baseline_run }}
+      baseline_overlap: ${{ steps.parse.outputs.baseline_overlap }}
+      baseline_shared: ${{ steps.parse.outputs.baseline_shared }}
 
     services:
       postgres:
@@ -212,6 +224,8 @@ jobs:
           KAIBENCH_EVAL_PARALLEL_WORKERS: '4'
           KAIBENCH_EVAL_KAI_BACKEND_URL: http://localhost:3000
           QUESTION_TYPES: ${{ inputs.question_types }}
+          QUESTION_IDS: ${{ inputs.questions }}
+          REPEAT: ${{ inputs.repeat }}
         run: |
           CMD_ARGS=()
           if [ -n "$QUESTION_TYPES" ]; then
@@ -223,11 +237,22 @@ jobs:
           else
             CMD_ARGS=(-t "Data Analysis Query" -t "Configuration Reasoning" -t "Storage Object Reasoning" -t "MCP Tool Validation")
           fi
+          if [ -n "$QUESTION_IDS" ]; then
+            IFS=',' read -ra QIDS <<< "$QUESTION_IDS"
+            for q in "${QIDS[@]}"; do
+              trimmed=$(echo "$q" | xargs)
+              CMD_ARGS+=(--question "$trimmed")
+            done
+          fi
+          if [ -n "$REPEAT" ]; then
+            CMD_ARGS+=(--repeat "$REPEAT")
+          fi
           if [ "${{ inputs.regression_only }}" = "true" ]; then
             # the CLI option is `--regression` (see kaibench/cli.py); `--regression-only` is rejected by
             # typer as an unknown option, and because this step is continue-on-error it failed silently
             CMD_ARGS+=(--regression)
           fi
+          echo "Running: kaibench run ${CMD_ARGS[*]}"
           uv run kaibench run "${CMD_ARGS[@]}"
         continue-on-error: true
 


### PR DESCRIPTION
Follow-up to #641.

## Why

The gate #641 added compares **a single trial per question** and fails a PR on any pass→fail flip. That only works if questions are deterministic. **Q12 is not** — it passes about half the time against an unmodified server:

| | Q12, 10 trials | passed |
|---|---|---|
| `main` | `[0,1,0,0,1,0,1,1,1,1]` | 6/10 |
| an unrelated branch | `[1,1,0,1,0,0,0,0,0,1]` | 4/10 |

Fisher exact **p = 0.66** — the sides are indistinguishable, so the instability belongs to the question, not to any change. Q12 is a six-value all-or-nothing `set_comparison` over a multi-source join whose date-overlap semantics, weekday/weekend boundary, and aggregation grain are all undefined; Kai picks a different defensible reading per run and one of six values drifts.

Left as-is, the gate throws a spurious red check on roughly half the PRs it runs on. **A gate that cries wolf at that rate gets learned as noise and ignored** — which costs more than the coverage it provides. This already happened once during #640's validation: a single-trial run appeared to show a Q12 regression, and only `--repeat` disproved it.

## What

- New `.github/kaibench-flaky-questions.txt` — one question ID per line, each with the measurement that justifies it. A question qualifies only once **measured** unstable against an unmodified server, not merely observed failing once. Currently one entry: `12`.
- `kaibench-parse-results.py` splits regressions into `regressions` (gating) and `flaky_regressions` (reported only), and now emits the offending question IDs for both.
- The gate **warns on every run that ignores something**, naming the questions and the file. Coverage given up here stays visible rather than quietly shrinking what the check verifies.
- Real regressions now name the questions too — the previous message said only how many.

Putting the list in a reviewable file rather than a script constant is deliberate: exclusions should be easy to audit and easy to delete, and each one should have to justify itself in writing.

## Verification

Parse script against fixtures:

| fixture | result |
|---|---|
| Q12 + R01 both regress | `regressions=1 regressed_qids=R01`, `flaky_regressions=1 flaky_regressed_qids=12` |
| Q12 only | `regressions=0`, `flaky_regressions=1` |

Gate script across all five paths:

| scenario | exit | behaviour |
|---|---|---|
| flaky-only regression | 0 | passes, warns naming Q12 |
| real regression | 1 | fails, names R01 |
| both | 1 | fails on R01, still warns about Q12 |
| clean | 0 | silent pass |
| no baseline | 0 | passes with the existing loud warning |

Both workflows parse; the parse script compiles.

## Follow-up

The right fix is making Q12 deterministic rather than excluding it. Tracked in keboola/KaiBench#80, which proposes modelling the missing business definitions in the **semantic layer** — a `labor_cost_per_checkin` metric with a fixed grain, a `day_type` dimension, and the co-covered-period rule as a constraint. That also upgrades what Q12 tests: from "did Kai guess the author's business rules" to "did Kai find and use the governed definition." **This exclusion comes out at that point.**

Worth noting the gate remains single-trial for everything else. That is fine for questions measured stable (R01–R08 were 3/3 on both sides), but the underlying limitation stands — a question that silently becomes flaky will produce false regressions until someone measures it. Running the gate at `--repeat 3` and failing only on a majority-of-trials regression would be the more robust design, at roughly 3× the runtime and spend per gated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)