### PR TITLE
chore: make ruff the only linter and formatter

### DIFF
--- a/.claude/skills/recreate-dependabot-pr/SKILL.md
+++ b/.claude/skills/recreate-dependabot-pr/SKILL.md
@@ -93,7 +93,7 @@ CI runs the same checks, so they must pass before pushing. If no venv exists, cr
 ```bash
 python3.10 -m venv 3.10.venv && source 3.10.venv/bin/activate
 pip install -q --upgrade pip uv && uv sync --active --extra dev --extra tests
-tox    # pytest, black, flake8, check-tools-docs — all must exit 0
+tox    # pytest, ruff, check-tools-docs — all must exit 0
 ```
 
 If tests fail because a new major version changed behavior, that package needs manual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,9 @@ Notes:
 - The image version is whatever `pyproject.toml` said **at that commit**; the latest production tag can lag behind `main` HEAD (merged but not yet deployed).
 
 ## Testing
-- **All tox checks must pass before pushing** — CI runs the same checks (pytest, black, flake8, check-tools-docs) and will fail the build if any of them fail
-- **Use tox** for final testing - it runs pytest, black (formatting), flake8 (linter), and check-tools-docs (verifies TOOLS.md is up-to-date)
+- **All tox checks must pass before pushing** — CI runs the same checks (pytest, ruff, check-tools-docs) and will fail the build if any of them fail
+- **Use tox** for final testing - it runs pytest, ruff (formatting + linting), and check-tools-docs (verifies TOOLS.md is up-to-date)
+- Auto-fix formatting and lint issues: `tox -m cs-fix` (runs `ruff format` + `ruff check --fix`; replaces the old black + isort envs)
 - It's OK to use pytest directly for running individual tests during development
 - Activate the virtual environment first (e.g., `source <venv>/bin/activate`)
 - Run specific tests: `tox -e py310 -- tests/test_file.py -v`
@@ -76,7 +77,7 @@ uv sync --active --extra dev --extra tests
 # 4. Verify everything works
 tox
 ```
-All four tox environments (pytest, black, flake8, check-tools-docs) should exit 0.
+All three tox environments (pytest, ruff, check-tools-docs) should exit 0.
 
 ## Integration Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,8 @@ Without a regression test the bug is likely to resurface silently.
 
 These apply to all change types:
 
-- Run `tox` before pushing. CI runs the same checks (pytest, black, isort, flake8,
-  check-tools-docs) and will fail if any of them fail.
+- Run `tox` before pushing. CI runs the same checks (pytest, ruff, check-tools-docs)
+  and will fail if any of them fail. Use `tox -m cs-fix` to auto-fix formatting and lint.
 - Declare `@pytest.mark.parametrize` parameter names as a tuple of strings, not a
   comma-separated string (e.g. `('a', 'b')` not `'a, b'`).
 - See [CLAUDE.md § Testing](CLAUDE.md) for venv setup and `tox` usage.
@@ -111,7 +111,7 @@ addressed before requesting review.
 - [ ] Commit messages start with the Linear issue ID
 - [ ] `pyproject.toml` version bumped (patch / minor / major per CLAUDE.md)
 - [ ] `uv.lock` synced (`uv lock`)
-- [ ] `tox` passes locally (pytest + black + isort + flake8 + check-tools-docs)
+- [ ] `tox` passes locally (pytest + ruff + check-tools-docs)
 - [ ] Self-review completed
 
 ### Bug fixes

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -76,6 +76,6 @@ Review standards for the keboola-mcp-server project, derived from patterns in te
 - No `print()` statements, debug logs, or leftover development artifacts in the final diff
 
 ## Skip
-- Formatting-only changes already enforced by `black` and `flake8` (run via tox)
+- Formatting-only changes already enforced by `ruff format` and `ruff check` (run via tox)
 - Changes to `uv.lock` that are only lockfile resolution updates
 - Auto-generated content in `TOOLS.md`

--- a/integtests/clients/test_client.py
+++ b/integtests/clients/test_client.py
@@ -10,7 +10,6 @@ LOG = logging.getLogger(__name__)
 
 
 class TestAsyncStorageClient:
-
     @pytest.fixture
     def storage_client(self, keboola_client: KeboolaClient, keboola_project: ProjectDef) -> AsyncStorageClient:
         return keboola_client.storage_client

--- a/integtests/test_project_lock.py
+++ b/integtests/test_project_lock.py
@@ -320,7 +320,7 @@ def test_clean_project_deletes_configs(mocker):
     mocker.patch.object(
         lock,
         '_get',
-        side_effect=lambda path, **params: ([] if path.endswith('/buckets') else components),
+        side_effect=lambda path, **params: [] if path.endswith('/buckets') else components,
     )
     delete_mock = mocker.patch.object(lock, '_delete')
 

--- a/integtests/test_workspace.py
+++ b/integtests/test_workspace.py
@@ -81,7 +81,6 @@ async def dynamic_manager(
 
 
 class TestWorkspaceManager:
-
     @pytest.mark.asyncio
     async def test_static_workspace(self, workspace_manager: WorkspaceManager, workspace_schema: str):
         assert workspace_manager._workspace_schema == workspace_schema

--- a/integtests/tools/components/test_tools.py
+++ b/integtests/tools/components/test_tools.py
@@ -342,7 +342,7 @@ async def test_update_config(
             Link(
                 type='ui-detail',
                 title=f'Configuration: {expected_name}',
-                url=f'{storage_api_url}/admin' f'/projects/{project_id}/components/{component_id}/{configuration_id}',
+                url=f'{storage_api_url}/admin/projects/{project_id}/components/{component_id}/{configuration_id}',
             ),
             Link(
                 type='ui-dashboard',
@@ -427,7 +427,6 @@ async def test_add_config_row(
     )
 
     try:
-
         # Create the row configuration
         created_row_config = await add_config_row(
             ctx=mcp_context,
@@ -597,7 +596,7 @@ async def test_update_config_row(
             Link(
                 type='ui-detail',
                 title=f'Configuration: {expected_row_name}',
-                url=f'{storage_api_url}/admin' f'/projects/{project_id}/components/{component_id}/{configuration_id}',
+                url=f'{storage_api_url}/admin/projects/{project_id}/components/{component_id}/{configuration_id}',
             ),
             Link(
                 type='ui-dashboard',
@@ -818,8 +817,7 @@ async def initial_sqltrfm(
                     block_id='b0',
                     code_id='b0.c0',
                     script=(
-                        'SELECT 1 as updated_column;\n\nSELECT 2 as additional_column;\n\n'
-                        'SELECT 3 as third_column;\n\n'
+                        'SELECT 1 as updated_column;\n\nSELECT 2 as additional_column;\n\nSELECT 3 as third_column;\n\n'
                     ),
                 ),
             ],

--- a/integtests/tools/flow/test_tools.py
+++ b/integtests/tools/flow/test_tools.py
@@ -326,9 +326,9 @@ async def test_update_flow(
         expected_phases = [
             phase.model_dump(exclude_unset=True, by_alias=True) for phase in initial_flow.configuration.phases
         ]
-    assert len(flow_data['phases']) == len(
-        expected_phases
-    ), f"Phases count mismatch: {len(flow_data['phases'])} vs {len(expected_phases)}"
+    assert len(flow_data['phases']) == len(expected_phases), (
+        f"Phases count mismatch: {len(flow_data['phases'])} vs {len(expected_phases)}"
+    )
     assert all(
         actual['id'] == expected['id']
         and actual['name'] == expected['name']

--- a/integtests/tools/test_data_apps.py
+++ b/integtests/tools/test_data_apps.py
@@ -50,7 +50,7 @@ def streamlit_app_entrypoint() -> str:
 @pytest.fixture
 def sample_streamlit_app(streamlit_app_imports: str, streamlit_app_entrypoint: str) -> str:
     """Return a minimal Streamlit app template that supports query injection."""
-    return f'{streamlit_app_imports}' '{QUERY_DATA_FUNCTION}\n\n' f'{streamlit_app_entrypoint}'
+    return f'{streamlit_app_imports}{{QUERY_DATA_FUNCTION}}\n\n{streamlit_app_entrypoint}'
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.74.8"
+version = "1.74.9"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,17 +27,6 @@ dependencies = [
 ]
 [project.optional-dependencies]
 codestyle = [
-    "black ~= 26.3",
-    "isort ~= 8.0",
-    "flake8 ~= 7.3",
-    "Flake8-pyproject ~= 1.2",
-    "flake8-bugbear ~= 25.11",
-    "flake8-colors ~= 0.1",
-    "flake8-isort ~= 7.0",
-    "flake8-pytest-style ~= 2.2",
-    "flake8-quotes ~= 3.4",
-    "flake8-typing-imports ~= 1.17",
-    "pep8-naming ~= 0.15",
     "ruff ~= 0.16",
 ]
 tests = [
@@ -64,32 +53,6 @@ keboola-mcp-server = "keboola_mcp_server.cli:main"
 [tool.setuptools.package-data]
 "keboola_mcp_server.resources" = ["storage-schema.json"]
 
-[tool.black]
-target-version = ["py310"]
-skip-string-normalization = true
-line-length = 120
-extend-exclude = '''
-/(
-  # directories
-  \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 120
-multi_line_output = 3
-use_parentheses = true
-
 [tool.uv]
 # Dependency cooldown (supply-chain hardening): never resolve a package version
 # published within the last 7 days. Freshly published malicious releases are
@@ -115,32 +78,23 @@ log_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(name)s: %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
-[tool.flake8]
-max-line-length = 120
-import-order-style = "edited"
-application-package-names = ["keboola_mcp_server"]
-min-python-version = "3.10.0"
-pytest-fixture-no-parentheses = true
-# Skip unused import checks F401 in __init__.py files; re-exported imports are intentional.
-per-file-ignores = [
-    "__init__.py: F401",
-]
-# For Compatibility with black we skip: E203 whitespace before ':', W503 checks line break before binary operator
-# For Compatibility with isort we skip: I101 Imported names are in the wrong order since we follow isort format using
-# alphabetical case-sensitive sort A, B, a, b
-extend-ignore = ["E203", "W503", "I101"]
-
 [tool.ruff]
 target-version = "py310"
 line-length = 120
 
 [tool.ruff.lint]
+# On top of ruff's (already broad) default rule set:
+extend-select = [
+    "I",     # isort -- import sorting; replaces isort + flake8-isort
+    "UP",    # pyupgrade -- modern Python syntax
+    "E402",  # module-level import not at top of file; was enforced by flake8. Keeps the
+             # deliberate `# noqa: E402` markers in tests/tools/test_data_apps.py meaningful
+             # instead of RUF100 flagging them as unused.
+]
 # BLE001: this server's tool/error boundary is built on deliberate broad `except Exception` catches
 # (never crash, always return a structured error/best-effort result) -- see keboola_mcp_server.errors.
 # tool_errors and the many "best effort, log and continue" catches throughout tools/.
-# RUF100: flake8 also lints this codebase and its E402/etc. detection doesn't always agree with
-# ruff's, so a `# noqa: E402` kept for flake8 can look "unused" to ruff. Don't auto-strip those.
-ignore = ["BLE001", "RUF100"]
+ignore = ["BLE001"]
 
 [tool.ruff.lint.per-file-ignores]
 # Re-exports for the package's public API; unused within the module itself.
@@ -151,10 +105,14 @@ ignore = ["BLE001", "RUF100"]
 "tests/**" = ["ASYNC220", "ASYNC221", "DTZ001", "DTZ007", "S102"]
 "integtests/**" = ["ASYNC220", "ASYNC221"]
 
+[tool.ruff.format]
+# Matches black's former `skip-string-normalization`: leave existing quote style alone.
+quote-style = "preserve"
+
 [tool.tox]
 requires = ["tox>=4.23"]
-env_list = ["python", "black", "isort", "flake8", "ruff", "check-tools-docs"]
-labels = { cs-fix = ["black", "isort"], cs = ["isort", "flake8", "ruff"] }
+env_list = ["python", "ruff", "check-tools-docs"]
+labels = { cs-fix = ["ruff-fix"], cs = ["ruff"] }
 
 [tool.tox.env_run_base]
 description = "Run tests"
@@ -201,45 +159,27 @@ commands = [
     ],
 ]
 
-[tool.tox.env.black]
-description = "Fix code formatting using black"
-package = "skip"
-deps = [
-    "black ~= 26.3",
-]
-commands = [["black", "src/", "tests/", "integtests/"]]
-
-[tool.tox.env.isort]
-description = "Sort imports using isort"
-package = "skip"
-deps = [
-    "isort ~= 8.0",
-]
-commands = [["isort", "src/", "tests/", "integtests/"]]
-
-[tool.tox.env.flake8]
-description = "Run code style check using flake8"
-package = "skip"
-deps = [
-    "flake8 ~= 7.3",
-    "Flake8-pyproject ~= 1.2",
-    "flake8-bugbear ~= 25.11",
-    "flake8-colors ~= 0.1",
-    "flake8-isort ~= 7.0",
-    "flake8-pytest-style ~= 2.2",
-    "flake8-quotes ~= 3.4",
-    "flake8-typing-imports ~= 1.17",
-    "pep8-naming ~= 0.15",
-]
-commands = [["flake8", "src/", "tests/", "integtests/"]]
-
 [tool.tox.env.ruff]
-description = "Run additional lint checks using ruff"
+description = "Check formatting and run lint checks using ruff"
 package = "skip"
 deps = [
     "ruff ~= 0.16",
 ]
-commands = [["ruff", "check", "src/", "tests/", "integtests/"]]
+commands = [
+    ["ruff", "format", "--check", "src/", "tests/", "integtests/"],
+    ["ruff", "check", "src/", "tests/", "integtests/"],
+]
+
+[tool.tox.env.ruff-fix]
+description = "Auto-fix formatting and lint issues using ruff (replaces the old black + isort envs)"
+package = "skip"
+deps = [
+    "ruff ~= 0.16",
+]
+commands = [
+    ["ruff", "format", "src/", "tests/", "integtests/"],
+    ["ruff", "check", "--fix", "src/", "tests/", "integtests/"],
+]
 
 [tool.tox.env.check-tools-docs]
 description = "Check if TOOLS.md is up-to-date with tool definitions"

--- a/src/keboola_mcp_server/clients/data_science.py
+++ b/src/keboola_mcp_server/clients/data_science.py
@@ -128,7 +128,7 @@ class CodeDataAppConfig(BaseModel):
                 repository: str = Field(description='HTTPS clone URL of the upstream managed git repo.')
                 username: str = Field(
                     description=(
-                        'Username for HTTPS basic auth. The git-service ignores this and only validates ' 'the token.'
+                        'Username for HTTPS basic auth. The git-service ignores this and only validates the token.'
                     ),
                 )
                 password: str = Field(
@@ -364,7 +364,6 @@ class AppRunResponse(BaseModel):
 
 
 class DataScienceClient(KeboolaServiceClient):
-
     def __init__(self, raw_client: RawKeboolaClient, branch_id: str | None = None) -> None:
         """
         Creates a DataScienceClient from a RawKeboolaClient and a branch id.

--- a/src/keboola_mcp_server/clients/encryption.py
+++ b/src/keboola_mcp_server/clients/encryption.py
@@ -60,7 +60,6 @@ def redact_secrets(value: Any, *, mask: str = REDACTED_SECRET_VALUE) -> Any:
 
 
 class EncryptionClient(KeboolaServiceClient):
-
     @classmethod
     def create(
         cls,

--- a/src/keboola_mcp_server/clients/query.py
+++ b/src/keboola_mcp_server/clients/query.py
@@ -26,7 +26,6 @@ _SUBMIT_JOB_RETRY_DELAY_SECONDS = 1.0
 
 
 class QueryServiceClient(KeboolaServiceClient):
-
     def __init__(self, raw_client: RawKeboolaClient, branch_id: str) -> None:
         """
         Creates a QueryServiceClient from a RawKeboolaClient and a branch id.
@@ -106,8 +105,7 @@ class QueryServiceClient(KeboolaServiceClient):
                 if not is_transient_credentials_failure or attempt == _SUBMIT_JOB_MAX_ATTEMPTS:
                     raise
                 LOG.warning(
-                    'Job submission failed to fetch workspace credentials '
-                    '(attempt %d/%d), retrying: workspace_id=%s',
+                    'Job submission failed to fetch workspace credentials (attempt %d/%d), retrying: workspace_id=%s',
                     attempt,
                     _SUBMIT_JOB_MAX_ATTEMPTS,
                     workspace_id,

--- a/src/keboola_mcp_server/clients/scheduler.py
+++ b/src/keboola_mcp_server/clients/scheduler.py
@@ -17,7 +17,6 @@ LOG = logging.getLogger(__name__)
 
 
 class Schedule(BaseModel):
-
     cron_tab: str = Field(
         validation_alias=AliasChoices('cronTab', 'cron_tab', 'cron-tab'),
         serialization_alias='cronTab',
@@ -28,7 +27,6 @@ class Schedule(BaseModel):
 
 
 class TargetConfiguration(BaseModel):
-
     component_id: str = Field(
         validation_alias=AliasChoices('componentId', 'component_id', 'component-id'),
         serialization_alias='componentId',

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -302,7 +302,6 @@ class CreateConfigurationAPIResponse(BaseModel):
 
 
 class AsyncStorageClient(KeboolaServiceClient):
-
     def __init__(
         self,
         raw_client: RawKeboolaClient,
@@ -686,7 +685,7 @@ class AsyncStorageClient(KeboolaServiceClient):
     async def configuration_metadata_delete(self, component_id: str, configuration_id: str, metadata_id: str) -> None:
         """Deletes a single metadata entry for a configuration."""
         endpoint = (
-            f'branch/{self._branch_id}/components/{component_id}' f'/configs/{configuration_id}/metadata/{metadata_id}'
+            f'branch/{self._branch_id}/components/{component_id}/configs/{configuration_id}/metadata/{metadata_id}'
         )
         await self.delete(endpoint=endpoint)
 

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -74,7 +74,7 @@ class Config:
 
     @classmethod
     def _read_options(cls, d: Mapping[str, str]) -> Mapping[str, Any]:
-        data = {cls._normalize(k): v for k, v, in d.items()}
+        data = {cls._normalize(k): v for k, v in d.items()}
         options: dict[str, Any] = {}
         for f in dataclasses.fields(cls):
             field_names = [f.name] + f.metadata.get('aliases', [])

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -300,9 +300,9 @@ class SessionStateMiddleware(fmw.Middleware):
         if user := http_rq.scope.get('user'):
             LOG.debug(f'Injecting bearer and SAPI tokens: user={user}, access_token={user.access_token}')
             assert isinstance(user, AuthenticatedUser), f'Expecting AuthenticatedUser, got: {type(user)}'
-            assert isinstance(
-                user.access_token, ProxyAccessToken
-            ), f'Expecting ProxyAccessToken, got: {type(user.access_token)}'
+            assert isinstance(user.access_token, ProxyAccessToken), (
+                f'Expecting ProxyAccessToken, got: {type(user.access_token)}'
+            )
             config = dataclasses.replace(
                 config,
                 storage_token=user.access_token.sapi_token,

--- a/src/keboola_mcp_server/oauth.py
+++ b/src/keboola_mcp_server/oauth.py
@@ -124,7 +124,6 @@ class ProxyRefreshToken(RefreshToken):
 
 
 class SimpleOAuthProvider(OAuthProvider):
-
     def __init__(
         self,
         *,
@@ -283,7 +282,7 @@ class SimpleOAuthProvider(OAuthProvider):
                     f'OAuth server response: status={response.status_code}, text={response.text}'
                 )
                 raise HTTPException(
-                    400, 'Failed to exchange code for token: ' f'status={response.status_code}, text={response.text}'
+                    400, f'Failed to exchange code for token: status={response.status_code}, text={response.text}'
                 )
 
             data = response.json()
@@ -375,7 +374,7 @@ class SimpleOAuthProvider(OAuthProvider):
         :raises HTTPException: If the OAuth server response indicates an error.
         """
         _log_debug(
-            f'[exchange_authorization_code] authorization_code={authorization_code}, ' f'client_id={client.client_id}'
+            f'[exchange_authorization_code] authorization_code={authorization_code}, client_id={client.client_id}'
         )
         # Check that we get the instance loaded by load_authorization_code() function.
         assert isinstance(authorization_code, _ExtendedAuthorizationCode)
@@ -445,8 +444,7 @@ class SimpleOAuthProvider(OAuthProvider):
         now = time.time()
         if proxy_token.expires_at and proxy_token.expires_at < now:
             LOG.info(
-                f'[load_access_token] Expired access token: proxy_token.expires_at={proxy_token.expires_at}, '
-                f'now={now}'
+                f'[load_access_token] Expired access token: proxy_token.expires_at={proxy_token.expires_at}, now={now}'
             )
 
         return proxy_token
@@ -501,7 +499,7 @@ class SimpleOAuthProvider(OAuthProvider):
         :raises HTTPException: If the OAuth server response indicates an error.
         """
         _log_debug(
-            f'[exchange_refresh_token] client_id={client.client_id}, refresh_token={refresh_token}, ' f'scopes={scopes}'
+            f'[exchange_refresh_token] client_id={client.client_id}, refresh_token={refresh_token}, scopes={scopes}'
         )
 
         assert isinstance(refresh_token, ProxyRefreshToken), f'Expected ProxyRefreshToken, got {type(refresh_token)}'
@@ -525,7 +523,7 @@ class SimpleOAuthProvider(OAuthProvider):
                     f'OAuth server response: status={response.status_code}, text={response.text}'
                 )
                 raise HTTPException(
-                    400, 'Failed to refresh token: ' f'status={response.status_code}, text={response.text}'
+                    400, f'Failed to refresh token: status={response.status_code}, text={response.text}'
                 )
 
             data = response.json()

--- a/src/keboola_mcp_server/resources/prompts/__init__.py
+++ b/src/keboola_mcp_server/resources/prompts/__init__.py
@@ -84,7 +84,7 @@ def _build_dialect_section(sql_dialect: str) -> str:
         '### SQL Identifiers\n',
         f'This project uses **{sql_dialect}** SQL dialect.',
         f'The delimited identifier character is the {cfg["delimiter"]}.',
-        ('**Always wrap every identifier** (column name, table name, alias) ' 'in delimited identifiers:\n'),
+        ('**Always wrap every identifier** (column name, table name, alias) in delimited identifiers:\n'),
         f'- Column reference: {cfg["col"]}',
         f'- Fully qualified table name: {cfg["fqn"]}',
         f'- New table in CREATE TABLE (table name only, no FQN): {cfg["new_table"]}',

--- a/src/keboola_mcp_server/tools/components/tools.py
+++ b/src/keboola_mcp_server/tools/components/tools.py
@@ -534,7 +534,7 @@ async def create_sql_transformation(
             )
             change_summary = None
 
-    LOG.info(f'Created new transformation "{component_id}" with configuration id ' f'"{configuration_id}".')
+    LOG.info(f'Created new transformation "{component_id}" with configuration id "{configuration_id}".')
 
     vars_result = None
     if variables:
@@ -1295,8 +1295,7 @@ async def add_config_row(
     links_manager = await ProjectLinksManager.from_client(client)
 
     LOG.info(
-        f'Creating new configuration row: {name} for component: {component_id} '
-        f'and configuration {configuration_id}.'
+        f'Creating new configuration row: {name} for component: {component_id} and configuration {configuration_id}.'
     )
 
     api_component = await fetch_component(client=client, component_id=component_id)
@@ -1344,9 +1343,7 @@ async def add_config_row(
         ),
     )
 
-    LOG.info(
-        f'Created new configuration for component "{component_id}" with configuration id ' f'"{configuration_id}".'
-    )
+    LOG.info(f'Created new configuration for component "{component_id}" with configuration id "{configuration_id}".')
 
     await set_cfg_update_metadata(
         client=client,
@@ -1547,7 +1544,7 @@ async def update_config(
             skip_trash=True,
         )
 
-    LOG.info(f'Updated configuration for component "{component_id}" with configuration id ' f'"{configuration_id}".')
+    LOG.info(f'Updated configuration for component "{component_id}" with configuration id "{configuration_id}".')
 
     folder_hint = (
         await apply_folder_metadata(client, component_id, configuration_id, folder, 'configurations', 'update_config')

--- a/src/keboola_mcp_server/tools/components/utils.py
+++ b/src/keboola_mcp_server/tools/components/utils.py
@@ -870,7 +870,6 @@ def _apply_param_update(params: dict[str, Any], update: ConfigParamUpdate) -> di
         return params
 
     elif update.op == 'str_replace':
-
         if not update.search_for:
             raise ValueError('Search string is empty')
 

--- a/src/keboola_mcp_server/tools/jobs.py
+++ b/src/keboola_mcp_server/tools/jobs.py
@@ -161,7 +161,7 @@ class JobDetail(JobListItem):
                 # ValueError/AssertionError get wrapped into a pydantic.ValidationError; other
                 # exception types propagate raw.
                 raise ValueError(  # noqa: TRY004
-                    'Field "result" or "config_data" cannot be a list, expecting dictionary, ' f'got: {current_value}.'
+                    f'Field "result" or "config_data" cannot be a list, expecting dictionary, got: {current_value}.'
                 )
         return current_value
 
@@ -236,7 +236,7 @@ async def get_jobs(
         int,
         Field(
             description=(
-                'The number of jobs to list when listing (ignored if job_ids is provided), ' 'default = 100, max = 500.'
+                'The number of jobs to list when listing (ignored if job_ids is provided), default = 100, max = 500.'
             ),
             ge=1,
             le=500,
@@ -253,7 +253,7 @@ async def get_jobs(
         SORT_BY_VALUES,
         Field(
             description=(
-                'The field to sort the jobs by when listing (ignored if job_ids is provided), ' 'default = "startTime".'
+                'The field to sort the jobs by when listing (ignored if job_ids is provided), default = "startTime".'
             ),
         ),
     ] = 'startTime',

--- a/src/keboola_mcp_server/tools/search_models.py
+++ b/src/keboola_mcp_server/tools/search_models.py
@@ -141,7 +141,7 @@ class SearchHit(BaseModel):
 
         if self.configuration_row_id and not all([self.component_id, self.configuration_id]):
             raise ValueError(
-                'If configuration_row_id is filled, ' 'both component_id and configuration_id must be filled.'
+                'If configuration_row_id is filled, both component_id and configuration_id must be filled.'
             )
 
         if self.configuration_id and not self.component_id:

--- a/src/keboola_mcp_server/tools/semantic/tools.py
+++ b/src/keboola_mcp_server/tools/semantic/tools.py
@@ -669,12 +669,12 @@ async def get_semantic_context(
     # Normalize the contexts to the SemanticObjectTypeContext format
     normalized_contexts: list[SemanticObjectTypeContext] = []
     for selection, context in zip(semantic_objects, groups, strict=True):
-        assert isinstance(
-            context, semantic_service.SemanticServiceDataTypeGroup
-        ), f'Expected SemanticServiceDataTypeGroup, got {type(context)}'
-        assert (
-            selection.object_type == context.object_type
-        ), f'Semantic object type mismatch: {selection.object_type} != {context.object_type}'
+        assert isinstance(context, semantic_service.SemanticServiceDataTypeGroup), (
+            f'Expected SemanticServiceDataTypeGroup, got {type(context)}'
+        )
+        assert selection.object_type == context.object_type, (
+            f'Semantic object type mismatch: {selection.object_type} != {context.object_type}'
+        )
         if selection.ids:
             # Detail context with specific IDs
             normalized_contexts.append(

--- a/src/keboola_mcp_server/tools/storage/tools.py
+++ b/src/keboola_mcp_server/tools/storage/tools.py
@@ -150,16 +150,15 @@ class BucketDetail(BaseModel):
     ) -> 'BucketDetail':
         if self.branch_id:
             raise ValueError(
-                f'Dev branch buckets cannot be shaded: ' f'bucket.id={self.id}, bucket.branch_id={self.branch_id}'
+                f'Dev branch buckets cannot be shaded: bucket.id={self.id}, bucket.branch_id={self.branch_id}'
             )
         if not other.branch_id:
             raise ValueError(
-                f'Prod branch buckets cannot shade others: ' f'bucket.id={other.id}, bucket.branch_id={other.branch_id}'
+                f'Prod branch buckets cannot shade others: bucket.id={other.id}, bucket.branch_id={other.branch_id}'
             )
         if other.branch_id != branch_id:
             raise ValueError(
-                f'Dev branch mismatch: '
-                f'bucket.id={other.id}, bucket.branch_id={other.branch_id}, branch_id={branch_id}'
+                f'Dev branch mismatch: bucket.id={other.id}, bucket.branch_id={other.branch_id}, branch_id={branch_id}'
             )
         if other.prod_id != self.id:
             raise ValueError(f'Prod and dev buckets mismatch: prod_bucket.id={self.id}, dev_bucket.id={other.id}')

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -108,7 +108,7 @@ class TestRawKeboolaClient:
         type(mock_http_response_500).text = PropertyMock(return_value='Invalid JSON')
         mock_http_response_500.json.side_effect = ValueError('Invalid JSON')
 
-        match = "Internal Server Error for url 'https://api.example.com/test'\n" 'API error: Invalid JSON'
+        match = "Internal Server Error for url 'https://api.example.com/test'\nAPI error: Invalid JSON"
         with pytest.raises(httpx.HTTPStatusError, match=match):
             raw_client._raise_for_status(mock_http_response_500)
 
@@ -339,7 +339,6 @@ class TestAsyncStorageClient:
 
 
 class TestKeboolaClient:
-
     @pytest.fixture
     def runtime_config(self) -> ServerRuntimeInfo:
         return ServerRuntimeInfo(transport='stdio', server_id='test')

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -176,13 +176,7 @@ def test_exclude_none_serializer(data, expected):
                 NestedModel(field1='value1', field2=['item1', 'item2']),
                 NestedModel(field1='value2', field2=['item3', 'item4']),
             ],
-            (
-                '[2]:\n'
-                '  - field1: value1\n'
-                '    field2[2]: item1,item2\n'
-                '  - field1: value2\n'
-                '    field2[2]: item3,item4'
-            ),
+            ('[2]:\n  - field1: value1\n    field2[2]: item1,item2\n  - field1: value2\n    field2[2]: item3,item4'),
         ),
         # Complex structure with models, lists, dicts, and None
         (
@@ -193,15 +187,7 @@ def test_exclude_none_serializer(data, expected):
                 ],
                 'meta': SimpleModel(field1='test'),
             },
-            (
-                'users[2]{name,active}:\n'
-                '  Alice,true\n'
-                '  Bob,null\n'
-                'meta:\n'
-                '  field1: test\n'
-                '  field2: null\n'
-                '  field3: null'
-            ),
+            ('users[2]{name,active}:\n  Alice,true\n  Bob,null\nmeta:\n  field1: test\n  field2: null\n  field3: null'),
         ),
     ],
 )

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -13,7 +13,6 @@ JWT_KEY = 'secret'
 
 
 class TestSimpleOAuthProvider:
-
     @pytest.fixture
     def oauth_provider(self) -> SimpleOAuthProvider:
         return SimpleOAuthProvider(

--- a/tests/tools/components/test_sql_utils.py
+++ b/tests/tools/components/test_sql_utils.py
@@ -155,7 +155,7 @@ def _short_id(value: object) -> str | None:
             ),
             [
                 'SELECT 1;',
-                ('-- Comment line\nexecute immediate $$\n  SELECT 2;\n  ' "SELECT 'value;still string';\n$$;"),
+                ('-- Comment line\nexecute immediate $$\n  SELECT 2;\n  SELECT \'value;still string\';\n$$;'),
                 'SELECT 3;',
                 '-- Another comment\nSELECT "double" as col;',
             ],

--- a/tests/tools/components/test_tools.py
+++ b/tests/tools/components/test_tools.py
@@ -1358,7 +1358,9 @@ async def test_get_config_examples(
     keboola_client.ai_service_client.get_component_detail = mocker.AsyncMock(return_value=mock_component)
 
     text = await get_config_examples(component_id='keboola.ex-aws-s3', ctx=context)
-    assert text == """# Configuration Examples for `keboola.ex-aws-s3`
+    assert (
+        text
+        == """# Configuration Examples for `keboola.ex-aws-s3`
 
 ## Root Configuration Examples
 
@@ -1379,6 +1381,7 @@ async def test_get_config_examples(
 ```
 
 """
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/tools/components/test_utils.py
+++ b/tests/tools/components/test_utils.py
@@ -112,10 +112,7 @@ def test_expand_component_types(
                                     name='Code 0',
                                     script=[
                                         'CREATE OR REPLACE TABLE "test_table_1" AS SELECT * FROM "test";',
-                                        (
-                                            '-- comment\n'
-                                            'CREATE OR REPLACE TABLE "test_table_2" AS SELECT * FROM "test";'
-                                        ),
+                                        ('-- comment\nCREATE OR REPLACE TABLE "test_table_2" AS SELECT * FROM "test";'),
                                     ],
                                 )
                             ],
@@ -1331,11 +1328,7 @@ def test_structure_summary(parameters: dict[str, Any], expected_markdown: str):
                     SimplifiedTfBlocks.Block(name='New Block', codes=[]),
                 ]
             ),
-            (
-                'Added block with name "New Block"\n'
-                'Added code with name "New Code"\n'
-                '## Updated Transformation Structure'
-            ),
+            ('Added block with name "New Block"\nAdded code with name "New Code"\n## Updated Transformation Structure'),
         ),
         # Empty updates list - should return empty message
         (

--- a/tests/tools/semantic/test_service.py
+++ b/tests/tools/semantic/test_service.py
@@ -729,7 +729,7 @@ def test_constraint_is_relevant_edge_cases(
         # Relationship with uppercase ON clause columns — but the actual SQL uses DIFFERENT columns
         # in the join (FK_ORDER_ID instead of FK_CUSTOMER_ID).  Should NOT detect the relationship.
         (
-            ('SELECT * FROM "DB"."s"."ORDERS" o ' 'JOIN "DB"."s"."CUSTOMERS" c ON o."FK_ORDER_ID" = c."PK_ORDER_ID"'),
+            ('SELECT * FROM "DB"."s"."ORDERS" o JOIN "DB"."s"."CUSTOMERS" c ON o."FK_ORDER_ID" = c."PK_ORDER_ID"'),
             [
                 (
                     'dataset-orders',

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -1095,7 +1095,7 @@ class TestGlobalTextualSearch:
                     Link(
                         type='ui-detail',
                         title='Flow: My Flow',
-                        url=(f'https://connection.test.keboola.com/admin/projects/{project_id}' '/flows/flow-1'),
+                        url=(f'https://connection.test.keboola.com/admin/projects/{project_id}/flows/flow-1'),
                     )
                 ],
             ),

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -125,9 +125,9 @@ async def test_query_data_emits_progress_notification_with_job_id(mcp_context_cl
     mcp_context_client.session.send_notification.assert_awaited_once()
     call_args = mcp_context_client.session.send_notification.await_args
     sent = call_args.args[0]
-    assert (
-        call_args.kwargs.get('related_request_id') == 'req-99'
-    ), f'related_request_id missing or wrong: {call_args.kwargs!r}'
+    assert call_args.kwargs.get('related_request_id') == 'req-99', (
+        f'related_request_id missing or wrong: {call_args.kwargs!r}'
+    )
     # The wrapper is ServerNotification(root=ProgressNotification(...)); both .root and
     # the wrapper's model_dump should expose the progress notification shape.
     progress = sent.root if hasattr(sent, 'root') else sent
@@ -209,7 +209,6 @@ async def test_query_data_skips_progress_when_request_id_missing(mcp_context_cli
 
 
 class TestWorkspaceManagerSnowflake:
-
     @pytest.fixture
     def context(self, keboola_client: KeboolaClient, empty_context: Context, mocker) -> Context:
         keboola_client.storage_client.workspace_list.return_value = [

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version < '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -41,7 +41,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -146,50 +146,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
-]
-
-[[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/84/b3f55026206a9e8820a91503308075ca48eadc515e436731ca01dbe043b3/black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893", size = 1987719, upload-time = "2026-05-18T17:05:02.757Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/34/7db312c5e5783d6e76cffd9d5ac8972a32badae4c6e3288dac0eed8d3bed/black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90", size = 1810083, upload-time = "2026-05-18T17:05:04.302Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e2/e0101e73c2c8727634e2efcb35e2b34bd23ad70dfa673789f5773a591b21/black-26.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4", size = 1860633, upload-time = "2026-05-18T17:05:06.391Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4c/e15c0c5b23cf3651035fe5addcce90e283af3548a3f91bb03d81b83106ab/black-26.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef", size = 1477886, upload-time = "2026-05-18T17:05:07.96Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3f/59d43ade98d2ce5c8dc34a4e46cbecd177e6d55d7d4092969c6003ccc655/black-26.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22", size = 1277111, upload-time = "2026-05-18T17:05:09.473Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
-    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -835,113 +791,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
-name = "flake8-bugbear"
-version = "25.11.29"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "flake8" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/20/2a996e2fca7810bd1b031901d65fc4292630895afcb946ebd00568bdc669/flake8_bugbear-25.11.29.tar.gz", hash = "sha256:b5d06710f3d26e595541ad303ad4d5cb52578bd4bccbb2c2c0b2c72e243dafc8", size = 84896, upload-time = "2025-11-29T20:51:57.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/42/c18f199780d99a6f6a64c4a36f4ad28a445d9e11968a6025b21d0c8b6802/flake8_bugbear-25.11.29-py3-none-any.whl", hash = "sha256:9bf15e2970e736d2340da4c0a70493db964061c9c38f708cfe1f7b2d87392298", size = 37861, upload-time = "2025-11-29T20:51:56.439Z" },
-]
-
-[[package]]
-name = "flake8-colors"
-version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/9b/d9431c1daca8cc0cd660e1a07272f896a38565207032985a600b9e08d492/flake8-colors-0.1.9.tar.gz", hash = "sha256:35a5483a7d156d0438b402faea2fefe45b411571ce5dc93ba28670fd9429cc46", size = 2882, upload-time = "2020-11-16T09:38:40.417Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/1c/9773d449a82b32d3e1677d2e081b1dadde514b749f62bea35bebd6c6a343/flake8_colors-0.1.9-py3-none-any.whl", hash = "sha256:e80ed1839dc151730adc51207e632823aa1f393d6db32897ffd0e60dceecfd9f", size = 3981, upload-time = "2020-11-16T09:38:39.087Z" },
-]
-
-[[package]]
-name = "flake8-isort"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-    { name = "isort" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/a4/4b170983fd2e9b5ecc40c88738db6dfb77e069c71be9a81f9893cdb8a0cc/flake8_isort-7.0.0.tar.gz", hash = "sha256:a677199d1197f826eb69084e7ac272f208f4583363285f43111c34272abe7e5d", size = 17796, upload-time = "2025-10-25T13:31:08.768Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/7d/907ef4135f6ede5187930d9ddd1f36564e07c6cdcd15ae8fb9849c9517e0/flake8_isort-7.0.0-py3-none-any.whl", hash = "sha256:c301a0e55fc77582348e636194b84b1a0baf0dfdaa6eddf3b0eeea75f8be7f36", size = 18383, upload-time = "2025-10-25T13:31:06.914Z" },
-]
-
-[[package]]
-name = "flake8-plugin-utils"
-version = "1.3.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/14/53727a2bc5bbda1e1f7e266e0e2d2718e5eb6c943a1e8cc2b33e5af002e0/flake8-plugin-utils-1.3.3.tar.gz", hash = "sha256:39f6f338d038b301c6fd344b06f2e81e382b68fa03c0560dff0d9b1791a11a2c", size = 10459, upload-time = "2023-06-26T16:42:20.946Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/a7/23c012c9becaacb24e9ba8e359e48db5f96982d505e38a3e7003902c5b9f/flake8_plugin_utils-1.3.3-py3-none-any.whl", hash = "sha256:e4848c57d9d50f19100c2d75fa794b72df068666a9041b4b0409be923356a3ed", size = 9664, upload-time = "2023-06-26T16:42:23.939Z" },
-]
-
-[[package]]
-name = "flake8-pyproject"
-version = "1.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/6a/cdee9ff7f2b7c6ddc219fd95b7c70c0a3d9f0367a506e9793eedfc72e337/flake8_pyproject-1.2.4-py3-none-any.whl", hash = "sha256:ea34c057f9a9329c76d98723bb2bb498cc6ba8ff9872c4d19932d48c91249a77", size = 5694, upload-time = "2025-11-28T21:40:01.309Z" },
-]
-
-[[package]]
-name = "flake8-pytest-style"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8-plugin-utils" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/18/b5115b91db2eca4d287d578f2f97c5e99e713ce4cb747774076f5a42fe1c/flake8_pytest_style-2.2.0.tar.gz", hash = "sha256:d23a33294bccfb9f1b11aaf5212256727b299b9c9b17cf21e230c52c1095a468", size = 17759, upload-time = "2025-10-20T07:52:25.129Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/de/36523c4defc0d02f1617de66e23cd18ad74b869d401269bba6d790abc95e/flake8_pytest_style-2.2.0-py3-none-any.whl", hash = "sha256:d01c4198a6c4e0ab759a92a0fa7710f10d83ec28e32a50ab6fb2e10f973a2f36", size = 22370, upload-time = "2025-10-20T07:52:23.82Z" },
-]
-
-[[package]]
-name = "flake8-quotes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/57/a173e3eb86072b7ee77650aca496b15d6886367d257f58ea9de5276e330a/flake8-quotes-3.4.0.tar.gz", hash = "sha256:aad8492fb710a2d3eabe68c5f86a1428de650c8484127e14c43d0504ba30276c", size = 14107, upload-time = "2024-02-10T21:58:22.357Z" }
-
-[[package]]
-name = "flake8-typing-imports"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/96/9d16adf5752cbf4ad8e47957c36a13749451aa60221ad350510bdfa966a0/flake8_typing_imports-1.17.0.tar.gz", hash = "sha256:ac7a328eca24ad5662bab58994cd1440412a5ca768cdf2d0705fbac767243ab2", size = 7509, upload-time = "2025-10-09T19:20:37.878Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/94/ab8f9ba92f7434c9195ac3ad77726536e79b156410bc0308542a713d1608/flake8_typing_imports-1.17.0-py2.py3-none-any.whl", hash = "sha256:4ec816ce0f4772ffd0b812a0bfd22883f699ad88dc945a67694246ca2ad50e19", size = 7820, upload-time = "2025-10-09T19:20:36.913Z" },
-]
-
-[[package]]
 name = "google-api-core"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1141,7 +990,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1164,15 +1013,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
-]
-
-[[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -1332,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.74.8"
+version = "1.74.9"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1352,17 +1192,6 @@ dependencies = [
 
 [package.optional-dependencies]
 codestyle = [
-    { name = "black" },
-    { name = "flake8" },
-    { name = "flake8-bugbear" },
-    { name = "flake8-colors" },
-    { name = "flake8-isort" },
-    { name = "flake8-pyproject" },
-    { name = "flake8-pytest-style" },
-    { name = "flake8-quotes" },
-    { name = "flake8-typing-imports" },
-    { name = "isort" },
-    { name = "pep8-naming" },
     { name = "ruff" },
 ]
 dev = [
@@ -1384,26 +1213,15 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'codestyle'", specifier = "~=26.3" },
     { name = "cryptography", specifier = "~=49.0" },
     { name = "fastmcp", specifier = "==3.4.4" },
-    { name = "flake8", marker = "extra == 'codestyle'", specifier = "~=7.3" },
-    { name = "flake8-bugbear", marker = "extra == 'codestyle'", specifier = "~=25.11" },
-    { name = "flake8-colors", marker = "extra == 'codestyle'", specifier = "~=0.1" },
-    { name = "flake8-isort", marker = "extra == 'codestyle'", specifier = "~=7.0" },
-    { name = "flake8-pyproject", marker = "extra == 'codestyle'", specifier = "~=1.2" },
-    { name = "flake8-pytest-style", marker = "extra == 'codestyle'", specifier = "~=2.2" },
-    { name = "flake8-quotes", marker = "extra == 'codestyle'", specifier = "~=3.4" },
-    { name = "flake8-typing-imports", marker = "extra == 'codestyle'", specifier = "~=1.17" },
     { name = "httpx", specifier = "~=0.28" },
     { name = "httpx-retries", specifier = "~=0.5" },
-    { name = "isort", marker = "extra == 'codestyle'", specifier = "~=8.0" },
     { name = "json-log-formatter", specifier = "~=1.1" },
     { name = "jsonpath-ng", specifier = "~=1.8" },
     { name = "jsonschema", specifier = "~=4.26" },
     { name = "kbcstorage", marker = "extra == 'integtests'", specifier = "~=0.9" },
     { name = "mcp", specifier = "==1.28.1" },
-    { name = "pep8-naming", marker = "extra == 'codestyle'", specifier = "~=0.15" },
     { name = "pydantic", specifier = "~=2.13.0" },
     { name = "pyjwt", specifier = "~=2.13" },
     { name = "pytest", marker = "extra == 'tests'", specifier = "~=9.0" },
@@ -1453,15 +1271,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1505,15 +1314,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1553,27 +1353,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
-]
-
-[[package]]
-name = "pep8-naming"
-version = "0.15.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/59/c32862134635ba231d45f1711035550dc38246396c27269a4cde4bfe18d2/pep8_naming-0.15.1.tar.gz", hash = "sha256:f6f4a499aba2deeda93c1f26ccc02f3da32b035c8b2db9696b730ef2c9639d29", size = 17640, upload-time = "2025-05-05T20:43:12.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/78/25281540f1121acaa78926f599a17ce102b8971bc20b096fa7fb6b5b59c1/pep8_naming-0.15.1-py3-none-any.whl", hash = "sha256:eb63925e7fd9e028c7f7ee7b1e413ec03d1ee5de0e627012102ee0222c273c86", size = 9561, upload-time = "2025-05-05T20:43:11.626Z" },
 ]
 
 [[package]]
@@ -1666,15 +1445,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
 ]
 
 [[package]]
@@ -1837,15 +1607,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2004,45 +1765,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/7e/9b35ad8f3d9ca680f7c87a88f19612fdd8da9796c4d3b46e560ac79dcc4a/python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680", size = 46689, upload-time = "2026-06-04T08:27:49.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/1e/7f7f299527a5a8ad90acd5f2f78dfa6c8495c6301a3205106ea68a84de96/python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28", size = 29996, upload-time = "2026-06-04T08:27:47.804Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -2536,21 +2258,12 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "83.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

**Linear**: AI-XXX

**Stacked on #651** — base is `add-ruff-linting`, so this diff shows only the follow-up. GitHub retargets it to `main` when #651 merges. Review/merge #651 first.

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

#651 added ruff *alongside* black/isort/flake8. This makes it the only linter and formatter. ruff's default rule set already covers `I001` and most of what the 7 flake8 plugins checked, so running all four was redundant — and the `RUF100` ignore #651 had to add was a direct symptom of flake8 and ruff disagreeing.

- **`codestyle` extra: 11 lint dependencies → 1.** Drops black, isort, flake8 and its 7 plugins; removes `[tool.black]`, `[tool.isort]`, `[tool.flake8]`.
- **`extend-select = ["I", "UP", "E402"]`** on top of ruff's defaults, at **zero new violations**. `I` replaces isort + flake8-isort; `E402` was previously enforced by flake8.
- **`[tool.ruff.format] quote-style = "preserve"`** carries over black's `skip-string-normalization`.
- **`RUF100` is no longer ignored.** It only existed because flake8's `E402` detection disagreed with ruff's. With `E402` selected explicitly, the deliberate `# noqa: E402` markers in `tests/tools/test_data_apps.py` stay meaningful instead of being auto-stripped.
- **This adds the repo's first real formatting gate.** The old `black` and `isort` tox envs ran as `black src/ tests/` — mutators, not `--check`. On CI they rewrote files and nothing verified the result. The `ruff` env now runs `ruff format --check` before `ruff check`.
- **`tox -m cs-fix` still works**: a new `ruff-fix` env (`ruff format` + `ruff check --fix`) replaces the old black + isort pair behind the same label.

`uv.lock`: **145 → 126 packages**. ruff stays pinned at 0.16.0.

### tox is deliberately left alone

The `black`/`isort`/`flake8` tox envs are removed because their tools and config are gone — flake8 without `[tool.flake8]` would fall back to line-length 79 and fail the build. Nothing else about tox changes.

There is a separate, real issue not addressed here: every tox lint env declares `package = "skip"` plus its own `deps`, so tox provisions a venv per env with **its own pip**, resolving live from PyPI. That bypasses `uv.lock` (which pins ruff 0.16.0 while CI actually lints with 0.16.1) and the `[tool.uv] exclude-newer` cooldown. Since `~= 0.16` admits 0.17, and ruff 0.16 expanded its default rule set from ~60 to 411 rules, an unrelated PR could go red on a ruff release nobody chose.

The fix is `tox-uv` with `runner = "uv-venv-lock-runner"` — note the default `uv-venv-runner` does *not* help, since it still resolves `deps` from PyPI; only the lock runner uses `uv sync`, and it ignores `deps` in favour of `extras`. Left for a follow-up so this PR stays a single concern.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Verified locally with a full `tox` run (the same entry point CI uses):

```
python: OK (141.46 seconds)            # 1672 tests, wheel-built install
ruff: OK (1.98 seconds)                # ruff format --check + ruff check
check-tools-docs: OK (11.44 seconds)   # TOOLS.md regenerated, no drift
congratulations :)
```

`TOOLS.md` is unchanged by this PR. Local run used Python 3.14; CI covers 3.10–3.12.

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable) — no behaviour change
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type — 1.74.9
- [x] Documentation updated (if applicable) — `CLAUDE.md`, `CONTRIBUTING.md`, `REVIEW.md`, `recreate-dependabot-pr` skill. Historical RFCs under `feature_spec/` left as point-in-time records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
