### PR TITLE
chore(deps): batch sqlglot 30.14.0 + docker/login-action 4.5.2

### DIFF
--- a/.github/actions/login-private-registries/action.yml
+++ b/.github/actions/login-private-registries/action.yml
@@ -52,14 +52,14 @@ runs:
         service_account: ${{ inputs.gcpServiceAccount }}
 
     - name: Login to GCP GAR
-      uses: docker/login-action@v4
+      uses: docker/login-action@v4.5.2
       with:
         registry: ${{ inputs.gcpRegistry }}
         username: oauth2accesstoken
         password: ${{ steps.gcpAuth.outputs.access_token }}
 
     - name: Login to Azure ACR
-      uses: docker/login-action@v4
+      uses: docker/login-action@v4.5.2
       with:
         registry: ${{ inputs.acrRegistry }}
         username: ${{ inputs.acrUsername }}

--- a/.github/workflows/kaibench.yml
+++ b/.github/workflows/kaibench.yml
@@ -76,13 +76,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Docker Hub login
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4.5.2
         with:
           username: keboolabot
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: GHCR login
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4.5.2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Docker login
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4.5.2
         with:
           username: ${{ secrets.DOCKERHUB_PUSH_USER }}
           password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.74.6"
+version = "1.74.7"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1332,7 +1332,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.74.6"
+version = "1.74.7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -2537,11 +2537,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "30.13.0"
+version = "30.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/62/6d5bd3169478b7f09e08ab3e50175d486a9e7f3a419b88fc9280ba564ab1/sqlglot-30.13.0.tar.gz", hash = "sha256:f0a6eb79de2fd6efe2689f8cf197caa4f08bfe77c7880315616fa4420b8ba2bf", size = 5932385, upload-time = "2026-07-20T20:16:54.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/cd/39a94f0f98076ee8e7c7c38fd4bba8d7845b0c629ff967057c64ef2c0989/sqlglot-30.14.0.tar.gz", hash = "sha256:df2ef5d2b8ca814313781f4ff35bf63e58f821ef517eeddbd523c19a61fa9bb9", size = 5944410, upload-time = "2026-07-27T11:23:30.698Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/2f/2076eca54f6a8ed1c86301bdb4bb2ae4181b0c1c4dbc041062ca997dc1b2/sqlglot-30.13.0-py3-none-any.whl", hash = "sha256:08f87ff7b052246d61b731628c8c2db0bc91f2c9e69f5ba68a1d160a9f5b49b1", size = 719120, upload-time = "2026-07-20T20:16:53.248Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ec/a729883ceda22dcd9117ce182f64d884bf494e72c4dfce00c2ad0a5978e1/sqlglot-30.14.0-py3-none-any.whl", hash = "sha256:fc768e24889d63a5e1237dea7ad305e5ffb4356a98b0bed828f89591ebcd3636", size = 719007, upload-time = "2026-07-27T11:23:28.637Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

**Linear**: n/a — dependency chore (supersedes dependabot PRs #658, #642)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Batches two open dependabot version bumps into one PR with a single version bump, following the
precedent of #650 / #626.

| Package | From | To |
|---|---|---|
| `sqlglot` | 30.13.0 | 30.14.0 |
| `docker/login-action` | 4.4.0 | 4.5.2 |
| project version | 1.74.6 | 1.74.7 |

**Backwards compatibility — `sqlglot` 30.14.0**

The release contains three commits marked breaking (`!`), but all are postgres/mysql-scoped:

- `feat(postgres)!` — preserve `x IS NOT NULL` instead of normalizing to `NOT x IS NULL`
- `feat(optimizer)!` — annotate `regexpsubstr` / `unhex` / `substringindex` **for mysql**

Our only consumer is a single `sqlglot.transpile()` call in `sql_utils.py:132` (`format_sql`), and the
only dialects that reach it are `snowflake` and `bigquery`. We don't use the optimizer or annotators.

Verified empirically rather than relying on the changelog: 43 cases (the existing test corpus plus
Snowflake/BigQuery-specific syntax — VARIANT casts, `LATERAL FLATTEN`, `COPY INTO`, MERGE,
STRUCT/ARRAY, backtick identifiers, and the changed `IS NOT NULL` / `UNHEX` / `SUBSTRING_INDEX` /
`REGEXP_SUBSTR` constructs) were transpiled under both versions and diffed. **1 of 43 differed, and
it is a fix, not a regression:**

```
[snowflake] CREATE OR REPLACE TABLE out AS SELECT a FROM src QUALIFY ROW_NUMBER() OVER (...) = 1
  30.13.0: ParseError
  30.14.0: parses correctly
```

That is an improvement for us — `CREATE TABLE AS … QUALIFY` is idiomatic Snowflake transformation
code that previously fell into the `except` branch and silently returned unformatted SQL.

Additionally `format_sql` wraps everything in `try/except Exception` and returns the original SQL on
failure, so even an unforeseen parse regression degrades to "not pretty-printed", never an error.
`pyproject.toml` already allows this via `sqlglot ~= 30.0`, so the change is lockfile-only.

**Backwards compatibility — `docker/login-action` 4.5.2**

Every change across 4.5.0 → 4.5.2 is on the Docker Hub OIDC path (OIDC login support, `dhi.io` as an
OIDC registry, surfacing OIDC error responses). All five of our call sites authenticate with classic
`username` + `password`, so the changed code path is never entered. No `EnableOIDC` / `registry-auth`
inputs anywhere.

This PR also pins the two floating `docker/login-action@v4` refs in
`.github/actions/login-private-registries/action.yml` (GCP GAR, Azure ACR) to `4.5.2`. Dependabot only
rewrites exact pins, so those were already floating to 4.5.2 implicitly — now all five call sites use
exact pins consistently.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Not applicable — no runtime/tool behavior changes. Verification was the `tox` gates plus the
differential transpile comparison described above.

`tox` gates run locally on Python 3.12 against the updated lock (`uv sync --frozen`, sqlglot 30.14.0
confirmed installed):

- **pytest** — 1671 passed, 1 failed
  - `tests/test_server.py::test_json_logging` fails identically on unmodified `origin/main` in this
    environment (subprocess/path issue, local-only); it passes in CI on `main`. Unrelated to these bumps.
- **black** (`src/ tests/ integtests/`) — clean, 136 files unchanged
- **flake8** (`src/ tests/ integtests/`) — clean
- **check-tools-docs** — `TOOLS.md` up-to-date

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable) — n/a, dependency-only change
- [ ] Integration tests added/updated (if applicable) — n/a
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable) — n/a

### Note on superseded PRs

Once this merges, #658 and #642 can be closed as superseded. Both currently show failing
**Integration Tests** — that is not caused by the bumps: dependabot-triggered runs don't receive repo
secrets, so the tests error at fixture setup with
`RuntimeError: INTEGTEST_STORAGE_TOKENS must be set...`. Unit tests pass on all three Python versions
in both, and CI on `main` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
