### PR TITLE
fix(release-ci): correctly detect dev-suffixed tags as non-production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
           tags: |
             type=sha,format=long
             # Production: clean v* / agent-v* tags -> production stacks.
-            type=raw,value=production-${{ github.sha }},enable=${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/agent-v')) && !contains(github.ref, '-dev.') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.') }}
+            type=raw,value=production-${{ github.sha }},enable=${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/agent-v')) && !contains(github.ref, '-dev') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev') }}
             # Canary: canary-orion-v* / canary-orion-agent* tags -> canary-orion stacks.
             type=raw,value=canary-orion-${{ github.sha }},enable=${{ startsWith(github.ref, 'refs/tags/canary-orion-') }}
             # Dev: dev-v* / dev-agent* tags -> testing stacks.
@@ -128,7 +128,7 @@ jobs:
 
       - name: Trigger image tag update for production
         uses: ./.github/actions/trigger-image-tag-update
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev')
         with:
           helm-chart: "mcp-server"
           image-tag: production-${{ github.sha }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Trigger image tag update for production (agent)
         uses: ./.github/actions/trigger-image-tag-update
-        if: startsWith(github.ref, 'refs/tags/agent-v') && !contains(github.ref, '-dev.')
+        if: startsWith(github.ref, 'refs/tags/agent-v') && !contains(github.ref, '-dev')
         with:
           helm-chart: "mcp-server-agent"
           image-tag: production-${{ github.sha }}
@@ -173,7 +173,7 @@ jobs:
   release-notes:
     name: Release notes
     needs: build-and-push
-    if: needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.')
+    if: needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev')
     runs-on: ubuntu-latest
     permissions:
       contents: write        # create the GitHub Release
@@ -220,6 +220,6 @@ jobs:
   kaibench:
     name: KaiBench Evaluation
     needs: build-and-push
-    if: needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev.')
+    if: needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev')
     uses: ./.github/workflows/kaibench.yml
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.78.0"
+version = "1.78.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.78.0"
+version = "1.78.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: N/A — infra hotfix, no ticket

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`release.yml` excluded pre-release tags from production/gitops handling via
`!contains(github.ref, '-dev.')`, which only matches when the tag has the
literal `.N` increment suffix (e.g. `v1.70.0-dev.1`). A tag missing that
suffix — e.g. `v1.78.0-dev` — slipped past the check and was treated as a
clean production tag. This actually happened today: pushing `v1.78.0-dev`
and `agent-v1.78.0-dev` caused the workflow to build `production-<sha>` /
`latest` images and fire a real (non-dry-run) GitOps image-tag update to
`kbc-stacks` for the `mcp-server-agent` chart.

Tightened every occurrence to `!contains(github.ref, '-dev')` — real
production tags (`v1.76.2`, `agent-v1.76.0`, ...) never contain that
substring at all, so this catches any dev-styled suffix regardless of
whether the numeric increment is present, with no effect on legitimate
`canary-orion-*` / `dev-*` / clean production tag handling.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

N/A — CI workflow-only change, no runtime server behavior affected. Verified the fixed condition logic by hand against both the incident tags (`v1.78.0-dev`, `agent-v1.78.0-dev`) and existing valid tags (`v1.76.2`, `dev-v1.76.1-dev.1`, `canary-orion-v1.74.3-dev.1`).

## Checklist

- [x] Self-review completed
- [ ] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)