### PR TITLE
fix(AJDA-3048): clarify transformations can call external APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.75.0"
+version = "1.75.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
+++ b/src/keboola_mcp_server/resources/prompts/project_system_prompt.md
@@ -34,18 +34,13 @@ possible, unless the user specifically requires Python or R.
 
 There are also Python Transformations (component ID: `keboola.python-transformation-v2`) and
 R Transformations (component ID: `keboola.r-transformation-v2`) that can serve the same purpose.
-However, even though Python and R transformations allow you to write code in these languages, never use them to create
+Python and R transformations can technically make outbound calls (e.g. to external APIs), but avoid using them for
 integrations with external systems that download or push data, manipulate remote systems, or require user parameters as
-input.
+input — prefer the Custom Python component for that (component ID: `kds-team.app-custom-python`), since transformations
+are optimized for processing data that already exists in Keboola Storage and storing the results back there.
 
 When updating an existing transformation, check its `component_id` first (`get_configs`): use `update_sql_transformation`
 only for SQL transformations; update Python and R transformations with `update_config`.
-
-The sole purpose of Transformations is to process data that already exists in Keboola and store the results back in
-Keboola Storage.
-
-If you need to write Python code to create an integration, use the Custom Python component
-(component ID: `kds-team.app-custom-python`).
 
 #### Input mapping vs RO Storage
 Transformations can read from Storage in two ways:

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.75.0"
+version = "1.75.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AJDA-3048](https://linear.app/keboola/issue/AJDA-3048/transformations-cant-call-external-apis)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Kai was incorrectly telling users that transformations can't call external APIs. This turned out to be a prompt issue, not a real platform limitation — Python/R transformations technically can make outbound HTTP calls (confirmed on the Linear ticket).

The `### Transformations` section of the base system prompt (`project_system_prompt.md`, injected into every agent session via `get_project_info`) told agents to "never use" Python/R transformations for external integrations and stated their "sole purpose" is processing in-Storage data — phrasing that reads as an absolute technical constraint rather than a routing preference. This got over-generalized into "transformations can't call external APIs."

Reworded the section to make clear this is a best-practice/routing rule (prefer the Custom Python component for integrations) rather than a capability limitation.

## Testing

- [x] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Ran `tox` locally (pytest, black, isort, flake8, check-tools-docs) — all green. `tests/tools/test_project.py` (exercises `get_project_info` / the system prompt content) passes unchanged.

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)