### PR TITLE
feat(AI-3657): push MCP server images to private registries (ECR, ACR, GCP GAR)

### DIFF
--- a/.github/actions/login-private-registries/action.yml
+++ b/.github/actions/login-private-registries/action.yml
@@ -1,0 +1,66 @@
+name: 'Login to Amazon ECR, Azure ACR and GCP GAR'
+description: 'Authenticate Docker to our private registries so a subsequent buildx push can push to all of them'
+inputs:
+  ecrRegion:
+    description: Amazon ECR region
+    required: true
+  ecrPushRole:
+    description: Amazon ECR push role
+    required: true
+  gcpRegistry:
+    description: GCP Artifact Registry root URL
+    required: true
+  gcpIdentityProvider:
+    description: GCP Identity Provider for OIDC integration
+    required: true
+  gcpServiceAccount:
+    description: GCP Service Account for OIDC integration
+    required: true
+  acrRegistry:
+    description: Azure ACR registry
+    required: true
+  acrUsername:
+    description: Azure ACR username
+    required: true
+  acrPassword:
+    description: Azure ACR password
+    required: true
+outputs:
+  ecrRegistry:
+    description: The Amazon ECR registry host (account + region specific)
+    value: ${{ steps.login-ecr.outputs.registry }}
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-region: ${{ inputs.ecrRegion }}
+        role-to-assume: ${{ inputs.ecrPushRole }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - id: gcpAuth
+      name: Authenticate to GCP
+      uses: google-github-actions/auth@v3
+      with:
+        token_format: access_token
+        create_credentials_file: true
+        workload_identity_provider: ${{ inputs.gcpIdentityProvider }}
+        service_account: ${{ inputs.gcpServiceAccount }}
+
+    - name: Login to GCP GAR
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ inputs.gcpRegistry }}
+        username: oauth2accesstoken
+        password: ${{ steps.gcpAuth.outputs.access_token }}
+
+    - name: Login to Azure ACR
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ inputs.acrRegistry }}
+        username: ${{ inputs.acrUsername }}
+        password: ${{ inputs.acrPassword }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,16 @@ permissions:
 
 env:
   SERVICE_IMAGE_NAME: "keboola/mcp-server"
+  ECR_REGION: "us-east-1"
+  ECR_REPOSITORY: "keboola/mcp-server"
+  ECR_PUSH_ROLE: "arn:aws:iam::968984773589:role/kbc-ecr-McpServerPushRole"
+  GCP_REGISTRY: "us-central1-docker.pkg.dev"
+  GCP_REPOSITORY: "keboola-prod-artifacts/mcp-server/mcp-server"
+  GCP_IDENTITY_PROVIDER: "projects/388088979044/locations/global/workloadIdentityPools/github/providers/github"
+  GCP_SERVICE_ACCOUNT: "mcp-server-ci-push@keboola-prod-artifacts.iam.gserviceaccount.com"
+  ACR_REGISTRY: "keboola.azurecr.io"
+  ACR_REPOSITORY: "mcp-server"
+  ACR_USERNAME: "mcp-server-push"
 
 jobs:
   build-and-push:
@@ -35,12 +45,34 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Docker login
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_PUSH_USER }}
+          password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
+
+      - name: Login to private registries (ECR, ACR, GCP GAR)
+        id: login-private-registries
+        uses: ./.github/actions/login-private-registries
+        with:
+          ecrRegion: ${{ env.ECR_REGION }}
+          ecrPushRole: ${{ env.ECR_PUSH_ROLE }}
+          gcpRegistry: ${{ env.GCP_REGISTRY }}
+          gcpIdentityProvider: ${{ env.GCP_IDENTITY_PROVIDER }}
+          gcpServiceAccount: ${{ env.GCP_SERVICE_ACCOUNT }}
+          acrRegistry: ${{ env.ACR_REGISTRY }}
+          acrUsername: ${{ env.ACR_USERNAME }}
+          acrPassword: ${{ secrets.MCP_SERVER_ACR_PASSWORD }}
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.SERVICE_IMAGE_NAME }}
+            ${{ steps.login-private-registries.outputs.ecrRegistry }}/${{ env.ECR_REPOSITORY }}
+            ${{ env.GCP_REGISTRY }}/${{ env.GCP_REPOSITORY }}
+            ${{ env.ACR_REGISTRY }}/${{ env.ACR_REPOSITORY }}
           tags: |
             type=sha,format=long
             # Production: clean v* / agent-v* tags -> production stacks.
@@ -50,12 +82,6 @@ jobs:
             type=raw,value=canary-orion-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/canary-orion-') }}
             # Dev: dev-v* / dev-agent* tags -> testing stacks.
             type=raw,value=dev-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/dev-') }}
-
-      - name: Docker login
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_PUSH_USER }}
-          password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       # Build for tests (single-arch, load into daemon)
       - name: Build Docker image


### PR DESCRIPTION
## Description

**Linear**: [AI-3657](https://linear.app/keboola/issue/AI-3657/ci-push-mcp-server-images-to-private-registries-ecr-acr-gcp-gar)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Adds a second push destination alongside Docker Hub: our private registries (Amazon ECR, Azure ACR, GCP Artifact Registry).

This mirrors the pattern already used in `go-monorepo`'s `push-image-acr-ecr-gcp` composite action, adapted to this repo's flow:
- New composite action `.github/actions/login-private-registries` — ports the ECR/GCP-GAR/ACR login steps from go-monorepo (drops the manual `docker tag && docker push` loop, since this repo's `release.yml` pushes a multi-arch manifest directly via buildx rather than tagging a locally-loaded single-arch image).
- `release.yml`: logs into the three private registries before the existing `docker/metadata-action` step, then adds their image references to that step's `images:` list. The same computed tags (`production-<sha>`, `canary-orion-<sha>`, `dev-<sha>`, `latest`, etc.) now fan out to all four registries in the existing single `docker/build-push-action` push — no separate build/push job needed.
- The `trigger-image-tag-update` steps are untouched: they only pass a helm chart name + tag to `kbc-stacks`, which resolves the actual registry per stack — so this doesn't need to live here (confirmed by mirroring how `go-monorepo` does it).

**This is a scaffold/draft.** The following are placeholder values that need to be confirmed/provisioned with infra before merging:
- `ECR_PUSH_ROLE` ARN (account ID reused from go-monorepo's shared org account as a guess)
- `GCP_REPOSITORY` path and `GCP_SERVICE_ACCOUNT`
- `ACR_REPOSITORY` / `ACR_USERNAME`
- New secret `MCP_SERVER_ACR_PASSWORD` (analogous to go-monorepo's `GIT_SERVICE_ACR_PASSWORD`) needs to be created

No `pyproject.toml` version bump in this PR — it's CI-only infra scaffolding with no runtime/package behavior change.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [ ] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [ ] Project version bumped according to the change type — N/A, see note above
- [ ] Documentation updated (if applicable)