### PR TITLE
fix: send idComponent to the component-configurations search endpoint

### DIFF
--- a/integtests/clients/test_client.py
+++ b/integtests/clients/test_client.py
@@ -1,12 +1,17 @@
 import logging
+from typing import Any, Mapping
 
 import pytest
 
 from integtests.conftest import ProjectDef, TableDef
-from keboola_mcp_server.clients.client import KeboolaClient
+from keboola_mcp_server.clients.client import KeboolaClient, get_metadata_property
 from keboola_mcp_server.clients.storage import AsyncStorageClient, GlobalSearchResponse
+from keboola_mcp_server.config import MetadataField
 
 LOG = logging.getLogger(__name__)
+
+# Any component works for the metadata search; a transformation needs no credentials to be created.
+_TEST_COMPONENT_ID = 'keboola.python-transformation-v2'
 
 
 class TestAsyncStorageClient:
@@ -39,3 +44,50 @@ class TestAsyncStorageClient:
         assert ret.all == len(tables)
         assert len(ret.items) == len(tables)
         assert all(item.type == 'table' for item in ret.items)
+
+    @pytest.mark.asyncio
+    async def test_component_configurations_search_returns_metadata(
+        self, storage_client: AsyncStorageClient, unique_id: str
+    ):
+        """
+        Tests the search endpoint against the live SAPI contract.
+
+        This guards two failure modes that unit tests with a mocked client cannot see, and that
+        together silently disabled the whole folder-hint feature:
+        - a wrong filter name (`componentId` instead of `idComponent`) fails the request with 400;
+        - omitting `include=filteredMetadata` returns rows with no `metadata` key at all, so no
+          folder name is ever found even though the request succeeds.
+        """
+        folder_name = f'Test Folder {unique_id}'
+        created = await storage_client.configuration_create(
+            component_id=_TEST_COMPONENT_ID,
+            name=f'search-metadata-test-{unique_id}',
+            description='Configuration created by an automated test of the metadata search endpoint',
+            configuration={},
+        )
+        configuration_id = str(created['id'])
+        try:
+            await storage_client.configuration_metadata_update(
+                component_id=_TEST_COMPONENT_ID,
+                configuration_id=configuration_id,
+                metadata={MetadataField.CONFIGURATION_FOLDER_NAME: folder_name},
+            )
+
+            results = await storage_client.component_configurations_search(
+                component_id=_TEST_COMPONENT_ID,
+                metadata_keys=[MetadataField.CONFIGURATION_FOLDER_NAME],
+            )
+
+            matching = [r for r in results if r.get('configurationId') == configuration_id]
+            assert len(matching) == 1, f'Configuration {configuration_id} not found in search results: {results}'
+            assert matching[0].get('idComponent') == _TEST_COMPONENT_ID
+            raw_metadata = matching[0].get('metadata')
+            assert isinstance(raw_metadata, list), f'Expected a "metadata" list, got: {raw_metadata!r}'
+            metadata: list[Mapping[str, Any]] = [md for md in raw_metadata if isinstance(md, dict)]
+            assert get_metadata_property(metadata, MetadataField.CONFIGURATION_FOLDER_NAME) == folder_name
+        finally:
+            await storage_client.configuration_delete(
+                component_id=_TEST_COMPONENT_ID,
+                configuration_id=configuration_id,
+                skip_trash=True,
+            )

--- a/integtests/clients/test_client.py
+++ b/integtests/clients/test_client.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import pytest
 

--- a/integtests/tools/components/test_tools.py
+++ b/integtests/tools/components/test_tools.py
@@ -41,6 +41,8 @@ from keboola_mcp_server.tools.components.model import (
 )
 from keboola_mcp_server.tools.components.sql_utils import split_sql_statements
 from keboola_mcp_server.tools.components.utils import (
+    PYTHON_TRANSFORMATION_ID,
+    apply_folder_metadata,
     clean_bucket_name,
     expand_component_types,
     get_sql_transformation_id_from_sql_dialect,
@@ -1047,3 +1049,63 @@ async def test_get_config_examples_with_invalid_component(mcp_context: Context):
     result = await get_config_examples(ctx=mcp_context, component_id='completely-non-existent-component-12345')
 
     assert result == ''
+
+
+# `build_folder_hint` only produces a hint once a component has this many configurations.
+_FOLDER_HINT_MIN_CONFIGS = 20
+
+
+@pytest.mark.asyncio
+async def test_apply_folder_metadata_returns_hint_with_existing_folders(
+    keboola_client: KeboolaClient, keboola_project: ProjectDef, unique_id: str
+):
+    """
+    Tests that a real project with enough configurations yields a folder hint naming existing folders.
+
+    This is the end-to-end guard for the folder-hint feature. It was silently dead for every
+    component: the underlying search call sent a param name the Storage API rejects, and
+    `apply_folder_metadata` swallowed the resulting error, so the hint was simply never produced
+    and no test noticed.
+    """
+    storage_client = keboola_client.storage_client
+    folders = [f'Folder A {unique_id}', f'Folder B {unique_id}']
+    created_ids: list[str] = []
+    try:
+        for i in range(_FOLDER_HINT_MIN_CONFIGS):
+            created = await storage_client.configuration_create(
+                component_id=PYTHON_TRANSFORMATION_ID,
+                name=f'folder-hint-test-{unique_id}-{i}',
+                description='Configuration created by an automated test of the folder hint',
+                configuration={},
+            )
+            created_ids.append(str(created['id']))
+
+        # Only some configurations get a folder, so the hint has to come from the full
+        # configuration count rather than the (smaller) set of folder-bearing ones.
+        for configuration_id, folder in zip(created_ids, folders):
+            await storage_client.configuration_metadata_update(
+                component_id=PYTHON_TRANSFORMATION_ID,
+                configuration_id=configuration_id,
+                metadata={MetadataField.CONFIGURATION_FOLDER_NAME: folder},
+            )
+
+        hint = await apply_folder_metadata(
+            keboola_client,
+            PYTHON_TRANSFORMATION_ID,
+            created_ids[-1],
+            None,  # no folder requested -> return a hint instead of writing metadata
+            'configurations',
+            'update_config',
+        )
+
+        assert hint is not None, 'Expected a folder hint for a component with 20+ configurations.'
+        assert 'Consider organizing them with folders' in hint
+        for folder in folders:
+            assert folder in hint, f'Existing folder "{folder}" missing from hint: {hint}'
+    finally:
+        for configuration_id in created_ids:
+            await storage_client.configuration_delete(
+                component_id=PYTHON_TRANSFORMATION_ID,
+                configuration_id=configuration_id,
+                skip_trash=True,
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.75.1"
+version = "1.75.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -676,19 +676,29 @@ class AsyncStorageClient(KeboolaServiceClient):
         Searches component configurations by component and metadata keys.
         All filters are applied server-side by the SAPI search endpoint.
 
+        The endpoint validates the query string against a fixed set of field names and rejects the
+        whole request with HTTP 400 if an unknown one is sent, so the param names below must match
+        the SAPI contract exactly: the component filter is `idComponent` (*not* `componentId`), and
+        `metadataKeys` must use the bracket-array form. `include=filteredMetadata` is required for
+        the response rows to carry their `metadata` at all — without it each row is only
+        `{'idComponent': ..., 'configurationId': ...}`.
+
         :param component_id: Optional component ID to filter results.
         :param metadata_keys: List of metadata keys to filter by — returns only configurations
             that have at least one of the specified metadata keys set.
-        :return: List of matching configurations as dictionaries.
+        :return: List of matching configurations, one entry per configuration, each with
+            'idComponent', 'configurationId' and a 'metadata' list of {'id', 'key', 'value',
+            'timestamp'} entries holding only the metadata matching `metadata_keys`.
         """
         if not (component_id or metadata_keys):
             return []
         endpoint = f'branch/{self._branch_id}/search/component-configurations'
         params: dict[str, Any] = {}
         if component_id:
-            params['componentId'] = component_id
+            params['idComponent'] = component_id
         for i, key in enumerate(metadata_keys or []):
             params[f'metadataKeys[{i}]'] = key
+        params['include'] = 'filteredMetadata'
         return cast(list[JsonDict], await self.get(endpoint=endpoint, params=params))
 
     async def configuration_metadata_get(self, component_id: str, configuration_id: str) -> list[JsonDict]:

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -697,12 +697,13 @@ async def apply_folder_metadata(
             total, existing_folders, lower_bound = await get_config_folders(client, component_id)
             return build_folder_hint(total, existing_folders, kind, tool_name, lower_bound=lower_bound)
         except Exception as e:
+            # Cause is duplicated into the message text on purpose (see test_apply_folder_metadata_*).
             LOG.exception(
                 'Unable to fetch %s folders for component "%s" when processing configuration "%s": %s',
                 kind,
                 component_id,
                 configuration_id,
-                e,
+                e,  # noqa: TRY401
             )
             return None
     normalized = folder.strip()
@@ -710,11 +711,12 @@ async def apply_folder_metadata(
         try:
             await set_configuration_folder_metadata(client, component_id, configuration_id, normalized)
         except Exception as e:
+            # Cause is duplicated into the message text on purpose (see test_apply_folder_metadata_*).
             LOG.exception(
                 'Unable to set folder metadata for component "%s", configuration "%s": %s',
                 component_id,
                 configuration_id,
-                e,
+                e,  # noqa: TRY401
             )
     elif not is_new:
         await clear_configuration_folder_metadata(client, component_id, configuration_id)

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -688,27 +688,33 @@ async def apply_folder_metadata(
     :param is_new: When True, an empty folder string is a no-op (no folder to remove on a new item).
     :return: Folder hint string if applicable, else None.
     """
+    # Both catches below stay broad on purpose: callers invoke this *after* the configuration has
+    # already been written, so letting anything escape would report a failure for a change that
+    # actually landed. They use LOG.exception (not LOG.warning) so the cause and traceback are
+    # always recorded — a swallowed cause here kept a fully broken folder search invisible.
     if folder is None:
         try:
             total, existing_folders, lower_bound = await get_config_folders(client, component_id)
             return build_folder_hint(total, existing_folders, kind, tool_name, lower_bound=lower_bound)
-        except Exception:
-            LOG.warning(
-                'Unable to fetch %s folders for component "%s" when processing configuration "%s".',
+        except Exception as e:
+            LOG.exception(
+                'Unable to fetch %s folders for component "%s" when processing configuration "%s": %s',
                 kind,
                 component_id,
                 configuration_id,
+                e,
             )
             return None
     normalized = folder.strip()
     if normalized:
         try:
             await set_configuration_folder_metadata(client, component_id, configuration_id, normalized)
-        except Exception:
-            LOG.warning(
-                'Unable to set folder metadata for component "%s", configuration "%s".',
+        except Exception as e:
+            LOG.exception(
+                'Unable to set folder metadata for component "%s", configuration "%s": %s',
                 component_id,
                 configuration_id,
+                e,
             )
     elif not is_new:
         await clear_configuration_folder_metadata(client, component_id, configuration_id)

--- a/tests/clients/test_storage.py
+++ b/tests/clients/test_storage.py
@@ -173,25 +173,62 @@ class TestSearchEndpoints:
         params = raw_client.get.call_args.kwargs['params']
         assert params == {'query': 'foo', 'projectIds[]': ['4214'], 'limit': 10, 'offset': 5, **expected_branch_params}
 
+    @pytest.mark.parametrize(
+        ('component_id', 'metadata_keys', 'expected_params'),
+        [
+            pytest.param(
+                'keboola.ex-test',
+                None,
+                {'idComponent': 'keboola.ex-test', 'include': 'filteredMetadata'},
+                id='component_only',
+            ),
+            pytest.param(
+                None,
+                ['KBC.configuration.folderName'],
+                {'metadataKeys[0]': 'KBC.configuration.folderName', 'include': 'filteredMetadata'},
+                id='metadata_keys_only',
+            ),
+            pytest.param(
+                'keboola.ex-test',
+                ['KBC.configuration.folderName', 'KBC.other'],
+                {
+                    'idComponent': 'keboola.ex-test',
+                    'metadataKeys[0]': 'KBC.configuration.folderName',
+                    'metadataKeys[1]': 'KBC.other',
+                    'include': 'filteredMetadata',
+                },
+                id='component_and_metadata_keys',
+            ),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_component_configurations_search_params(self, raw_client: RawKeboolaClient) -> None:
-        raw_client.get.return_value = [{'id': 'config-1', 'componentId': 'keboola.ex-test'}]
+    async def test_component_configurations_search_params(
+        self,
+        raw_client: RawKeboolaClient,
+        component_id: str | None,
+        metadata_keys: list[str] | None,
+        expected_params: dict[str, Any],
+    ) -> None:
+        """
+        The params must match the SAPI contract exactly, or the feature breaks silently.
+
+        The endpoint validates the query string against a fixed field list and rejects the whole
+        request with HTTP 400 on an unknown name, so the component filter has to be `idComponent`
+        (*not* `componentId`). And `include=filteredMetadata` is what makes the response rows carry
+        their `metadata` at all — without it each row is only `{idComponent, configurationId}` and
+        no caller can read a metadata value, even though the request succeeds.
+        """
+        response = [{'idComponent': 'keboola.ex-test', 'configurationId': 'config-1', 'metadata': []}]
+        raw_client.get.return_value = response
         client = AsyncStorageClient(raw_client=raw_client, branch_id='123')
 
-        result = await client.component_configurations_search(
-            component_id='keboola.ex-test',
-            metadata_keys=['KBC.configuration.folderName', 'KBC.other'],
-        )
+        result = await client.component_configurations_search(component_id=component_id, metadata_keys=metadata_keys)
 
         raw_client.get.assert_called_once_with(
             endpoint='branch/123/search/component-configurations',
-            params={
-                'componentId': 'keboola.ex-test',
-                'metadataKeys[0]': 'KBC.configuration.folderName',
-                'metadataKeys[1]': 'KBC.other',
-            },
+            params=expected_params,
         )
-        assert result == [{'id': 'config-1', 'componentId': 'keboola.ex-test'}]
+        assert result == response
 
     @pytest.mark.asyncio
     async def test_component_configurations_search_requires_filter(self, raw_client: RawKeboolaClient) -> None:

--- a/tests/tools/components/test_utils.py
+++ b/tests/tools/components/test_utils.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from collections.abc import Sequence
 from typing import Any
@@ -28,6 +29,7 @@ from keboola_mcp_server.tools.components.model import (
 from keboola_mcp_server.tools.components.utils import (
     _apply_param_update,
     _normalize_jsonpath,
+    apply_folder_metadata,
     clean_bucket_name,
     clear_configuration_folder_metadata,
     create_transformation_configuration,
@@ -1424,7 +1426,7 @@ async def test_get_config_folders_skips_list_when_enough_folder_configs() -> Non
     folder_configs = [
         {
             'id': str(i),
-            'componentId': 'keboola.snowflake-transformation',
+            'idComponent': 'keboola.snowflake-transformation',
             'metadata': [{'key': MetadataField.CONFIGURATION_FOLDER_NAME, 'value': f'Folder{i % 5}'}],
         }
         for i in range(22)
@@ -1454,12 +1456,12 @@ _MANY_CONFIGS = [{'id': str(i)} for i in range(25)]
             [
                 {
                     'id': '1',
-                    'componentId': 'keboola.snowflake-transformation',
+                    'idComponent': 'keboola.snowflake-transformation',
                     'metadata': [{'key': MetadataField.CONFIGURATION_FOLDER_NAME, 'value': 'Analytics'}],
                 },
                 {
                     'id': '2',
-                    'componentId': 'keboola.snowflake-transformation',
+                    'idComponent': 'keboola.snowflake-transformation',
                     'metadata': [{'key': MetadataField.CONFIGURATION_FOLDER_NAME, 'value': 'Sales'}],
                 },
             ],
@@ -1470,12 +1472,12 @@ _MANY_CONFIGS = [{'id': str(i)} for i in range(25)]
             [
                 {
                     'id': '1',
-                    'componentId': 'keboola.snowflake-transformation',
+                    'idComponent': 'keboola.snowflake-transformation',
                     'metadata': [{'key': MetadataField.CONFIGURATION_FOLDER_NAME, 'value': 'Analytics'}],
                 },
                 {
                     'id': '2',
-                    'componentId': 'keboola.snowflake-transformation',
+                    'idComponent': 'keboola.snowflake-transformation',
                     'metadata': [{'key': MetadataField.CONFIGURATION_FOLDER_NAME, 'value': 'Analytics'}],
                 },
             ],
@@ -1500,6 +1502,55 @@ async def test_get_config_folders(
         component_id='keboola.snowflake-transformation',
         metadata_keys=[MetadataField.CONFIGURATION_FOLDER_NAME],
     )
+
+
+@pytest.mark.asyncio
+async def test_apply_folder_metadata_logs_cause_when_folder_lookup_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test that a failing folder lookup is logged with its cause and does not fail the caller.
+
+    A silent `except Exception` here hid a fully broken search endpoint: every call 400'd, the hint
+    was never produced, and nothing in the logs said why.
+    """
+    client = _make_client([], [])
+    client.storage_client.component_configurations_search = AsyncMock(
+        side_effect=RuntimeError('componentId: "This field was not expected."')
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = await apply_folder_metadata(
+            client, 'keboola.snowflake-transformation', 'cfg-1', None, 'configurations', 'update_config'
+        )
+
+    assert result is None
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    # The cause must be in the message *and* attached as exc_info, so neither a log aggregator
+    # that drops tracebacks nor one that only shows them loses the reason.
+    assert 'This field was not expected.' in record.getMessage()
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_apply_folder_metadata_logs_cause_when_setting_folder_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a failing folder write is logged with its cause and does not fail the caller."""
+    client = _make_client([], [])
+    client.storage_client.configuration_metadata_update = AsyncMock(side_effect=RuntimeError('boom'))
+
+    with caplog.at_level(logging.ERROR):
+        result = await apply_folder_metadata(
+            client, 'keboola.snowflake-transformation', 'cfg-1', 'Analytics', 'configurations', 'update_config'
+        )
+
+    assert result is None
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert 'boom' in record.getMessage()
+    assert record.exc_info is not None
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.75.1"
+version = "1.75.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: n/a — found while investigating CI on #639, unrelated to that change, so scoped as its own PR.

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`SyncStorageClient.component_configurations_search` sent a query param the Storage API rejects, so every call that passed a component ID failed with HTTP 400:

```
GET /v2/storage/branch/default/search/component-configurations?componentId=keboola.data-apps&metadataKeys%5B0%5D=KBC.configuration.folderName
400 {"error": "Invalid request:\n - componentId: \"This field was not expected.\"", "code": "validation.failed"}
```

Observed live in CI integration-test logs ([run 30461862581](https://github.com/keboola/mcp-server/actions/runs/30461862581)); it reproduced on every call with a `component_id`.

**Two bugs, stacked.**

1. **Wrong param name.** The endpoint validates its query string against a fixed field list (a Symfony `Assert\Collection`), so an unknown name fails the whole request. The correct filter is **`idComponent`** — a scalar string, not an array:

   ```php
   // keboola/connection: SearchComponentConfigurationsRequest.php
   public const PARAM_ID_COMPONENT = 'idComponent';
   public const PARAM_CONFIGURATION_ID = 'configurationId';
   public const PARAM_METADATA_KEYS = 'metadataKeys';   // array, bracket form
   public const PARAM_INCLUDE = 'include';
   ```

   So `componentId[]=` would have failed too — the shape was never the problem, the name was.

2. **Missing `include=filteredMetadata`.** Fixing the name alone would have turned the 400 into a silently empty result. `SearchComponentConfigurationsResponseProvider` only attaches per-row `metadata` when that param is present; otherwise each row is just `{idComponent, configurationId}`. `get_config_folders` reads exactly `cfg['metadata']`, so no folder name would ever be found even though the request now succeeds.

Verified against four independent sources: the request class, the controller's OpenAPI attributes, the generated schema in `keboola/ui` (`packages/api-client/.../schema.d.ts`), and what kbc-ui actually sends (`loadComponentsMetadataForce` passes both `idComponent` and `include: 'filteredMetadata'`). The folder metadata key matches the UI's exactly (`KBC.configuration.folderName`), so the server now reads the same folders users see.

**Why nothing failed.** Two reasons, both addressed:

- `apply_folder_metadata` caught the error with a bare `except Exception` and logged a warning *without the exception*, so the cause never reached the logs. The folder hint was dead for **all** components, not just data apps. It now uses `LOG.exception` and includes the exception object. Both catches stay broad on purpose — callers run this *after* the configuration write has landed, so letting anything escape would report failure for a change that actually succeeded. That reasoning is now a comment in the code.
- The existing unit test in `tests/clients/test_storage.py` asserted the *buggy* param name, pinning the bug in place. It now covers all three filter combinations plus `include`.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Verification done here:

- `pytest tests/` → **1613 passed**. `tests/test_server.py::test_json_logging` fails, but it fails identically on a clean `main` — pre-existing and unrelated.
- flake8 / black / isort clean.
- Both new integration tests **collect** but were **not run** — no `INTEGTEST_*` tokens available locally. CI will be their first real execution.
- Confirmed the new tests are genuine regression guards by running them against the old code: the param test fails on both defects independently, and the logging tests fail with zero log records.

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [x] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)

### Notes for the reviewer

- **No Linear issue** — branch and commits therefore don't carry an ID, contrary to `CONTRIBUTING.md`. Confirmed acceptable for this fix; happy to rename if you'd like a ticket created.
- **Integration coverage didn't exist for folders at all**, which is how this reached production. Added at both levels the bug spanned: a client-level test that fails on either defect, and a hint-level test asserting `apply_folder_metadata` returns a hint naming existing folders. The latter creates 20 configurations because that's the `build_folder_hint` threshold — below it `get_config_folders` discards folder names, so a smaller fixture can't assert them. It cleans up in a `finally`.
- **`uv.lock`** was edited in place for the version bump rather than regenerated: the locally available uv (0.7.2) can't parse this repo's `exclude-newer = "7 days"` and rewrites the entire lock file when run. The one-line change is what a version-only `uv lock` would emit — worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
