### PR TITLE
docs(AI-3692): Data Catalog RFC — bucket sharing tools

### DIFF
--- a/feature_spec/data_catalog/RFC.md
+++ b/feature_spec/data_catalog/RFC.md
@@ -138,13 +138,75 @@ not `in.c-shared-project-42`), never a lineage-encoding prefix.
    https://github.com/keboola/ai-kit and proceed with the guidance above.
    ```
 
+## Semantic layer interaction (AI-3737)
+
+Raised in review: a bare `share_bucket_to_project`/`share_bucket_to_organization` shares the
+bucket but not any semantic definitions (datasets, metrics, relationships) built on top of it —
+a consumer gets tables with no meaning attached, silently.
+
+The Keboola UI has already worked through this exact problem
+([ui#7885](https://github.com/keboola/ui/pull/7885), also currently unshippable — no backend
+model-sharing endpoint exists yet). Its resolved design, which this RFC now mirrors per
+@tomasfejfar's review comment ("I vote to mirror the UI"):
+
+- **"Share" is a model-level action composed over two independent APIs** — Storage (buckets) and
+  the Metastore (semantic-object scope) — not a bucket-only action. There is no single endpoint
+  that spans both; the composition lives in a dedicated SDK layer
+  (`semanticLayerSharingSdk.shareModel`/`unshareModel` in the UI's case) rather than in each
+  caller, so kbc-ui, Kai's tools, and this MCP server don't drift apart on the semantics.
+- **Order is deliberate and asymmetric.** Share: buckets first, then widen semantic-object scope.
+  Rationale — data without meaning is a degraded-but-usable share; meaning pointing at
+  unreadable tables is worse. Unshare: reverse order — revoke semantic scope first, then unshare
+  buckets, so a consumer is never left holding metric definitions over tables that just vanished.
+- **Not atomic, and reported rather than thrown.** Two independent, partially-async APIs cannot be
+  made transactional. Each bucket gets an outcome (`shared` / `failed` / `excluded`); the overall
+  result carries a `degraded` reason (`partial-failure`, `buckets-held-back`,
+  `definitions-not-shareable-to-users`) instead of a bare success/error. Nothing is rolled back on
+  partial failure — the caller re-runs to retry just the failed parts.
+- **Raw bucket-only sharing stays a legitimate, explicit path** (data with no model behind it),
+  it's just no longer the *default* one the system prompt should steer an agent toward.
+
+**Decision for this RFC:** adopt the same shape rather than Matovidlo's "couple both into one
+tool call, atomic-ish" alternative — the UI's own answer to that exact tradeoff was reported
+partial failure, not forced all-or-nothing, and diverging from it here would leave kbc-ui, Kai,
+and this server disagreeing on what "share" means for the same data.
+
+**Blocking gap:** MCP has no primitive for widening a semantic object's scope. The existing
+semantic tool group (`tools/semantic/`, `tools/semantic/service.py`) is read/validation-only
+(`search_semantic_context`, `validate_semantic_query_with_used_objects`, …) — there is no
+equivalent of the UI's `promoteToOrganizationScope`/`replaceTargetProjects` Metastore calls. A
+`share_semantic_model`/`unshare_semantic_model` tool pair therefore cannot be built until:
+1. a Metastore scoping endpoint exists and is confirmed callable from this server's auth context
+   (same "unshippable without backend" state the UI PR is in), and
+2. this RFC (or a follow-up) specifies the new client methods, the bucket-resolution step (walk a
+   model's datasets → table ids → bucket ids, as the UI's `bucketsForModel` does), and the
+   `ShareSemanticModelResult` shape (per-bucket outcomes + `degraded` reason, mirroring
+   `ShareModelResult`/`SharedBucketOutcome` above).
+
+Until that backend primitive exists, this RFC's three bucket-level tools ship as the explicit
+raw-bucket path, and the system prompt (see below) must say plainly that they do **not** carry
+semantic definitions with them — closing the silent-gap risk AI-3737 flagged, without blocking on
+the semantic-layer work.
+
+**System-prompt addendum** (extends the drafted text in Resolution Strategy step 4 above):
+
+> **Semantic layer note:** these tools share/unshare the bucket only. If the bucket has semantic
+> models, datasets, or metrics defined on top of it, those definitions are **not** shared and the
+> consumer will see tables without any of that meaning attached. Tell the user this explicitly
+> before sharing a bucket that has a semantic model on it. Model-level sharing (bucket +
+> definitions together) is not yet available via MCP tools.
+
 ## Scope
 
 **In scope:** `share_bucket_to_organization`, `share_bucket_to_project`, `unshare_bucket`;
 `wait_for_storage_job`; the three new `AsyncStorageClient` methods; the system-prompt extension
-above.
+above, including the semantic-layer caveat.
 
 **Out of scope:**
+- `share_semantic_model` / `unshare_semantic_model` (model-level sharing composing Storage +
+  Metastore scope, mirroring [ui#7885](https://github.com/keboola/ui/pull/7885)) — blocked on a
+  Metastore scoping endpoint that doesn't exist yet; tracked as a follow-up RFC once that backend
+  primitive ships. See "Semantic layer interaction" above.
 - `get_shared_buckets` / `link_shared_bucket` — PR #646, separate track (rebase/merge tracked
   independently of this RFC).
 - Table aliases / "cherry-pick specific tables into a new named alias bucket" — the
@@ -188,3 +250,11 @@ above.
    but not decided.
 3. **Where the three tools live** — folded into PR #646's `shared_buckets.py` vs. a new
    `sharing.py` — depends on that file's size once #646 merges; decide at implementation time.
+4. **Semantic-model sharing timeline (AI-3737).** `share_semantic_model`/`unshare_semantic_model`
+   are blocked on a Metastore scoping endpoint that doesn't exist yet — the same blocker the UI's
+   prototype ([ui#7885](https://github.com/keboola/ui/pull/7885)) is in. Until it ships, do the
+   three bucket-level tools in this RFC need to actively *warn* the agent (via tool response, not
+   just the system prompt) when the target bucket has semantic objects on it, or is the
+   system-prompt caveat sufficient? Leaning toward system-prompt-only for this RFC to avoid adding
+   a Metastore read dependency to a Storage-only tool, revisit if AI-3737 needs stronger
+   guarantees.

--- a/feature_spec/data_catalog/RFC.md
+++ b/feature_spec/data_catalog/RFC.md
@@ -1,0 +1,190 @@
+# RFC: Data Catalog sharing tools (`share_bucket_to_organization` / `share_bucket_to_project` / `unshare_bucket`)
+
+Linear: [AI-3692](https://linear.app/keboola/issue/AI-3692/data-catalog-rfc-support-sharinglinking-storage-buckets-across)
+
+## Problem
+
+An agent that finishes a pipeline (creates a transformation, runs the job, fills a Storage
+bucket) has no way to publish that bucket into the Data Catalog so another project can reuse it.
+The **consumer** half of this workflow already exists or is in flight:
+
+- `get_buckets`/`get_tables` (`tools/storage/tools.py`) already surface `source_project` on a
+  bucket/table that's already linked into the current project (read side, shipped).
+- `get_shared_buckets` + `link_shared_bucket` (PR #646, `feature_spec/list_shared_buckets/RFC.md`,
+  not yet merged — `CONFLICTING` against main, needs its own rebase, tracked separately) will let
+  an agent discover what other projects have shared and link a chosen bucket in.
+
+But there is no **producer** tool: nothing wraps the Storage API's `share-organization`,
+`share-organization-project`, or unshare (`DELETE .../share`) operations. Without it, step 2 of
+the intended workflow — *"agent shares data from the project it just built to other projects in
+the organization"* — has to be done by hand in the Keboola UI, breaking the agent's end-to-end
+loop:
+
+1. Agent finishes a pipeline in project A (transformation → job run → bucket filled).
+2. **Agent shares the resulting bucket** to the org, or to specific projects. ← missing (this RFC)
+3. An agent in project B discovers and links the shared bucket (PR #646, separate track).
+4. The agent in project B reuses the linked data in a new pipeline (already works — linked
+   buckets/tables behave like any other Storage bucket/table for reads).
+
+## Required Behavior
+
+Three new write tools in the Storage tool group, all **branch-scoped** and **always async**
+(the underlying endpoints have no synchronous option — see below), each **polling its Storage
+job to completion inside the tool call** and returning one final result, not a job handle the
+agent has to poll itself:
+
+| Tool | Wraps | Params | Returns |
+| --- | --- | --- | --- |
+| `share_bucket_to_organization` | `POST /v2/storage/branch/{branchId}/buckets/{bucketId}/share-organization` | `bucket_id: str`, `project_id: ProjectIdArg = None` | `ShareBucketResult` (job id, final status, error message if failed) |
+| `share_bucket_to_project` | `POST /v2/storage/branch/{branchId}/buckets/{bucketId}/share-organization-project` | `bucket_id: str`, `target_project_ids: list[int]` (**name/shape unverified — see Open Questions**), `project_id: ProjectIdArg = None` | `ShareBucketResult` |
+| `unshare_bucket` | `DELETE /v2/storage/branch/{branchId}/buckets/{bucketId}/share` | `bucket_id: str`, `project_id: ProjectIdArg = None` | `ShareBucketResult` |
+
+`project_id` is the existing multi-project write-targeting parameter
+(`keboola_mcp_server.scope.ProjectIdArg`, introduced for PSGO-261) — required only when the
+session is scoped to 2+ projects, otherwise defaults to the single scoped project. It selects
+*which project's Storage API the call runs against*, not the sharing target (that's
+`target_project_ids` for `share_bucket_to_project`).
+
+**No naming parameter on any of these three tools.** They act on an existing bucket by id — the
+bucket keeps its name; sharing/unsharing never renames anything. (This differs from
+`link_shared_bucket` in PR #646, which *does* take a name, because linking creates a *new* local
+bucket. See "Naming convention" below.)
+
+**Confirmed from the Storage OpenAPI spec** (`https://api.keboola.com/specs/storage.json`):
+
+- `share-organization`: no request body; only success response is `202` with a job envelope
+  (`id`, `status`, `url`, `operationName`, `createdTime`, …). Errors: `400` (branch/dev bucket
+  unsupported), `403` (insufficient permissions), `501` (Snowflake Partner Connect projects).
+- `share-organization-project`: same job-envelope shape, only `202`. **The spec does not document
+  a request body at all** — how the target project(s) are specified is unknown from the spec (see
+  Open Questions).
+- Unsharing is `DELETE .../buckets/{bucketId}/share` (there is no `.../unshare` path) — same
+  job-envelope shape, only `202`. A sibling `PUT .../buckets/{bucketId}/share` exists but is an
+  undocumented stub in the spec; not used here.
+- None of the three endpoints accept an `?async=true` toggle — they are unconditionally async.
+  ("Always async, always branch-scoped" also matches this feature's explicit design constraint,
+  independent of the spec.)
+
+### Naming convention (Data Catalog-wide, not just this RFC)
+
+The historical convention at some customers was a `shared-` name prefix (for buckets holding
+cherry-picked table aliases) or embedding the source project's name in a linked bucket's name.
+That convention is now obsolete: the Keboola UI tags a bucket's shared-out/linked-in status
+directly, so the name doesn't need to encode it. The only remaining naming decision is
+`link_shared_bucket`'s bucket name (PR #646) and any future cherry-pick-tables tool — those
+names should be **descriptive of the data/model the bucket holds** (e.g. `in.c-customer-360`,
+not `in.c-shared-project-42`), never a lineage-encoding prefix.
+
+## Resolution Strategy
+
+1. **New `AsyncStorageClient` methods** in `clients/storage.py`, modeled on the existing
+   branch-scoped bucket methods (`bucket_list`, `storage.py:442`) rather than the legacy
+   non-branch metadata methods:
+   - `bucket_share_organization(bucket_id, branch_id=None) -> JsonDict` — `POST
+     branch/{bid}/buckets/{bucket_id}/share-organization`.
+   - `bucket_share_organization_project(bucket_id, target_project_ids, branch_id=None) ->
+     JsonDict` — `POST branch/{bid}/buckets/{bucket_id}/share-organization-project`. Body shape
+     pending the verification in Open Questions.
+   - `bucket_unshare(bucket_id, branch_id=None) -> JsonDict` — `DELETE
+     branch/{bid}/buckets/{bucket_id}/share`.
+   - All three return the raw job envelope (`{id, status, ...}`); none poll internally.
+
+2. **New job-poll helper**, also on `AsyncStorageClient`: `wait_for_storage_job(job_id, *,
+   timeout_seconds=60, poll_interval_seconds=2) -> JsonDict`. Repeatedly calls the existing
+   `job_detail(job_id)` (`storage.py:848`) until `status` is a terminal value (`success`,
+   `error`, `cancelled`) or the timeout elapses, then returns the final job dict (or raises/flags
+   a timeout — exact contract in the implementation PR). **No existing helper does this** — the
+   closest analogues (`clients/jobs_queue.py`'s Queue-API jobs, `workspace.py`'s SQL-job polling)
+   poll a different API and aren't reusable directly, but their backoff/cadence style should
+   inform this one.
+
+3. **New tools**, added to PR #646's `tools/storage/shared_buckets.py` module (same "Data
+   Catalog" tool family as `get_shared_buckets`/`link_shared_bucket` — kept in one place rather
+   than forking a second module, unless that file has grown unreasonably large by the time this
+   is implemented, in which case split into `tools/storage/sharing.py`):
+   - `share_bucket_to_organization`, `share_bucket_to_project`, `unshare_bucket` — each calls its
+     client method, then `wait_for_storage_job`, then maps the final job status to
+     `ShareBucketResult`.
+   - All three get `ToolAnnotations(destructiveHint=True)` (they change who can access existing
+     data, unlike `link_shared_bucket`'s `destructiveHint=False` create-only semantics agreed in
+     PR #646's review thread).
+
+4. **System prompt.** Extend (not replace) the existing "Data Catalog & Data Sharing" section of
+   `resources/prompts/project_system_prompt.md` (currently lines 215-238) with the full 4-step
+   workflow, the naming guidance above, and a pointer to the `keboola/ai-kit` plugin for a fuller
+   guided skill. Drafted text for review (final wording may be adjusted at implementation time):
+
+   ```markdown
+   ### Data Catalog & Data Sharing
+
+   ... (existing Core Concepts / Read-Write Rules paragraphs unchanged) ...
+
+   **Sharing workflow (producer → consumer)**
+   1. After a pipeline finishes and fills a bucket, share it with `share_bucket_to_organization`
+      (whole org) or `share_bucket_to_project` (specific projects) if the user wants to publish it.
+   2. In the target project, discover what's available with `get_shared_buckets`, then bring a
+      chosen bucket in with `link_shared_bucket`.
+   3. Reuse the linked bucket's tables like any other Storage tables (read-only; see Read/Write
+      Rules above).
+   4. `unshare_bucket` revokes sharing; existing links elsewhere are unaffected unless the source
+      project's admin also removes them.
+
+   **Naming:** when linking, choose a descriptive name for what the bucket contains (e.g.
+   `in.c-customer-360`) — the Keboola UI already tags shared/linked status, so don't encode
+   lineage or "shared" in the name.
+
+   **Fuller guidance:** if the `keboola/ai-kit` plugin's data-catalog skill is loaded, defer to
+   it for detailed walkthroughs; if not, tell the user it's available at
+   https://github.com/keboola/ai-kit and proceed with the guidance above.
+   ```
+
+## Scope
+
+**In scope:** `share_bucket_to_organization`, `share_bucket_to_project`, `unshare_bucket`;
+`wait_for_storage_job`; the three new `AsyncStorageClient` methods; the system-prompt extension
+above.
+
+**Out of scope:**
+- `get_shared_buckets` / `link_shared_bucket` — PR #646, separate track (rebase/merge tracked
+  independently of this RFC).
+- Table aliases / "cherry-pick specific tables into a new named alias bucket" — the
+  `table-aliases` endpoint the ticket originally referenced does not appear in the current
+  Storage OpenAPI spec at all (zero occurrences); needs live verification against a test project
+  or the `storage-api-php-client` source before it can be specified. Deferred to a follow-up RFC.
+- The generic `PUT .../buckets/{bucketId}/share`, `POST .../share-to-projects`, `POST
+  .../share-to-users` endpoints — all undocumented stubs in the spec; not used.
+- BigQuery Analytics Hub "listing" endpoints (`.../buckets/{bucketId}/listing`) — a different,
+  unrelated sharing mechanism that happens to live in the same spec neighborhood.
+- Actually authoring a `keboola/ai-kit` data-catalog skill file — that's a separate repository;
+  this RFC only adds the in-prompt pointer to it.
+
+## Testing / Verification
+
+1. **Before implementation**: verify `share-organization-project`'s request body against a live
+   call or the `keboola/storage-api-php-client` source (the same diligence PR #646 applied to
+   `link_shared_bucket`, whose ticket-suggested endpoint turned out to be wrong) — see Open
+   Questions.
+2. Unit tests for `wait_for_storage_job`: immediate success, pending→success after N polls,
+   pending→error, and timeout-without-terminal-status.
+3. Unit tests per tool: happy path (job succeeds), job error surfaced as a clear tool error,
+   `project_id` ambiguity/out-of-scope behavior reusing the existing `MultiProjectMiddleware`
+   write-dispatch tests (`tests/test_multiproject.py`) as a pattern.
+4. `tox` — pytest, black, isort, flake8, `check-tools-docs` all exit 0; `TOOLS.md` regenerated.
+5. Manual smoke test via local `.mcp.json` against two real projects in the same organization:
+   share a bucket to the org, confirm it appears in the other project's `get_shared_buckets`,
+   link it, unshare it, confirm it drops out of `get_shared_buckets` for a project that hadn't
+   already linked it.
+
+## Open Questions
+
+1. **`share_bucket_to_project`'s target-project parameter is unverified.** The Storage OpenAPI
+   spec documents no request body for `share-organization-project` at all. Before implementing,
+   confirm the actual field name/shape (likely something like `{"projects": [<id>, ...]}` or
+   `{"targetProjectId": <id>}`, but this must be confirmed, not assumed) against a live call or
+   the PHP client source, exactly as PR #646 did for `link_shared_bucket`.
+2. **Job-timeout UX.** If a share/unshare job doesn't finish within the poll timeout, should the
+   tool return a "still processing, check back" result, or raise an error? Leaning toward the
+   former (report last-known status rather than fail a probably-succeeding-eventually operation),
+   but not decided.
+3. **Where the three tools live** — folded into PR #646's `shared_buckets.py` vs. a new
+   `sharing.py` — depends on that file's size once #646 merges; decide at implementation time.

--- a/feature_spec/data_catalog/brainstorm.md
+++ b/feature_spec/data_catalog/brainstorm.md
@@ -1,0 +1,167 @@
+---
+slug: data_catalog
+status: ready-for-rfc
+author: Martin Vaško
+created: 2026-08-05
+linear: AI-3692
+---
+
+# Brainstorm: Data Catalog sharing tools for MCP Server
+
+> This document is the discovery artifact that precedes the formal RFC at `./RFC.md`. Anything in the RFC must be traceable to a decision recorded here.
+
+## 1. Problem framing
+
+### Trigger
+The user wants a fully agent-driven Data Catalog loop:
+1. Agent finishes a pipeline in project A (transformation → job run → bucket filled with data).
+2. Agent shares the resulting bucket to the org, or to specific projects.
+3. An agent in project B sees the shared bucket and links it in.
+4. The agent in project B reuses that data in a new pipeline, based on semantics/naming.
+
+Step 3 was already independently in flight as PR #646 (`get_shared_buckets` +
+`link_shared_bucket`, Linear AI-3243, from a support ticket — SUPPORT-16377/Groupon). Steps 1 and
+4 already work today with existing tools (components/flows for pipelines, `get_buckets`/
+`get_tables`/`query_data` for reuse). **Step 2 — the producer side, sharing itself — has no tool
+at all.** That's the actual gap this RFC closes.
+
+### Pain
+- An agent that just built something useful in project A has no way to publish it without the
+  user manually clicking through the Keboola UI's sharing dialog — breaking the "agent does the
+  whole workflow" promise for any cross-project data-sharing scenario.
+- Without a producer tool, PR #646's consumer-side tools (`get_shared_buckets`/
+  `link_shared_bucket`) are only half the loop: useful for *discovering* what a human already
+  shared, useless for an agent trying to *complete* a share→link→reuse workflow end-to-end.
+
+### Cost of inaction
+- Cross-project reuse stays a manual, UI-only, human-in-the-loop step even as the rest of the
+  pipeline (build → run → fill Storage) becomes fully agentic.
+- PR #646 ships a discovery tool with no producer counterpart — the Data Catalog surface stays
+  asymmetric (you can find what others shared, but an agent can never be the one sharing).
+
+## 2. Constraints
+
+### Hard constraints (can't change)
+- **Always branch-scoped, always async** — explicit user instruction, and also the reality of
+  the underlying endpoints: `share-organization`, `share-organization-project`, and the unshare
+  `DELETE .../share` all return **only** `202` + a job envelope (confirmed against the live
+  Storage OpenAPI spec) — there is no synchronous path to skip.
+- **No naming parameter on share/unshare** — they act on an existing bucket by id; only
+  `link_shared_bucket` (a *create*, not a share/unshare) takes a name, per user decision.
+- **RFC before implementation** — `CONTRIBUTING.md`'s RFC Requirement table marks "New MCP tool"
+  as RFC-required; three new tools here means an RFC is mandatory before any tool code lands.
+
+### Prior art
+- **PR #646** (`martinvasko-ai-3243-...`, `feature_spec/list_shared_buckets/RFC.md`) — the
+  consumer-side sibling. Its module (`tools/storage/shared_buckets.py`), its
+  `AsyncStorageClient.shared_bucket_list`/`.bucket_link` pattern, and its careful verification of
+  `link_shared_bucket`'s real request body (the ticket's suggested endpoint was wrong; the actual
+  one was found via the `storage-api-php-client` source) are the template for this RFC's
+  resolution strategy and for flagging `share-organization-project`'s body as unverified rather
+  than guessing.
+- **Existing branch-scoped bucket reads** (`bucket_list`, `bucket_detail` in `clients/storage.py`)
+  — the pattern new sharing methods must follow (`branch/{bid}/...`), as opposed to this
+  codebase's legacy non-branch metadata methods (`bucket_metadata_update` etc.), which must not
+  be copied.
+- **PSGO-261's `ProjectIdArg`** (`keboola_mcp_server.scope`) — the existing multi-project
+  write-targeting parameter every write tool in this codebase now takes; the new sharing tools
+  reuse it rather than inventing a second project-targeting convention.
+- **No existing Storage-job poller** — `jobs_queue.py` (Queue API jobs) and `workspace.py` (SQL
+  job polling) both poll *different* APIs; neither is directly reusable for a Storage-API job id,
+  so `wait_for_storage_job` is new code, informed by their backoff style but not extending them.
+- **No skill/plugin mechanism in this codebase at all** (confirmed: zero references to "skill" or
+  "plugin" in `src/`). The `keboola/ai-kit` pointer can only be a text recommendation in the
+  system prompt, not an actual install trigger.
+
+### Scope split (user-stated)
+The user explicitly scoped this task to **RFC + brainstorm + a drafted system-prompt diff only**;
+new tool/client code is a separate, later implementation PR gated on this RFC being agreed. PR
+#646's rebase/merge is also explicitly a separate, already-identified follow-up — not part of
+this RFC's deliverable.
+
+## 3. Stakeholders
+
+- **Kai / multi-project agents** — the direct beneficiary; this is what makes the share step
+  agent-drivable instead of UI-only.
+- **Customers who filed the underlying support ticket for PR #646** (SUPPORT-16377) — indirectly
+  benefit once the loop is symmetric (their original ask was discovery; full sharing closes the
+  loop their workaround component was trying to bridge).
+- **Whoever implements the follow-up PR** — inherits the one open verification task
+  (`share-organization-project`'s body shape) as a concrete first step, not a vague TODO.
+
+## 4. Alternatives considered
+
+**Async job handling:**
+- **Option A (chosen): tool polls to completion internally.** One tool call, one final answer.
+  Matches how a human/agent expects a "share this bucket" action to feel, and avoids adding a
+  second "check job status" tool just for this feature.
+- **Option B: tool returns the job id immediately**, agent must call a separate poll tool.
+  More technically "correct" for a long-running op, but doubles the tool surface for no benefit
+  here — share/unshare jobs are typically fast, and the agent gains nothing from manual polling
+  it wouldn't also want automated.
+- Rejected B in favor of A (this is also what the user chose when asked directly).
+
+**Skill delivery for `ai-kit`:**
+- **Option A (chosen): a text pointer inside the existing system prompt.** Zero new
+  infrastructure; degrades gracefully when the plugin isn't installed.
+- **Option B: build a real MCP resource/skill-loading mechanism first.** Rejected as far out of
+  proportion to this RFC — this codebase has no resource-listing wiring at all today
+  (`@mcp.resource`/`list_resources` unused), and building one is a separate architectural RFC in
+  its own right, not a "pilot."
+
+**Where the new tools live:**
+- **Option A (chosen): extend PR #646's `tools/storage/shared_buckets.py`.** Same tool family
+  (Data Catalog), avoids fragmenting related tools across files for no reason.
+- **Option B: a brand-new `tools/storage/sharing.py`.** Left as a fallback only if #646's file
+  has grown too large by implementation time — not decided now, deferred to that PR.
+
+## 5. Impact analysis
+
+### Files/symbols touched (implementation PR, not this one)
+- `src/keboola_mcp_server/clients/storage.py` — three new `AsyncStorageClient` methods +
+  `wait_for_storage_job`.
+- `src/keboola_mcp_server/tools/storage/shared_buckets.py` (from #646) or a new `sharing.py` —
+  three new tools.
+- `src/keboola_mcp_server/resources/prompts/project_system_prompt.md` — extend the existing
+  "Data Catalog & Data Sharing" section (lines 215-238 on current main).
+- `TOOLS.md` — regenerated.
+- Tests: `tests/clients/test_storage.py`, `tests/tools/storage/test_shared_buckets.py` (or
+  equivalent), extending #646's existing test files.
+
+### Services/APIs touched
+- Keboola Storage API: `POST .../share-organization`, `POST .../share-organization-project`,
+  `DELETE .../share`, `GET .../jobs/{id}` (existing `job_detail`, now polled).
+
+### Cross-cutting checklist
+- Version bump (minor — new tools) in the implementation PR, once it lands after #646.
+- `uv.lock` sync after the version bump.
+- No new dependencies, no new client classes, no new session/auth model — this is additive to
+  the existing Storage tool surface.
+
+## 6. Security pass
+
+- Sharing/unsharing changes **who can access existing data** — this is exactly why the new tools
+  get `ToolAnnotations(destructiveHint=True)` (unlike `link_shared_bucket`'s
+  `destructiveHint=False`, which only creates a new local pointer, per #646's review thread).
+- No new credentials or token types introduced — sharing runs on the same session token already
+  used for other Storage writes; permission enforcement (403 on insufficient rights) is the
+  Storage API's own, not something this RFC needs to reimplement.
+- No secrets/tokens are logged by the new job-poll helper — it only logs job id/status, mirroring
+  this codebase's existing convention of never logging token material.
+
+## 7. Open questions
+
+Carried into the RFC's own "Open Questions" section verbatim:
+1. `share_bucket_to_project`'s target-project request body is undocumented in the Storage
+   OpenAPI spec — needs live verification before implementation.
+2. Job-timeout UX (report last-known status vs. raise) — not decided.
+3. Final module placement (`shared_buckets.py` vs. a new `sharing.py`) — decide at
+   implementation time based on #646's file size after merge.
+
+## 8. Next step
+
+RFC written (`./RFC.md`) and a system-prompt diff drafted inside it for review. Once agreed:
+1. Rebase/merge PR #646 first (separate task, already identified).
+2. Verify `share-organization-project`'s body shape (Open Question 1).
+3. Open the implementation PR: new client methods, new tools, system-prompt edit, tests,
+   `TOOLS.md` regen, version bump.


### PR DESCRIPTION
## Description

**Linear**: [AI-3692](https://linear.app/keboola/issue/AI-3692/data-catalog-rfc-support-sharinglinking-storage-buckets-across)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

RFC-only PR — no tool/client code. Adds `feature_spec/data_catalog/RFC.md` and
`brainstorm.md` designing the **producer** side of the Data Catalog workflow: three new tools,
`share_bucket_to_organization`, `share_bucket_to_project`, and `unshare_bucket`, wrapping the
Storage API's `share-organization` / `share-organization-project` / `DELETE .../share`
endpoints. All three are always branch-scoped and async (the endpoints have no sync option),
and poll their Storage job to completion inside the tool call rather than exposing a separate
job-status tool.

This builds on top of PR #646 (`get_shared_buckets` + `link_shared_bucket`, the **consumer**
side — discovery + linking), which is not yet merged (currently `CONFLICTING` against main;
rebasing/merging it is a separate, already-identified follow-up, not part of this PR). Together
they complete the loop: build a pipeline → **share** it (this RFC) → discover + **link** it
elsewhere (#646) → reuse it.

One open risk flagged explicitly in the RFC: `share_bucket_to_project`'s target-project request
body is undocumented in the Storage OpenAPI spec and needs live verification (same diligence
#646 applied to `link_shared_bucket`) before the follow-up implementation PR.

Per `CONTRIBUTING.md`'s RFC Requirement table, new MCP tools require an agreed RFC before
implementation — this PR is that RFC. The actual `share_bucket_to_organization` /
`share_bucket_to_project` / `unshare_bucket` tool code, the new `AsyncStorageClient` methods,
the Storage-job poll helper, and the system-prompt edit all land in a separate implementation PR
once this RFC is agreed.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable) — N/A, docs only
- [ ] Integration tests added/updated (if applicable) — N/A, docs only
- [ ] Project version bumped according to the change type — N/A, no code change
- [x] Documentation updated (if applicable) — RFC + brainstorm added