### PR TITLE
fix(INC-02580): keep the Storage token on jobs-queue/AI-service/sync-actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.76.1"
+version = "1.76.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/client.py
+++ b/src/keboola_mcp_server/clients/client.py
@@ -192,15 +192,17 @@ class KeboolaClient:
             readonly=readonly,
             encryption_client=self._encryption_client,
         )
+        # Jobs-queue / AI-service / sync-actions keep the raw Storage token and must NOT be given
+        # the OAuth bearer: the queue's NewJobFactory re-sends whatever it receives to Storage as a
+        # legacy X-StorageApi-Token (hardcoded AuthType::STORAGE_TOKEN), so an OAuth bearer arrives
+        # there as an invalid Storage token and every run_job 401s (INC-02580 / SUPPORT-17416).
+        # Reverts the client.py part of AI-3755; the programmatic-token path is unaffected, see the
+        # PR description.
         self._jobs_queue_client = JobsQueueClient.create(
-            root_url=queue_api_url,
-            token=bearer_or_sapi_token,
-            branch_id=branch_id,
-            headers=self._headers,
-            readonly=readonly,
+            root_url=queue_api_url, token=self._token, branch_id=branch_id, headers=self._headers, readonly=readonly
         )
         self._ai_service_client = AIServiceClient.create(
-            root_url=ai_service_api_url, token=bearer_or_sapi_token, headers=self._headers, readonly=readonly
+            root_url=ai_service_api_url, token=self._token, headers=self._headers, readonly=readonly
         )
         # Data-science (sandboxes-service) git-repo credential endpoints require an admin-context
         # token (CanManageAppRepoCredentials -> StorageApiToken::isAdminToken()). The OAuth bearer
@@ -219,7 +221,7 @@ class KeboolaClient:
         )
         self._sync_actions_client = SyncActionsClient.create(
             root_url=sync_actions_api_url,
-            token=bearer_or_sapi_token,
+            token=self._token,
             branch_id=branch_id,
             headers=self._headers,
             readonly=readonly,

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -416,21 +416,16 @@ class TestKeboolaClient:
         assert client.metastore_client.raw_client.base_api_url == 'https://metastore.canary-orion.keboola.dev'
         assert client.metastore_client.raw_client.headers['X-StorageAPI-Token'] == 'sapi_token_456'
 
-    # All clients below use the bearer token (Authorization header) when one is available and fall
-    # back to the raw storage token (X-StorageAPI-Token) otherwise. The jobs-queue/ai-service/
-    # sync-actions clients were switched onto the bearer token so PAT (kbc_at_/kbc_pat_) sessions
-    # work end-to-end — the queue accepts `Authorization: Bearer kbc_at_...` + X-KBC-ProjectId but
-    # rejects the PAT sent as X-StorageAPI-Token (PSGO-261). Data-science needs it for admin-context
-    # git-credential endpoints (AI-3398).
+    # The clients below use the bearer token (Authorization header) when one is available and fall
+    # back to the raw storage token (X-StorageAPI-Token) otherwise. Data-science needs it for
+    # admin-context git-credential endpoints (AI-3398). Jobs-queue/AI-service/sync-actions are
+    # deliberately NOT in this list — see test_queue_backed_clients_never_use_bearer_token.
     @pytest.mark.parametrize(
         'client_attr',
         [
             'scheduler_client',
             'metastore_client',
             'data_science_client',
-            'jobs_queue_client',
-            'ai_service_client',
-            'sync_actions_client',
         ],
     )
     @pytest.mark.parametrize(
@@ -460,6 +455,29 @@ class TestKeboolaClient:
         else:
             assert headers.get('X-StorageAPI-Token') == expected_token
             assert 'Authorization' not in headers
+
+    @pytest.mark.parametrize(
+        'client_attr',
+        ['jobs_queue_client', 'ai_service_client', 'sync_actions_client'],
+    )
+    def test_queue_backed_clients_never_use_bearer_token(self, client_attr: str) -> None:
+        """Regression for INC-02580 / SUPPORT-17416.
+
+        The Job Queue re-sends the credential it receives to Storage as a legacy Storage token
+        (NewJobFactory, hardcoded AuthType::STORAGE_TOKEN), so an OAuth bearer forwarded here comes
+        back as `Invalid access token` and every run_job of an OAuth session fails. These three
+        clients must therefore always send the Storage token, even when a bearer token is present.
+        """
+        client = KeboolaClient(
+            storage_api_url='https://connection.keboola.com',
+            storage_api_token='sapi_token_456',
+            bearer_token='oauth_bearer_123',
+        )
+
+        headers = getattr(client, client_attr).raw_client.headers
+
+        assert headers.get('X-StorageAPI-Token') == 'sapi_token_456'
+        assert 'Authorization' not in headers
 
 
 def test_flow_schema_cache_roundtrip():

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.76.1"
+version = "1.76.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

**Incident**: INC-02580 / SUPPORT-17416 — `run_job` 401s for all OAuth-session users since Aug 19
**Regressed by**: #674 (AI-3755), commit `53da9a5`, released as v1.76.0

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Since v1.76.0 deployed on 2026-08-19 (~10:36 UTC), the `run_job` tool has had a 0% success rate
for OAuth-session users — 197 `Invalid access token` errors across six stacks (eu-central-1,
gcp-europe-west3, us-east-1, azure-north-europe, groupon, gcp-us-east4), none before that date.
Tools backed by the Storage API are unaffected.

**Root cause.** #674 switched `jobs_queue`, `ai_service` and `sync_actions` from `self._token`
onto `bearer_or_sapi_token`:

```python
bearer_or_sapi_token = f'Bearer {bearer_token}' if bearer_token else self._token
```

For an OAuth session `bearer_token` is set, so the Queue now receives
`Authorization: Bearer <oauth access token>` instead of the minted Storage token. The Queue's
`NewJobFactory` re-sends whatever credential it gets to the Storage API as a legacy
`X-StorageApi-Token` (hardcoded `AuthType::STORAGE_TOKEN`); Storage rejects the OAuth bearer with
`storage.tokenInvalid`, surfaced to the caller as `Cannot create job: "Invalid access token"`.

**Fix.** Revert those three clients to `self._token`. Nothing else from #674 is touched.

**Why this does not break AI-3755.** The RFC justifies the `client.py` hunk with "without this, a
resolved token still 401s on `get_jobs`/`run_job`" — that holds on the PSGO-261 branch (#605) it
was cherry-picked from, but not in the shape that actually merged here.
`SessionStateMiddleware.create_session_state` does:

```python
storage_token = await cls._exchange_programmatic_token(config)
bearer_token = None
```

so on the programmatic-token path the exchanged legacy Storage token *is* `self._token`, and
`bearer_or_sapi_token` collapses to it. The three clients behave identically for `kbc_at_`/
`kbc_pat_` sessions before and after this revert. `tools/list` for Kai's bearer sessions — the
thing #674 exists to fix — is likewise untouched.

Storage, scheduler, data-science and metastore keep `bearer_or_sapi_token`: they consume the token
themselves instead of forwarding it to Storage, and data-science needs the bearer for the
admin-context git-credential endpoints (AI-3398).

**Scope note.** Datadog only shows job-queue failing, but `ai_service` and `sync_actions` got the
same switch and are sending OAuth bearers today too — they may simply happen to accept them.
Reverting all three restores known-good v1.75.x behaviour rather than leaving two unverified paths
in a hotfix.

**Deliberately out of scope** — worth a follow-up ticket, not an incident fix: whether the Queue
should accept a Keboola bearer at all, i.e. stop hardcoding `AuthType::STORAGE_TOKEN` in
`NewJobFactory` and forward the caller's credential as-is.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

- New `test_queue_backed_clients_never_use_bearer_token` asserts all three clients send
  `X-StorageAPI-Token` and no `Authorization` header when a bearer token is present. Verified it
  fails on the pre-fix code (3 failed) and passes on the fix (3 passed).
- `test_client_bearer_token_selection`'s client list drops the three reverted clients; scheduler,
  metastore and data-science keep their bearer coverage.
- `tests/clients` — 58 passed. `tests/test_mcp.py tests/clients tests/test_config.py` — 305 passed,
  the only failures being `test_toon_serializer` from a `toon-format` version mismatch in the
  sandbox, unrelated and reproducible on unmodified `main`.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (regression test included, per CONTRIBUTING § Bug fixes)
- [ ] Integration tests added/updated — N/A
- [x] Project version bumped according to the change type (1.76.1 → 1.76.2, `uv.lock` synced)
- [ ] Documentation updated — N/A

No RFC: bug fix (CONTRIBUTING § RFC Requirement).
