### PR TITLE
feat(AI-3669): support pinning MCP queries to an explicit workspace ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ For client–server communication, Keboola credentials must be provided to enabl
 - For personal use (mainly with stdio transport): set the environment variables before starting the server. All requests will reuse these predefined credentials.
 - For multi-user use: include the variables in the request headers so that each request uses the credentials provided with it.
 
-Two of the variables are not taken from the request headers:
+Some of the variables are not taken from the request headers:
 - `KBC_STORAGE_API_URL`: a server that was started with its own Storage API URL (the `--api-url` parameter or the `KBC_STORAGE_API_URL` environment variable) only serves that one Keboola stack. An `X-Storage-Api-Url` header asking for a different host is ignored (a warning is logged) — the server keeps its own URL for the request. Start the server without a Storage API URL of its own if you want each request to choose its stack.
 - `KBC_KUBERNETES_TOKEN_PATH` (deployed servers only, see [docs/kubernetes-sa-auth.md](docs/kubernetes-sa-auth.md)): read from the environment only, never from a header.
+- `KBC_WORKSPACE_ID` / `KBC_WORKSPACE_SCHEMA`: same idea as the Storage API URL above — a server started with its own workspace pin (via either variable, or `--workspace-id`) keeps that pin for every request; an `X-Workspace-Id` or `X-Workspace-Schema` header asking for a different workspace is ignored (a warning is logged). A server with no pin of its own (the shared multi-user case) keeps taking the pin from the request, per-request, as described below.
 
 
 ### KBC_STORAGE_TOKEN

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ This identifies your workspace in Keboola and is used for SQL queries. However, 
 
 **Note**: KBC_WORKSPACE_SCHEMA is called Dataset Name in BigQuery workspaces, you simply click connect and copy the Dataset Name
 
+### KBC_WORKSPACE_ID
+
+Pins queries to one specific, already-existing workspace by its ID instead of the schema-based lookup above, and takes precedence over `KBC_WORKSPACE_SCHEMA` when both are set. This is the option a Data App / kai-agent caller supplies, as the `X-Workspace-Id` header, so that Kai embedded in that app queries only through its own workspace.
+
+Set via the `KBC_WORKSPACE_ID` environment variable, the `--workspace-id` CLI flag, or (per-request, for multi-user deployments) the `X-Workspace-Id` header.
+
 ### KBC_STORAGE_API_URL (Keboola Region)
 
 Your Keboola Region API URL depends on your deployment region. You can determine your region by looking at the URL in your browser when logged into your Keboola project:
@@ -438,7 +444,7 @@ For a complete list of available tools with detailed descriptions, parameters, a
 | Issue | Solution |
 |-------|----------|
 | **Authentication Errors** | Verify `KBC_STORAGE_TOKEN` is valid |
-| **Workspace Issues** | Confirm `KBC_WORKSPACE_SCHEMA` is correct |
+| **Workspace Issues** | Confirm `KBC_WORKSPACE_SCHEMA` / `KBC_WORKSPACE_ID` is correct |
 | **Connection Timeout** | Check network connectivity |
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.76.2"
+version = "1.77.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.75.2"
+version = "1.76.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -53,6 +53,7 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument('--storage-token', metavar='STR', help='Keboola Storage API token.')
     parser.add_argument('--workspace-schema', metavar='STR', help='Keboola Storage API workspace schema.')
+    parser.add_argument('--workspace-id', metavar='STR', help='Keboola Storage API workspace ID.')
     parser.add_argument('--host', default='localhost', metavar='STR', help='The host to listen on.')
     parser.add_argument('--port', type=int, default=8000, metavar='INT', help='The port to listen on.')
     parser.add_argument('--log-config', type=pathlib.Path, metavar='PATH', help='Logging config file.')
@@ -129,6 +130,7 @@ async def run_server(args: list[str] | None = None) -> None:
         storage_api_url=parsed_args.api_url,
         storage_token=parsed_args.storage_token,
         workspace_schema=parsed_args.workspace_schema,
+        workspace_id=parsed_args.workspace_id,
     )
 
     try:

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -125,15 +125,17 @@ async def run_server(args: list[str] | None = None) -> None:
             stream=sys.stderr,
         )
 
-    # Create config from the CLI arguments
-    config = Config(
-        storage_api_url=parsed_args.api_url,
-        storage_token=parsed_args.storage_token,
-        workspace_schema=parsed_args.workspace_schema,
-        workspace_id=parsed_args.workspace_id,
-    )
-
     try:
+        # Create config from the CLI arguments -- inside the `try` so a malformed flag (e.g.
+        # a non-numeric `--workspace-id`) is reported via the same log-and-exit path as any
+        # other startup failure, instead of an unhandled traceback.
+        config = Config(
+            storage_api_url=parsed_args.api_url,
+            storage_token=parsed_args.storage_token,
+            workspace_schema=parsed_args.workspace_schema,
+            workspace_id=parsed_args.workspace_id,
+        )
+
         # Create and run the server
         if parsed_args.transport == 'stdio':
             runtime_config = ServerRuntimeInfo(transport=parsed_args.transport)

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -151,13 +151,18 @@ class Config:
         A malformed `workspace_id` (the only field `__post_init__` validates) degrades to "not
         provided" rather than raising: `d` is untrusted per-request input (an HTTP header), so a
         junk value from a client should drop the pin, not turn into an unhandled server error.
+        Any other `ValueError` (e.g. a malformed URL) is not ours to fix by dropping `workspace_id`
+        -- re-raise it unchanged so the request still fails, instead of logging a misleading
+        "ignoring" message for a value that was in fact never touched.
         """
         options = self._read_options(d)
         try:
             return dataclasses.replace(self, **options)
         except ValueError as e:
+            if 'workspace_id' not in options:
+                raise
             LOG.warning(f'Ignoring invalid request header value(s): {e}')
-            options.pop('workspace_id', None)
+            options.pop('workspace_id')
             return dataclasses.replace(self, **options)
 
     def __repr__(self) -> str:

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -27,6 +27,10 @@ class Config:
     """The branch ID to access the storage API using the MCP tools."""
     workspace_schema: str | None = None
     """Workspace schema to access the buckets, tables and execute sql queries."""
+    workspace_id: str | None = None
+    """Workspace ID to access the buckets, tables and execute sql queries (e.g. a Data App's own
+    workspace, supplied per-request via the 'X-Workspace-Id' header). Takes precedence over
+    `workspace_schema` when both are set."""
     oauth_client_id: str | None = None
     """OAuth client ID registered in the Keboola OAuth Server."""
     oauth_client_secret: str | None = None

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -25,7 +25,7 @@ class Config:
     """The token to access the storage API using the MCP tools."""
     branch_id: str | None = None
     """The branch ID to access the storage API using the MCP tools."""
-    workspace_schema: str | None = field(default=None, metadata={'empty_means_absent': True})
+    workspace_schema: str | None = None
     """Workspace schema to access the buckets, tables and execute sql queries."""
     workspace_id: str | None = field(default=None, metadata={'empty_means_absent': True, 'require_prefix': True})
     """Workspace ID to access the buckets, tables and execute sql queries (e.g. a Data App's own
@@ -35,10 +35,10 @@ class Config:
     `require_prefix` is set because the bare `WORKSPACE_ID` env var is what Keboola injects into
     Data App containers -- without it, that variable would pin every session on such a server.
     `empty_means_absent` is set so an unset header template (`X-Workspace-Id:`) forwarded as an
-    empty string is not mistaken for an explicit pin to override a server-side default with.
-    Both intentionally do NOT apply to most other fields, e.g. `branch_id` relies on an empty
-    `X-Branch-Id` header clearing a server-configured branch (see the `branch_id` normalization
-    below) -- these two flags are opt-in per field precisely to avoid that kind of regression."""
+    empty string is not mistaken for an explicit pin to override a server-side default with. This
+    intentionally does NOT apply to `workspace_schema` (an empty `X-Workspace-Schema` header must
+    keep clearing it back to the MCP-managed workspace, same as `branch_id` below) nor to most
+    other fields -- it is opt-in per field precisely to avoid that kind of regression."""
     oauth_client_id: str | None = None
     """OAuth client ID registered in the Keboola OAuth Server."""
     oauth_client_secret: str | None = None
@@ -147,8 +147,18 @@ class Config:
         Creates new `Config` instance from the existing one by replacing the values from the input mapping.
         The keys in the input mapping can either be the names of the fields in `Config` class
         or their uppercase variant prefixed with 'KBC_'.
+
+        A malformed `workspace_id` (the only field `__post_init__` validates) degrades to "not
+        provided" rather than raising: `d` is untrusted per-request input (an HTTP header), so a
+        junk value from a client should drop the pin, not turn into an unhandled server error.
         """
-        return dataclasses.replace(self, **self._read_options(d))
+        options = self._read_options(d)
+        try:
+            return dataclasses.replace(self, **options)
+        except ValueError as e:
+            LOG.warning(f'Ignoring invalid request header value(s): {e}')
+            options.pop('workspace_id', None)
+            return dataclasses.replace(self, **options)
 
     def __repr__(self) -> str:
         params: list[str] = []

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -148,22 +148,14 @@ class Config:
         The keys in the input mapping can either be the names of the fields in `Config` class
         or their uppercase variant prefixed with 'KBC_'.
 
-        A malformed `workspace_id` (the only field `__post_init__` validates) degrades to "not
-        provided" rather than raising: `d` is untrusted per-request input (an HTTP header), so a
-        junk value from a client should drop the pin, not turn into an unhandled server error.
-        Any other `ValueError` (e.g. a malformed URL) is not ours to fix by dropping `workspace_id`
-        -- re-raise it unchanged so the request still fails, instead of logging a misleading
-        "ignoring" message for a value that was in fact never touched.
+        A malformed `workspace_id` (or any other invalid value `__post_init__` rejects) always
+        raises -- same as every other field. A per-request caller (e.g.
+        `SessionStateMiddleware.apply_request_config`) that degrades this into "not provided"
+        would silently widen an unpinned multi-tenant session's scope instead of rejecting the
+        bad request; a trusted caller (the startup env merge in `create_server()`) needs it to
+        fail loudly, the same way a malformed `--workspace-id` CLI flag already does.
         """
-        options = self._read_options(d)
-        try:
-            return dataclasses.replace(self, **options)
-        except ValueError as e:
-            if 'workspace_id' not in options:
-                raise
-            LOG.warning(f'Ignoring invalid request header value(s): {e}')
-            options.pop('workspace_id')
-            return dataclasses.replace(self, **options)
+        return dataclasses.replace(self, **self._read_options(d))
 
     def __repr__(self) -> str:
         params: list[str] = []

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -25,12 +25,20 @@ class Config:
     """The token to access the storage API using the MCP tools."""
     branch_id: str | None = None
     """The branch ID to access the storage API using the MCP tools."""
-    workspace_schema: str | None = None
+    workspace_schema: str | None = field(default=None, metadata={'empty_means_absent': True})
     """Workspace schema to access the buckets, tables and execute sql queries."""
-    workspace_id: str | None = None
+    workspace_id: str | None = field(default=None, metadata={'empty_means_absent': True, 'require_prefix': True})
     """Workspace ID to access the buckets, tables and execute sql queries (e.g. a Data App's own
     workspace, supplied per-request via the 'X-Workspace-Id' header). Takes precedence over
-    `workspace_schema` when both are set."""
+    `workspace_schema` when both are set.
+
+    `require_prefix` is set because the bare `WORKSPACE_ID` env var is what Keboola injects into
+    Data App containers -- without it, that variable would pin every session on such a server.
+    `empty_means_absent` is set so an unset header template (`X-Workspace-Id:`) forwarded as an
+    empty string is not mistaken for an explicit pin to override a server-side default with.
+    Both intentionally do NOT apply to most other fields, e.g. `branch_id` relies on an empty
+    `X-Branch-Id` header clearing a server-configured branch (see the `branch_id` normalization
+    below) -- these two flags are opt-in per field precisely to avoid that kind of regression."""
     oauth_client_id: str | None = None
     """OAuth client ID registered in the Keboola OAuth Server."""
     oauth_client_secret: str | None = None
@@ -77,6 +85,9 @@ class Config:
         if self.branch_id is not None and self.branch_id.lower() in ['', 'none', 'null', 'default', 'production']:
             object.__setattr__(self, 'branch_id', None)
 
+        if self.workspace_id is not None and not self.workspace_id.isdigit():
+            raise ValueError(f'Invalid workspace_id: {self.workspace_id!r}')
+
     @staticmethod
     def _normalize(name: str) -> str:
         """Removes dashes and underscores from the input string and turns it into lowercase."""
@@ -89,19 +100,27 @@ class Config:
         for f in dataclasses.fields(cls):
             field_names = [f.name] + f.metadata.get('aliases', [])
 
+            require_prefix = f.metadata.get('require_prefix', False)
+            empty_means_absent = f.metadata.get('empty_means_absent', False)
+
             for name in field_names:
                 value: str | None = _NO_VALUE_MARKER
+                # `require_prefix` skips the bare field name -- only the KBC_/X- prefixed forms
+                # count as "provided". Needed for fields whose bare name collides with a
+                # variable set by something other than this server's own config (see
+                # `workspace_id`'s docstring).
+                candidates = (f'KBC_{name}', f'X-{name}') if require_prefix else (name, f'KBC_{name}', f'X-{name}')
 
-                if (dict_name := cls._normalize(name)) in data:
-                    value = data[dict_name]
-
-                elif (dict_name := cls._normalize(f'KBC_{name}')) in data:
-                    # environment variables start with KBC_
-                    value = data[dict_name]
-
-                elif (dict_name := cls._normalize(f'X-{name}')) in data:
-                    # HTTP headers start with X-
-                    value = data[dict_name]
+                for candidate in candidates:
+                    if (dict_name := cls._normalize(candidate)) in data:
+                        candidate_value = data[dict_name]
+                        # An empty value means "not provided" for opted-in fields only -- an
+                        # unset header template (e.g. `X-Workspace-Id:`) must not be mistaken
+                        # for an explicit request to override a server-side default with ''.
+                        if empty_means_absent and candidate_value == '':
+                            continue
+                        value = candidate_value
+                        break
 
                 if value is not _NO_VALUE_MARKER:
                     if f.type == (bool | None):

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -317,23 +317,24 @@ class SessionStateMiddleware(fmw.Middleware):
         # reasoning above: a deployment that pinned itself must not be overridable by a header.
         # A server with no pin of its own (the shared multi-tenant case, e.g. AJDA-3052's Data
         # App flow) keeps taking the pin from the request, which is the only source it has.
-        # Each field is gated independently -- a server pinned only by `workspace_schema` (the
-        # README's documented `KBC_WORKSPACE_SCHEMA` setup) must not veto a request's
-        # `X-Workspace-Id`, and vice versa; the two are alternative keys for the same pin, not a
-        # pair that should be vetoed together.
-        if server_config.workspace_id and config.workspace_id != server_config.workspace_id:
+        # Checked/restored together (not per-field): the same silent-override risk that justifies
+        # this for an id-based server pin applies just as much to a schema-based one, and a
+        # schema-pinned server is a single-project deployment that isn't a target for per-request
+        # `X-Workspace-Id` headers in the first place -- see the mcp.py:320 review thread.
+        if (server_config.workspace_id or server_config.workspace_schema) and (
+            config.workspace_id != server_config.workspace_id
+            or config.workspace_schema != server_config.workspace_schema
+        ):
             LOG.warning(
-                f'Ignoring the requested workspace_id={config.workspace_id!r}; this server is '
-                f'pinned to workspace_id={server_config.workspace_id!r}.'
+                f'Ignoring the requested workspace pin (workspace_id={config.workspace_id!r}, '
+                f'workspace_schema={config.workspace_schema!r}); this server is pinned to '
+                f'workspace_id={server_config.workspace_id!r}, workspace_schema={server_config.workspace_schema!r}.'
             )
-            config = dataclasses.replace(config, workspace_id=server_config.workspace_id)
-
-        if server_config.workspace_schema and config.workspace_schema != server_config.workspace_schema:
-            LOG.warning(
-                f'Ignoring the requested workspace_schema={config.workspace_schema!r}; this server is '
-                f'pinned to workspace_schema={server_config.workspace_schema!r}.'
+            config = dataclasses.replace(
+                config,
+                workspace_id=server_config.workspace_id,
+                workspace_schema=server_config.workspace_schema,
             )
-            config = dataclasses.replace(config, workspace_schema=server_config.workspace_schema)
 
         if own_stack_storage_api_url and not is_same_stack(config.storage_api_url, own_stack_storage_api_url):
             LOG.warning(

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -321,9 +321,16 @@ class SessionStateMiddleware(fmw.Middleware):
         # this for an id-based server pin applies just as much to a schema-based one, and a
         # schema-pinned server is a single-project deployment that isn't a target for per-request
         # `X-Workspace-Id` headers in the first place -- see the mcp.py:320 review thread.
+        #
+        # `workspace_schema` has no `empty_means_absent` (unlike `workspace_id`), so an explicit
+        # `X-Workspace-Schema: ''` opt-out (the multi-user pattern the README describes) survives
+        # `replace_by` as `''`, not `None` -- comparing it directly against the server's pin here
+        # would treat that falsy-but-set value as an override and restore the pin right back,
+        # defeating the opt-out. Only a genuinely non-empty, different value counts as a request
+        # to override.
         if (server_config.workspace_id or server_config.workspace_schema) and (
             config.workspace_id != server_config.workspace_id
-            or config.workspace_schema != server_config.workspace_schema
+            or (config.workspace_schema and config.workspace_schema != server_config.workspace_schema)
         ):
             LOG.warning(
                 f'Ignoring the requested workspace pin (workspace_id={config.workspace_id!r}, '

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -435,7 +435,10 @@ class SessionStateMiddleware(fmw.Middleware):
             # therefore attaches the JWT only when the target is this server's own stack.
             kubernetes_token_path = os.environ.get('KBC_KUBERNETES_TOKEN_PATH')
             workspace_manager = await WorkspaceManager.create(
-                client, config.workspace_schema, kubernetes_token_path=kubernetes_token_path
+                client,
+                config.workspace_schema,
+                kubernetes_token_path=kubernetes_token_path,
+                workspace_id=config.workspace_id,
             )
             state[WorkspaceManager.STATE_KEY] = workspace_manager
             LOG.info('Successfully initialized Storage API Workspace manager.')

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -317,21 +317,20 @@ class SessionStateMiddleware(fmw.Middleware):
         # reasoning above: a deployment that pinned itself must not be overridable by a header.
         # A server with no pin of its own (the shared multi-tenant case, e.g. AJDA-3052's Data
         # App flow) keeps taking the pin from the request, which is the only source it has.
-        if server_config.workspace_id or server_config.workspace_schema:
-            if (
-                config.workspace_id != server_config.workspace_id
-                or config.workspace_schema != server_config.workspace_schema
-            ):
-                LOG.warning(
-                    f'Ignoring the requested workspace pin (workspace_id={config.workspace_id!r}, '
-                    f'workspace_schema={config.workspace_schema!r}); this server is pinned to '
-                    f'workspace_id={server_config.workspace_id!r}, workspace_schema={server_config.workspace_schema!r}.'
-                )
-                config = dataclasses.replace(
-                    config,
-                    workspace_id=server_config.workspace_id,
-                    workspace_schema=server_config.workspace_schema,
-                )
+        if (server_config.workspace_id or server_config.workspace_schema) and (
+            config.workspace_id != server_config.workspace_id
+            or config.workspace_schema != server_config.workspace_schema
+        ):
+            LOG.warning(
+                f'Ignoring the requested workspace pin (workspace_id={config.workspace_id!r}, '
+                f'workspace_schema={config.workspace_schema!r}); this server is pinned to '
+                f'workspace_id={server_config.workspace_id!r}, workspace_schema={server_config.workspace_schema!r}.'
+            )
+            config = dataclasses.replace(
+                config,
+                workspace_id=server_config.workspace_id,
+                workspace_schema=server_config.workspace_schema,
+            )
 
         if own_stack_storage_api_url and not is_same_stack(config.storage_api_url, own_stack_storage_api_url):
             LOG.warning(

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -367,7 +367,10 @@ class SessionStateMiddleware(fmw.Middleware):
             # therefore attaches the JWT only when the target is this server's own stack.
             kubernetes_token_path = os.environ.get('KBC_KUBERNETES_TOKEN_PATH')
             workspace_manager = await WorkspaceManager.create(
-                client, config.workspace_schema, kubernetes_token_path=kubernetes_token_path
+                client,
+                config.workspace_schema,
+                kubernetes_token_path=kubernetes_token_path,
+                workspace_id=config.workspace_id,
             )
             state[WorkspaceManager.STATE_KEY] = workspace_manager
             LOG.info('Successfully initialized Storage API Workspace manager.')

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -317,20 +317,23 @@ class SessionStateMiddleware(fmw.Middleware):
         # reasoning above: a deployment that pinned itself must not be overridable by a header.
         # A server with no pin of its own (the shared multi-tenant case, e.g. AJDA-3052's Data
         # App flow) keeps taking the pin from the request, which is the only source it has.
-        if (server_config.workspace_id or server_config.workspace_schema) and (
-            config.workspace_id != server_config.workspace_id
-            or config.workspace_schema != server_config.workspace_schema
-        ):
+        # Each field is gated independently -- a server pinned only by `workspace_schema` (the
+        # README's documented `KBC_WORKSPACE_SCHEMA` setup) must not veto a request's
+        # `X-Workspace-Id`, and vice versa; the two are alternative keys for the same pin, not a
+        # pair that should be vetoed together.
+        if server_config.workspace_id and config.workspace_id != server_config.workspace_id:
             LOG.warning(
-                f'Ignoring the requested workspace pin (workspace_id={config.workspace_id!r}, '
-                f'workspace_schema={config.workspace_schema!r}); this server is pinned to '
-                f'workspace_id={server_config.workspace_id!r}, workspace_schema={server_config.workspace_schema!r}.'
+                f'Ignoring the requested workspace_id={config.workspace_id!r}; this server is '
+                f'pinned to workspace_id={server_config.workspace_id!r}.'
             )
-            config = dataclasses.replace(
-                config,
-                workspace_id=server_config.workspace_id,
-                workspace_schema=server_config.workspace_schema,
+            config = dataclasses.replace(config, workspace_id=server_config.workspace_id)
+
+        if server_config.workspace_schema and config.workspace_schema != server_config.workspace_schema:
+            LOG.warning(
+                f'Ignoring the requested workspace_schema={config.workspace_schema!r}; this server is '
+                f'pinned to workspace_schema={server_config.workspace_schema!r}.'
             )
+            config = dataclasses.replace(config, workspace_schema=server_config.workspace_schema)
 
         if own_stack_storage_api_url and not is_same_stack(config.storage_api_url, own_stack_storage_api_url):
             LOG.warning(

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -300,6 +300,7 @@ class SessionStateMiddleware(fmw.Middleware):
         # of Authorization (see below), so the set of sensitive header names logging could sweep up
         # here is no longer just Storage tokens.
         LOG.debug(f'Injecting headers: http_rq={http_rq}, header_names={list(http_rq.headers.keys())}')
+        server_config = config
         config = config.replace_by(http_rq.headers)
 
         # A programmatic bearer token (kbc_at_/kbc_pat_) is sent as `Authorization: Bearer <token>`,
@@ -310,6 +311,27 @@ class SessionStateMiddleware(fmw.Middleware):
         # bearer scheme downstream as if it were a Storage token.
         if not config.storage_token and is_programmatic_token(auth_header := http_rq.headers.get('Authorization')):
             config = dataclasses.replace(config, storage_token=strip_bearer(auth_header))
+
+        # A workspace pin (`workspace_id`/`workspace_schema`) configured on the server fences
+        # off which project data a request can reach -- mirror the `own_stack_storage_api_url`
+        # reasoning above: a deployment that pinned itself must not be overridable by a header.
+        # A server with no pin of its own (the shared multi-tenant case, e.g. AJDA-3052's Data
+        # App flow) keeps taking the pin from the request, which is the only source it has.
+        if server_config.workspace_id or server_config.workspace_schema:
+            if (
+                config.workspace_id != server_config.workspace_id
+                or config.workspace_schema != server_config.workspace_schema
+            ):
+                LOG.warning(
+                    f'Ignoring the requested workspace pin (workspace_id={config.workspace_id!r}, '
+                    f'workspace_schema={config.workspace_schema!r}); this server is pinned to '
+                    f'workspace_id={server_config.workspace_id!r}, workspace_schema={server_config.workspace_schema!r}.'
+                )
+                config = dataclasses.replace(
+                    config,
+                    workspace_id=server_config.workspace_id,
+                    workspace_schema=server_config.workspace_schema,
+                )
 
         if own_stack_storage_api_url and not is_same_stack(config.storage_api_url, own_stack_storage_api_url):
             LOG.warning(

--- a/src/keboola_mcp_server/preview.py
+++ b/src/keboola_mcp_server/preview.py
@@ -108,7 +108,10 @@ async def _extract_coordinates(
             configuration_row_id=tool_params.get('configuration_row_id'),
         )
     elif tool_name == 'update_sql_transformation':
-        sql_dialect = await workspace_manager.get_sql_dialect()
+        # The SQL-transformation component id is project-level identity (which component a
+        # transformation runs under), not the session's query target -- must not follow a
+        # `workspace_id` pin, same reasoning as `get_data_app_workspace_id()`.
+        sql_dialect = await workspace_manager.get_data_app_sql_dialect()
         return ConfigCoordinates(
             component_id=get_sql_transformation_id_from_sql_dialect(sql_dialect),
             configuration_id=tool_params.get('configuration_id'),

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -473,9 +473,11 @@ async def create_sql_transformation(
         - returns the created SQL transformation configuration if successful.
     """
 
-    # Get the SQL dialect to use the correct transformation ID (Snowflake or BigQuery)
+    # Get the SQL dialect to use the correct transformation ID (Snowflake or BigQuery). This is
+    # project-level identity (which component the transformation runs under), not the session's
+    # query target -- must not follow a `workspace_id` pin, same as `get_data_app_workspace_id()`.
     # This can raise an exception if workspace is not set or different backend than BigQuery or Snowflake is used
-    sql_dialect = await WorkspaceManager.from_state(ctx.session.state).get_sql_dialect()
+    sql_dialect = await WorkspaceManager.from_state(ctx.session.state).get_data_app_sql_dialect()
     component_id = get_sql_transformation_id_from_sql_dialect(sql_dialect)
     LOG.info(f'Creating transformation. SQL dialect: {sql_dialect}, using transformation ID: {component_id}')
 
@@ -854,7 +856,9 @@ async def update_sql_transformation(
     """
     client = KeboolaClient.from_state(ctx.session.state)
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
-    sql_dialect = await workspace_manager.get_sql_dialect()
+    # Project-level identity (which component the transformation runs under) -- must not follow a
+    # `workspace_id` pin, same as `get_data_app_workspace_id()`.
+    sql_dialect = await workspace_manager.get_data_app_sql_dialect()
     sql_transformation_id = get_sql_transformation_id_from_sql_dialect(sql_dialect)
 
     links_manager = await ProjectLinksManager.from_client(client)
@@ -985,7 +989,9 @@ async def update_sql_transformation_internal(
     storage: dict[str, Any] | None = None,
     folder: str | None = None,
 ) -> tuple[JsonDict, JsonDict, str, dict | None]:
-    sql_dialect = await workspace_manager.get_sql_dialect()
+    # Project-level identity (which component the transformation runs under) -- must not follow a
+    # `workspace_id` pin, same as `get_data_app_workspace_id()`.
+    sql_dialect = await workspace_manager.get_data_app_sql_dialect()
     sql_transformation_id = get_sql_transformation_id_from_sql_dialect(sql_dialect)
     try:
         config_details = await client.storage_client.configuration_detail(

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -553,7 +553,7 @@ async def modify_streamlit_data_app(
 
     project_id = await client.storage_client.project_id()
     workspace_id = await workspace_manager.get_data_app_workspace_id()
-    sql_dialect = await workspace_manager.get_sql_dialect()
+    sql_dialect = await workspace_manager.get_data_app_sql_dialect()
     branch_id = await workspace_manager.get_data_app_branch_id()
 
     secrets = _get_secrets(
@@ -720,7 +720,7 @@ async def modify_streamlit_data_app_internal(
         packages,
         authentication_type,
         secrets,
-        await workspace_manager.get_sql_dialect(),
+        await workspace_manager.get_data_app_sql_dialect(),
     )
     updated_config = cast(
         JsonDict,

--- a/src/keboola_mcp_server/tools/data_apps.py
+++ b/src/keboola_mcp_server/tools/data_apps.py
@@ -552,9 +552,9 @@ async def modify_streamlit_data_app(
     links_manager = await ProjectLinksManager.from_client(client)
 
     project_id = await client.storage_client.project_id()
-    workspace_id = await workspace_manager.get_workspace_id()
+    workspace_id = await workspace_manager.get_data_app_workspace_id()
     sql_dialect = await workspace_manager.get_sql_dialect()
-    branch_id = await workspace_manager.get_branch_id()
+    branch_id = await workspace_manager.get_data_app_branch_id()
 
     secrets = _get_secrets(
         workspace_id=str(workspace_id),
@@ -708,8 +708,8 @@ async def modify_streamlit_data_app_internal(
     folder: str | None = None,
 ) -> tuple[DataApp, JsonDict, dict | None]:
     secrets = _get_secrets(
-        workspace_id=str(await workspace_manager.get_workspace_id()),
-        branch_id=str(await workspace_manager.get_branch_id()),
+        workspace_id=str(await workspace_manager.get_data_app_workspace_id()),
+        branch_id=str(await workspace_manager.get_data_app_branch_id()),
     )
     data_app = await _fetch_data_app(client, configuration_id=configuration_id, data_app_id=None)
     existing_config = data_app.configuration
@@ -1096,7 +1096,7 @@ async def modify_python_js_data_app(
     legacy_secrets: dict[str, Any] | None = None
     if not has_storage_workspace:
         workspace_manager = WorkspaceManager.from_state(ctx.session.state)
-        legacy_secrets = {SECRET_WORKSPACE_ID: str(await workspace_manager.get_workspace_id())}
+        legacy_secrets = {SECRET_WORKSPACE_ID: str(await workspace_manager.get_data_app_workspace_id())}
 
     if configuration_id:
         # Update existing python-js data app

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -544,13 +544,21 @@ class _BigQueryWorkspace(_Workspace):
         return message
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class _WspInfo:
     id: int
     schema: str
     backend: str
     credentials: str | None  # the backend credentials; it can contain serialized JSON data
     readonly: bool | None
+
+    def __repr__(self) -> str:
+        # Redact `credentials` (the backend's credential blob, e.g. a service-account JSON for
+        # BigQuery) so a bare `LOG.info(f'... {info}')` anywhere can never leak it.
+        return (
+            f'_WspInfo(id={self.id!r}, schema={self.schema!r}, backend={self.backend!r}, '
+            f'credentials={"****" if self.credentials else None}, readonly={self.readonly!r})'
+        )
 
     @staticmethod
     def from_sapi_info(sapi_wsp_info: Mapping[str, Any]) -> '_WspInfo':
@@ -624,6 +632,8 @@ class WorkspaceManager:
         self._kubernetes_token_path = kubernetes_token_path
         self._provisioning_client: AsyncStorageClient | None = None
         self._workspace: _Workspace | None = None
+        # Separate cache for the pin-agnostic managed workspace -- see `_get_managed_workspace`.
+        self._managed_workspace: _Workspace | None = None
         self._table_info_cache: dict[str, DbTableInfo] = {}
 
     async def _provisioning_storage_client(self) -> AsyncStorageClient:
@@ -666,24 +676,42 @@ class WorkspaceManager:
 
         return None
 
-    async def _find_ws_by_id(self, workspace_id: str | int) -> _WspInfo | None:
-        """Finds the workspace info by its ID."""
-
+    @staticmethod
+    async def _fetch_ws(client: KeboolaClient, workspace_id: str | int) -> _WspInfo | None:
+        """Fetches the workspace info by its ID from the given client, or None if the id does
+        not resolve on it. A 400/403 is treated the same as a 404: the id is caller-supplied and
+        unvalidated, so a malformed or inaccessible id means the same thing -- "not usable" here.
+        """
         try:
-            sapi_wsp_info = await self._client.storage_client.workspace_detail(workspace_id)
-            assert isinstance(sapi_wsp_info, dict)
-            wi = _WspInfo.from_sapi_info(sapi_wsp_info)  # type: ignore[attr-defined]
-
-            if wi.id and wi.backend and wi.schema:
-                return wi
-            else:
-                raise ValueError(f'Invalid workspace info: {sapi_wsp_info}')
-
+            sapi_wsp_info = await client.storage_client.workspace_detail(workspace_id)
         except HTTPStatusError as e:
-            if e.response.status_code == 404:
+            if e.response.status_code in (400, 403, 404):
                 return None
-            else:
-                raise
+            raise
+
+        assert isinstance(sapi_wsp_info, dict)
+        wi = _WspInfo.from_sapi_info(sapi_wsp_info)  # type: ignore[attr-defined]
+        if wi.id and wi.backend and wi.schema:
+            return wi
+        raise ValueError(f'Invalid workspace info: {sapi_wsp_info}')
+
+    async def _find_ws_by_id(self, workspace_id: str | int) -> _WspInfo | None:
+        """Finds the workspace info by its ID.
+
+        Tries this manager's own (possibly branch-bound) client first, then -- since a
+        workspace is not necessarily tied to the branch this manager happens to be bound to
+        (e.g. a Data App's workspace is project-wide) -- falls back to the production-branch
+        client if that differs. `workspace_detail` is branch-scoped, so skipping this fallback
+        would 404 for a workspace that only lives on the other branch even though the id exists
+        in the project.
+        """
+        if info := await self._fetch_ws(self._client, workspace_id):
+            return info
+        if self._client.branch_id is not None:
+            prod_client = await self._client.with_branch_id(None)
+            if info := await self._fetch_ws(prod_client, workspace_id):
+                return info
+        return None
 
     async def _find_ws_in_branch(self) -> _WspInfo | None:
         """Finds the shared read-only MCP workspace in the current branch.
@@ -824,19 +852,52 @@ class WorkspaceManager:
             raise ValueError(f'Unexpected backend type "{info.backend}" in workspace: {info.schema}')
 
     async def _get_workspace(self) -> _Workspace:
+        """The workspace queries run against -- honors an explicit `workspace_id` pin (e.g. a
+        Data App's own workspace) ahead of `workspace_schema` and the default MCP-managed
+        workspace. Pin-aware: do not use this for anything attributed back to the *session's
+        own* identity rather than the query target (e.g. a data app's own persisted config) --
+        use `_get_managed_workspace()`/`get_data_app_workspace_id()`/`get_data_app_branch_id()`
+        for that instead (see AI-3669 review, mcp.py:373 thread).
+        """
         if self._workspace:
             return self._workspace
 
-        if self._workspace_id:
+        if self._workspace_id is not None:
             # use the workspace that was explicitly requested (e.g. a Data App's own workspace)
             # this workspace must never be written to the default branch metadata
             LOG.info(f'Looking up workspace by id: {self._workspace_id}')
-            if info := await self._find_ws_by_id(self._workspace_id):
-                LOG.info(f'Found workspace: {info}')
-                self._workspace = self._init_workspace(info)
-                return self._workspace
-            else:
-                raise ValueError(f'No Keboola workspace found: workspace_id={self._workspace_id}')
+            info = await self._find_ws_by_id(self._workspace_id)
+            if info is None:
+                raise ValueError(
+                    f'No Keboola workspace found: workspace_id={self._workspace_id}, branch_id={self._client.branch_id}'
+                )
+            if not info.readonly:
+                # Every other resolution path enforces read-only storage access; this is a
+                # caller-supplied id, so it *could* widen `query_data` from read-only to
+                # read-write. Not hard-enforced here -- whether a Data App's platform-provisioned
+                # workspace is actually read-only is unconfirmed (needs checking against a real
+                # stack); enforcing blindly could break the feature outright. Warn for now; if it
+                # turns out these workspaces are read-only, promote this to a raise. Either way,
+                # `tools/sql.py` has no SELECT-only guard of its own, which is the real missing
+                # control and worth a follow-up regardless of this policy.
+                LOG.warning(f'Pinned workspace {self._workspace_id} has no read-only storage access.')
+            LOG.info(f'Found workspace: {info}')
+            self._workspace = self._init_workspace(info)
+            return self._workspace
+
+        self._workspace = await self._get_managed_workspace()
+        return self._workspace
+
+    async def _get_managed_workspace(self) -> _Workspace:
+        """The MCP-managed workspace, honoring `workspace_schema` but ignoring any `workspace_id`
+        pin: `workspace_schema` first, then the default per-branch MCP-managed workspace.
+
+        Data apps persist this id into their own configuration (`SECRET_WORKSPACE_ID`), so it
+        must never be the caller-supplied `workspace_id` pin of whichever session happened to
+        create/update the app -- see `get_data_app_workspace_id()`/`get_data_app_branch_id()`.
+        """
+        if self._managed_workspace:
+            return self._managed_workspace
 
         if self._workspace_schema:
             # use the workspace that was explicitly requested
@@ -844,8 +905,8 @@ class WorkspaceManager:
             LOG.info(f'Looking up workspace by schema: {self._workspace_schema}')
             if info := await self._find_ws_by_schema(self._workspace_schema):
                 LOG.info(f'Found workspace: {info}')
-                self._workspace = self._init_workspace(info)
-                return self._workspace
+                self._managed_workspace = self._init_workspace(info)
+                return self._managed_workspace
             else:
                 raise ValueError(
                     f'No Keboola workspace found or the workspace has no read-only storage access: '
@@ -856,8 +917,8 @@ class WorkspaceManager:
         if info := await self._find_ws_in_branch():
             # use the workspace that has already been created by the MCP server and noted to the branch
             LOG.info(f'Found workspace: {info}')
-            self._workspace = self._init_workspace(info)
-            return self._workspace
+            self._managed_workspace = self._init_workspace(info)
+            return self._managed_workspace
 
         # create a new workspace under the MCP component
         LOG.info('Creating workspace in the default branch.')
@@ -867,8 +928,8 @@ class WorkspaceManager:
             # written, so no elevated metadata write is needed. Concurrent first-use
             # may create more than one workspace; that is acceptable, _find_ws_in_branch
             # returns the first match on the next lookup.
-            self._workspace = self._init_workspace(info)
-            return self._workspace
+            self._managed_workspace = self._init_workspace(info)
+            return self._managed_workspace
         else:
             raise ValueError('Failed to initialize Keboola Workspace.')
 
@@ -915,4 +976,21 @@ class WorkspaceManager:
 
     async def get_branch_id(self) -> str:
         workspace = await self._get_workspace()
+        return await workspace.get_branch_id()
+
+    async def get_data_app_workspace_id(self) -> int:
+        """The MCP-managed workspace's id, ignoring any `workspace_id` pin.
+
+        Use this (not `get_workspace_id()`) for anything written into a data app's own
+        persisted configuration (e.g. `SECRET_WORKSPACE_ID`) -- a session pinned to one Data
+        App's workspace must not leak that id into a *different* app's config when creating or
+        updating it. See AI-3669 review (mcp.py:373 thread).
+        """
+        workspace = await self._get_managed_workspace()
+        return workspace.id
+
+    async def get_data_app_branch_id(self) -> str:
+        """The MCP-managed workspace's branch id, ignoring any `workspace_id` pin. See
+        `get_data_app_workspace_id()`."""
+        workspace = await self._get_managed_workspace()
         return await workspace.get_branch_id()

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -677,15 +677,21 @@ class WorkspaceManager:
         return None
 
     @staticmethod
-    async def _fetch_ws(client: KeboolaClient, workspace_id: str | int) -> _WspInfo | None:
+    async def _fetch_ws(client: KeboolaClient, workspace_id: str | int, *, strict: bool = False) -> _WspInfo | None:
         """Fetches the workspace info by its ID from the given client, or None if the id does
-        not resolve on it. A 400/403 is treated the same as a 404: the id is caller-supplied and
-        unvalidated, so a malformed or inaccessible id means the same thing -- "not usable" here.
+        not resolve on it.
+
+        :param strict: if False (default), a 400/403 is treated the same as a 404: the id is
+            caller-supplied and unvalidated, so a malformed or inaccessible id means the same
+            thing -- "not usable" here. Pass True when the id is already known-good (e.g. a
+            workspace this server just created), so a permission or validation error on the
+            follow-up lookup is raised instead of being mistaken for "workspace doesn't exist".
         """
         try:
             sapi_wsp_info = await client.storage_client.workspace_detail(workspace_id)
         except HTTPStatusError as e:
-            if e.response.status_code in (400, 403, 404):
+            not_found_codes = (404,) if strict else (400, 403, 404)
+            if e.response.status_code in not_found_codes:
                 return None
             raise
 
@@ -695,7 +701,7 @@ class WorkspaceManager:
             return wi
         raise ValueError(f'Invalid workspace info: {sapi_wsp_info}')
 
-    async def _find_ws_by_id(self, workspace_id: str | int) -> _WspInfo | None:
+    async def _find_ws_by_id(self, workspace_id: str | int, *, strict: bool = False) -> _WspInfo | None:
         """Finds the workspace info by its ID.
 
         Tries this manager's own (possibly branch-bound) client first, then -- since a
@@ -703,13 +709,18 @@ class WorkspaceManager:
         (e.g. a Data App's workspace is project-wide) -- falls back to the production-branch
         client if that differs. `workspace_detail` is branch-scoped, so skipping this fallback
         would 404 for a workspace that only lives on the other branch even though the id exists
-        in the project.
+        in the project. When the fallback is the one that resolves it, this manager rebinds to
+        that client so subsequent queries run against the branch the workspace was actually
+        found on, not the branch it started on.
+
+        :param strict: see `_fetch_ws`.
         """
-        if info := await self._fetch_ws(self._client, workspace_id):
+        if info := await self._fetch_ws(self._client, workspace_id, strict=strict):
             return info
         if self._client.branch_id is not None:
             prod_client = await self._client.with_branch_id(None)
-            if info := await self._fetch_ws(prod_client, workspace_id):
+            if info := await self._fetch_ws(prod_client, workspace_id, strict=strict):
+                self._client = prod_client
                 return info
         return None
 
@@ -819,7 +830,7 @@ class WorkspaceManager:
 
                 workspace_id = job_results['id']
                 LOG.info(f'Created workspace: {workspace_id}')
-                return await self._find_ws_by_id(workspace_id)
+                return await self._find_ws_by_id(workspace_id, strict=True)
 
             elif duration > timeout_sec:
                 LOG.info(f'Workspace creation timed out after {duration:.2f} seconds.')
@@ -856,8 +867,8 @@ class WorkspaceManager:
         Data App's own workspace) ahead of `workspace_schema` and the default MCP-managed
         workspace. Pin-aware: do not use this for anything attributed back to the *session's
         own* identity rather than the query target (e.g. a data app's own persisted config) --
-        use `_get_managed_workspace()`/`get_data_app_workspace_id()`/`get_data_app_branch_id()`
-        for that instead (see AI-3669 review, mcp.py:373 thread).
+        use `_get_managed_workspace()`/`get_data_app_workspace_id()`/`get_data_app_branch_id()`/
+        `get_data_app_sql_dialect()` for that instead.
         """
         if self._workspace:
             return self._workspace
@@ -919,6 +930,18 @@ class WorkspaceManager:
             LOG.info(f'Found workspace: {info}')
             self._managed_workspace = self._init_workspace(info)
             return self._managed_workspace
+
+        if self._workspace_id is not None:
+            # A pinned session (e.g. a Data App session using `X-Workspace-Id`) has no reason to
+            # provision a brand new MCP-managed workspace of its own -- that workspace would be
+            # billed and owned by this session's token, not the caller who actually needs it, and
+            # provisioning can outright fail on a read-only token. Only an already-existing
+            # managed workspace is usable here; if none exists yet, that is a real "not
+            # available" case, not something to paper over by creating one.
+            raise ValueError(
+                f'No MCP-managed workspace exists for this project/branch, and one will not be '
+                f'created for a session pinned to workspace_id={self._workspace_id}.'
+            )
 
         # create a new workspace under the MCP component
         LOG.info('Creating workspace in the default branch.')
@@ -984,7 +1007,7 @@ class WorkspaceManager:
         Use this (not `get_workspace_id()`) for anything written into a data app's own
         persisted configuration (e.g. `SECRET_WORKSPACE_ID`) -- a session pinned to one Data
         App's workspace must not leak that id into a *different* app's config when creating or
-        updating it. See AI-3669 review (mcp.py:373 thread).
+        updating it.
         """
         workspace = await self._get_managed_workspace()
         return workspace.id
@@ -994,3 +1017,11 @@ class WorkspaceManager:
         `get_data_app_workspace_id()`."""
         workspace = await self._get_managed_workspace()
         return await workspace.get_branch_id()
+
+    async def get_data_app_sql_dialect(self) -> str:
+        """The MCP-managed workspace's SQL dialect, ignoring any `workspace_id` pin. See
+        `get_data_app_workspace_id()` -- the dialect baked into a data app's generated source
+        code must match the workspace whose id/branch are persisted into that same app, not
+        whichever workspace the creating/updating session happened to be pinned to."""
+        workspace = await self._get_managed_workspace()
+        return workspace.get_sql_dialect()

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -701,27 +701,30 @@ class WorkspaceManager:
             return wi
         raise ValueError(f'Invalid workspace info: {sapi_wsp_info}')
 
-    async def _find_ws_by_id(self, workspace_id: str | int, *, strict: bool = False) -> _WspInfo | None:
-        """Finds the workspace info by its ID.
+    async def _find_ws_by_id(
+        self, workspace_id: str | int, *, strict: bool = False
+    ) -> tuple[_WspInfo, KeboolaClient] | None:
+        """Finds the workspace info by its ID, together with the client it was actually resolved
+        on.
 
         Tries this manager's own (possibly branch-bound) client first, then -- since a
         workspace is not necessarily tied to the branch this manager happens to be bound to
         (e.g. a Data App's workspace is project-wide) -- falls back to the production-branch
         client if that differs. `workspace_detail` is branch-scoped, so skipping this fallback
         would 404 for a workspace that only lives on the other branch even though the id exists
-        in the project. When the fallback is the one that resolves it, this manager rebinds to
-        that client so subsequent queries run against the branch the workspace was actually
-        found on, not the branch it started on.
+        in the project. The resolving client is returned rather than assigned to `self._client`,
+        so that resolving one pinned workspace this way does not silently rebind *this manager's*
+        client -- and with it every other lookup this manager makes (e.g. the MCP-managed
+        workspace via `_find_ws_in_branch`) -- onto a different branch.
 
         :param strict: see `_fetch_ws`.
         """
         if info := await self._fetch_ws(self._client, workspace_id, strict=strict):
-            return info
+            return info, self._client
         if self._client.branch_id is not None:
             prod_client = await self._client.with_branch_id(None)
             if info := await self._fetch_ws(prod_client, workspace_id, strict=strict):
-                self._client = prod_client
-                return info
+                return info, prod_client
         return None
 
     async def _find_ws_in_branch(self) -> _WspInfo | None:
@@ -746,16 +749,18 @@ class WorkspaceManager:
 
         return None
 
-    async def _create_ws(self, *, timeout_sec: float = 300.0) -> _WspInfo | None:
+    async def _create_ws(self, *, timeout_sec: float = 300.0) -> tuple[_WspInfo, KeboolaClient] | None:
         """
-        Creates a new workspace under a component configuration and returns its info.
+        Creates a new workspace under a component configuration and returns its info, together
+        with the client it was resolved on (see `_find_ws_by_id`).
 
         The workspace is created under the MCP_WORKSPACE_COMPONENT_ID component so that
         it is correctly attributed for billing. This method creates the configuration,
         creates the workspace under it, and cleans up the configuration on failure.
 
         :param timeout_sec: The number of seconds to wait for the workspace creation job to finish.
-        :return: The workspace info if the workspace was created successfully, None otherwise.
+        :return: The workspace info and resolving client if the workspace was created successfully,
+            None otherwise.
         """
 
         # Verify token before creating workspace to ensure it has proper permissions
@@ -840,11 +845,17 @@ class WorkspaceManager:
                 remaining_time = max(0.0, timeout_sec - duration)
                 await asyncio.sleep(min(5.0, remaining_time))
 
-    def _init_workspace(self, info: _WspInfo) -> _Workspace:
-        """Creates a new `Workspace` instance based on the workspace info."""
+    def _init_workspace(self, info: _WspInfo, *, client: KeboolaClient | None = None) -> _Workspace:
+        """Creates a new `Workspace` instance based on the workspace info.
+
+        :param client: the client the workspace's queries should run through; defaults to this
+            manager's own client. Pass the client the info was actually resolved on when it
+            differs (see `_find_ws_by_id`), without changing this manager's own client.
+        """
+        client = client if client is not None else self._client
 
         if info.backend == 'snowflake':
-            return _SnowflakeWorkspace(workspace_id=info.id, schema=info.schema, client=self._client)
+            return _SnowflakeWorkspace(workspace_id=info.id, schema=info.schema, client=client)
 
         elif info.backend == 'bigquery':
             credentials = json.loads(info.credentials or '{}')
@@ -853,7 +864,7 @@ class WorkspaceManager:
                     workspace_id=info.id,
                     dataset_id=info.schema,
                     project_id=project_id,
-                    client=self._client,
+                    client=client,
                 )
 
             else:
@@ -877,11 +888,12 @@ class WorkspaceManager:
             # use the workspace that was explicitly requested (e.g. a Data App's own workspace)
             # this workspace must never be written to the default branch metadata
             LOG.info(f'Looking up workspace by id: {self._workspace_id}')
-            info = await self._find_ws_by_id(self._workspace_id)
-            if info is None:
+            result = await self._find_ws_by_id(self._workspace_id)
+            if result is None:
                 raise ValueError(
                     f'No Keboola workspace found: workspace_id={self._workspace_id}, branch_id={self._client.branch_id}'
                 )
+            info, resolved_client = result
             if not info.readonly:
                 # Every other resolution path enforces read-only storage access; this is a
                 # caller-supplied id, so it *could* widen `query_data` from read-only to
@@ -893,7 +905,7 @@ class WorkspaceManager:
                 # control and worth a follow-up regardless of this policy.
                 LOG.warning(f'Pinned workspace {self._workspace_id} has no read-only storage access.')
             LOG.info(f'Found workspace: {info}')
-            self._workspace = self._init_workspace(info)
+            self._workspace = self._init_workspace(info, client=resolved_client)
             return self._workspace
 
         self._workspace = await self._get_managed_workspace()
@@ -945,13 +957,14 @@ class WorkspaceManager:
 
         # create a new workspace under the MCP component
         LOG.info('Creating workspace in the default branch.')
-        if info := await self._create_ws():
+        if result := await self._create_ws():
             # All tokens share the same read-only workspace, rediscovered by its
             # component id (see _find_ws_in_branch) — no branch-metadata pointer is
             # written, so no elevated metadata write is needed. Concurrent first-use
             # may create more than one workspace; that is acceptable, _find_ws_in_branch
             # returns the first match on the next lookup.
-            self._managed_workspace = self._init_workspace(info)
+            info, resolved_client = result
+            self._managed_workspace = self._init_workspace(info, client=resolved_client)
             return self._managed_workspace
         else:
             raise ValueError('Failed to initialize Keboola Workspace.')

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -700,11 +700,12 @@ class WorkspaceManager:
         wi = _WspInfo.from_sapi_info(sapi_wsp_info)  # type: ignore[attr-defined]
         if wi.id and wi.backend and wi.schema:
             return wi
-        raise ValueError(f'Invalid workspace info: {sapi_wsp_info}')
+        # `wi!r` (not `sapi_wsp_info`), so `_WspInfo.__repr__`'s credential redaction actually
+        # applies here -- the raw dict's `connection.user` is the backend's credential blob, and
+        # `workspace_id` is now caller-supplied, so this path is reachable with untrusted input.
+        raise ValueError(f'Invalid workspace info: {wi!r}')
 
-    async def _find_ws_by_id(
-        self, workspace_id: str | int, *, strict: bool = False
-    ) -> tuple[_WspInfo, KeboolaClient] | None:
+    async def _find_ws_by_id(self, workspace_id: str | int) -> tuple[_WspInfo, KeboolaClient] | None:
         """Finds the workspace info by its ID, together with the client it was actually resolved
         on.
 
@@ -717,14 +718,12 @@ class WorkspaceManager:
         so that resolving one pinned workspace this way does not silently rebind *this manager's*
         client -- and with it every other lookup this manager makes (e.g. the MCP-managed
         workspace via `_find_ws_in_branch`) -- onto a different branch.
-
-        :param strict: see `_fetch_ws`.
         """
-        if info := await self._fetch_ws(self._client, workspace_id, strict=strict):
+        if info := await self._fetch_ws(self._client, workspace_id):
             return info, self._client
         if self._client.branch_id is not None:
             prod_client = await self._client.with_branch_id(None)
-            if info := await self._fetch_ws(prod_client, workspace_id, strict=strict):
+            if info := await self._fetch_ws(prod_client, workspace_id):
                 return info, prod_client
         return None
 
@@ -969,7 +968,9 @@ class WorkspaceManager:
             # available" case, not something to paper over by creating one.
             raise ValueError(
                 f'No MCP-managed workspace exists for this project/branch, and one will not be '
-                f'created for a session pinned to workspace_id={self._workspace_id}.'
+                f'created for a session pinned to workspace_id={self._workspace_id}. Run one '
+                f'unpinned session (without an X-Workspace-Id header) against this project/branch '
+                f'first to provision it.'
             )
 
         # create a new workspace under the MCP component

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -692,6 +692,7 @@ class WorkspaceManager:
         except HTTPStatusError as e:
             not_found_codes = (404,) if strict else (400, 403, 404)
             if e.response.status_code in not_found_codes:
+                LOG.debug(f'Workspace {workspace_id} not resolved on this client: status={e.response.status_code}.')
                 return None
             raise
 
@@ -835,7 +836,12 @@ class WorkspaceManager:
 
                 workspace_id = job_results['id']
                 LOG.info(f'Created workspace: {workspace_id}')
-                return await self._find_ws_by_id(workspace_id, strict=True)
+                # Provisioned through `self._client`, so it is by construction in this manager's
+                # own branch -- fetch it directly rather than through `_find_ws_by_id`, whose
+                # production-branch fallback exists for caller-supplied ids, not ones we just
+                # created ourselves.
+                info = await self._fetch_ws(self._client, workspace_id, strict=True)
+                return (info, self._client) if info else None
 
             elif duration > timeout_sec:
                 LOG.info(f'Workspace creation timed out after {duration:.2f} seconds.')
@@ -894,6 +900,17 @@ class WorkspaceManager:
                     f'No Keboola workspace found: workspace_id={self._workspace_id}, branch_id={self._client.branch_id}'
                 )
             info, resolved_client = result
+            if resolved_client is not self._client:
+                # The pin only resolved via the production-branch fallback (see `_find_ws_by_id`);
+                # `self._client` -- and everything else this manager looks up (get_tables,
+                # get_bucket_detail, get_table_detail) -- stays on this session's own branch, so
+                # queries against this workspace and metadata reads about it now describe two
+                # different branches. Not fixable here without rebinding the whole manager onto
+                # the wrong branch; at minimum make it diagnosable from logs.
+                LOG.warning(
+                    f'Pinned workspace {self._workspace_id} resolved via the production-branch '
+                    f'fallback; other lookups for this session still use branch_id={self._client.branch_id!r}.'
+                )
             if not info.readonly:
                 # Every other resolution path enforces read-only storage access; this is a
                 # caller-supplied id, so it *could* widen `query_data` from read-only to

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -578,6 +578,7 @@ class WorkspaceManager:
         client: KeboolaClient,
         workspace_schema: str | None = None,
         kubernetes_token_path: str | None = None,
+        workspace_id: str | int | None = None,
     ) -> 'WorkspaceManager':
         # On projects with the `storage-branches` feature, each dev branch needs its own
         # workspace so the agent's queries (FQN paths, `query_data`) see that branch's
@@ -588,15 +589,18 @@ class WorkspaceManager:
         # `has_storage_branches` already requires `branch_id is not None`, so the default
         # branch always takes the prod-client path.
         if await has_storage_branches(client):
-            return cls(client, workspace_schema, kubernetes_token_path=kubernetes_token_path)
+            return cls(client, workspace_schema, kubernetes_token_path=kubernetes_token_path, workspace_id=workspace_id)
         prod_client = await client.with_branch_id(None)
-        return cls(prod_client, workspace_schema, kubernetes_token_path=kubernetes_token_path)
+        return cls(
+            prod_client, workspace_schema, kubernetes_token_path=kubernetes_token_path, workspace_id=workspace_id
+        )
 
     def __init__(
         self,
         client: KeboolaClient,
         workspace_schema: str | None = None,
         kubernetes_token_path: str | None = None,
+        workspace_id: str | int | None = None,
     ):
         """
         Initializes the WorkspaceManager.
@@ -611,9 +615,12 @@ class WorkspaceManager:
             JWT as the X-Kubernetes-Authorization step-up header alongside the user's
             own token, so Connection can waive permissions the user's token lacks
             (e.g. read-only users).
+        :param workspace_id: The ID of the workspace to use (e.g. a Data App's own workspace).
+            Takes precedence over `workspace_schema` when both are set.
         """
         self._client = client
         self._workspace_schema = workspace_schema
+        self._workspace_id = workspace_id
         self._kubernetes_token_path = kubernetes_token_path
         self._provisioning_client: AsyncStorageClient | None = None
         self._workspace: _Workspace | None = None
@@ -819,6 +826,17 @@ class WorkspaceManager:
     async def _get_workspace(self) -> _Workspace:
         if self._workspace:
             return self._workspace
+
+        if self._workspace_id:
+            # use the workspace that was explicitly requested (e.g. a Data App's own workspace)
+            # this workspace must never be written to the default branch metadata
+            LOG.info(f'Looking up workspace by id: {self._workspace_id}')
+            if info := await self._find_ws_by_id(self._workspace_id):
+                LOG.info(f'Found workspace: {info}')
+                self._workspace = self._init_workspace(info)
+                return self._workspace
+            else:
+                raise ValueError(f'No Keboola workspace found: workspace_id={self._workspace_id}')
 
         if self._workspace_schema:
             # use the workspace that was explicitly requested

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from keboola_mcp_server.cli import parse_args
+
+
+def test_parse_args_workspace_id() -> None:
+    parsed = parse_args(['--workspace-id', 'ws-123'])
+    assert parsed.workspace_id == 'ws-123'
+
+
+def test_parse_args_workspace_id_defaults_to_none() -> None:
+    parsed = parse_args([])
+    assert parsed.workspace_id is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,8 @@ from keboola_mcp_server.cli import parse_args
 
 
 def test_parse_args_workspace_id() -> None:
-    parsed = parse_args(['--workspace-id', 'ws-123'])
-    assert parsed.workspace_id == 'ws-123'
+    parsed = parse_args(['--workspace-id', '123'])
+    assert parsed.workspace_id == '123'
 
 
 def test_parse_args_workspace_id_defaults_to_none() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,16 @@
+import pytest
+
 from keboola_mcp_server.cli import parse_args
 
 
-def test_parse_args_workspace_id() -> None:
-    parsed = parse_args(['--workspace-id', '123'])
-    assert parsed.workspace_id == '123'
-
-
-def test_parse_args_workspace_id_defaults_to_none() -> None:
-    parsed = parse_args([])
-    assert parsed.workspace_id is None
+@pytest.mark.parametrize(
+    ('args', 'expected'),
+    [
+        (['--workspace-id', '123'], '123'),
+        ([], None),
+    ],
+    ids=['workspace_id_set', 'workspace_id_defaults_to_none'],
+)
+def test_parse_args_workspace_id(args: list[str], expected: str | None) -> None:
+    parsed = parse_args(args)
+    assert parsed.workspace_id == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,30 +112,31 @@ class TestConfig:
                 {'X-Workspace-Schema': ''},
                 Config(workspace_schema=''),
             ),
-            (
-                # A malformed workspace_id header must degrade to "not provided" rather than
-                # raising -- it is untrusted per-request input, so a junk value from a client
-                # should drop the pin, not turn into an unhandled server error.
-                Config(),
-                {'X-Workspace-Id': 'abc'},
-                Config(),
-            ),
-            (
-                # A malformed header must not clear an existing server-configured pin either.
-                Config(workspace_id='999'),
-                {'X-Workspace-Id': 'abc'},
-                Config(workspace_id='999'),
-            ),
         ],
     )
     def test_replace_by(self, orig: Config, d: Mapping[str, str], expected: Config) -> None:
         assert orig.replace_by(d) == expected
 
-    def test_replace_by_reraises_non_workspace_id_error(self) -> None:
-        """A malformed value for a field other than `workspace_id` (e.g. a header that fails the
-        URL check) must not be masked by the `workspace_id` degrade-to-absent path -- there is no
-        junk `workspace_id` here to drop, so the request should still fail loudly rather than log
-        a misleading "ignoring" message and re-raise the same, still-unhandled error anyway."""
+    @pytest.mark.parametrize(
+        ('orig', 'd'),
+        [
+            # A malformed workspace_id always raises, same as any other invalid field -- it is
+            # a per-request caller's job (e.g. `apply_request_config`) to decide how to turn that
+            # into a clean rejection, not `replace_by`'s job to silently drop the pin (which would
+            # widen an unpinned multi-tenant session's scope instead of rejecting the request).
+            (Config(), {'X-Workspace-Id': 'abc'}),
+            # A malformed header must not be treated any differently when it would have
+            # overridden an existing server-configured pin.
+            (Config(workspace_id='999'), {'X-Workspace-Id': 'abc'}),
+        ],
+    )
+    def test_replace_by_reraises_malformed_workspace_id(self, orig: Config, d: Mapping[str, str]) -> None:
+        with pytest.raises(ValueError, match='Invalid workspace_id'):
+            orig.replace_by(d)
+
+    def test_replace_by_reraises_other_errors(self) -> None:
+        """A malformed value for an unrelated field (e.g. a header that fails the URL check)
+        must also raise, exactly like a malformed `workspace_id` does."""
         with pytest.raises(ValueError, match='Invalid URL'):
             Config().replace_by({'X-Storage-Api-Url': '???'})
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,14 @@ class TestConfig:
                 Config(storage_token='foo', workspace_schema='bar'),
             ),
             (
+                {'storage_token': 'foo', 'workspace_id': '123'},
+                Config(storage_token='foo', workspace_id='123'),
+            ),
+            (
+                {'X-Workspace-Id': '123'},
+                Config(workspace_id='123'),
+            ),
+            (
                 {'foo': 'bar', 'storage_api_url': 'http://nowhere'},
                 Config(storage_api_url='http://nowhere'),
             ),
@@ -67,6 +75,11 @@ class TestConfig:
             (Config(branch_id='foo'), {'branch-id': 'Null'}, Config()),
             (Config(branch_id='foo'), {'branch-id': 'Default'}, Config()),
             (Config(branch_id='foo'), {'branch-id': 'pRoDuCtIoN'}, Config()),
+            (
+                Config(),
+                {'storage_token': 'foo', 'workspace_id': '123'},
+                Config(storage_token='foo', workspace_id='123'),
+            ),
         ],
     )
     def test_replace_by(self, orig: Config, d: Mapping[str, str], expected: Config) -> None:
@@ -81,6 +94,7 @@ class TestConfig:
         config = Config(storage_token='foo')
         assert str(config) == (
             "Config(storage_api_url=None, storage_token='****', branch_id=None, workspace_schema=None, "
+            'workspace_id=None, '
             'oauth_client_id=None, oauth_client_secret=None, '
             'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
             'jwt_secret=None, bearer_token=None, conversation_id=None, project_id=None)'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,12 +27,24 @@ class TestConfig:
                 Config(storage_token='foo', workspace_schema='bar'),
             ),
             (
+                # workspace_id requires the KBC_/X- prefix -- a bare `workspace_id`/`WORKSPACE_ID`
+                # key must NOT be picked up (it collides with the variable Keboola injects into
+                # Data App containers).
                 {'storage_token': 'foo', 'workspace_id': '123'},
+                Config(storage_token='foo'),
+            ),
+            (
+                {'storage_token': 'foo', 'KBC_WORKSPACE_ID': '123'},
                 Config(storage_token='foo', workspace_id='123'),
             ),
             (
                 {'X-Workspace-Id': '123'},
                 Config(workspace_id='123'),
+            ),
+            (
+                # An empty value means "not provided" for workspace_id/workspace_schema.
+                {'X-Workspace-Id': ''},
+                Config(),
             ),
             (
                 {'foo': 'bar', 'storage_api_url': 'http://nowhere'},
@@ -78,7 +90,18 @@ class TestConfig:
             (
                 Config(),
                 {'storage_token': 'foo', 'workspace_id': '123'},
+                Config(storage_token='foo'),
+            ),
+            (
+                Config(),
+                {'storage_token': 'foo', 'KBC_WORKSPACE_ID': '123'},
                 Config(storage_token='foo', workspace_id='123'),
+            ),
+            (
+                # An empty header must not un-pin a server-configured workspace_id/workspace_schema.
+                Config(workspace_id='999'),
+                {'X-Workspace-Id': ''},
+                Config(workspace_id='999'),
             ),
         ],
     )
@@ -99,6 +122,10 @@ class TestConfig:
             'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
             'jwt_secret=None, bearer_token=None, conversation_id=None, project_id=None)'
         )
+
+    def test_workspace_id_must_be_numeric(self) -> None:
+        with pytest.raises(ValueError, match='Invalid workspace_id'):
+            Config(workspace_id='not-a-valid-id')
 
     @pytest.mark.parametrize(
         ('url', 'expected'),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,7 @@ class TestConfig:
                 Config(workspace_id='123'),
             ),
             (
-                # An empty value means "not provided" for workspace_id/workspace_schema.
+                # An empty value means "not provided" for workspace_id.
                 {'X-Workspace-Id': ''},
                 Config(),
             ),
@@ -98,9 +98,32 @@ class TestConfig:
                 Config(storage_token='foo', workspace_id='123'),
             ),
             (
-                # An empty header must not un-pin a server-configured workspace_id/workspace_schema.
+                # An empty header must not un-pin a server-configured workspace_id.
                 Config(workspace_id='999'),
                 {'X-Workspace-Id': ''},
+                Config(workspace_id='999'),
+            ),
+            (
+                # Unlike workspace_id, an empty workspace_schema header must still clear a
+                # server default (to the falsy '', same as pre-existing main behavior) -- this is
+                # the multi-user opt-out the README describes for X-Workspace-Schema, and must
+                # not regress into keeping the server's pin.
+                Config(workspace_schema='SERVER'),
+                {'X-Workspace-Schema': ''},
+                Config(workspace_schema=''),
+            ),
+            (
+                # A malformed workspace_id header must degrade to "not provided" rather than
+                # raising -- it is untrusted per-request input, so a junk value from a client
+                # should drop the pin, not turn into an unhandled server error.
+                Config(),
+                {'X-Workspace-Id': 'abc'},
+                Config(),
+            ),
+            (
+                # A malformed header must not clear an existing server-configured pin either.
+                Config(workspace_id='999'),
+                {'X-Workspace-Id': 'abc'},
                 Config(workspace_id='999'),
             ),
         ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,6 +131,14 @@ class TestConfig:
     def test_replace_by(self, orig: Config, d: Mapping[str, str], expected: Config) -> None:
         assert orig.replace_by(d) == expected
 
+    def test_replace_by_reraises_non_workspace_id_error(self) -> None:
+        """A malformed value for a field other than `workspace_id` (e.g. a header that fails the
+        URL check) must not be masked by the `workspace_id` degrade-to-absent path -- there is no
+        junk `workspace_id` here to drop, so the request should still fail loudly rather than log
+        a misleading "ignoring" message and re-raise the same, still-unhandled error anyway."""
+        with pytest.raises(ValueError, match='Invalid URL'):
+            Config().replace_by({'X-Storage-Api-Url': '???'})
+
     def test_defaults(self) -> None:
         config = Config()
         for f in dataclasses.fields(Config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,14 @@ class TestConfig:
                 Config(storage_token='foo', workspace_schema='bar'),
             ),
             (
+                {'storage_token': 'foo', 'workspace_id': '123'},
+                Config(storage_token='foo', workspace_id='123'),
+            ),
+            (
+                {'X-Workspace-Id': '123'},
+                Config(workspace_id='123'),
+            ),
+            (
                 {'foo': 'bar', 'storage_api_url': 'http://nowhere'},
                 Config(storage_api_url='http://nowhere'),
             ),
@@ -67,6 +75,11 @@ class TestConfig:
             (Config(branch_id='foo'), {'branch-id': 'Null'}, Config()),
             (Config(branch_id='foo'), {'branch-id': 'Default'}, Config()),
             (Config(branch_id='foo'), {'branch-id': 'pRoDuCtIoN'}, Config()),
+            (
+                Config(),
+                {'storage_token': 'foo', 'workspace_id': '123'},
+                Config(storage_token='foo', workspace_id='123'),
+            ),
         ],
     )
     def test_replace_by(self, orig: Config, d: Mapping[str, str], expected: Config) -> None:
@@ -81,6 +94,7 @@ class TestConfig:
         config = Config(storage_token='foo')
         assert str(config) == (
             "Config(storage_api_url=None, storage_token='****', branch_id=None, workspace_schema=None, "
+            'workspace_id=None, '
             'oauth_client_id=None, oauth_client_secret=None, '
             'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
             'jwt_secret=None, bearer_token=None, conversation_id=None)'

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -859,6 +859,54 @@ class TestSessionStateMiddleware:
 
         assert applied.storage_token == expected_storage_token
 
+    @pytest.mark.parametrize(
+        ('server_kwargs', 'headers', 'expected_workspace_id', 'expected_workspace_schema', 'expect_warning'),
+        [
+            # server pinned by id: header asking for a different id/schema is ignored outright.
+            ({'workspace_id': '111'}, {'X-Workspace-Id': '222'}, '111', None, True),
+            ({'workspace_id': '111'}, {'X-Workspace-Schema': 'OTHER'}, '111', None, True),
+            ({'workspace_id': '111'}, {'X-Workspace-Id': '111'}, '111', None, False),
+            ({'workspace_id': '111'}, {}, '111', None, False),
+            # server pinned by schema: same treatment.
+            ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Schema': 'OTHER'}, None, 'SERVER_SCHEMA', True),
+            # no server-side pin (the shared multi-tenant / AJDA-3052 Data App flow): the header
+            # is the only source, so it keeps working.
+            ({}, {'X-Workspace-Id': '222'}, '222', None, False),
+        ],
+        ids=[
+            'id_overridden',
+            'id_overridden_by_schema_header',
+            'id_unchanged',
+            'id_no_header',
+            'schema_overridden',
+            'no_server_pin',
+        ],
+    )
+    def test_apply_request_config_pins_workspace(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        server_kwargs: dict[str, str],
+        headers: dict[str, str],
+        expected_workspace_id: str | None,
+        expected_workspace_schema: str | None,
+        expect_warning: bool,
+    ):
+        """A workspace pin configured on the server must be authoritative over a request header
+        -- mirroring the Storage API URL check above -- but a server with no pin of its own must
+        keep taking it from the request (AI-3669 review, workspace.py:836 thread)."""
+        config = Config(storage_token='server-token', **server_kwargs)
+        http_rq = MagicMock(spec=Request)
+        http_rq.headers = headers
+        http_rq.scope = {}
+
+        with caplog.at_level('WARNING'):
+            applied = SessionStateMiddleware.apply_request_config(http_rq, config, own_stack_storage_api_url=None)
+
+        assert applied.workspace_id == expected_workspace_id
+        assert applied.workspace_schema == expected_workspace_schema
+        warned = any('is pinned' in r.message for r in caplog.records)
+        assert warned is expect_warning
+
 
 class TestProgrammaticTokenExchange:
     """SessionStateMiddleware exchanges programmatic tokens via the auth-bridge resolver (PSGO-261)."""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -862,23 +862,31 @@ class TestSessionStateMiddleware:
     @pytest.mark.parametrize(
         ('server_kwargs', 'headers', 'expected_workspace_id', 'expected_workspace_schema', 'expect_warning'),
         [
-            # server pinned by id: header asking for a different id/schema is ignored outright.
+            # server pinned by id: a header asking for a different id is ignored outright, but a
+            # `workspace_schema` header is a different field -- the server has no schema pin, so
+            # it passes through untouched (Miro review, mcp.py:320 thread: a schema-only server
+            # pin must not veto a request's X-Workspace-Id, and symmetrically here).
             ({'workspace_id': '111'}, {'X-Workspace-Id': '222'}, '111', None, True),
-            ({'workspace_id': '111'}, {'X-Workspace-Schema': 'OTHER'}, '111', None, True),
+            ({'workspace_id': '111'}, {'X-Workspace-Schema': 'OTHER'}, '111', 'OTHER', False),
             ({'workspace_id': '111'}, {'X-Workspace-Id': '111'}, '111', None, False),
             ({'workspace_id': '111'}, {}, '111', None, False),
-            # server pinned by schema: same treatment.
+            # server pinned by schema: same treatment, and symmetrically an id header passes
+            # through since the server has no id pin (the actual regression Miro flagged: a
+            # deployment that only sets KBC_WORKSPACE_SCHEMA -- the README's documented setup --
+            # must not silently discard a request's X-Workspace-Id).
             ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Schema': 'OTHER'}, None, 'SERVER_SCHEMA', True),
+            ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Id': '222'}, '222', 'SERVER_SCHEMA', False),
             # no server-side pin (the shared multi-tenant / AJDA-3052 Data App flow): the header
             # is the only source, so it keeps working.
             ({}, {'X-Workspace-Id': '222'}, '222', None, False),
         ],
         ids=[
             'id_overridden',
-            'id_overridden_by_schema_header',
+            'schema_header_passes_when_only_id_pinned',
             'id_unchanged',
             'id_no_header',
             'schema_overridden',
+            'id_header_passes_when_only_schema_pinned',
             'no_server_pin',
         ],
     )
@@ -893,7 +901,8 @@ class TestSessionStateMiddleware:
     ):
         """A workspace pin configured on the server must be authoritative over a request header
         -- mirroring the Storage API URL check above -- but a server with no pin of its own must
-        keep taking it from the request (AI-3669 review, workspace.py:836 thread)."""
+        keep taking it from the request (AI-3669 review, workspace.py:836 thread). Each field is
+        gated independently: a pin on one field must not veto a header for the other."""
         config = Config(storage_token='server-token', **server_kwargs)
         http_rq = MagicMock(spec=Request)
         http_rq.headers = headers

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -862,31 +862,28 @@ class TestSessionStateMiddleware:
     @pytest.mark.parametrize(
         ('server_kwargs', 'headers', 'expected_workspace_id', 'expected_workspace_schema', 'expect_warning'),
         [
-            # server pinned by id: a header asking for a different id is ignored outright, but a
-            # `workspace_schema` header is a different field -- the server has no schema pin, so
-            # it passes through untouched (Miro review, mcp.py:320 thread: a schema-only server
-            # pin must not veto a request's X-Workspace-Id, and symmetrically here).
+            # server pinned by id: header asking for a different id/schema is ignored outright.
             ({'workspace_id': '111'}, {'X-Workspace-Id': '222'}, '111', None, True),
-            ({'workspace_id': '111'}, {'X-Workspace-Schema': 'OTHER'}, '111', 'OTHER', False),
+            ({'workspace_id': '111'}, {'X-Workspace-Schema': 'OTHER'}, '111', None, True),
             ({'workspace_id': '111'}, {'X-Workspace-Id': '111'}, '111', None, False),
             ({'workspace_id': '111'}, {}, '111', None, False),
-            # server pinned by schema: same treatment, and symmetrically an id header passes
-            # through since the server has no id pin (the actual regression Miro flagged: a
-            # deployment that only sets KBC_WORKSPACE_SCHEMA -- the README's documented setup --
-            # must not silently discard a request's X-Workspace-Id).
+            # server pinned by schema: same treatment, checked/restored together with `workspace_id`
+            # rather than per-field -- a schema-pinned server is a single-project deployment that
+            # doesn't receive per-request X-Workspace-Id headers in the first place, so an id header
+            # here is also dropped (the one previously-uncovered cell from the mcp.py:320 thread).
             ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Schema': 'OTHER'}, None, 'SERVER_SCHEMA', True),
-            ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Id': '222'}, '222', 'SERVER_SCHEMA', False),
+            ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Id': '222'}, None, 'SERVER_SCHEMA', True),
             # no server-side pin (the shared multi-tenant / AJDA-3052 Data App flow): the header
             # is the only source, so it keeps working.
             ({}, {'X-Workspace-Id': '222'}, '222', None, False),
         ],
         ids=[
             'id_overridden',
-            'schema_header_passes_when_only_id_pinned',
+            'id_overridden_by_schema_header',
             'id_unchanged',
             'id_no_header',
             'schema_overridden',
-            'id_header_passes_when_only_schema_pinned',
+            'schema_pin_also_drops_id_header',
             'no_server_pin',
         ],
     )
@@ -901,8 +898,10 @@ class TestSessionStateMiddleware:
     ):
         """A workspace pin configured on the server must be authoritative over a request header
         -- mirroring the Storage API URL check above -- but a server with no pin of its own must
-        keep taking it from the request (AI-3669 review, workspace.py:836 thread). Each field is
-        gated independently: a pin on one field must not veto a header for the other."""
+        keep taking it from the request (AI-3669 review, workspace.py:836 thread). `workspace_id`
+        and `workspace_schema` are checked/restored together, not per-field: the same
+        silent-override risk applies to either kind of server pin (AI-3669 review, mcp.py:320
+        thread)."""
         config = Config(storage_token='server-token', **server_kwargs)
         http_rq = MagicMock(spec=Request)
         http_rq.headers = headers

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -873,6 +873,9 @@ class TestSessionStateMiddleware:
             # here is also dropped (the one previously-uncovered cell from the mcp.py:320 thread).
             ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Schema': 'OTHER'}, None, 'SERVER_SCHEMA', True),
             ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Id': '222'}, None, 'SERVER_SCHEMA', True),
+            # an empty schema header is the multi-user opt-out (README), not an override -- it
+            # must not restore the server's schema pin.
+            ({'workspace_schema': 'SERVER_SCHEMA'}, {'X-Workspace-Schema': ''}, None, '', False),
             # no server-side pin (the shared multi-tenant / AJDA-3052 Data App flow): the header
             # is the only source, so it keeps working.
             ({}, {'X-Workspace-Id': '222'}, '222', None, False),
@@ -884,6 +887,7 @@ class TestSessionStateMiddleware:
             'id_no_header',
             'schema_overridden',
             'schema_pin_also_drops_id_header',
+            'empty_schema_header_is_opt_out_not_override',
             'no_server_pin',
         ],
     )

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -543,7 +543,7 @@ class TestPreviewConfigDiff:
 
         # Mock WorkspaceManager
         mock_workspace_manager = mocker.AsyncMock()
-        mock_workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
+        mock_workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='snowflake')
 
         mocker.patch(
             'keboola_mcp_server.preview.WorkspaceManager.from_state',

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -942,8 +942,8 @@ class TestPreviewConfigDiff:
 
         # Mock WorkspaceManager
         mock_workspace_manager = mocker.AsyncMock()
-        mock_workspace_manager.get_workspace_id = mocker.AsyncMock(return_value=123)
-        mock_workspace_manager.get_branch_id = mocker.AsyncMock(return_value=456)
+        mock_workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=123)
+        mock_workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value=456)
         mock_workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
 
         mocker.patch(

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -944,7 +944,7 @@ class TestPreviewConfigDiff:
         mock_workspace_manager = mocker.AsyncMock()
         mock_workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=123)
         mock_workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value=456)
-        mock_workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
+        mock_workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='snowflake')
 
         mocker.patch(
             'keboola_mcp_server.preview.WorkspaceManager.from_state',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,6 +43,15 @@ from keboola_mcp_server.workspace import WorkspaceManager
 
 
 class TestServer:
+    def test_create_server_fails_loudly_on_malformed_env_workspace_id(self, monkeypatch) -> None:
+        """`create_server()` merges `os.environ` into the config via `Config.replace_by()`
+        (KBC_WORKSPACE_ID is trusted operator input, not an untrusted per-request header) -- a
+        malformed value here must crash startup, the same way a malformed `--workspace-id` CLI
+        flag already does, instead of silently starting the server unpinned."""
+        monkeypatch.setenv('KBC_WORKSPACE_ID', 'not-a-valid-id')
+        with pytest.raises(ValueError, match='Invalid workspace_id'):
+            create_server(Config(), runtime_info=ServerRuntimeInfo(transport='stdio'))
+
     @pytest.mark.asyncio
     async def test_list_tools(self):
         server = create_server(Config(), runtime_info=ServerRuntimeInfo(transport='stdio'))

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -173,22 +173,28 @@ async def test_workspace_creation_cleans_up_config_on_failure():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('input_branch_id', 'has_sb_feature', 'workspace_schema', 'expected_bound_branch_id'),
+    ('input_branch_id', 'has_sb_feature', 'workspace_schema', 'workspace_id', 'expected_bound_branch_id'),
     [
         # default branch: always production, regardless of feature
-        (None, True, None, None),
-        (None, False, None, None),
+        (None, True, None, None, None),
+        (None, False, None, None, None),
         # dev branch + storage-branches feature on: keep dev branch
-        ('456', True, None, '456'),
+        ('456', True, None, None, '456'),
         # dev branch without storage-branches (legacy): fall back to production
-        ('456', False, None, None),
+        ('456', False, None, None, None),
         # dev branch + storage-branches + explicit workspace_schema (KBC_WORKSPACE_SCHEMA):
         # stay branch-aware. The user is responsible for ensuring the named workspace
         # exists in the explicitly-bound branch — there is no carve-out for explicit schemas.
-        ('456', True, 'WORKSPACE_XYZ', '456'),
+        ('456', True, 'WORKSPACE_XYZ', None, '456'),
         # dev branch + legacy + explicit workspace_schema: still rebinds to production,
         # since branched workspaces don't exist on legacy projects.
-        ('456', False, 'WORKSPACE_XYZ', None),
+        ('456', False, 'WORKSPACE_XYZ', None, None),
+        # dev branch + storage-branches + explicit workspace_id: the pin must reach `cls(...)`
+        # on the storage-branches construction path too (mutation-tested: dropping
+        # `workspace_id=workspace_id` there leaves the rest of the suite green).
+        ('456', True, None, '123', '456'),
+        # default branch + explicit workspace_id: same, on the prod-client construction path.
+        (None, False, None, '123', None),
     ],
     ids=[
         'default_branch_with_sb',
@@ -197,20 +203,24 @@ async def test_workspace_creation_cleans_up_config_on_failure():
         'dev_branch_legacy',
         'dev_branch_with_sb_explicit_schema',
         'dev_branch_legacy_explicit_schema',
+        'dev_branch_with_sb_explicit_id',
+        'default_branch_without_sb_explicit_id',
     ],
 )
 async def test_workspace_manager_create_is_branch_aware(
     input_branch_id: str | None,
     has_sb_feature: bool,
     workspace_schema: str | None,
+    workspace_id: str | None,
     expected_bound_branch_id: str | None,
 ):
     """
     WorkspaceManager.create() must keep the client on the dev branch only when the project
     has the `storage-branches` feature; otherwise it must rebind to the production branch.
     The rule applies uniformly whether the workspace is auto-managed or pinned via an
-    explicit `workspace_schema` (KBC_WORKSPACE_SCHEMA) — branch context is governed solely
-    by KBC_BRANCH_ID and the project's `storage-branches` feature.
+    explicit `workspace_schema` (KBC_WORKSPACE_SCHEMA) or `workspace_id` (KBC_WORKSPACE_ID) —
+    branch context is governed solely by KBC_BRANCH_ID and the project's `storage-branches`
+    feature, and both pins must reach `cls(...)` on either construction path.
     """
     input_client = Mock(spec=KeboolaClient)
     input_client.branch_id = input_branch_id
@@ -227,13 +237,15 @@ async def test_workspace_manager_create_is_branch_aware(
 
     input_client.with_branch_id = AsyncMock(side_effect=_rebind)
 
-    manager = await WorkspaceManager.create(input_client, workspace_schema=workspace_schema)
+    manager = await WorkspaceManager.create(input_client, workspace_schema=workspace_schema, workspace_id=workspace_id)
 
     # noinspection PyProtectedMember
     bound_client = manager._client
     assert bound_client.branch_id == expected_bound_branch_id
     # noinspection PyProtectedMember
     assert manager._workspace_schema == workspace_schema
+    # noinspection PyProtectedMember
+    assert manager._workspace_id == workspace_id
 
     # has_feature is only meaningful when the client is on a dev branch — the helper
     # short-circuits otherwise, so on the default branch we should not even ask.
@@ -272,6 +284,135 @@ async def test_get_workspace_raises_when_id_not_found():
 
     with pytest.raises(ValueError, match='workspace_id=999'):
         await manager._get_workspace()
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_warns_when_pinned_workspace_is_not_readonly(caplog: pytest.LogCaptureFixture) -> None:
+    """A `workspace_id` pin resolving to a writable workspace must not silently pass through --
+    at minimum it needs a warning (whether a Data App's platform-provisioned workspace is
+    actually read-only is unconfirmed against a real stack; hard-enforcing here without knowing
+    that could break the feature outright -- see AI-3669 review, workspace.py:834 thread)."""
+    mock_client = Mock(spec=KeboolaClient)
+    manager = WorkspaceManager(mock_client, workspace_id='123')
+    writable_info = _WspInfo(id=123, schema='APP_SCHEMA', backend='snowflake', credentials=None, readonly=False)
+    manager._find_ws_by_id = AsyncMock(return_value=writable_info)  # type: ignore[method-assign]
+
+    with caplog.at_level('WARNING'):
+        workspace = await manager._get_workspace()
+
+    assert workspace.id == 123
+    assert any('no read-only storage access' in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_data_app_workspace_id_ignores_the_pin():
+    """`get_data_app_workspace_id()`/`get_data_app_branch_id()` must resolve the *managed*
+    workspace even when a session is pinned via `workspace_id` -- they feed into
+    `tools/data_apps.py`, which writes the result into a *different* data app's own persisted
+    `WORKSPACE_ID` secret. If they returned the pinned workspace, creating/updating data app B
+    from a session pinned to app A's workspace would permanently point B at A's workspace."""
+    mock_client = Mock(spec=KeboolaClient)
+    manager = WorkspaceManager(mock_client, workspace_id='999')
+
+    pinned_info = _WspInfo(id=999, schema='PINNED_SCHEMA', backend='snowflake', credentials=None, readonly=True)
+    managed_info = _WspInfo(id=111, schema='MANAGED_SCHEMA', backend='snowflake', credentials=None, readonly=True)
+    manager._find_ws_by_id = AsyncMock(return_value=pinned_info)  # type: ignore[method-assign]
+    manager._find_ws_in_branch = AsyncMock(return_value=managed_info)  # type: ignore[method-assign]
+
+    assert await manager.get_data_app_workspace_id() == 111
+    pinned_workspace = await manager._get_workspace()
+    assert pinned_workspace.id == 999
+
+
+@pytest.mark.asyncio
+async def test_found_workspace_repr_never_prints_credentials() -> None:
+    """`_WspInfo.credentials` holds the backend's credential blob (a service-account JSON for
+    BigQuery) -- its repr, which every `LOG.info(f'... {info}')` call site relies on, must
+    never include it."""
+    secret = 'super-secret-service-account-json'
+    info = _WspInfo(id=123, schema='APP_SCHEMA', backend='snowflake', credentials=secret, readonly=True)
+
+    assert secret not in repr(info)
+    assert 'credentials=****' in repr(info)
+
+
+@pytest.mark.asyncio
+async def test_find_ws_by_id_falls_back_to_production_branch() -> None:
+    """A Data App workspace is not tied to any particular branch, but `workspace_detail` is
+    branch-scoped -- a dev-branch session pinned to a workspace that lives on the default
+    branch must not 404 just because the first lookup used the wrong branch prefix."""
+    dev_client = Mock(spec=KeboolaClient)
+    dev_client.branch_id = '456'
+    dev_client.storage_client = AsyncMock()
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = 404
+    mock_request = Mock(spec=Request)
+    dev_client.storage_client.workspace_detail = AsyncMock(
+        side_effect=HTTPStatusError('not found', request=mock_request, response=mock_response)
+    )
+
+    prod_client = Mock(spec=KeboolaClient)
+    prod_client.branch_id = None
+    prod_client.storage_client = AsyncMock()
+    prod_client.storage_client.workspace_detail = AsyncMock(
+        return_value={
+            'id': 123,
+            'connection': {'backend': 'snowflake', 'schema': 'APP_SCHEMA', 'user': None},
+            'readOnlyStorageAccess': True,
+        }
+    )
+    dev_client.with_branch_id = AsyncMock(return_value=prod_client)
+
+    manager = WorkspaceManager(dev_client, workspace_id='123')
+
+    info = await manager._find_ws_by_id('123')
+
+    assert info is not None
+    assert info.id == 123
+    dev_client.storage_client.workspace_detail.assert_awaited_once_with('123')
+    dev_client.with_branch_id.assert_awaited_once_with(None)
+    prod_client.storage_client.workspace_detail.assert_awaited_once_with('123')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('status_code', [400, 403, 404])
+async def test_find_ws_by_id_treats_400_403_404_alike(status_code: int) -> None:
+    """The header value is unvalidated: a non-numeric id (400), an id the token can't read
+    (403), and a nonexistent id (404) must all mean the same thing -- "not usable" -- rather
+    than 400/403 bypassing the intended `ValueError` and surfacing a raw `HTTPStatusError`."""
+    mock_client = Mock(spec=KeboolaClient)
+    mock_client.branch_id = None
+    mock_client.storage_client = AsyncMock()
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = status_code
+    mock_request = Mock(spec=Request)
+    mock_client.storage_client.workspace_detail = AsyncMock(
+        side_effect=HTTPStatusError('error', request=mock_request, response=mock_response)
+    )
+
+    manager = WorkspaceManager(mock_client, workspace_id='not-a-valid-id')
+
+    assert await manager._find_ws_by_id('not-a-valid-id') is None
+
+
+@pytest.mark.asyncio
+async def test_find_ws_by_id_reraises_unexpected_status() -> None:
+    """A 5xx (or any other unexpected status) is a real failure, not an absent/inaccessible
+    workspace -- it must propagate rather than being swallowed into a misleading "not found"."""
+    mock_client = Mock(spec=KeboolaClient)
+    mock_client.branch_id = None
+    mock_client.storage_client = AsyncMock()
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = 500
+    mock_request = Mock(spec=Request)
+    mock_client.storage_client.workspace_detail = AsyncMock(
+        side_effect=HTTPStatusError('error', request=mock_request, response=mock_response)
+    )
+
+    manager = WorkspaceManager(mock_client, workspace_id='123')
+
+    with pytest.raises(HTTPStatusError):
+        await manager._find_ws_by_id('123')
 
 
 def _make_snowflake_workspace_with_mocked_qs(job_id: str = 'job-abc-123') -> tuple[_SnowflakeWorkspace, AsyncMock]:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -264,7 +264,7 @@ async def test_get_workspace_resolves_by_id_when_set():
     manager = WorkspaceManager(mock_client, workspace_schema='SOME_SCHEMA', workspace_id='123')
 
     ws_info = _WspInfo(id=123, schema='APP_SCHEMA', backend='snowflake', credentials=None, readonly=True)
-    manager._find_ws_by_id = AsyncMock(return_value=ws_info)  # type: ignore[method-assign]
+    manager._find_ws_by_id = AsyncMock(return_value=(ws_info, mock_client))  # type: ignore[method-assign]
     manager._find_ws_by_schema = AsyncMock()  # type: ignore[method-assign]
 
     workspace = await manager._get_workspace()
@@ -295,7 +295,7 @@ async def test_get_workspace_warns_when_pinned_workspace_is_not_readonly(caplog:
     mock_client = Mock(spec=KeboolaClient)
     manager = WorkspaceManager(mock_client, workspace_id='123')
     writable_info = _WspInfo(id=123, schema='APP_SCHEMA', backend='snowflake', credentials=None, readonly=False)
-    manager._find_ws_by_id = AsyncMock(return_value=writable_info)  # type: ignore[method-assign]
+    manager._find_ws_by_id = AsyncMock(return_value=(writable_info, mock_client))  # type: ignore[method-assign]
 
     with caplog.at_level('WARNING'):
         workspace = await manager._get_workspace()
@@ -319,7 +319,7 @@ async def test_get_data_app_workspace_id_ignores_the_pin():
         id=999, schema='PINNED_SCHEMA', backend='bigquery', credentials='{"project_id": "proj"}', readonly=True
     )
     managed_info = _WspInfo(id=111, schema='MANAGED_SCHEMA', backend='snowflake', credentials=None, readonly=True)
-    manager._find_ws_by_id = AsyncMock(return_value=pinned_info)  # type: ignore[method-assign]
+    manager._find_ws_by_id = AsyncMock(return_value=(pinned_info, mock_client))  # type: ignore[method-assign]
     manager._find_ws_in_branch = AsyncMock(return_value=managed_info)  # type: ignore[method-assign]
 
     assert await manager.get_data_app_workspace_id() == 111
@@ -385,16 +385,63 @@ async def test_find_ws_by_id_falls_back_to_production_branch() -> None:
 
     manager = WorkspaceManager(dev_client, workspace_id='123')
 
-    info = await manager._find_ws_by_id('123')
+    result = await manager._find_ws_by_id('123')
 
-    assert info is not None
+    assert result is not None
+    info, resolved_client = result
     assert info.id == 123
     dev_client.storage_client.workspace_detail.assert_awaited_once_with('123')
     dev_client.with_branch_id.assert_awaited_once_with(None)
     prod_client.storage_client.workspace_detail.assert_awaited_once_with('123')
-    # The workspace was only resolvable via the prod-branch client -- this manager must rebind to
-    # it, or later queries would run against a production workspace through the dev-branch client.
-    assert manager._client is prod_client
+    # The workspace was only resolvable via the prod-branch client -- that client is returned for
+    # use on this one workspace, but this manager's own client must NOT change: mutating
+    # `manager._client` would also redirect every other lookup this manager makes (e.g. the
+    # MCP-managed workspace) onto the wrong branch.
+    assert resolved_client is prod_client
+    assert manager._client is dev_client
+
+
+@pytest.mark.asyncio
+async def test_pin_resolution_via_prod_fallback_does_not_leak_into_managed_lookup() -> None:
+    """Regression test for a real bug caught in review: resolving a `workspace_id` pin through
+    the prod-branch fallback must not affect the *managed* workspace lookup afterwards -- that
+    lookup (feeding `get_data_app_workspace_id()`/`get_data_app_branch_id()`/
+    `get_data_app_sql_dialect()`, which get persisted into a Data App's own config) must keep
+    running on the manager's original (dev-branch) client, not the prod client the pin happened
+    to resolve on."""
+    dev_client = Mock(spec=KeboolaClient)
+    dev_client.branch_id = '456'
+    dev_client.storage_client = AsyncMock()
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = 404
+    mock_request = Mock(spec=Request)
+    dev_client.storage_client.workspace_detail = AsyncMock(
+        side_effect=HTTPStatusError('not found', request=mock_request, response=mock_response)
+    )
+
+    prod_client = Mock(spec=KeboolaClient)
+    prod_client.branch_id = None
+    prod_client.storage_client = AsyncMock()
+    prod_client.storage_client.workspace_detail = AsyncMock(
+        return_value={
+            'id': 123,
+            'connection': {'backend': 'snowflake', 'schema': 'PINNED_SCHEMA', 'user': None},
+            'readOnlyStorageAccess': True,
+        }
+    )
+    dev_client.with_branch_id = AsyncMock(return_value=prod_client)
+
+    manager = WorkspaceManager(dev_client, workspace_id='123')
+    managed_info = _WspInfo(id=111, schema='MANAGED_SCHEMA', backend='snowflake', credentials=None, readonly=True)
+    manager._find_ws_in_branch = AsyncMock(return_value=managed_info)  # type: ignore[method-assign]
+
+    pinned_workspace = await manager._get_workspace()
+    assert pinned_workspace.id == 123
+
+    managed_workspace_id = await manager.get_data_app_workspace_id()
+
+    assert managed_workspace_id == 111
+    assert manager._client is dev_client
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -172,6 +172,39 @@ async def test_workspace_creation_cleans_up_config_on_failure():
 
 
 @pytest.mark.asyncio
+async def test_create_ws_does_not_use_prod_branch_fallback() -> None:
+    """`_create_ws` provisions through `self._client`, so the workspace is by construction in
+    this manager's own branch -- it must fetch the just-created id directly rather than through
+    `_find_ws_by_id`, whose production-branch fallback exists for caller-supplied ids, not ones
+    this manager just created itself (AI-3669 review, workspace.py:838 thread). A transient 404
+    on the fresh id here must surface as "creation failed", not silently resolve to a different
+    workspace with the same id on the production branch."""
+    mock_client = Mock(spec=KeboolaClient)
+    mock_client.branch_id = '456'
+    mock_storage_client = AsyncMock()
+    mock_client.storage_client = mock_storage_client
+    mock_storage_client.verify_token.return_value = {'owner': {'defaultBackend': 'snowflake'}}
+    mock_storage_client.configuration_create.return_value = {'id': 'test-config-123', 'name': 'test'}
+    mock_storage_client.workspace_create_for_config.return_value = {'id': 42}
+    mock_storage_client.job_detail.return_value = {'status': 'success', 'results': {'id': 42}}
+
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = 404
+    mock_request = Mock(spec=Request)
+    mock_storage_client.workspace_detail = AsyncMock(
+        side_effect=HTTPStatusError('not found', request=mock_request, response=mock_response)
+    )
+    mock_client.with_branch_id = AsyncMock()
+
+    manager = WorkspaceManager(mock_client)
+
+    result = await manager._create_ws()
+
+    assert result is None
+    mock_client.with_branch_id.assert_not_called()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ('input_branch_id', 'has_sb_feature', 'workspace_schema', 'workspace_id', 'expected_bound_branch_id'),
     [
@@ -445,11 +478,51 @@ async def test_pin_resolution_via_prod_fallback_does_not_leak_into_managed_looku
 
 
 @pytest.mark.asyncio
+async def test_get_workspace_warns_when_pin_resolves_via_prod_fallback(caplog: pytest.LogCaptureFixture) -> None:
+    """When a `workspace_id` pin only resolves via the production-branch fallback, `self._client`
+    stays on the dev branch for every other lookup (get_tables, get_bucket_detail, ...) while
+    queries run against the prod-branch workspace -- nothing else makes that branch mismatch
+    diagnosable, so it must at least be logged (AI-3669 review, workspace.py:908 thread)."""
+    dev_client = Mock(spec=KeboolaClient)
+    dev_client.branch_id = '456'
+    dev_client.storage_client = AsyncMock()
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = 404
+    mock_request = Mock(spec=Request)
+    dev_client.storage_client.workspace_detail = AsyncMock(
+        side_effect=HTTPStatusError('not found', request=mock_request, response=mock_response)
+    )
+
+    prod_client = Mock(spec=KeboolaClient)
+    prod_client.branch_id = None
+    prod_client.storage_client = AsyncMock()
+    prod_client.storage_client.workspace_detail = AsyncMock(
+        return_value={
+            'id': 123,
+            'connection': {'backend': 'snowflake', 'schema': 'APP_SCHEMA', 'user': None},
+            'readOnlyStorageAccess': True,
+        }
+    )
+    dev_client.with_branch_id = AsyncMock(return_value=prod_client)
+
+    manager = WorkspaceManager(dev_client, workspace_id='123')
+
+    with caplog.at_level('WARNING'):
+        workspace = await manager._get_workspace()
+
+    assert workspace.id == 123
+    assert any('production-branch fallback' in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize('status_code', [400, 403, 404])
-async def test_find_ws_by_id_treats_400_403_404_alike(status_code: int) -> None:
+async def test_find_ws_by_id_treats_400_403_404_alike(status_code: int, caplog: pytest.LogCaptureFixture) -> None:
     """The header value is unvalidated: a non-numeric id (400), an id the token can't read
     (403), and a nonexistent id (404) must all mean the same thing -- "not usable" -- rather
-    than 400/403 bypassing the intended `ValueError` and surfacing a raw `HTTPStatusError`."""
+    than 400/403 bypassing the intended `ValueError` and surfacing a raw `HTTPStatusError`. The
+    status code is still logged, so a permissions problem (403) is distinguishable from a typo
+    (404) in server logs even though both resolve to the same "not found" `ValueError` (AI-3669
+    review, workspace.py:696 thread)."""
     mock_client = Mock(spec=KeboolaClient)
     mock_client.branch_id = None
     mock_client.storage_client = AsyncMock()
@@ -462,7 +535,9 @@ async def test_find_ws_by_id_treats_400_403_404_alike(status_code: int) -> None:
 
     manager = WorkspaceManager(mock_client, workspace_id='not-a-valid-id')
 
-    assert await manager._find_ws_by_id('not-a-valid-id') is None
+    with caplog.at_level('DEBUG'):
+        assert await manager._find_ws_by_id('not-a-valid-id') is None
+    assert any(str(status_code) in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -665,7 +740,7 @@ async def test_workspace_creation_uses_step_up_client(tmp_path):
 
     manager = WorkspaceManager(mock_client, kubernetes_token_path=str(token_file))
     # Stop the flow right after the provisioning calls we want to assert on.
-    manager._find_ws_by_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    manager._fetch_ws = AsyncMock(return_value=None)  # type: ignore[method-assign]
     mock_storage_client.job_detail.return_value = {'status': 'success', 'results': {'id': 42}}
 
     await manager._create_ws()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -542,11 +542,13 @@ async def test_find_ws_by_id_treats_400_403_404_alike(status_code: int, caplog: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('status_code', [400, 403])
-async def test_find_ws_by_id_strict_reraises_400_403(status_code: int) -> None:
+async def test_fetch_ws_strict_reraises_400_403(status_code: int) -> None:
     """`strict=True` (used for the id of a workspace this server just created, e.g. in
     `_create_ws`) must only treat a 404 as "not found" -- a 400/403 on that known-good id is a
     real failure (e.g. the creating token can't read what it just provisioned) that must not be
-    silently swallowed into a generic "workspace creation failed" error."""
+    silently swallowed into a generic "workspace creation failed" error. `strict` only exists on
+    `_fetch_ws` -- `_find_ws_by_id` (the pin-lookup caller) has no legitimate use for it, since a
+    caller-supplied id is unvalidated by definition."""
     mock_client = Mock(spec=KeboolaClient)
     mock_client.branch_id = None
     mock_client.storage_client = AsyncMock()
@@ -557,10 +559,34 @@ async def test_find_ws_by_id_strict_reraises_400_403(status_code: int) -> None:
         side_effect=HTTPStatusError('error', request=mock_request, response=mock_response)
     )
 
-    manager = WorkspaceManager(mock_client, workspace_id='123')
-
     with pytest.raises(HTTPStatusError):
-        await manager._find_ws_by_id('123', strict=True)
+        await WorkspaceManager._fetch_ws(mock_client, '123', strict=True)
+
+
+@pytest.mark.asyncio
+async def test_fetch_ws_raises_without_leaking_credentials() -> None:
+    """A workspace whose detail 200s but has an empty `backend`/`schema` (e.g. a non-SQL/sandbox
+    workspace) raises `ValueError` -- since `workspace_id` is now caller-supplied via
+    `X-Workspace-Id`, this path is reachable with untrusted input, so the raw Storage API payload
+    (whose `connection.user` is the backend's credential blob, e.g. a BigQuery service-account
+    JSON) must never end up in the error message that server logs / client responses / Storage
+    events pick up."""
+    secret = 'super-secret-service-account-json'
+    mock_client = Mock(spec=KeboolaClient)
+    mock_client.storage_client = AsyncMock()
+    mock_client.storage_client.workspace_detail = AsyncMock(
+        return_value={
+            'id': 123,
+            'connection': {'backend': '', 'schema': '', 'user': secret},
+            'readOnlyStorageAccess': True,
+        }
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await WorkspaceManager._fetch_ws(mock_client, '123')
+
+    assert secret not in str(exc_info.value)
+    assert 'credentials=****' in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7,7 +7,7 @@ from httpx import HTTPStatusError, Request, Response
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
-from keboola_mcp_server.workspace import JobSubmittedInfo, WorkspaceManager, _SnowflakeWorkspace
+from keboola_mcp_server.workspace import JobSubmittedInfo, WorkspaceManager, _SnowflakeWorkspace, _WspInfo
 
 
 @pytest.mark.parametrize(
@@ -241,6 +241,37 @@ async def test_workspace_manager_create_is_branch_aware(
         input_client.has_feature.assert_not_called()
     else:
         input_client.has_feature.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_resolves_by_id_when_set():
+    """An explicit `workspace_id` (e.g. a Data App's own workspace) must be looked up by ID
+    and take precedence over `workspace_schema`, instead of falling back to the default
+    per-branch MCP-managed workspace."""
+    mock_client = Mock(spec=KeboolaClient)
+    manager = WorkspaceManager(mock_client, workspace_schema='SOME_SCHEMA', workspace_id='123')
+
+    ws_info = _WspInfo(id=123, schema='APP_SCHEMA', backend='snowflake', credentials=None, readonly=True)
+    manager._find_ws_by_id = AsyncMock(return_value=ws_info)  # type: ignore[method-assign]
+    manager._find_ws_by_schema = AsyncMock()  # type: ignore[method-assign]
+
+    workspace = await manager._get_workspace()
+
+    assert workspace.id == 123
+    manager._find_ws_by_id.assert_awaited_once_with('123')
+    manager._find_ws_by_schema.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_raises_when_id_not_found():
+    """A `workspace_id` that resolves to no workspace must fail loudly rather than silently
+    falling back to the default workspace — the caller asked for a specific workspace."""
+    mock_client = Mock(spec=KeboolaClient)
+    manager = WorkspaceManager(mock_client, workspace_id='999')
+    manager._find_ws_by_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match='workspace_id=999'):
+        await manager._get_workspace()
 
 
 def _make_snowflake_workspace_with_mocked_qs(job_id: str = 'job-abc-123') -> tuple[_SnowflakeWorkspace, AsyncMock]:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -306,22 +306,42 @@ async def test_get_workspace_warns_when_pinned_workspace_is_not_readonly(caplog:
 
 @pytest.mark.asyncio
 async def test_get_data_app_workspace_id_ignores_the_pin():
-    """`get_data_app_workspace_id()`/`get_data_app_branch_id()` must resolve the *managed*
-    workspace even when a session is pinned via `workspace_id` -- they feed into
-    `tools/data_apps.py`, which writes the result into a *different* data app's own persisted
-    `WORKSPACE_ID` secret. If they returned the pinned workspace, creating/updating data app B
-    from a session pinned to app A's workspace would permanently point B at A's workspace."""
+    """`get_data_app_workspace_id()`/`get_data_app_branch_id()`/`get_data_app_sql_dialect()` must
+    resolve the *managed* workspace even when a session is pinned via `workspace_id` -- they feed
+    into `tools/data_apps.py`, which writes the result into a *different* data app's own
+    persisted `WORKSPACE_ID` secret and bakes the dialect into that same app's generated source
+    code. If they returned the pinned workspace, creating/updating data app B from a session
+    pinned to app A's workspace would permanently point B at A's workspace/dialect."""
     mock_client = Mock(spec=KeboolaClient)
     manager = WorkspaceManager(mock_client, workspace_id='999')
 
-    pinned_info = _WspInfo(id=999, schema='PINNED_SCHEMA', backend='snowflake', credentials=None, readonly=True)
+    pinned_info = _WspInfo(
+        id=999, schema='PINNED_SCHEMA', backend='bigquery', credentials='{"project_id": "proj"}', readonly=True
+    )
     managed_info = _WspInfo(id=111, schema='MANAGED_SCHEMA', backend='snowflake', credentials=None, readonly=True)
     manager._find_ws_by_id = AsyncMock(return_value=pinned_info)  # type: ignore[method-assign]
     manager._find_ws_in_branch = AsyncMock(return_value=managed_info)  # type: ignore[method-assign]
 
     assert await manager.get_data_app_workspace_id() == 111
+    assert await manager.get_data_app_sql_dialect() == 'Snowflake'
     pinned_workspace = await manager._get_workspace()
     assert pinned_workspace.id == 999
+
+
+@pytest.mark.asyncio
+async def test_get_managed_workspace_raises_instead_of_provisioning_when_pinned():
+    """A session pinned via `workspace_id` (e.g. a Data App session) must not provision a brand
+    new MCP-managed workspace on demand when none exists yet -- that workspace would be billed
+    to this session's token, not whoever actually needs it, and provisioning can outright fail on
+    a read-only token. It should fail loudly instead of silently creating one."""
+    mock_client = Mock(spec=KeboolaClient)
+    manager = WorkspaceManager(mock_client, workspace_id='999')
+    manager._find_ws_in_branch = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    manager._create_ws = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match='workspace_id=999'):
+        await manager._get_managed_workspace()
+    manager._create_ws.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -372,6 +392,9 @@ async def test_find_ws_by_id_falls_back_to_production_branch() -> None:
     dev_client.storage_client.workspace_detail.assert_awaited_once_with('123')
     dev_client.with_branch_id.assert_awaited_once_with(None)
     prod_client.storage_client.workspace_detail.assert_awaited_once_with('123')
+    # The workspace was only resolvable via the prod-branch client -- this manager must rebind to
+    # it, or later queries would run against a production workspace through the dev-branch client.
+    assert manager._client is prod_client
 
 
 @pytest.mark.asyncio
@@ -393,6 +416,29 @@ async def test_find_ws_by_id_treats_400_403_404_alike(status_code: int) -> None:
     manager = WorkspaceManager(mock_client, workspace_id='not-a-valid-id')
 
     assert await manager._find_ws_by_id('not-a-valid-id') is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('status_code', [400, 403])
+async def test_find_ws_by_id_strict_reraises_400_403(status_code: int) -> None:
+    """`strict=True` (used for the id of a workspace this server just created, e.g. in
+    `_create_ws`) must only treat a 404 as "not found" -- a 400/403 on that known-good id is a
+    real failure (e.g. the creating token can't read what it just provisioned) that must not be
+    silently swallowed into a generic "workspace creation failed" error."""
+    mock_client = Mock(spec=KeboolaClient)
+    mock_client.branch_id = None
+    mock_client.storage_client = AsyncMock()
+    mock_response = Mock(spec=Response)
+    mock_response.status_code = status_code
+    mock_request = Mock(spec=Request)
+    mock_client.storage_client.workspace_detail = AsyncMock(
+        side_effect=HTTPStatusError('error', request=mock_request, response=mock_response)
+    )
+
+    manager = WorkspaceManager(mock_client, workspace_id='123')
+
+    with pytest.raises(HTTPStatusError):
+        await manager._find_ws_by_id('123', strict=True)
 
 
 @pytest.mark.asyncio

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -765,7 +765,7 @@ async def test_create_sql_transformation(
 
     # Mock the WorkspaceManager
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
     # Mock the KeboolaClient
     keboola_client = KeboolaClient.from_state(context.session.state)
     component = mock_component
@@ -852,7 +852,7 @@ async def test_sql_transformation_rejects_oversized_sql(
     """
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
 
     keboola_client = KeboolaClient.from_state(context.session.state)
     keboola_client.ai_service_client = mocker.MagicMock()
@@ -923,7 +923,7 @@ async def test_create_sql_transformation_fail(
     """Test create_sql_transformation tool which should raise an error if the sql dialect is unknown."""
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
 
     with pytest.raises(ValueError, match='Unsupported SQL dialect'):
         _ = await create_sql_transformation(
@@ -966,7 +966,7 @@ async def test_create_sql_transformation_folder(
     """Test folder metadata and change_summary hint for create_sql_transformation."""
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
     keboola_client = KeboolaClient.from_state(context.session.state)
     mock_component['id'] = 'keboola.snowflake-transformation'
     mock_configuration['id'] = '9999'
@@ -1039,7 +1039,7 @@ async def test_update_sql_transformation_folder(
     """Test folder metadata and change_summary hint for update_sql_transformation."""
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
     keboola_client = KeboolaClient.from_state(context.session.state)
     mock_component['id'] = 'keboola.snowflake-transformation'
     configuration_id = 'cfg-folder-test'
@@ -1117,7 +1117,7 @@ async def test_update_sql_transformation_folder_metadata_error_is_swallowed(
     """Metadata errors in update_sql_transformation are swallowed and logged, not raised."""
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
     keboola_client = KeboolaClient.from_state(context.session.state)
     mock_component['id'] = 'keboola.snowflake-transformation'
     configuration_id = 'cfg-error-test'
@@ -1243,7 +1243,7 @@ async def test_update_sql_transformation(
     keboola_client = KeboolaClient.from_state(context.session.state)
     # Mock the WorkspaceManager
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value=sql_dialect)
 
     component_id = mock_component['id'] = expected_component_id
     configuration_id = 'test-config-id'
@@ -1320,7 +1320,7 @@ async def test_update_sql_transformation_wrong_component_type(
     context = mcp_context_components_configs
     keboola_client = KeboolaClient.from_state(context.session.state)
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
 
     # Simulate Storage returning 404: the config exists under python-transformation-v2,
     # not under keboola.snowflake-transformation.
@@ -2364,7 +2364,7 @@ async def test_create_sql_transformation_variables(
 ) -> None:
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
     keboola_client = KeboolaClient.from_state(context.session.state)
 
     component = mock_component
@@ -2508,7 +2508,7 @@ async def test_update_sql_transformation_variables(
 ) -> None:
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='Snowflake')
     keboola_client = KeboolaClient.from_state(context.session.state)
 
     component = mock_component

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -814,9 +814,9 @@ async def test_modify_streamlit_data_app_folder(
     """Test folder metadata and change_summary hint for modify_streamlit_data_app (create and update paths)."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
 
-    workspace_manager.get_workspace_id = mocker.AsyncMock(return_value=1)
+    workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=1)
     workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='default')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='default')
 
     keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
 
@@ -936,9 +936,9 @@ async def test_modify_streamlit_data_app_partial_success_when_response_building_
     regardless of failure point, and that the response wording still reflects the app state."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
 
-    workspace_manager.get_workspace_id = mocker.AsyncMock(return_value=1)
+    workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=1)
     workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='default')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='default')
     keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
 
     encrypted_config = {
@@ -1079,9 +1079,9 @@ async def test_modify_streamlit_data_app_update_skips_metadata_when_version_miss
     (review hardening on AJDA-2852). The tool still returns a normal success."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
 
-    workspace_manager.get_workspace_id = mocker.AsyncMock(return_value=1)
+    workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=1)
     workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='default')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='default')
     keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
 
     encrypted_config = {
@@ -1208,7 +1208,7 @@ async def test_modify_python_js_data_app_create_prod_derives_or_honors_slug(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(
         return_value=_make_python_js_data_app_response()
@@ -1270,7 +1270,7 @@ async def test_modify_python_js_data_app_create_calls_full_provisioning_chain(
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
 
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     app_response = _make_python_js_data_app_response()
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=app_response)
@@ -1347,7 +1347,7 @@ async def test_modify_python_js_data_app_create_authentication_type(
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
 
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     app_response = _make_python_js_data_app_response()
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=app_response)
@@ -1390,7 +1390,7 @@ async def test_modify_python_js_data_app_update_patches_storage_config(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
 
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     existing_data_app = DataApp(
         name='Old',
@@ -1462,7 +1462,7 @@ async def test_modify_python_js_data_app_update_repoints_external_git_branch(
     preserved, no re-encryption happens, and the change_summary hints at redeploy (CFTL-714)."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     git_block = {
         'repository': 'https://github.com/org/repo.git',
@@ -1535,7 +1535,7 @@ async def test_modify_python_js_data_app_update_branch_rejected_on_managed_repo_
     is written (CFTL-714 review)."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     managed_repo_app = DataApp(
         name='Prod App',
@@ -1587,7 +1587,7 @@ async def test_modify_python_js_data_app_create_without_workspace_feature(
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=False)
 
-    workspace_manager.get_workspace_id = mocker.AsyncMock(return_value='wid-legacy')
+    workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value='wid-legacy')
 
     app_response = _make_python_js_data_app_response()
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=app_response)
@@ -1628,7 +1628,7 @@ async def test_modify_python_js_data_app_update_injects_workspace_id_without_fea
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.has_feature = mocker.AsyncMock(return_value=False)
 
-    workspace_manager.get_workspace_id = mocker.AsyncMock(return_value='wid-legacy')
+    workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value='wid-legacy')
 
     existing_data_app = DataApp(
         name='Old',
@@ -1689,7 +1689,7 @@ async def test_modify_python_js_data_app_create_passes_storage_through(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
 
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     app_response = _make_python_js_data_app_response()
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=app_response)
@@ -1737,7 +1737,7 @@ async def test_modify_python_js_data_app_create_omits_empty_storage(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
 
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     app_response = _make_python_js_data_app_response()
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(return_value=app_response)
@@ -1774,7 +1774,7 @@ async def test_modify_python_js_data_app_update_replaces_storage(
     """Update path: a non-empty `storage` argument replaces the entire stored storage block."""
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
 
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     existing_data_app = DataApp(
         name='Old',
@@ -2176,7 +2176,7 @@ async def test_modify_python_js_data_app_create_draft_uses_external_git(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     parent_repo = 'https://managed.repo/org/prod.git'
     parent_data_app_id = 'app-prod-1'
@@ -2273,7 +2273,7 @@ async def test_modify_python_js_data_app_create_draft_defaults_branch_to_init(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     parent = _make_python_js_parent_data_app()
     mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=parent))
@@ -2337,7 +2337,7 @@ async def test_modify_python_js_data_app_create_draft_auto_derives_slug(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     parent = _make_python_js_parent_data_app()
     mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=parent))
@@ -2406,7 +2406,7 @@ async def test_modify_python_js_data_app_create_draft_rejects_when_parent_is_str
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     streamlit_parent = _make_python_js_parent_data_app(type='streamlit', repo_url=None)
     mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=streamlit_parent))
@@ -2432,7 +2432,7 @@ async def test_modify_python_js_data_app_create_draft_rejects_when_parent_is_dra
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     # A draft has no repo_url of its own; the guard must fire before the repo_url check below.
     draft_parent = _make_python_js_parent_data_app(is_draft=True, repo_url=None)
@@ -2460,7 +2460,7 @@ async def test_modify_python_js_data_app_create_draft_rejects_when_parent_missin
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     parent = _make_python_js_parent_data_app(repo_url=None)
     mocker.patch('keboola_mcp_server.tools.data_apps._fetch_data_app', mocker.AsyncMock(return_value=parent))
@@ -2485,7 +2485,7 @@ async def test_modify_python_js_data_app_create_prod_calls_get_app_git_repo_for_
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
     keboola_client.data_science_client = mocker.AsyncMock()
     keboola_client.has_feature = mocker.AsyncMock(return_value=True)
-    workspace_manager.get_branch_id = mocker.AsyncMock(return_value='branch-1')
+    workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='branch-1')
 
     keboola_client.data_science_client.create_data_app = mocker.AsyncMock(
         return_value=_make_python_js_data_app_response()

--- a/tests/tools/test_data_apps.py
+++ b/tests/tools/test_data_apps.py
@@ -815,7 +815,7 @@ async def test_modify_streamlit_data_app_folder(
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
 
     workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=1)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='snowflake')
     workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='default')
 
     keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
@@ -937,7 +937,7 @@ async def test_modify_streamlit_data_app_partial_success_when_response_building_
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
 
     workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=1)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='snowflake')
     workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='default')
     keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
 
@@ -1080,7 +1080,7 @@ async def test_modify_streamlit_data_app_update_skips_metadata_when_version_miss
     keboola_client = KeboolaClient.from_state(mcp_context_client.session.state)
 
     workspace_manager.get_data_app_workspace_id = mocker.AsyncMock(return_value=1)
-    workspace_manager.get_sql_dialect = mocker.AsyncMock(return_value='snowflake')
+    workspace_manager.get_data_app_sql_dialect = mocker.AsyncMock(return_value='snowflake')
     workspace_manager.get_data_app_branch_id = mocker.AsyncMock(return_value='default')
     keboola_client.storage_client.project_id = mocker.AsyncMock(return_value='proj-1')
 

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.75.2"
+version = "1.76.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.76.2"
+version = "1.77.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3669](https://linear.app/keboola/issue/AI-3669/use-app-workspace-for-kai-queries-in-apps)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Kai currently always queries the default per-branch, MCP-managed workspace — even when invoked
inside a Data App, which has its own dedicated workspace with its own (potentially more
restricted) permissions. This is the first step towards fixing that: it adds a `workspace_id`
option to the server `Config`, settable via CLI (`--workspace-id`), env (`KBC_WORKSPACE_ID`), or
— since HTTP headers are read per-request — the `X-Workspace-Id` header. When set,
`WorkspaceManager` now resolves that specific workspace via the existing `_find_ws_by_id` lookup
instead of the default per-branch workspace, and takes precedence over the existing
`workspace_schema` option when both are set.

This mirrors the `workspace_schema`/`X-Workspace-Schema` mechanism that already existed, but
keyed by workspace ID instead of schema — Data App runtimes only know their own workspace as a
`WORKSPACE_ID` (see `tools/data_apps.py`), not a schema name, so the ID-based lookup is what a
caller (e.g. kai-agent, when Kai is embedded in a running Data App) will actually be able to
supply.

Follow-up work (separate repos, not part of this PR): `kai-client` needs to accept and forward a
workspace id as a header, `kai-agent` needs to thread that header through to both of its MCP
client paths (backend-side calls and the sandbox's own MCP client), and the Data App /
kbc-ui embed needs to actually supply the app's `WORKSPACE_ID` into the chat request.

### Review round 2 (@MiroCillik) — what changed

- The pin is now decoupled from the two `tools/data_apps.py` bookkeeping call sites
  (`get_data_app_workspace_id()`/`get_data_app_branch_id()`), which previously leaked a pinned
  session's workspace into a *different* data app's own persisted `WORKSPACE_ID` secret.
- A server-configured `workspace_id`/`workspace_schema` is now authoritative over a request
  header (warns instead of silently being overridden); an empty header/env value no longer
  un-pins a server-side default.
- `workspace_id` now requires the `KBC_`/`X-` prefix (a bare `WORKSPACE_ID` env var collides
  with the variable Keboola injects into Data App containers), is validated as numeric, and its
  lookup now falls back to the production-branch client and maps 400/403 like 404.
- `_WspInfo`'s repr no longer prints `credentials`.
- See the review thread for the full point-by-point replies.

### Review round 3 (@cjayyy) — what changed

- A malformed `workspace_id` (header or env) now always rejects instead of silently degrading to
  "not provided" — this closed three related holes at once: a bad `X-Workspace-Id` no longer
  silently widens an unpinned multi-tenant session's scope, a bad `KBC_WORKSPACE_ID` at startup
  now fails loudly like a malformed `--workspace-id` CLI flag already did, and an unrelated
  field's error (e.g. a bad Storage API URL) is no longer misattributed to `workspace_id`.
- Fixed a regression from round 2's joint restore check: an explicit empty `X-Workspace-Schema`
  (the multi-user opt-out) was being treated as an override and silently restored back to the
  server's schema pin.
- `_find_ws_by_id`'s raise on an unusable workspace payload now goes through `_WspInfo`'s
  redacted repr instead of the raw Storage API dict, so `connection.user` (the backend credential
  blob) can't leak into logs/responses/events for the one case round 2's repr fix didn't cover.
- `get_sql_transformation_id_from_sql_dialect()` callers (`create_sql_transformation`,
  `update_sql_transformation`, and the `/preview/configuration` route) now use
  `get_data_app_sql_dialect()` instead of the pin-aware `get_sql_dialect()` — a session pinned to
  a workspace on a different backend than the project's no longer resolves the wrong
  SQL-transformation component. `get_project_info`'s `workspace_id`/`sql_dialect` fields
  intentionally stay pin-aware (they report what the session is actually working against).
- Dropped the unused `strict` parameter from `_find_ws_by_id`; the "no MCP-managed workspace for
  a pinned session" error now includes a recovery hint.
- README: documented that a server's own `KBC_WORKSPACE_ID`/`KBC_WORKSPACE_SCHEMA` pin is
  authoritative over the corresponding per-request header, alongside the existing
  `KBC_STORAGE_API_URL` note.
- See the review thread for the full point-by-point replies.

### Design note (not fully resolved in this PR)

- **Trust boundary**: the workspace pin is a client-supplied header, not an enforcement boundary
  — it narrows access only as much as whoever sets the header is trusted to. This is not a
  regression (`workspace_schema` has always had the same trust model), but it means this PR does
  **not** by itself prevent a Data App user from reaching org data outside their app's workspace
  (the AJDA-3052 "no backdoor" goal) — `get_tables`/`get_bucket_detail`/`get_project_info` still
  read through the caller's own Storage API token, unaffected by this pin. Limiting the token
  itself is tracked separately in `keboola/connection#7981`/`#7985`.
- **Read-only enforcement policy (open)**: a pinned workspace with write access currently only
  gets a `LOG.warning`, not a hard rejection — whether a Data App's platform-provisioned
  workspace actually has `readOnlyStorageAccess: true` is unconfirmed against a real stack.
  Enforcing blindly could break the feature outright if it turns out to be `false`. Once
  confirmed, this should either be promoted to a hard `raise` (if read-only) or backed by a
  `SELECT`-only guard in `tools/sql.py` (if not) — `query_data` has no statement-type guard of
  its own today regardless of this pin.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Unit tests cover the `workspace_id`/`workspace_schema` config parsing (incl. the KBC_-prefix
requirement and empty-value handling), `WorkspaceManager`'s pin-vs-managed workspace split
(precedence, not-found, non-readonly-warning, branch fallback, 400/403 handling), the
`apply_request_config` authoritative-pin behavior, and the CLI `--workspace-id` flag. Full
`pytest` suite passes (1780 passed, 1 deselected — a pre-existing, environment-only flake in
`test_json_logging` unrelated to this PR). `ruff format`/`ruff check` clean; `tox -e
check-tools-docs` unaffected (no tool signature changes).

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable)

