### PR TITLE
feat(AI-3755): accept programmatic bearer tokens for tools/list, scoped by X-KBC-ProjectId

### DIFF
--- a/feature_spec/programmatic_token_project_scope/RFC.md
+++ b/feature_spec/programmatic_token_project_scope/RFC.md
@@ -52,17 +52,27 @@ narrower scope specifically calls for:
    `5xx`/timeout/network map to `502`. No token material is ever logged.
 2. **`config.py`**: new `project_id` field, mapping `X-KBC-ProjectId` (via alias) and
    `KBC_PROJECT_ID`.
-3. **`mcp.py`**: `SessionStateMiddleware.create_session_state` detects a programmatic token and
+3. **`mcp.py`**: the token itself arrives only as `Authorization: Bearer kbc_at_...`/`kbc_pat_...`
+   — never as a Storage-token header or alias, so `Config.replace_by`'s generic header-to-field
+   mapping cannot route it into `storage_token` (caught in review: an earlier version of this
+   change read `config.storage_token` in the exchange path without ever populating it from
+   `Authorization`, so the exchange never actually triggered for the traffic this RFC exists to
+   fix). `SessionStateMiddleware.apply_request_config` now reads the `Authorization` header
+   directly, and — only when it's empty and the header value looks like a programmatic token —
+   populates `storage_token` from it (stripping the `Bearer` scheme). An explicit
+   `X-Storage-(Api-)Token` always wins; a non-programmatic `Authorization` value (e.g. this
+   server's own OAuth bearer) is never forwarded as a Storage token.
+4. **`mcp.py`**: `SessionStateMiddleware.create_session_state` detects a programmatic token and
    exchanges it before building `KeboolaClient`, using `config.project_id` to pin the exchange to
    one project. No scope object, no multi-project fan-out, no ask-first gate — a session either has
    a legacy token (used as today) or a bearer token + project id (exchanged once, used as today
    from that point on).
-4. **`clients/client.py`**: `jobs_queue`, `ai_service`, and `sync_actions` are switched onto the
+5. **`clients/client.py`**: `jobs_queue`, `ai_service`, and `sync_actions` are switched onto the
    already-existing `bearer_or_sapi_token` (storage/scheduler/data-science/metastore already use
    it) instead of the raw `self._token`. Without this, a resolved token still 401s on
    `get_jobs`/`run_job` because those three clients were wired to send the pre-exchange raw token.
    Cherry-picked from later in the PSGO-261 branch, where this exact gap was found and fixed.
-5. **New for this narrower scope — skip the exchange on `/list`.** The resolver call has up to a
+6. **New for this narrower scope — skip the exchange on `/list`.** The resolver call has up to a
    ~35s timeout (`connect=5s, read=30s`); a client's initial `tools/list` fetch must be fast, and
    this server already has a precedent for this exact trade-off (branch-id validation is likewise
    skipped for `/list`). `create_session_state` gains a `skip_token_exchange` flag, set from
@@ -72,6 +82,32 @@ narrower scope specifically calls for:
    `project_has_semantic_models` fails closed on any exception. This directly forecloses the
    `tools/list`-hangs-under-a-bad-credential failure mode this incident is about, for the new
    bearer-token path specifically.
+
+## Security review notes
+
+- **Token leakage**: `apply_request_config`'s pre-existing debug log used to dump the full inbound
+  headers mapping (`headers={http_rq.headers}`), which already covered `X-Storage-(Api-)Token`.
+  Adding `Authorization` as a second live-credential-bearing header this server actually consumes
+  widened that log line's blast radius, so it now logs header **names** only, never values.
+  `StorageTokenResolver`/`StorageTokenExchangeError` never log or place token material in exception
+  messages (existing behavior, re-verified); `Config.__repr__` already redacts any field whose name
+  contains `token`/`password`/`secret`, so `LOG.info(f'...{config}.')` in `create_session_state`
+  stays safe.
+- **SSRF / stack pinning**: `StorageTokenResolver`'s own `connection.`-prefix hostname check is a
+  weak allowlist (matches `connection.attacker.tld` too) — the same known gap as the parent RFC's
+  increment-7 finding #4, deliberately not re-fixed here (that fix is a separate, larger increment).
+  It is not independently reachable in the deployed case this feature runs in: `apply_request_config`
+  already pins `storage_api_url` back to the server's own configured stack before the resolver ever
+  sees it, whenever the server has one configured (the normal, expected shape of a deployed
+  server). A deployed server started with no stack of its own would lose that pinning — a
+  misconfiguration, not a state this change introduces.
+- **Authorization scope**: only a value that already looks like `kbc_at_`/`kbc_pat_` is ever copied
+  out of `Authorization` into `storage_token`; this server's own OAuth bearer (or any other scheme)
+  is left untouched, and an explicit `X-Storage-(Api-)Token` always takes precedence.
+- **Access control**: this server does not itself decide whether `subject_token`'s owner may access
+  `X-KBC-ProjectId` — that authorization boundary is Connection's resolver endpoint, exactly as the
+  parent RFC's contract already specifies. A caller supplying a project id it has no access to gets
+  the resolver's own 400/401/403, passed through unchanged.
 
 ## Scope
 
@@ -103,6 +139,14 @@ data-science, scheduler) work with the resolved token for that one pinned projec
 - `tests/clients/test_client.py`: parametrized token-selection test across all six
   bearer-capable clients (storage, scheduler, data-science, metastore, jobs-queue, ai-service,
   sync-actions), confirming a bearer token takes precedence over the raw token everywhere.
+- `tests/test_mcp.py` (`test_apply_request_config_reads_programmatic_token_from_authorization_header`,
+  `test_end_to_end_from_authorization_header_and_x_kbc_project_id`): regression for the review
+  finding above — a bearer token in `Authorization` reaches `storage_token`, an explicit
+  `X-Storage-(Api-)Token` always wins, a non-programmatic `Authorization` value is never forwarded,
+  and the full `Authorization` + `X-KBC-ProjectId` → resolver chain is exercised end to end.
+- `tests/test_mcp.py` (`test_apply_request_config_never_logs_header_values`): regression for the
+  logging fix — asserts neither an `Authorization` nor an `X-Storage-Api-Token` value ever appears
+  in the debug log `apply_request_config` emits.
 - `tox` (pytest, ruff, check-tools-docs) green.
 - Manual/integration verification against a dev stack (bearer token + `X-KBC-ProjectId` against a
   real `tools/list` and a real `get_jobs`) is still pending — no dev-stack access from this

--- a/feature_spec/programmatic_token_project_scope/RFC.md
+++ b/feature_spec/programmatic_token_project_scope/RFC.md
@@ -1,0 +1,109 @@
+# RFC: Accept programmatic bearer tokens, scoped by `X-KBC-ProjectId`
+
+Linear: [AI-3755](https://linear.app/keboola/issue/AI-3755/accept-programmatic-bearer-tokens-for-toolslist-scoped-by-x-kbc) —
+filed off the "Plan D aftermath" `tools/list` incident writeup (kai-agent).
+Superset design: [`feature_spec/pat_token_support/RFC.md`](../pat_token_support/RFC.md) (PSGO-261,
+PR #605, unmerged) — this RFC extracts and ships only that RFC's "Part A" in isolation; see Scope.
+
+## Problem
+
+A one-line cache-key fix in Kai's tool-inventory cache (adding `principal.projectId` to the key)
+stopped a shared cache entry from silently answering one project's `tools/list` with another
+project's data. Fixing that correctness bug surfaced a second, previously-masked one: some Kai
+sessions carry a Keboola **bearer session token** (`kbc_at_...`) instead of a legacy **Storage API
+token**. Before the cache fix, the first successful (SAPI) caller's response was cached under a
+project-less key and served to every other project — so a bearer session's request never actually
+reached this MCP server, and its broken credential was invisible. After the fix, every project asks
+with its own credential, and bearer sessions now make the call they were always supposed to make —
+which fails, because **this server accepts only legacy Storage API tokens**. It has no way to turn
+a bearer token into something Keboola's Storage API will accept.
+
+**Symptom:** `tools/list` (and any other call) 401s for a session whose credential is a bearer
+token, with no path to make it work — kbc-ui's bearer-token rollout is not something Kai (or this
+server) can opt out of, and there is no client-side exchange path (`getSapiTokenString()`
+deliberately returns empty under a bearer session).
+
+## Required Behavior
+
+- A request carrying `Authorization: Bearer kbc_at_...` (or `kbc_pat_...`) **and** an
+  `X-KBC-ProjectId` header must be accepted and resolved to that project's legacy Storage token,
+  exactly like a `X-StorageAPI-Token` request is today.
+- Legacy `X-StorageAPI-Token` traffic is completely unaffected.
+- `X-KBC-ProjectId` **pins** the session to exactly one project — there is no project enumeration,
+  no scope confirmation, and no "ask which project(s)" gate. The caller (kbc-ui/Kai) already knows
+  which project the request is for; this server does not need to ask again.
+- `get_jobs`/`run_job` and the other AI-service/sync-actions-backed tools must keep working for a
+  bearer session once `tools/list` succeeds — not just the Storage-API-backed tools.
+- `tools/list` (and `resources/list`, `prompts/list`) must stay fast regardless of credential type.
+
+## Resolution Strategy
+
+This is "Part A" of the already-written and reviewed PSGO-261 RFC, cherry-picked out of the
+(much larger, still-unmerged) PR #605 branch as its own standalone change, plus one fix from
+later in that branch that Part A needs to be useful end-to-end, plus one new robustness fix this
+narrower scope specifically calls for:
+
+1. **`clients/auth_bridge.py`** (new file): `is_programmatic_token()` detects a `kbc_at_`/`kbc_pat_`
+   bearer token; `StorageTokenResolver.resolve()` exchanges it at Connection's
+   `POST /manage/internal/auth-bridge/resolve-storage-token`, authenticating with the server's own
+   projected ServiceAccount JWT (`X-Kubernetes-Authorization`, read from
+   `KBC_KUBERNETES_TOKEN_PATH` per request) plus the caller's token as `X-Subject-Token` and the
+   project id (from `X-KBC-ProjectId`) in the body. Resolver `400/401/403` pass through unchanged;
+   `5xx`/timeout/network map to `502`. No token material is ever logged.
+2. **`config.py`**: new `project_id` field, mapping `X-KBC-ProjectId` (via alias) and
+   `KBC_PROJECT_ID`.
+3. **`mcp.py`**: `SessionStateMiddleware.create_session_state` detects a programmatic token and
+   exchanges it before building `KeboolaClient`, using `config.project_id` to pin the exchange to
+   one project. No scope object, no multi-project fan-out, no ask-first gate — a session either has
+   a legacy token (used as today) or a bearer token + project id (exchanged once, used as today
+   from that point on).
+4. **`clients/client.py`**: `jobs_queue`, `ai_service`, and `sync_actions` are switched onto the
+   already-existing `bearer_or_sapi_token` (storage/scheduler/data-science/metastore already use
+   it) instead of the raw `self._token`. Without this, a resolved token still 401s on
+   `get_jobs`/`run_job` because those three clients were wired to send the pre-exchange raw token.
+   Cherry-picked from later in the PSGO-261 branch, where this exact gap was found and fixed.
+5. **New for this narrower scope — skip the exchange on `/list`.** The resolver call has up to a
+   ~35s timeout (`connect=5s, read=30s`); a client's initial `tools/list` fetch must be fast, and
+   this server already has a precedent for this exact trade-off (branch-id validation is likewise
+   skipped for `/list`). `create_session_state` gains a `skip_token_exchange` flag, set from
+   `on_request` whenever `context.method.endswith('/list')`. On `/list`, the raw (unexchanged)
+   token is used to build `KeboolaClient` as-is: any Storage/metastore call made with it fails fast
+   (an ordinary 401/403, not a hang) and is already handled as a soft failure —
+   `project_has_semantic_models` fails closed on any exception. This directly forecloses the
+   `tools/list`-hangs-under-a-bad-credential failure mode this incident is about, for the new
+   bearer-token path specifically.
+
+## Scope
+
+**In scope:** accepting a bearer token + `X-KBC-ProjectId`, resolving it to a legacy Storage token,
+and making every downstream service (Storage, AI Service, Jobs Queue, sync-actions, metastore,
+data-science, scheduler) work with the resolved token for that one pinned project.
+
+**Explicitly out of scope** (all still live only on the unmerged PSGO-261 branch, PR #605):
+
+- Local browser PKCE login (Part B).
+- Multi-project scope: `get_accessible_projects`/`set_project_scope`, token introspection,
+  scoped-token exchange, per-project fan-out, the ask-first gate, per-call `project_ids` filtering.
+  `X-KBC-ProjectId` here pins one project outright; there is no session-scope object to manage and
+  nothing for an ask-first gate to guard.
+- OAuth session exchange (Part D).
+- Everything under "Security hardening" (increment 7) in the PSGO-261 RFC — credential-race
+  fixes, `scope_token` encryption/binding, login-time scoping, etc. None of that machinery exists
+  in this narrower change, so none of those findings apply to it.
+
+## Testing / Verification
+
+- `tests/clients/test_auth_bridge.py`: `is_programmatic_token` detection, resolver success/error
+  mapping (`400/401/403` passthrough, `5xx`/timeout/network → `502`), no-token-material-logged.
+- `tests/test_mcp.py` (`TestProgrammaticTokenExchange`): missing `KBC_KUBERNETES_TOKEN_PATH`,
+  missing/invalid `project_id`, happy-path resolver call; `test_on_request_branch_handling`
+  extended to assert `skip_token_exchange` is `True` for every `/list` method and `False`
+  otherwise; `test_create_session_state_skips_exchange_for_list_requests` asserts the resolver is
+  never constructed when `skip_token_exchange=True` and the raw token is used as-is.
+- `tests/clients/test_client.py`: parametrized token-selection test across all six
+  bearer-capable clients (storage, scheduler, data-science, metastore, jobs-queue, ai-service,
+  sync-actions), confirming a bearer token takes precedence over the raw token everywhere.
+- `tox` (pytest, ruff, check-tools-docs) green.
+- Manual/integration verification against a dev stack (bearer token + `X-KBC-ProjectId` against a
+  real `tools/list` and a real `get_jobs`) is still pending — no dev-stack access from this
+  environment; flagged as a known limitation until verified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.75.4"
+version = "1.76.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/auth_bridge.py
+++ b/src/keboola_mcp_server/clients/auth_bridge.py
@@ -26,12 +26,10 @@ _PAT_PREFIX = 'kbc_pat_'
 _RESOLVE_ENDPOINT = 'manage/internal/auth-bridge/resolve-storage-token'
 # Resolver statuses passed through to the client verbatim; anything else (incl. 5xx,
 # timeouts, network failures) is mapped to 502 Bad Gateway.
-_PASS_THROUGH_STATUSES = frozenset(
-    {int(HTTPStatus.BAD_REQUEST), int(HTTPStatus.UNAUTHORIZED), int(HTTPStatus.FORBIDDEN)}
-)
+_PASS_THROUGH_STATUSES = (int(HTTPStatus.BAD_REQUEST), int(HTTPStatus.UNAUTHORIZED), int(HTTPStatus.FORBIDDEN))
 
 
-def _strip_bearer(token: str) -> str:
+def strip_bearer(token: str) -> str:
     """Removes a leading case-insensitive ``Bearer `` scheme from a token, if present."""
     if token[:7].lower() == 'bearer ':
         return token[7:].strip()
@@ -42,7 +40,7 @@ def is_programmatic_token(token: str | None) -> bool:
     """True if ``token`` is a Keboola programmatic bearer token (``kbc_at_`` / ``kbc_pat_``)."""
     if not token:
         return False
-    bare = _strip_bearer(token)
+    bare = strip_bearer(token)
     return bare.startswith((_ACCESS_TOKEN_PREFIX, _PAT_PREFIX))
 
 
@@ -104,7 +102,7 @@ class StorageTokenResolver:
             'Content-Type': 'application/json',
             'Accept': 'application/json',
             'X-Kubernetes-Authorization': f'Bearer {self._read_sa_jwt()}',
-            'X-Subject-Token': f'Bearer {_strip_bearer(subject_token)}',
+            'X-Subject-Token': f'Bearer {strip_bearer(subject_token)}',
         }
         try:
             async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:

--- a/src/keboola_mcp_server/clients/auth_bridge.py
+++ b/src/keboola_mcp_server/clients/auth_bridge.py
@@ -1,0 +1,140 @@
+"""Exchange Keboola programmatic tokens for legacy Storage tokens (PSGO-261).
+
+Implements the decentralized auth-bridge exchange: a programmatic bearer token
+(`kbc_at_*` access token or `kbc_pat_*` personal access token) presented to the MCP
+server is exchanged at Connection for a legacy Storage token, which is then used for
+all downstream Storage-token APIs exactly as before.
+
+The MCP server authenticates to the resolver with its own projected Kubernetes
+ServiceAccount JWT (`X-Kubernetes-Authorization`); the user's token travels as
+`X-Subject-Token`. The SA token file is read per call so kubelet rotation is honored.
+No token material is ever logged or placed in exception messages.
+"""
+
+import logging
+from http import HTTPStatus
+from pathlib import Path
+from typing import cast
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+LOG = logging.getLogger(__name__)
+
+_ACCESS_TOKEN_PREFIX = 'kbc_at_'
+_PAT_PREFIX = 'kbc_pat_'
+_RESOLVE_ENDPOINT = 'manage/internal/auth-bridge/resolve-storage-token'
+# Resolver statuses passed through to the client verbatim; anything else (incl. 5xx,
+# timeouts, network failures) is mapped to 502 Bad Gateway.
+_PASS_THROUGH_STATUSES = frozenset(
+    {int(HTTPStatus.BAD_REQUEST), int(HTTPStatus.UNAUTHORIZED), int(HTTPStatus.FORBIDDEN)}
+)
+
+
+def _strip_bearer(token: str) -> str:
+    """Removes a leading case-insensitive ``Bearer `` scheme from a token, if present."""
+    if token[:7].lower() == 'bearer ':
+        return token[7:].strip()
+    return token
+
+
+def is_programmatic_token(token: str | None) -> bool:
+    """True if ``token`` is a Keboola programmatic bearer token (``kbc_at_`` / ``kbc_pat_``)."""
+    if not token:
+        return False
+    bare = _strip_bearer(token)
+    return bare.startswith((_ACCESS_TOKEN_PREFIX, _PAT_PREFIX))
+
+
+class StorageTokenExchangeError(RuntimeError):
+    """Raised when the auth-bridge resolver fails to exchange a programmatic token.
+
+    :ivar status_code: The client-facing HTTP status (resolver 400/401/403 pass through;
+        5xx/timeout/network map to 502).
+    """
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message, status_code)
+        self.status_code = status_code
+
+    def __str__(self) -> str:
+        return self.args[0]
+
+
+class StorageTokenResolver:
+    """Exchanges a programmatic token for a legacy Storage token via the Connection resolver."""
+
+    def __init__(
+        self,
+        *,
+        storage_api_url: str,
+        kubernetes_token_path: str,
+        timeout: httpx.Timeout | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        """
+        :param storage_api_url: Connection Storage API URL (``https://connection.<stack>``).
+        :param kubernetes_token_path: Path to the projected ServiceAccount token file.
+        :param timeout: Optional HTTP timeout override.
+        :param transport: Optional httpx transport (for testing).
+        """
+        parsed = urlparse(storage_api_url)
+        if not parsed.hostname or not parsed.hostname.startswith('connection.'):
+            raise ValueError(f'Invalid Keboola Storage API URL: {storage_api_url}')
+        self._base_url = urlunparse(('https', parsed.hostname, '', '', '', ''))
+        self._kubernetes_token_path = kubernetes_token_path
+        self._timeout = timeout or httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
+        self._transport = transport
+
+    def _read_sa_jwt(self) -> str:
+        # Read per call — the kubelet rotates the projected token in place.
+        jwt = Path(self._kubernetes_token_path).read_text().strip()
+        if not jwt:
+            raise ValueError(f'Kubernetes ServiceAccount token file is empty: {self._kubernetes_token_path}')
+        return jwt
+
+    async def resolve(self, *, subject_token: str, project_id: int) -> str:
+        """
+        Exchanges ``subject_token`` for the legacy Storage token of ``project_id``.
+
+        :return: The legacy Storage token.
+        :raises StorageTokenExchangeError: On any resolver failure (status carried on the error).
+        """
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Kubernetes-Authorization': f'Bearer {self._read_sa_jwt()}',
+            'X-Subject-Token': f'Bearer {_strip_bearer(subject_token)}',
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:
+                response = await client.post(
+                    f'{self._base_url}/{_RESOLVE_ENDPOINT}',
+                    headers=headers,
+                    json={'projectId': project_id},
+                )
+        except httpx.HTTPError as e:
+            # Network / timeout failure. Raise without chaining so no request (and thus no
+            # token material) can surface in a traceback.
+            raise StorageTokenExchangeError(
+                f'Auth-bridge token exchange could not reach Connection ({type(e).__name__}).',
+                status_code=int(HTTPStatus.BAD_GATEWAY),
+            ) from None
+
+        if response.status_code != HTTPStatus.OK:
+            status = response.status_code
+            mapped = status if status in _PASS_THROUGH_STATUSES else int(HTTPStatus.BAD_GATEWAY)
+            LOG.error(f'Auth-bridge token exchange failed: resolver status {status}, mapped to {mapped}.')
+            raise StorageTokenExchangeError(
+                f'Auth-bridge token exchange was rejected (resolver status {status}).',
+                status_code=mapped,
+            )
+
+        body = cast(dict, response.json())
+        storage_token = body.get('storageToken')
+        if not storage_token:
+            raise StorageTokenExchangeError(
+                'Auth-bridge token exchange returned no storageToken.',
+                status_code=int(HTTPStatus.BAD_GATEWAY),
+            )
+        return cast(str, storage_token)

--- a/src/keboola_mcp_server/clients/client.py
+++ b/src/keboola_mcp_server/clients/client.py
@@ -193,10 +193,14 @@ class KeboolaClient:
             encryption_client=self._encryption_client,
         )
         self._jobs_queue_client = JobsQueueClient.create(
-            root_url=queue_api_url, token=self._token, branch_id=branch_id, headers=self._headers, readonly=readonly
+            root_url=queue_api_url,
+            token=bearer_or_sapi_token,
+            branch_id=branch_id,
+            headers=self._headers,
+            readonly=readonly,
         )
         self._ai_service_client = AIServiceClient.create(
-            root_url=ai_service_api_url, token=self._token, headers=self._headers, readonly=readonly
+            root_url=ai_service_api_url, token=bearer_or_sapi_token, headers=self._headers, readonly=readonly
         )
         # Data-science (sandboxes-service) git-repo credential endpoints require an admin-context
         # token (CanManageAppRepoCredentials -> StorageApiToken::isAdminToken()). The OAuth bearer
@@ -215,7 +219,7 @@ class KeboolaClient:
         )
         self._sync_actions_client = SyncActionsClient.create(
             root_url=sync_actions_api_url,
-            token=self._token,
+            token=bearer_or_sapi_token,
             branch_id=branch_id,
             headers=self._headers,
             readonly=readonly,

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -43,6 +43,12 @@ class Config:
     """The access-token issued by Keboola OAuth server to be sent in 'Authorization: Bearer <access-token>' header."""
     conversation_id: str | None = None
     """The ID of the ongoing conversation with the MCP server. This is supplied only by the HTTP header."""
+    project_id: str | None = field(default=None, metadata={'aliases': ['kbc_project_id']})
+    """Project id used to scope a programmatic-token (kbc_at_/kbc_pat_) exchange.
+
+    Maps the `X-KBC-ProjectId` HTTP header (via the alias) and the `KBC_PROJECT_ID` env var.
+    Only consulted when the inbound Storage token is a Keboola programmatic token; the legacy
+    project-bound Storage token derives its project from the token itself."""
 
     def __post_init__(self) -> None:
         for f in dataclasses.fields(self):

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -29,6 +29,7 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from keboola_mcp_server.clients.auth_bridge import StorageTokenResolver, is_programmatic_token
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo, is_same_stack
@@ -232,13 +233,14 @@ class SessionStateMiddleware(fmw.Middleware):
             # so that clients can discover available tools even when the configured branch ID doesn't
             # exist yet. For these requests the client is created without a branch ID. Otherwise, the branch is
             # validated via a SAPI call.
-            if context.method.endswith('/list'):
+            is_list = context.method.endswith('/list')
+            if is_list:
                 if config.branch_id:
                     LOG.info(f'Skipping branch validation for {context.method} request.')
                 config = dataclasses.replace(config, branch_id=None)
 
             state = await self.create_session_state(
-                config, runtime_info, own_stack_storage_api_url=own_stack_storage_api_url
+                config, runtime_info, own_stack_storage_api_url=own_stack_storage_api_url, skip_token_exchange=is_list
             )
             ctx.session.state = state
 
@@ -312,6 +314,38 @@ class SessionStateMiddleware(fmw.Middleware):
         return config
 
     @classmethod
+    async def _exchange_programmatic_token(cls, config: Config) -> str:
+        """
+        Exchanges a programmatic token (kbc_at_/kbc_pat_) for the project's legacy Storage token.
+
+        The resolver is reached only on the deployed MCP server, which has a projected
+        ServiceAccount token at ``KBC_KUBERNETES_TOKEN_PATH`` (read from the process
+        environment only, never from per-request config). A project id is required because
+        a programmatic token is not project-bound.
+        """
+        kubernetes_token_path = os.environ.get('KBC_KUBERNETES_TOKEN_PATH')
+        if not kubernetes_token_path:
+            raise ValueError(
+                'Received a Keboola programmatic token (kbc_at_/kbc_pat_) but KBC_KUBERNETES_TOKEN_PATH '
+                'is not configured. Programmatic-token exchange is available only on the deployed MCP server.'
+            )
+        if not config.project_id:
+            raise ValueError(
+                'A project id is required to exchange a programmatic token. '
+                'Set the KBC_PROJECT_ID env var or the X-KBC-ProjectId header.'
+            )
+        try:
+            project_id = int(config.project_id)
+        except (TypeError, ValueError):
+            raise ValueError(f'Invalid project id for programmatic-token exchange: {config.project_id!r}')
+
+        resolver = StorageTokenResolver(
+            storage_api_url=config.storage_api_url,
+            kubernetes_token_path=kubernetes_token_path,
+        )
+        return await resolver.resolve(subject_token=config.storage_token, project_id=project_id)
+
+    @classmethod
     async def create_session_state(
         cls,
         config: Config,
@@ -319,6 +353,7 @@ class SessionStateMiddleware(fmw.Middleware):
         readonly: bool | None = None,
         *,
         own_stack_storage_api_url: str | None,
+        skip_token_exchange: bool = False,
     ) -> dict[str, Any]:
         """
         Creates `KeboolaClient` and `WorkspaceManager` instances and returns them in the session state.
@@ -332,6 +367,12 @@ class SessionStateMiddleware(fmw.Middleware):
             to the `KeboolaClient`, which sends the Kubernetes ServiceAccount step-up header only when
             the session talks to that stack. It must never come from a request header, so it is passed
             separately instead of being read off `config`, whose Storage API URL a header can set.
+        :param skip_token_exchange: Skip the programmatic-token exchange (used for capability-discovery
+            `/list` requests -- see `on_request`). The resolver call has up to a ~35s timeout; a client's
+            initial `tools/list` fetch must be fast, so `/list` builds its `KeboolaClient` with the raw,
+            unexchanged token instead. Storage/metastore calls made with it fail fast (a normal 401/403,
+            not a hang) and are already handled as a soft failure (e.g. `project_has_semantic_models`
+            fails closed) -- the same trade-off this method already makes for branch validation on `/list`.
         :return: The session state dictionary containing the created client and workspace manager instances.
         """
         LOG.info(f'Creating SessionState from config: {config}.')
@@ -343,10 +384,18 @@ class SessionStateMiddleware(fmw.Middleware):
             if not config.storage_api_url:
                 raise ValueError('Storage API URL is not provided.')
 
+            storage_token = config.storage_token
+            bearer_token = config.bearer_token
+            if is_programmatic_token(storage_token) and not skip_token_exchange:
+                # A Keboola programmatic token (kbc_at_/kbc_pat_) is not a Storage token; exchange
+                # it for the project's legacy Storage token and use that downstream unchanged.
+                storage_token = await cls._exchange_programmatic_token(config)
+                bearer_token = None
+
             client = await KeboolaClient(
                 storage_api_url=config.storage_api_url,
-                storage_api_token=config.storage_token,
-                bearer_token=config.bearer_token,
+                storage_api_token=storage_token,
+                bearer_token=bearer_token,
                 headers=cls._get_headers(runtime_info),
                 readonly=readonly,
                 own_stack_storage_api_url=own_stack_storage_api_url,

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -29,7 +29,7 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from keboola_mcp_server.clients.auth_bridge import StorageTokenResolver, is_programmatic_token
+from keboola_mcp_server.clients.auth_bridge import StorageTokenResolver, is_programmatic_token, strip_bearer
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo, is_same_stack
@@ -282,6 +282,12 @@ class SessionStateMiddleware(fmw.Middleware):
         is kept. The check is an exact host match against that single known URL (see
         `is_same_stack()`); no prefix or pattern matching is used.
 
+        A programmatic bearer token (`kbc_at_`/`kbc_pat_`) is likewise treated specially: it
+        arrives only as `Authorization: Bearer <token>`, which `Config.replace_by` cannot route
+        into `storage_token` (no header/alias maps to it), so it is read directly off the request
+        here into an otherwise-empty `storage_token` slot for `create_session_state`'s exchange to
+        pick up.
+
         :param http_rq: The incoming HTTP request whose headers are applied.
         :param config: The server's own configuration (from CLI parameters and environment).
         :param own_stack_storage_api_url: The Storage API URL of the server's own stack
@@ -289,8 +295,21 @@ class SessionStateMiddleware(fmw.Middleware):
             therefore takes the URL from the request. It must never come from a request header.
         :return: The configuration to use for this request.
         """
-        LOG.debug(f'Injecting headers: http_rq={http_rq}, headers={http_rq.headers}')
+        # Header names only, never values -- Authorization and the X-Storage-(Api-)Token variants
+        # carry live credentials, and this server now also routes a programmatic bearer token out
+        # of Authorization (see below), so the set of sensitive header names logging could sweep up
+        # here is no longer just Storage tokens.
+        LOG.debug(f'Injecting headers: http_rq={http_rq}, header_names={list(http_rq.headers.keys())}')
         config = config.replace_by(http_rq.headers)
+
+        # A programmatic bearer token (kbc_at_/kbc_pat_) is sent as `Authorization: Bearer <token>`,
+        # never as a Storage-token header/alias -- `Config.replace_by` above has no way to route it
+        # into `storage_token` (`Authorization` matches no field name or alias). Read it here, but
+        # only into an otherwise-empty slot and only when it actually looks like one of these
+        # tokens, so this never overrides an explicit X-Storage-(Api-)Token or forwards an unrelated
+        # bearer scheme downstream as if it were a Storage token.
+        if not config.storage_token and is_programmatic_token(auth_header := http_rq.headers.get('Authorization')):
+            config = dataclasses.replace(config, storage_token=strip_bearer(auth_header))
 
         if own_stack_storage_api_url and not is_same_stack(config.storage_api_url, own_stack_storage_api_url):
             LOG.warning(

--- a/tests/clients/test_auth_bridge.py
+++ b/tests/clients/test_auth_bridge.py
@@ -1,0 +1,123 @@
+"""Tests for the auth-bridge programmatic-token exchange (PSGO-261)."""
+
+from http import HTTPStatus
+from pathlib import Path
+
+import httpx
+import pytest
+
+from keboola_mcp_server.clients.auth_bridge import (
+    StorageTokenExchangeError,
+    StorageTokenResolver,
+    is_programmatic_token,
+)
+
+STORAGE_API_URL = 'https://connection.keboola.com'
+
+
+@pytest.mark.parametrize(
+    ('token', 'expected'),
+    [
+        ('kbc_at_019ef801_abc', True),
+        ('kbc_pat_019ef801_abc', True),
+        ('Bearer kbc_at_019ef801_abc', True),
+        ('bearer kbc_pat_019ef801_abc', True),
+        ('123-legacy-storage-token', False),
+        ('kbc_rt_019ef801_abc', False),  # refresh token is not a Storage-token bearer
+        ('', False),
+        (None, False),
+    ],
+)
+def test_is_programmatic_token(token: str | None, expected: bool) -> None:
+    assert is_programmatic_token(token) is expected
+
+
+@pytest.fixture
+def sa_token_file(tmp_path: Path) -> Path:
+    path = tmp_path / 'sa-token'
+    path.write_text('  sa-jwt-value\n')  # surrounding whitespace must be stripped
+    return path
+
+
+def _resolver(sa_token_file: Path, handler) -> StorageTokenResolver:
+    return StorageTokenResolver(
+        storage_api_url=STORAGE_API_URL,
+        kubernetes_token_path=str(sa_token_file),
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_success_sends_expected_request(sa_token_file: Path) -> None:
+    captured: dict[str, httpx.Request] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured['request'] = request
+        return httpx.Response(HTTPStatus.OK, json={'storageToken': 'legacy-token', 'projectId': 42})
+
+    resolver = _resolver(sa_token_file, handler)
+    token = await resolver.resolve(subject_token='Bearer kbc_pat_abc', project_id=42)
+
+    assert token == 'legacy-token'
+    rq = captured['request']
+    assert rq.url.path == '/manage/internal/auth-bridge/resolve-storage-token'
+    assert rq.headers['X-Kubernetes-Authorization'] == 'Bearer sa-jwt-value'
+    # Subject token is normalized to a single Bearer scheme regardless of inbound form.
+    assert rq.headers['X-Subject-Token'] == 'Bearer kbc_pat_abc'
+
+
+@pytest.mark.parametrize('status', [HTTPStatus.BAD_REQUEST, HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN])
+@pytest.mark.asyncio
+async def test_resolve_passes_through_client_errors(sa_token_file: Path, status: HTTPStatus) -> None:
+    resolver = _resolver(sa_token_file, lambda rq: httpx.Response(status, json={'error': 'nope'}))
+    with pytest.raises(StorageTokenExchangeError) as exc:
+        await resolver.resolve(subject_token='kbc_at_abc', project_id=1)
+    assert exc.value.status_code == int(status)
+
+
+@pytest.mark.parametrize('status', [HTTPStatus.INTERNAL_SERVER_ERROR, HTTPStatus.BAD_GATEWAY, HTTPStatus.NOT_FOUND])
+@pytest.mark.asyncio
+async def test_resolve_maps_other_statuses_to_502(sa_token_file: Path, status: HTTPStatus) -> None:
+    resolver = _resolver(sa_token_file, lambda rq: httpx.Response(status))
+    with pytest.raises(StorageTokenExchangeError) as exc:
+        await resolver.resolve(subject_token='kbc_at_abc', project_id=1)
+    assert exc.value.status_code == int(HTTPStatus.BAD_GATEWAY)
+
+
+@pytest.mark.asyncio
+async def test_resolve_maps_network_error_to_502(sa_token_file: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('boom', request=request)
+
+    resolver = _resolver(sa_token_file, handler)
+    with pytest.raises(StorageTokenExchangeError) as exc:
+        await resolver.resolve(subject_token='kbc_at_abc', project_id=1)
+    assert exc.value.status_code == int(HTTPStatus.BAD_GATEWAY)
+    # No token material leaks into the message.
+    assert 'kbc_at_abc' not in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_missing_storage_token_maps_to_502(sa_token_file: Path) -> None:
+    resolver = _resolver(sa_token_file, lambda rq: httpx.Response(HTTPStatus.OK, json={'projectId': 1}))
+    with pytest.raises(StorageTokenExchangeError) as exc:
+        await resolver.resolve(subject_token='kbc_at_abc', project_id=1)
+    assert exc.value.status_code == int(HTTPStatus.BAD_GATEWAY)
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_sa_token_file_fails_loudly(tmp_path: Path) -> None:
+    empty = tmp_path / 'empty'
+    empty.write_text('   ')
+    resolver = StorageTokenResolver(
+        storage_api_url=STORAGE_API_URL,
+        kubernetes_token_path=str(empty),
+        transport=httpx.MockTransport(lambda rq: httpx.Response(HTTPStatus.OK, json={'storageToken': 'x'})),
+    )
+    with pytest.raises(ValueError, match='empty'):
+        await resolver.resolve(subject_token='kbc_at_abc', project_id=1)
+
+
+def test_invalid_storage_api_url_rejected(sa_token_file: Path) -> None:
+    with pytest.raises(ValueError, match='Invalid Keboola Storage API URL'):
+        StorageTokenResolver(storage_api_url='https://example.com', kubernetes_token_path=str(sa_token_file))

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -407,41 +407,6 @@ class TestKeboolaClient:
                 await keboola_client.with_branch_id('non-existent-branch')
             mock_client.get.assert_called_once()
 
-    @pytest.mark.parametrize(
-        ('bearer_token', 'storage_token', 'expected_scheduler_token'),
-        [
-            ('oauth_bearer_123', 'sapi_token_456', 'Bearer oauth_bearer_123'),
-            (None, 'sapi_token_456', 'sapi_token_456'),
-            ('', 'sapi_token_456', 'sapi_token_456'),
-        ],
-        ids=['with_bearer_token', 'without_bearer_token', 'empty_bearer_token'],
-    )
-    def test_scheduler_client_token_selection(
-        self, bearer_token: str | None, storage_token: str, expected_scheduler_token: str
-    ):
-        """Test SchedulerClient uses bearer token when available, falls back to storage token."""
-        # Create KeboolaClient with different token configurations
-        client = KeboolaClient(
-            storage_api_url='https://connection.keboola.com',
-            storage_api_token=storage_token,
-            bearer_token=bearer_token,
-        )
-
-        # Verify scheduler client was initialized with correct token
-        # Check the headers of the underlying RawKeboolaClient
-        scheduler_headers = client.scheduler_client.raw_client.headers
-
-        if expected_scheduler_token.startswith('Bearer '):
-            # Should use Authorization header for bearer token
-            assert 'Authorization' in scheduler_headers
-            assert scheduler_headers['Authorization'] == expected_scheduler_token
-            assert 'X-StorageAPI-Token' not in scheduler_headers
-        else:
-            # Should use X-StorageAPI-Token header for storage token
-            assert 'X-StorageAPI-Token' in scheduler_headers
-            assert scheduler_headers['X-StorageAPI-Token'] == expected_scheduler_token
-            assert 'Authorization' not in scheduler_headers
-
     def test_metastore_client_url_derivation(self) -> None:
         client = KeboolaClient(
             storage_api_url='https://connection.canary-orion.keboola.dev',
@@ -451,8 +416,25 @@ class TestKeboolaClient:
         assert client.metastore_client.raw_client.base_api_url == 'https://metastore.canary-orion.keboola.dev'
         assert client.metastore_client.raw_client.headers['X-StorageAPI-Token'] == 'sapi_token_456'
 
+    # All clients below use the bearer token (Authorization header) when one is available and fall
+    # back to the raw storage token (X-StorageAPI-Token) otherwise. The jobs-queue/ai-service/
+    # sync-actions clients were switched onto the bearer token so PAT (kbc_at_/kbc_pat_) sessions
+    # work end-to-end — the queue accepts `Authorization: Bearer kbc_at_...` + X-KBC-ProjectId but
+    # rejects the PAT sent as X-StorageAPI-Token (PSGO-261). Data-science needs it for admin-context
+    # git-credential endpoints (AI-3398).
     @pytest.mark.parametrize(
-        ('bearer_token', 'storage_token', 'expected_metastore_token'),
+        'client_attr',
+        [
+            'scheduler_client',
+            'metastore_client',
+            'data_science_client',
+            'jobs_queue_client',
+            'ai_service_client',
+            'sync_actions_client',
+        ],
+    )
+    @pytest.mark.parametrize(
+        ('bearer_token', 'storage_token', 'expected_token'),
         [
             ('oauth_bearer_123', 'sapi_token_456', 'Bearer oauth_bearer_123'),
             (None, 'sapi_token_456', 'sapi_token_456'),
@@ -460,61 +442,24 @@ class TestKeboolaClient:
         ],
         ids=['with_bearer_token', 'without_bearer_token', 'empty_bearer_token'],
     )
-    def test_metastore_client_token_selection(
-        self, bearer_token: str | None, storage_token: str, expected_metastore_token: str
+    def test_client_bearer_token_selection(
+        self, client_attr: str, bearer_token: str | None, storage_token: str, expected_token: str
     ):
-        """Test MetastoreClient uses bearer token when available, falls back to storage token."""
+        """Clients use the bearer token when available, falling back to the storage token."""
         client = KeboolaClient(
             storage_api_url='https://connection.keboola.com',
             storage_api_token=storage_token,
             bearer_token=bearer_token,
         )
 
-        metastore_headers = client.metastore_client.raw_client.headers
+        headers = getattr(client, client_attr).raw_client.headers
 
-        if expected_metastore_token.startswith('Bearer '):
-            assert 'Authorization' in metastore_headers
-            assert metastore_headers['Authorization'] == expected_metastore_token
-            assert 'X-StorageAPI-Token' not in metastore_headers
+        if expected_token.startswith('Bearer '):
+            assert headers.get('Authorization') == expected_token
+            assert 'X-StorageAPI-Token' not in headers
         else:
-            assert 'X-StorageAPI-Token' in metastore_headers
-            assert metastore_headers['X-StorageAPI-Token'] == expected_metastore_token
-            assert 'Authorization' not in metastore_headers
-
-    @pytest.mark.parametrize(
-        ('bearer_token', 'storage_token', 'expected_data_science_token'),
-        [
-            ('oauth_bearer_123', 'sapi_token_456', 'Bearer oauth_bearer_123'),
-            (None, 'sapi_token_456', 'sapi_token_456'),
-            ('', 'sapi_token_456', 'sapi_token_456'),
-        ],
-        ids=['with_bearer_token', 'without_bearer_token', 'empty_bearer_token'],
-    )
-    def test_data_science_client_token_selection(
-        self, bearer_token: str | None, storage_token: str, expected_data_science_token: str
-    ):
-        """DataScienceClient uses the bearer token when available, falls back to the storage token.
-
-        The sandboxes-service git-repo credential endpoints require an admin-context token
-        (CanManageAppRepoCredentials -> isAdminToken()); the OAuth bearer token carries it while the
-        minted SAPI token does not (AI-3398).
-        """
-        client = KeboolaClient(
-            storage_api_url='https://connection.keboola.com',
-            storage_api_token=storage_token,
-            bearer_token=bearer_token,
-        )
-
-        data_science_headers = client.data_science_client.raw_client.headers
-
-        if expected_data_science_token.startswith('Bearer '):
-            assert 'Authorization' in data_science_headers
-            assert data_science_headers['Authorization'] == expected_data_science_token
-            assert 'X-StorageAPI-Token' not in data_science_headers
-        else:
-            assert 'X-StorageAPI-Token' in data_science_headers
-            assert data_science_headers['X-StorageAPI-Token'] == expected_data_science_token
-            assert 'Authorization' not in data_science_headers
+            assert headers.get('X-StorageAPI-Token') == expected_token
+            assert 'Authorization' not in headers
 
 
 def test_flow_schema_cache_roundtrip():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,7 +83,7 @@ class TestConfig:
             "Config(storage_api_url=None, storage_token='****', branch_id=None, workspace_schema=None, "
             'oauth_client_id=None, oauth_client_secret=None, '
             'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
-            'jwt_secret=None, bearer_token=None, conversation_id=None)'
+            'jwt_secret=None, bearer_token=None, conversation_id=None, project_id=None)'
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -658,17 +658,19 @@ class TestToolsFilteringMiddleware:
 class TestSessionStateMiddleware:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ('method', 'expected_branch_id'),
+        ('method', 'expected_branch_id', 'expected_skip_token_exchange'),
         [
-            ('tools/list', None),
-            ('resources/list', None),
-            ('prompts/list', None),
-            ('tools/call', '999'),
-            ('resources/read', '999'),
+            ('tools/list', None, True),
+            ('resources/list', None, True),
+            ('prompts/list', None, True),
+            ('tools/call', '999', False),
+            ('resources/read', '999', False),
         ],
         ids=['tools_list', 'resources_list', 'prompts_list', 'tools_call', 'resources_read'],
     )
-    async def test_on_request_branch_handling(self, method: str, expected_branch_id: str | None):
+    async def test_on_request_branch_handling(
+        self, method: str, expected_branch_id: str | None, expected_skip_token_exchange: bool
+    ):
         config = Config(
             storage_api_url='https://connection.test.keboola.com',
             storage_token='test-token',
@@ -694,10 +696,14 @@ class TestSessionStateMiddleware:
 
         captured_configs: list[Config] = []
         captured_own_stack_urls: list[str | None] = []
+        captured_skip_token_exchange: list[bool] = []
 
-        async def fake_create_session_state(cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url):
+        async def fake_create_session_state(
+            cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url, skip_token_exchange=False
+        ):
             captured_configs.append(cfg)
             captured_own_stack_urls.append(own_stack_storage_api_url)
+            captured_skip_token_exchange.append(skip_token_exchange)
             return {'fake': 'state'}
 
         middleware = SessionStateMiddleware()
@@ -714,6 +720,9 @@ class TestSessionStateMiddleware:
         # The session's client is told which stack is the server's own one, so that it can decide
         # whether the Kubernetes step-up header may be sent.
         assert captured_own_stack_urls == ['https://connection.test.keboola.com']
+        # /list requests skip the programmatic-token exchange (up to a ~35s resolver round trip) --
+        # a client's initial tools/list fetch must be fast; see create_session_state's docstring.
+        assert captured_skip_token_exchange == [expected_skip_token_exchange]
 
     @pytest.mark.parametrize(
         ('server_storage_api_url', 'headers', 'expected_storage_api_url'),
@@ -797,3 +806,64 @@ class TestSessionStateMiddleware:
         # Only the Storage API URL is pinned; the other per-request headers keep working.
         assert applied.storage_token == headers.get('X-Storage-Api-Token', 'server-token')
         assert applied.branch_id == headers.get('X-Branch-Id')
+
+
+class TestProgrammaticTokenExchange:
+    """SessionStateMiddleware exchanges programmatic tokens via the auth-bridge resolver (PSGO-261)."""
+
+    @pytest.mark.asyncio
+    async def test_missing_kubernetes_token_path_raises(self, monkeypatch) -> None:
+        monkeypatch.delenv('KBC_KUBERNETES_TOKEN_PATH', raising=False)
+        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_pat_abc', project_id='1')
+        with pytest.raises(ValueError, match='KBC_KUBERNETES_TOKEN_PATH'):
+            await SessionStateMiddleware._exchange_programmatic_token(config)
+
+    @pytest.mark.asyncio
+    async def test_missing_project_id_raises(self, monkeypatch) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_pat_abc')
+        with pytest.raises(ValueError, match='project id is required'):
+            await SessionStateMiddleware._exchange_programmatic_token(config)
+
+    @pytest.mark.asyncio
+    async def test_invalid_project_id_raises(self, monkeypatch) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(
+            storage_api_url='https://connection.keboola.com', storage_token='kbc_pat_abc', project_id='not-an-int'
+        )
+        with pytest.raises(ValueError, match='Invalid project id'):
+            await SessionStateMiddleware._exchange_programmatic_token(config)
+
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_resolver(self, monkeypatch) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id='42')
+
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value='legacy-storage-token')
+        with patch('keboola_mcp_server.mcp.StorageTokenResolver', return_value=resolver) as resolver_cls:
+            token = await SessionStateMiddleware._exchange_programmatic_token(config)
+
+        assert token == 'legacy-storage-token'
+        resolver_cls.assert_called_once_with(
+            storage_api_url='https://connection.keboola.com', kubernetes_token_path='/var/run/secrets/token'
+        )
+        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
+
+    @pytest.mark.asyncio
+    async def test_create_session_state_skips_exchange_for_list_requests(self, monkeypatch) -> None:
+        # The resolver call has up to a ~35s timeout; tools/list must stay fast, so
+        # create_session_state(skip_token_exchange=True) must never reach it -- a raw, unexchanged
+        # programmatic token is used instead (storage/metastore calls with it fail fast, not slow).
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id='42')
+        runtime_info = ServerRuntimeInfo(transport='http-compat/streamable-http')
+
+        with patch('keboola_mcp_server.mcp.StorageTokenResolver') as resolver_cls:
+            state = await SessionStateMiddleware.create_session_state(
+                config, runtime_info, own_stack_storage_api_url=None, skip_token_exchange=True
+            )
+
+        resolver_cls.assert_not_called()
+        client = state[KeboolaClient.STATE_KEY]
+        assert client.token == 'kbc_at_abc'

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 from starlette.requests import Request
 
+from keboola_mcp_server.clients.auth_bridge import is_programmatic_token
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
 from keboola_mcp_server.mcp import (
@@ -656,6 +657,21 @@ class TestToolsFilteringMiddleware:
 
 
 class TestSessionStateMiddleware:
+    def test_apply_request_config_never_logs_header_values(self, mocker) -> None:
+        # Authorization (a live programmatic bearer token) and X-Storage-Api-Token must never
+        # appear in the debug log this method emits -- only header names, never values.
+        log_debug = mocker.patch('keboola_mcp_server.mcp.LOG.debug')
+        config = Config(storage_api_url='https://connection.keboola.com')
+        http_rq = MagicMock(spec=Request)
+        http_rq.headers = {'Authorization': 'Bearer kbc_at_super_secret', 'X-Storage-Api-Token': 'legacy-secret'}
+        http_rq.scope = {}
+
+        SessionStateMiddleware.apply_request_config(http_rq, config, own_stack_storage_api_url=None)
+
+        logged = ' '.join(str(call) for call in log_debug.call_args_list)
+        assert 'kbc_at_super_secret' not in logged
+        assert 'legacy-secret' not in logged
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ('method', 'expected_branch_id', 'expected_skip_token_exchange'),
@@ -807,6 +823,42 @@ class TestSessionStateMiddleware:
         assert applied.storage_token == headers.get('X-Storage-Api-Token', 'server-token')
         assert applied.branch_id == headers.get('X-Branch-Id')
 
+    @pytest.mark.parametrize(
+        ('headers', 'expected_storage_token'),
+        [
+            # A programmatic bearer token arrives only via Authorization -- no Storage-token
+            # header/alias reaches it, so apply_request_config must read it directly.
+            ({'Authorization': 'Bearer kbc_at_abc'}, 'kbc_at_abc'),
+            ({'Authorization': 'Bearer kbc_pat_abc'}, 'kbc_pat_abc'),
+            # Case-insensitive "bearer" scheme, matching is_programmatic_token/strip_bearer.
+            ({'Authorization': 'bearer kbc_at_abc'}, 'kbc_at_abc'),
+            # An explicit Storage-token header always wins; Authorization is never consulted.
+            ({'Authorization': 'Bearer kbc_at_abc', 'X-Storage-Api-Token': 'legacy-token'}, 'legacy-token'),
+            # A non-programmatic Authorization value must never be forwarded as a Storage token.
+            ({'Authorization': 'Bearer some-other-oauth-token'}, None),
+            ({}, None),
+        ],
+        ids=[
+            'bearer_access_token',
+            'bearer_pat',
+            'lowercase_bearer_scheme',
+            'explicit_storage_token_wins',
+            'non_programmatic_bearer_ignored',
+            'no_authorization_header',
+        ],
+    )
+    def test_apply_request_config_reads_programmatic_token_from_authorization_header(
+        self, headers: dict[str, str], expected_storage_token: str | None
+    ) -> None:
+        config = Config(storage_api_url='https://connection.keboola.com')
+        http_rq = MagicMock(spec=Request)
+        http_rq.headers = headers
+        http_rq.scope = {}
+
+        applied = SessionStateMiddleware.apply_request_config(http_rq, config, own_stack_storage_api_url=None)
+
+        assert applied.storage_token == expected_storage_token
+
 
 class TestProgrammaticTokenExchange:
     """SessionStateMiddleware exchanges programmatic tokens via the auth-bridge resolver (PSGO-261)."""
@@ -848,6 +900,29 @@ class TestProgrammaticTokenExchange:
         resolver_cls.assert_called_once_with(
             storage_api_url='https://connection.keboola.com', kubernetes_token_path='/var/run/secrets/token'
         )
+        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_from_authorization_header_and_x_kbc_project_id(self, monkeypatch) -> None:
+        # Regression for the actual inbound shape this feature exists for: Kai's bearer sessions
+        # send the token only as Authorization, never as a Storage-token header (that's the sapi
+        # branch). apply_request_config must route it into storage_token before
+        # _exchange_programmatic_token ever runs, or the exchange never triggers at all.
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(storage_api_url='https://connection.keboola.com')
+        http_rq = MagicMock(spec=Request)
+        http_rq.headers = {'Authorization': 'Bearer kbc_at_abc', 'X-KBC-ProjectId': '42'}
+        http_rq.scope = {}
+
+        applied = SessionStateMiddleware.apply_request_config(http_rq, config, own_stack_storage_api_url=None)
+        assert is_programmatic_token(applied.storage_token)
+
+        resolver = MagicMock()
+        resolver.resolve = AsyncMock(return_value='legacy-storage-token')
+        with patch('keboola_mcp_server.mcp.StorageTokenResolver', return_value=resolver):
+            token = await SessionStateMiddleware._exchange_programmatic_token(applied)
+
+        assert token == 'legacy-storage-token'
         resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
 
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.75.4"
+version = "1.76.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3755](https://linear.app/keboola/issue/AI-3755/accept-programmatic-bearer-tokens-for-toolslist-scoped-by-x-kbc)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

A one-line cache-key fix in Kai's tool-inventory cache (adding `principal.projectId` to the key)
stopped a shared cache entry from silently answering one project's `tools/list` with another
project's data. Fixing that surfaced a second, previously-masked issue: some Kai sessions carry a
Keboola **bearer session token** (`kbc_at_...`) instead of a legacy Storage API token — decided by
kbc-ui's auth strategy, not by Kai — and this server has never been able to accept one. Every call,
including `tools/list`, 401s with no path to make it work (there is no client-side exchange: kbc-ui's
`getSapiTokenString()` deliberately returns empty under a bearer session).

This PR accepts a programmatic bearer token (`kbc_at_*`/`kbc_pat_*`) together with `X-KBC-ProjectId`
and exchanges it at Connection's auth-bridge resolver for that project's legacy Storage token —
pinned to exactly one project, with none of the multi-project scoping machinery (no scope object,
no ask-first gate). It is a minimal, standalone cherry-pick out of "Part A" of the much larger,
still-unmerged [PSGO-261 branch (PR #605)](https://github.com/keboola/mcp-server/pull/605), plus one
fix from later in that branch that Part A needs to be useful end-to-end (jobs-queue/ai-service/
sync-actions wired onto the resolved token, so `get_jobs`/`run_job` work too), plus one new
robustness fix specific to this narrower scope (`tools/list` skips the exchange, since the resolver
call has up to a ~35s timeout and a client's initial capability-discovery fetch must stay fast).

Full design, scope, and what's deliberately excluded (local PKCE login, multi-project scope, OAuth
session exchange — all still only on PR #605) is in
[`feature_spec/programmatic_token_project_scope/RFC.md`](https://github.com/keboola/mcp-server/blob/martinvasko-ai-3755-accept-programmatic-bearer-tokens-for-toolslist-scoped-by-x/feature_spec/programmatic_token_project_scope/RFC.md).

Files: `clients/auth_bridge.py` (new — `is_programmatic_token()`, `StorageTokenResolver`),
`config.py` (`project_id`), `mcp.py` (exchange wiring + `/list` skip), `clients/client.py`
(jobs-queue/ai-service/sync-actions bearer wiring).

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

`tox` (pytest, ruff, check-tools-docs) green — except the pre-existing, environment-specific
`test_server.py::test_json_logging` flake, which fails identically on `origin/main` and is unrelated
to this change.

Unit tests: `tests/clients/test_auth_bridge.py` (detection, resolver success/error mapping,
no-token-material-logged), `tests/test_mcp.py` (`TestProgrammaticTokenExchange`; `/list`-skip
threading through `on_request`/`create_session_state`), `tests/clients/test_client.py`
(parametrized token-selection across all six bearer-capable clients).

No dev-stack access from this environment — live verification of the resolver exchange against a
real stack is still pending.

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable) — no dev-stack access to wire up live PAT integtests from this environment
- [x] Project version bumped according to the change type (→ 1.76.0, minor) + `uv.lock`
- [x] Documentation updated (if applicable) — RFC at `feature_spec/programmatic_token_project_scope/RFC.md`