### PR TITLE
fix(sql): raise query_data max rows limit to 10k

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4287,7 +4287,13 @@ ERROR PREVENTION:
 * Check for division by zero using NULLIF(denominator, 0)
 * Always use the LIMIT clause in your SELECT statements when fetching data. There are hard limits imposed
   by this tool on the maximum number of rows that can be fetched and the maximum number of characters.
-  The tool will truncate the data if those limits are exceeded.
+  The tool will truncate the data if those limits are exceeded. Pick the LIMIT to match the actual need:
+  - Use a small LIMIT (<=100) for inspection, sampling, or checking distinct values.
+  - Compute aggregates (COUNT, GROUP BY, SUM, AVG, etc.) in SQL rather than pulling raw rows to aggregate
+    them yourself — a large LIMIT does not make row-level aggregation in context correct or efficient.
+  - Only use a large LIMIT when the user explicitly asked for row-level data.
+  - A truncated result is a contiguous prefix of the query's output, not a random sample: any aggregate
+    computed over truncated data is wrong, not just incomplete.
 
 DATA VALIDATION:
 * When querying columns with categorical values, use query_data tool to inspect distinct values beforehand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.75.3"
+version = "1.75.4"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -295,7 +295,13 @@ async def query_data(
     * Check for division by zero using NULLIF(denominator, 0)
     * Always use the LIMIT clause in your SELECT statements when fetching data. There are hard limits imposed
       by this tool on the maximum number of rows that can be fetched and the maximum number of characters.
-      The tool will truncate the data if those limits are exceeded.
+      The tool will truncate the data if those limits are exceeded. Pick the LIMIT to match the actual need:
+      - Use a small LIMIT (<=100) for inspection, sampling, or checking distinct values.
+      - Compute aggregates (COUNT, GROUP BY, SUM, AVG, etc.) in SQL rather than pulling raw rows to aggregate
+        them yourself — a large LIMIT does not make row-level aggregation in context correct or efficient.
+      - Only use a large LIMIT when the user explicitly asked for row-level data.
+      - A truncated result is a contiguous prefix of the query's output, not a random sample: any aggregate
+        computed over truncated data is wrong, not just incomplete.
 
     DATA VALIDATION:
     * When querying columns with categorical values, use query_data tool to inspect distinct values beforehand

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -25,7 +25,7 @@ from keboola_mcp_server.workspace import JobSubmittedInfo, QueryResult, SqlSelec
 LOG = logging.getLogger(__name__)
 
 SQL_TOOLS_TAG = 'sql'
-MAX_ROWS = 1_000
+MAX_ROWS = 10_000
 MAX_CHARS = 50_000
 # How often to check whether the HTTP client has disconnected during a long query.
 # Mirrors the 1 s job-poll cadence in `_Workspace.execute_query`.

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version < '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -41,7 +41,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -990,7 +990,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2258,8 +2258,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.75.3"
+version = "1.75.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: N/A

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Raises the `query_data` tool's `MAX_ROWS` cap from 1,000 to 10,000 so larger result sets can be returned in one call without truncation. `MAX_CHARS` (50,000) is unchanged and still truncates before 10k rows are reached for wide/large result sets.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable) — existing `tests/tools/test_sql.py` suite passes (61 passed)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)