### PR TITLE
fix(PSGO-280): resolve legacy Storage token for jobs-queue/AI-service/sync-actions

### DIFF
--- a/integtests/conftest.py
+++ b/integtests/conftest.py
@@ -609,7 +609,7 @@ def sync_storage_client(storage_api_token: str, storage_api_url: str) -> SyncSto
 @pytest.fixture
 def keboola_client(sync_storage_client: SyncStorageClient) -> KeboolaClient:
     return KeboolaClient(
-        storage_api_token=sync_storage_client.token,
+        legacy_storage_token=sync_storage_client.token,
         storage_api_url=sync_storage_client.root_url,
         headers={'User-Agent': INTEGTEST_USER_AGENT},
     )

--- a/integtests/conftest.py
+++ b/integtests/conftest.py
@@ -364,8 +364,7 @@ def _sync_storage_client(storage_api_token: str, storage_api_url: str) -> SyncSt
     client = SyncStorageClient(storage_api_url, storage_api_token)
     token_info = client.tokens.verify()
     LOG.info(
-        f'Authorized as "{token_info["description"]}" ({token_info["id"]}) '
-        f'to project "{token_info["owner"]["name"]}" ({token_info["owner"]["id"]}) '
+        f'Authorized to project "{token_info["owner"]["name"]}" ({token_info["owner"]["id"]}) '
         f'at "{client.root_url}" stack.'
     )
     return client

--- a/integtests/project_lock.py
+++ b/integtests/project_lock.py
@@ -57,12 +57,8 @@ class ProjectEndpoint:
     token_description: str = ''
 
     def describe(self) -> str:
-        """Return a human-readable summary of the project and token."""
-        return (
-            f'Authorized as "{self.token_description}" ({self.token_id}, ...{self.storage_api_token[-4:]}) '
-            f'to project "{self.project_name}" ({self.project_id}) '
-            f'at "{self.storage_api_url}" stack.'
-        )
+        """Return a human-readable summary of the project. Never includes token material."""
+        return f'Authorized to project "{self.project_name}" ({self.project_id}) at "{self.storage_api_url}" stack.'
 
 
 @dataclass(frozen=True)

--- a/integtests/tools/test_storage_branches.py
+++ b/integtests/tools/test_storage_branches.py
@@ -358,7 +358,7 @@ async def _build_context(
     """Build an MCP context bound to a specific branch (or the default branch when None)."""
     keboola_client = KeboolaClient(
         storage_api_url=branch_project.storage_api_url,
-        storage_api_token=branch_project.storage_api_token,
+        legacy_storage_token=branch_project.storage_api_token,
         headers={'User-Agent': 'KeboolaMCPServer/integtest'},
     )
     if branch_id is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.78.2"
+version = "1.78.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/auth_bridge.py
+++ b/src/keboola_mcp_server/clients/auth_bridge.py
@@ -8,14 +8,16 @@ exception messages.
 
 `StorageTokenResolver` exchanges a programmatic bearer token (`kbc_at_*` access token or
 `kbc_pat_*` personal access token) for the legacy per-project Storage token, for downstream
-services that only understand that format.
+services that only understand that format (jobs-queue, AI-service, sync-actions -- see
+`SessionStateMiddleware.create_session_state`, which calls this before building `KeboolaClient`
+whenever a project is known).
 
 `OAuthSessionExchanger` exchanges a league OAuth access token from the remote/HTTP OAuth
 login flow (`oauth.py`) for a whole-stack Keboola programmatic session (`kbc_at_*`). The
 resulting session feeds into the same downstream pipe as a directly-supplied programmatic
-token -- forwarded as a Bearer to every service `KeboolaClient` wraps (Storage, Queue, AI,
-etc.), narrowed to a project via `X-KBC-ProjectId` once known. No further exchange into a
-legacy per-project Storage token is needed or performed for those services.
+token -- forwarded as a Bearer to Storage/data-science/scheduler/metastore, narrowed to a
+project via `X-KBC-ProjectId` once known, and separately resolved via `StorageTokenResolver`
+above for jobs-queue/AI-service/sync-actions, which don't accept that Bearer (INC-02580).
 """
 
 import logging

--- a/src/keboola_mcp_server/clients/auth_bridge.py
+++ b/src/keboola_mcp_server/clients/auth_bridge.py
@@ -107,10 +107,27 @@ class StorageTokenResolver:
         self._kubernetes_token_path = kubernetes_token_path
         self._timeout = timeout or httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
         self._transport = transport
+        self._http: httpx.AsyncClient | None = None
 
     def _read_sa_jwt(self) -> str:
         # Read per call — the kubelet rotates the projected token in place.
         return read_service_account_jwt(self._kubernetes_token_path)
+
+    def _client(self) -> httpx.AsyncClient:
+        """One client -- one connection pool -- reused across resolves.
+
+        A resolver is held for the life of the server (`ServerState.storage_token_resolver`), so a
+        multi-project fan-out (and every request after it) pays one TLS handshake instead of one
+        per resolve. Created lazily so `__init__` stays synchronous.
+        """
+        if self._http is None or self._http.is_closed:
+            self._http = httpx.AsyncClient(timeout=self._timeout, transport=self._transport)
+        return self._http
+
+    async def aclose(self) -> None:
+        if self._http is not None:
+            await self._http.aclose()
+            self._http = None
 
     async def resolve(self, *, subject_token: str, project_id: int) -> str:
         """
@@ -126,12 +143,11 @@ class StorageTokenResolver:
             'X-Subject-Token': f'Bearer {strip_bearer(subject_token)}',
         }
         try:
-            async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:
-                response = await client.post(
-                    f'{self._base_url}/{_RESOLVE_ENDPOINT}',
-                    headers=headers,
-                    json={'projectId': project_id},
-                )
+            response = await self._client().post(
+                f'{self._base_url}/{_RESOLVE_ENDPOINT}',
+                headers=headers,
+                json={'projectId': project_id},
+            )
         except httpx.HTTPError as e:
             # Network / timeout failure. Raise without chaining so no request (and thus no
             # token material) can surface in a traceback.

--- a/src/keboola_mcp_server/clients/client.py
+++ b/src/keboola_mcp_server/clients/client.py
@@ -192,10 +192,13 @@ class KeboolaClient:
         )
         # Jobs-queue / AI-service / sync-actions keep the raw Storage token and must NOT be given
         # the OAuth bearer: the queue's NewJobFactory re-sends whatever it receives to Storage as a
-        # legacy X-StorageApi-Token (hardcoded AuthType::STORAGE_TOKEN), so an OAuth bearer arrives
-        # there as an invalid Storage token and every run_job 401s (INC-02580 / SUPPORT-17416).
-        # Reverts the client.py part of AI-3755; the programmatic-token path is unaffected, see the
-        # PR description.
+        # legacy X-StorageApi-Token (hardcoded AuthType::STORAGE_TOKEN), so a bearer-shaped credential
+        # arrives there as an invalid Storage token and every run_job 401s (INC-02580 / SUPPORT-17416).
+        # Reverts the client.py part of AI-3755. For a programmatic token (kbc_at_/kbc_pat_), it is
+        # `self._token`'s job to already be the legacy per-project Storage token by the time it gets
+        # here -- SessionStateMiddleware.create_session_state resolves it via the auth-bridge
+        # (StorageTokenResolver) before constructing this client; a raw, unresolved kbc_at_/kbc_pat_
+        # string 401s here exactly like an OAuth bearer would.
         self._jobs_queue_client = JobsQueueClient.create(
             root_url=queue_api_url, token=self._token, branch_id=branch_id, headers=self._headers, readonly=readonly
         )

--- a/src/keboola_mcp_server/clients/client.py
+++ b/src/keboola_mcp_server/clients/client.py
@@ -8,6 +8,12 @@ from urllib.parse import urlparse, urlunparse
 import httpx
 
 from keboola_mcp_server.clients.ai_service import AIServiceClient
+from keboola_mcp_server.clients.auth_bridge import (
+    StorageTokenExchangeError,
+    StorageTokenResolver,
+    is_programmatic_token,
+    strip_bearer,
+)
 from keboola_mcp_server.clients.base import normalize_storage_api_url, read_service_account_jwt
 from keboola_mcp_server.clients.data_science import DataScienceClient
 from keboola_mcp_server.clients.encryption import EncryptionClient
@@ -86,6 +92,82 @@ class KeboolaClient:
         assert isinstance(instance, KeboolaClient), f'Expected KeboolaClient, got: {instance}'
         return instance
 
+    @classmethod
+    async def create(
+        cls,
+        *,
+        storage_api_url: str,
+        storage_token: str,
+        bearer_token: str | None = None,
+        branch_id: str | None = None,
+        project_id: str | int | None = None,
+        token_resolver: StorageTokenResolver | None = None,
+        headers: Mapping[str, Any] | None = None,
+        readonly: bool | None = None,
+        own_stack_storage_api_url: str | None = None,
+    ) -> 'KeboolaClient':
+        """
+        Builds a client from the credential a caller was handed, classifying it and -- when it is
+        a programmatic token narrowed to one project -- exchanging it for that project's legacy
+        Storage token.
+
+        `__init__` takes the two *already-classified* credentials (`legacy_storage_token` and
+        `bearer_token`); this factory is the one place that decides which is which:
+
+        * A programmatic token (``kbc_at_``/``kbc_pat_``) is forwarded downstream as a Bearer for
+          Storage/data-science/scheduler/metastore. Jobs-queue/AI-service/sync-actions re-send
+          whatever they receive to Storage as a legacy ``X-StorageApi-Token``, so that Bearer 401s
+          there (INC-02580 / SUPPORT-17416); with `project_id` and a `token_resolver` we exchange
+          it for the real per-project Storage token via the auth-bridge. On failure we keep the raw
+          token, degrading to the pre-existing 401 rather than breaking session creation.
+        * Anything else (a legacy project-bound Storage token, or an OAuth session whose bearer is
+          supplied separately) is passed through untouched.
+
+        :param storage_token: The credential the caller presented (legacy Storage token, or a
+            programmatic kbc_at_/kbc_pat_ token, with or without a `Bearer ` scheme).
+        :param bearer_token: An OAuth bearer, when the session has one alongside a legacy Storage
+            token. Ignored (overwritten) for a programmatic `storage_token`.
+        :param project_id: The project this client is narrowed to, if any. Only used to pick the
+            project for the legacy-token exchange -- the caller still owns the X-KBC-ProjectId
+            header.
+        :param token_resolver: The auth-bridge resolver, or None to skip the exchange (a local/
+            non-deployed server, or a request that must add no auth round-trips -- see
+            `SessionStateMiddleware.on_request`'s `is_list`).
+        """
+        if not storage_api_url:
+            raise ValueError('Storage API URL is not provided.')
+        if not storage_token:
+            raise ValueError('Storage API token is not provided.')
+
+        legacy_storage_token = storage_token
+        if is_programmatic_token(storage_token):
+            bearer_token = strip_bearer(storage_token)
+        if token_resolver is not None and project_id is not None and is_programmatic_token(bearer_token):
+            try:
+                # int() stays INSIDE the try: project_id can come from the caller-supplied
+                # X-KBC-ProjectId header, and a non-numeric value must degrade to the warning
+                # below, not 500 the request.
+                legacy_storage_token = await token_resolver.resolve(
+                    subject_token=cast(str, bearer_token), project_id=int(project_id)
+                )
+            except (StorageTokenExchangeError, OSError, ValueError) as e:
+                # OSError/ValueError: the projected ServiceAccount JWT file is missing or empty.
+                LOG.warning(
+                    'Could not resolve a legacy Storage token for jobs-queue/AI-service/sync-actions '
+                    f'calls on project {project_id}; those calls will keep 401ing: {e}',
+                    exc_info=True,
+                )
+
+        client = cls(
+            storage_api_url=storage_api_url,
+            legacy_storage_token=legacy_storage_token,
+            bearer_token=bearer_token,
+            headers=headers,
+            readonly=readonly,
+            own_stack_storage_api_url=own_stack_storage_api_url,
+        )
+        return await client.with_branch_id(branch_id)
+
     async def with_branch_id(self, branch_id: str | None) -> 'KeboolaClient':
         """
         Gets a KeboolaClient configured for the given branch. It verifies that the branch exists
@@ -96,7 +178,7 @@ class KeboolaClient:
         elif not branch_id:
             return KeboolaClient(
                 storage_api_url=self.storage_api_url,
-                storage_api_token=self.token,
+                legacy_storage_token=self.legacy_storage_token,
                 bearer_token=self._bearer_token,
                 branch_id=None,
                 headers=self._headers,
@@ -121,7 +203,7 @@ class KeboolaClient:
             normalized_branch_id = None if is_default else branch_id
             return KeboolaClient(
                 storage_api_url=self.storage_api_url,
-                storage_api_token=self.token,
+                legacy_storage_token=self.legacy_storage_token,
                 bearer_token=self._bearer_token,
                 branch_id=normalized_branch_id,
                 headers=self._headers,
@@ -133,7 +215,7 @@ class KeboolaClient:
         self,
         *,
         storage_api_url: str,
-        storage_api_token: str,
+        legacy_storage_token: str,
         bearer_token: str | None = None,
         branch_id: str | None = None,
         headers: Mapping[str, Any] | None = None,
@@ -141,9 +223,14 @@ class KeboolaClient:
         own_stack_storage_api_url: str | None = None,
     ) -> None:
         """
-        Initialize the client.
+        Initialize the client from two already-classified credentials. A raw, not-yet-classified
+        caller credential (e.g. straight off a request) should go through `create()` instead,
+        which decides `legacy_storage_token` vs `bearer_token` and performs the legacy-token
+        exchange when applicable.
 
-        :param storage_api_token: Keboola Storage API token
+        :param legacy_storage_token: A legacy project-scoped Storage API token. Sent as-is to
+            jobs-queue/AI-service/sync-actions; also used for every other service when no
+            `bearer_token` is given.
         :param storage_api_url: Keboola Storage API URL
         :param bearer_token: The access token issued by Keboola OAuth server
         :param branch_id: Keboola branch ID
@@ -156,7 +243,7 @@ class KeboolaClient:
             Kubernetes ServiceAccount credential may be sent to `storage_api_url`; when it is None,
             the step-up is never attempted. See `step_up_storage_client()`.
         """
-        self._token = storage_api_token
+        self._legacy_storage_token = legacy_storage_token
         self._bearer_token = bearer_token
         self._branch_id = branch_id
         self._own_stack_storage_api_url = own_stack_storage_api_url
@@ -177,7 +264,9 @@ class KeboolaClient:
         sync_actions_api_url = urlunparse(('https', f'sync-actions.{self._hostname_suffix}', '', '', '', ''))
 
         # Initialize clients for individual services
-        bearer_or_sapi_token = self._bearer_or_sapi_token = f'Bearer {bearer_token}' if bearer_token else self._token
+        bearer_or_sapi_token = self._bearer_or_sapi_token = (
+            f'Bearer {bearer_token}' if bearer_token else self._legacy_storage_token
+        )
         # The encryption service does not require an authorization header, so we pass None as the token
         self._encryption_client = EncryptionClient.create(
             root_url=encryption_api_url, token=None, headers=self._headers
@@ -190,20 +279,23 @@ class KeboolaClient:
             readonly=readonly,
             encryption_client=self._encryption_client,
         )
-        # Jobs-queue / AI-service / sync-actions keep the raw Storage token and must NOT be given
+        # Jobs-queue / AI-service / sync-actions keep the legacy Storage token and must NOT be given
         # the OAuth bearer: the queue's NewJobFactory re-sends whatever it receives to Storage as a
         # legacy X-StorageApi-Token (hardcoded AuthType::STORAGE_TOKEN), so a bearer-shaped credential
         # arrives there as an invalid Storage token and every run_job 401s (INC-02580 / SUPPORT-17416).
         # Reverts the client.py part of AI-3755. For a programmatic token (kbc_at_/kbc_pat_), it is
-        # `self._token`'s job to already be the legacy per-project Storage token by the time it gets
-        # here -- SessionStateMiddleware.create_session_state resolves it via the auth-bridge
-        # (StorageTokenResolver) before constructing this client; a raw, unresolved kbc_at_/kbc_pat_
-        # string 401s here exactly like an OAuth bearer would.
+        # `create()`'s job to already have exchanged it for the legacy per-project Storage token via
+        # the auth-bridge (StorageTokenResolver) before this constructor runs; a raw, unresolved
+        # kbc_at_/kbc_pat_ string 401s here exactly like an OAuth bearer would.
         self._jobs_queue_client = JobsQueueClient.create(
-            root_url=queue_api_url, token=self._token, branch_id=branch_id, headers=self._headers, readonly=readonly
+            root_url=queue_api_url,
+            token=self._legacy_storage_token,
+            branch_id=branch_id,
+            headers=self._headers,
+            readonly=readonly,
         )
         self._ai_service_client = AIServiceClient.create(
-            root_url=ai_service_api_url, token=self._token, headers=self._headers, readonly=readonly
+            root_url=ai_service_api_url, token=self._legacy_storage_token, headers=self._headers, readonly=readonly
         )
         # Data-science (sandboxes-service) git-repo credential endpoints require an admin-context
         # token (CanManageAppRepoCredentials -> StorageApiToken::isAdminToken()). The OAuth bearer
@@ -222,7 +314,7 @@ class KeboolaClient:
         )
         self._sync_actions_client = SyncActionsClient.create(
             root_url=sync_actions_api_url,
-            token=self._token,
+            token=self._legacy_storage_token,
             branch_id=branch_id,
             headers=self._headers,
             readonly=readonly,
@@ -244,8 +336,8 @@ class KeboolaClient:
         return self._storage_api_url
 
     @property
-    def token(self) -> str:
-        return self._token
+    def legacy_storage_token(self) -> str:
+        return self._legacy_storage_token
 
     @property
     def bearer_token(self) -> str | None:
@@ -350,7 +442,7 @@ class KeboolaClient:
         headers['X-Kubernetes-Authorization'] = f'Bearer {jwt}'
         return AsyncStorageClient.create(
             root_url=self._storage_api_url,
-            # Bearer, not the raw storage_api_token: for a programmatic (kbc_at_/kbc_pat_) session
+            # Bearer, not the raw legacy_storage_token: for a programmatic (kbc_at_/kbc_pat_) session
             # the raw token would be sent as X-StorageAPI-Token, which Storage API rejects outright
             # -- it only accepts a programmatic token via Authorization: Bearer.
             token=self._bearer_or_sapi_token,

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -29,7 +29,12 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from keboola_mcp_server.auth_login import exchange_scoped_token, get_access_token, introspect_token, load_tokens
-from keboola_mcp_server.clients.auth_bridge import is_programmatic_token, strip_bearer
+from keboola_mcp_server.clients.auth_bridge import (
+    StorageTokenExchangeError,
+    StorageTokenResolver,
+    is_programmatic_token,
+    strip_bearer,
+)
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import (
@@ -827,16 +832,37 @@ class SessionStateMiddleware(fmw.Middleware):
             bearer_token = config.bearer_token
             extra_headers: dict[str, Any] = {}
             if is_programmatic_token(storage_token):
-                # A programmatic token (kbc_at_/kbc_pat_) is forwarded downstream as a Bearer --
-                # KeboolaClient already sends it that way to every service it wraps (Storage, Queue,
-                # AI, etc.), so no legacy per-project Storage token needs to be minted for it. Strip
-                # any inbound `Bearer ` scheme so the client's own `Bearer ` prefixing can't produce
-                # `Bearer Bearer …`. Narrow to a specific project via X-KBC-ProjectId when known
-                # (header, or a prior scope selection) -- unset (whole-stack) is exactly what
-                # get_accessible_projects/set_project_scope need before a project is chosen.
+                # A programmatic token (kbc_at_/kbc_pat_) is forwarded downstream as a Bearer for
+                # Storage/data-science/scheduler/metastore. Strip any inbound `Bearer ` scheme so
+                # the client's own `Bearer ` prefixing can't produce `Bearer Bearer …`. Narrow to a
+                # specific project via X-KBC-ProjectId when known (header, or a prior scope
+                # selection) -- unset (whole-stack) is exactly what get_accessible_projects/
+                # set_project_scope need before a project is chosen.
                 bearer_token = strip_bearer(storage_token)
                 if config.project_id:
                     extra_headers['X-KBC-ProjectId'] = config.project_id
+                    # jobs-queue/AI-service/sync-actions forward whatever they receive to Storage
+                    # as a legacy X-StorageApi-Token (see client.py) -- a kbc_at_/kbc_pat_ token
+                    # 401s there (INC-02580's fix was correct for that; it just can't help this
+                    # token type). Resolve the real per-project Storage token via the auth-bridge
+                    # for those three clients. Only possible on the deployed server (needs the SA
+                    # JWT to call the resolver); on failure (e.g. the resolver's Manage scope isn't
+                    # granted on this stack yet, see 78a0bf6e) keep the raw token so this degrades
+                    # to the pre-existing 401 instead of breaking session creation outright.
+                    if kubernetes_token_path := deployed_sa_token_path():
+                        try:
+                            storage_token = await StorageTokenResolver(
+                                storage_api_url=config.storage_api_url,
+                                kubernetes_token_path=kubernetes_token_path,
+                            ).resolve(subject_token=bearer_token, project_id=int(config.project_id))
+                        except (StorageTokenExchangeError, OSError, ValueError) as e:
+                            # OSError/ValueError: the projected SA JWT file is missing/empty (should
+                            # never happen when KBC_KUBERNETES_TOKEN_PATH is set on a real deployment,
+                            # but must not crash session creation if it does).
+                            LOG.warning(
+                                'Could not resolve a legacy Storage token for jobs-queue/AI-service/'
+                                f'sync-actions calls; those calls will keep 401ing: {e}'
+                            )
 
             client = await KeboolaClient(
                 storage_api_url=config.storage_api_url,

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -29,12 +29,7 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from keboola_mcp_server.auth_login import exchange_scoped_token, get_access_token, introspect_token, load_tokens
-from keboola_mcp_server.clients.auth_bridge import (
-    StorageTokenExchangeError,
-    StorageTokenResolver,
-    is_programmatic_token,
-    strip_bearer,
-)
+from keboola_mcp_server.clients.auth_bridge import StorageTokenResolver, is_programmatic_token, strip_bearer
 from keboola_mcp_server.clients.base import JsonDict
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import (
@@ -128,6 +123,38 @@ class ServerState:
     runtime_info: ServerRuntimeInfo
     session_store: SessionStore | None = None
     kai_scope_store: KaiScopeStore | None = None
+    _token_resolvers: dict[str, StorageTokenResolver] = dataclasses.field(
+        default_factory=dict, compare=False, repr=False
+    )
+
+    def storage_token_resolver(self, storage_api_url: str | None) -> StorageTokenResolver | None:
+        """The auth-bridge resolver for `storage_api_url`, or None when this process is not the
+        deployed server.
+
+        One instance per stack URL, reused for the life of the server -- each holds its own pooled
+        `httpx.AsyncClient` (see `StorageTokenResolver`), so a fanned-out multi-project call, and
+        every request after it, reuse one connection instead of a TLS handshake per resolve. This
+        is also the single place that answers "am I the deployed server?" for token exchange --
+        `KeboolaClient.create` just uses the resolver it is handed, or skips the exchange when
+        handed None.
+        """
+        path = deployed_sa_token_path()
+        if not path or not storage_api_url:
+            return None
+        # `path` is not part of the cache key: it comes from the process environment only
+        # (KBC_KUBERNETES_TOKEN_PATH), so it is a constant for the life of this ServerState.
+        if (resolver := self._token_resolvers.get(storage_api_url)) is None:
+            resolver = self._token_resolvers[storage_api_url] = StorageTokenResolver(
+                storage_api_url=storage_api_url, kubernetes_token_path=path
+            )
+        return resolver
+
+    async def aclose(self) -> None:
+        """Closes every pooled connection held by `storage_token_resolver`. Call once, from the
+        server's lifespan teardown."""
+        for resolver in self._token_resolvers.values():
+            await resolver.aclose()
+        self._token_resolvers.clear()
 
     @property
     def own_stack_storage_api_url(self) -> str | None:
@@ -350,6 +377,9 @@ class SessionStateMiddleware(fmw.Middleware):
                 runtime_info,
                 readonly=readonly,
                 own_stack_storage_api_url=own_stack_storage_api_url,
+                # /list must add no Connection auth round-trips (see the is_list comment above):
+                # no resolver means no auth-bridge exchange. Mirrors `refresh=not is_list` above.
+                token_resolver=None if is_list else server_state.storage_token_resolver(config.storage_api_url),
             )
             if scope is not None:
                 state[SCOPE_KEY] = scope
@@ -804,6 +834,7 @@ class SessionStateMiddleware(fmw.Middleware):
         readonly: bool | None = None,
         *,
         own_stack_storage_api_url: str | None,
+        token_resolver: StorageTokenResolver | None = None,
     ) -> dict[str, Any]:
         """
         Creates `KeboolaClient` and `WorkspaceManager` instances and returns them in the session state.
@@ -817,6 +848,10 @@ class SessionStateMiddleware(fmw.Middleware):
             to the `KeboolaClient`, which sends the Kubernetes ServiceAccount step-up header only when
             the session talks to that stack. It must never come from a request header, so it is passed
             separately instead of being read off `config`, whose Storage API URL a header can set.
+        :param token_resolver: The auth-bridge resolver `KeboolaClient.create` uses to exchange a
+            programmatic token for a project's legacy Storage token, or None to skip that exchange
+            (a local/non-deployed server, or a request -- `/list` -- that must add no auth
+            round-trips; see the `on_request` call site).
         :return: The session state dictionary containing the created client and workspace manager instances.
         """
         LOG.info(f'Creating SessionState from config: {config}.')
@@ -828,50 +863,26 @@ class SessionStateMiddleware(fmw.Middleware):
             if not config.storage_api_url:
                 raise ValueError('Storage API URL is not provided.')
 
-            storage_token = config.storage_token
-            bearer_token = config.bearer_token
-            extra_headers: dict[str, Any] = {}
-            if is_programmatic_token(storage_token):
-                # A programmatic token (kbc_at_/kbc_pat_) is forwarded downstream as a Bearer for
-                # Storage/data-science/scheduler/metastore. Strip any inbound `Bearer ` scheme so
-                # the client's own `Bearer ` prefixing can't produce `Bearer Bearer …`. Narrow to a
-                # specific project via X-KBC-ProjectId when known (header, or a prior scope
-                # selection) -- unset (whole-stack) is exactly what get_accessible_projects/
-                # set_project_scope need before a project is chosen.
-                bearer_token = strip_bearer(storage_token)
-                if config.project_id:
-                    extra_headers['X-KBC-ProjectId'] = config.project_id
-                    # jobs-queue/AI-service/sync-actions forward whatever they receive to Storage
-                    # as a legacy X-StorageApi-Token (see client.py) -- a kbc_at_/kbc_pat_ token
-                    # 401s there (INC-02580's fix was correct for that; it just can't help this
-                    # token type). Resolve the real per-project Storage token via the auth-bridge
-                    # for those three clients. Only possible on the deployed server (needs the SA
-                    # JWT to call the resolver); on failure (e.g. the resolver's Manage scope isn't
-                    # granted on this stack yet, see 78a0bf6e) keep the raw token so this degrades
-                    # to the pre-existing 401 instead of breaking session creation outright.
-                    if kubernetes_token_path := deployed_sa_token_path():
-                        try:
-                            storage_token = await StorageTokenResolver(
-                                storage_api_url=config.storage_api_url,
-                                kubernetes_token_path=kubernetes_token_path,
-                            ).resolve(subject_token=bearer_token, project_id=int(config.project_id))
-                        except (StorageTokenExchangeError, OSError, ValueError) as e:
-                            # OSError/ValueError: the projected SA JWT file is missing/empty (should
-                            # never happen when KBC_KUBERNETES_TOKEN_PATH is set on a real deployment,
-                            # but must not crash session creation if it does).
-                            LOG.warning(
-                                'Could not resolve a legacy Storage token for jobs-queue/AI-service/'
-                                f'sync-actions calls; those calls will keep 401ing: {e}'
-                            )
-
-            client = await KeboolaClient(
+            # A programmatic token (kbc_at_/kbc_pat_) is narrowed to a specific project via
+            # X-KBC-ProjectId when known (header, or a prior scope selection) -- unset
+            # (whole-stack) is exactly what get_accessible_projects/set_project_scope need before
+            # a project is chosen. A legacy project-bound Storage token derives its project from
+            # the token itself and must not get the header.
+            project_id = config.project_id if is_programmatic_token(config.storage_token) else None
+            client = await KeboolaClient.create(
                 storage_api_url=config.storage_api_url,
-                storage_api_token=storage_token,
-                bearer_token=bearer_token,
-                headers={**build_tracing_headers(runtime_info), **extra_headers},
+                storage_token=config.storage_token,
+                bearer_token=config.bearer_token,
+                branch_id=config.branch_id,
+                project_id=project_id,
+                token_resolver=token_resolver,
+                headers={
+                    **build_tracing_headers(runtime_info),
+                    **({'X-KBC-ProjectId': project_id} if project_id else {}),
+                },
                 readonly=readonly,
                 own_stack_storage_api_url=own_stack_storage_api_url,
-            ).with_branch_id(config.branch_id)
+            )
 
             state[KeboolaClient.STATE_KEY] = client
             LOG.info('Successfully initialized Storage API client.')
@@ -980,7 +991,7 @@ class ToolsFilteringMiddleware(fmw.Middleware):
         # programmatic sessions and advertise the superset; the on_call_tool guards still enforce every
         # feature/role/branch rule per project (with the right project_id) when a tool is invoked.
         client = KeboolaClient.from_state(context.fastmcp_context.session.state)
-        if is_programmatic_token(client.token):
+        if is_programmatic_token(client.bearer_token):
             return tools
 
         token_info = await self.get_token_info(context.fastmcp_context)

--- a/src/keboola_mcp_server/multiproject.py
+++ b/src/keboola_mcp_server/multiproject.py
@@ -16,7 +16,7 @@ from fastmcp.tools.tool import ToolResult
 from mcp import types as mt
 from pydantic import ValidationError as PydanticValidationError
 
-from keboola_mcp_server.clients.auth_bridge import strip_bearer
+from keboola_mcp_server.clients.auth_bridge import StorageTokenExchangeError, StorageTokenResolver, strip_bearer
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import build_tracing_headers, deployed_sa_token_path
 from keboola_mcp_server.mcp import ServerState, is_read_only_tool
@@ -324,9 +324,25 @@ class MultiProjectMiddleware(fmw.Middleware):
         # Normalize any inbound `Bearer ` scheme; KeboolaClient adds it back for bearer tokens,
         # so a pre-prefixed value would otherwise become `Authorization: Bearer Bearer …`.
         token = strip_bearer(token)
+        # jobs-queue/AI-service/sync-actions reject this programmatic token the same way the
+        # primary session client's did before it was resolved in `create_session_state` (INC-02580 /
+        # PSGO-261) -- resolve the legacy per-project Storage token here too, so a fanned-out
+        # read/write against a non-active project doesn't 401 on those three clients either.
+        storage_api_token = token
+        if kubernetes_token_path := deployed_sa_token_path():
+            try:
+                storage_api_token = await StorageTokenResolver(
+                    storage_api_url=storage_api_url,
+                    kubernetes_token_path=kubernetes_token_path,
+                ).resolve(subject_token=token, project_id=project_id)
+            except (StorageTokenExchangeError, OSError, ValueError) as e:
+                LOG.warning(
+                    'Could not resolve a legacy Storage token for jobs-queue/AI-service/'
+                    f'sync-actions calls on project {project_id}; those calls will keep 401ing: {e}'
+                )
         return await KeboolaClient(
             storage_api_url=storage_api_url,
-            storage_api_token=token,
+            storage_api_token=storage_api_token,
             bearer_token=token,
             headers={
                 **build_tracing_headers(server_state.runtime_info),

--- a/src/keboola_mcp_server/multiproject.py
+++ b/src/keboola_mcp_server/multiproject.py
@@ -135,8 +135,12 @@ class MultiProjectMiddleware(fmw.Middleware):
         original_client = state.get(KeboolaClient.STATE_KEY)
         original_workspace = state.get(WorkspaceManager.STATE_KEY)
         is_real_client = isinstance(original_client, KeboolaClient)
-        # Default (auto-leased) scope carries no minted token; fall back to the active client's token.
-        base_token = scope.scoped_token or (original_client.token if is_real_client else '')
+        # Default (auto-leased) scope carries no minted token; fall back to the active client's
+        # bearer token -- the whole-stack kbc_at_/kbc_pat_ subject token. `.token` is the wrong
+        # property here: for a deployed, project-scoped session it may be the *active* project's
+        # resolved legacy Storage token (see create_session_state), which must not be reused as the
+        # subject token for a *different* target project below.
+        base_token = scope.scoped_token or (original_client.bearer_token if is_real_client else '')
         # The active client's own URL — the current request/session's, not the startup config's
         # (which can differ or be unset for streamable-HTTP setups that supply it per request).
         storage_api_url = original_client.storage_api_url if is_real_client else server_state.config.storage_api_url
@@ -233,7 +237,8 @@ class MultiProjectMiddleware(fmw.Middleware):
         original_client = state.get(KeboolaClient.STATE_KEY)
         original_workspace = state.get(WorkspaceManager.STATE_KEY)
         is_real_client = isinstance(original_client, KeboolaClient)
-        base_token = scope.scoped_token or (original_client.token if is_real_client else '')
+        # See the identical fallback in on_call_tool above for why .bearer_token, not .token.
+        base_token = scope.scoped_token or (original_client.bearer_token if is_real_client else '')
         storage_api_url = original_client.storage_api_url if is_real_client else server_state.config.storage_api_url
         try:
             await self._swap_project(state, server_state, storage_api_url, base_token, target, scope.read_only)

--- a/src/keboola_mcp_server/multiproject.py
+++ b/src/keboola_mcp_server/multiproject.py
@@ -16,7 +16,6 @@ from fastmcp.tools.tool import ToolResult
 from mcp import types as mt
 from pydantic import ValidationError as PydanticValidationError
 
-from keboola_mcp_server.clients.auth_bridge import StorageTokenExchangeError, StorageTokenResolver, strip_bearer
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import build_tracing_headers, deployed_sa_token_path
 from keboola_mcp_server.mcp import ServerState, is_read_only_tool
@@ -136,10 +135,10 @@ class MultiProjectMiddleware(fmw.Middleware):
         original_workspace = state.get(WorkspaceManager.STATE_KEY)
         is_real_client = isinstance(original_client, KeboolaClient)
         # Default (auto-leased) scope carries no minted token; fall back to the active client's
-        # bearer token -- the whole-stack kbc_at_/kbc_pat_ subject token. `.token` is the wrong
-        # property here: for a deployed, project-scoped session it may be the *active* project's
-        # resolved legacy Storage token (see create_session_state), which must not be reused as the
-        # subject token for a *different* target project below.
+        # bearer token -- the whole-stack kbc_at_/kbc_pat_ subject token. `.legacy_storage_token`
+        # is the wrong property here: for a deployed, project-scoped session it may be the
+        # *active* project's resolved legacy Storage token (see KeboolaClient.create), which must
+        # not be reused as the subject token for a *different* target project below.
         base_token = scope.scoped_token or (original_client.bearer_token if is_real_client else '')
         # The active client's own URL — the current request/session's, not the startup config's
         # (which can differ or be unset for streamable-HTTP setups that supply it per request).
@@ -237,7 +236,8 @@ class MultiProjectMiddleware(fmw.Middleware):
         original_client = state.get(KeboolaClient.STATE_KEY)
         original_workspace = state.get(WorkspaceManager.STATE_KEY)
         is_real_client = isinstance(original_client, KeboolaClient)
-        # See the identical fallback in on_call_tool above for why .bearer_token, not .token.
+        # See the identical fallback in on_call_tool above for why .bearer_token, not
+        # .legacy_storage_token.
         base_token = scope.scoped_token or (original_client.bearer_token if is_real_client else '')
         storage_api_url = original_client.storage_api_url if is_real_client else server_state.config.storage_api_url
         try:
@@ -326,35 +326,21 @@ class MultiProjectMiddleware(fmw.Middleware):
         # `storage_api_url` is the current request/session URL (e.g. the active `KeboolaClient`'s),
         # not `server_state.config.storage_api_url` — that's the startup/lifespan config, which can
         # differ (or be unset) for streamable-HTTP setups that supply the URL per request.
-        # Normalize any inbound `Bearer ` scheme; KeboolaClient adds it back for bearer tokens,
-        # so a pre-prefixed value would otherwise become `Authorization: Bearer Bearer …`.
-        token = strip_bearer(token)
-        # jobs-queue/AI-service/sync-actions reject this programmatic token the same way the
-        # primary session client's did before it was resolved in `create_session_state` (INC-02580 /
-        # PSGO-261) -- resolve the legacy per-project Storage token here too, so a fanned-out
-        # read/write against a non-active project doesn't 401 on those three clients either.
-        storage_api_token = token
-        if kubernetes_token_path := deployed_sa_token_path():
-            try:
-                storage_api_token = await StorageTokenResolver(
-                    storage_api_url=storage_api_url,
-                    kubernetes_token_path=kubernetes_token_path,
-                ).resolve(subject_token=token, project_id=project_id)
-            except (StorageTokenExchangeError, OSError, ValueError) as e:
-                LOG.warning(
-                    'Could not resolve a legacy Storage token for jobs-queue/AI-service/'
-                    f'sync-actions calls on project {project_id}; those calls will keep 401ing: {e}'
-                )
-        return await KeboolaClient(
+        # `KeboolaClient.create` classifies `token` (strips any inbound `Bearer ` scheme) and, for a
+        # programmatic token, resolves this project's legacy Storage token so a fanned-out call
+        # doesn't 401 on jobs-queue/AI-service/sync-actions (INC-02580 / PSGO-261).
+        return await KeboolaClient.create(
             storage_api_url=storage_api_url,
-            storage_api_token=storage_api_token,
-            bearer_token=token,
+            storage_token=token,
+            branch_id=None,
+            project_id=project_id,
+            token_resolver=server_state.storage_token_resolver(storage_api_url),
             headers={
                 **build_tracing_headers(server_state.runtime_info),
                 'X-KBC-ProjectId': str(project_id),
             },
             readonly=read_only or None,
-        ).with_branch_id(None)
+        )
 
     @staticmethod
     def _deep_merge(a: Any, b: Any) -> Any:

--- a/src/keboola_mcp_server/preview.py
+++ b/src/keboola_mcp_server/preview.py
@@ -295,7 +295,11 @@ async def preview_config_diff(rq: Request) -> Response:
         rq, server_state.config, own_stack_storage_api_url=own_stack_storage_api_url
     )
     state = await SessionStateMiddleware.create_session_state(
-        config, server_state.runtime_info, readonly=True, own_stack_storage_api_url=own_stack_storage_api_url
+        config,
+        server_state.runtime_info,
+        readonly=True,
+        own_stack_storage_api_url=own_stack_storage_api_url,
+        token_resolver=server_state.storage_token_resolver(config.storage_api_url),
     )
     client = KeboolaClient.from_state(state)
     workspace_manager = WorkspaceManager.from_state(state)

--- a/src/keboola_mcp_server/scope.py
+++ b/src/keboola_mcp_server/scope.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Annotated
 
 from pydantic import Field
 
+from keboola_mcp_server.clients.auth_bridge import strip_bearer
 from keboola_mcp_server.config import Config, deployed_sa_token_path
 from keboola_mcp_server.session_store.crypto import decrypt, encrypt, resolve_encryption_key
 
@@ -81,7 +82,10 @@ def resolve_scope_binding_aad(storage_token: str | None) -> bytes | None:
     """
     if not deployed_sa_token_path() or not storage_token:
         return None
-    return hashlib.sha256(storage_token.encode('utf-8')).digest()
+    # Normalize a `Bearer `-prefixed inbound token so the seal side (KeboolaClient.bearer_token,
+    # always stripped) and the unseal side (config.storage_token, stripped on most but not
+    # necessarily every inbound path) can never drift on the scheme alone.
+    return hashlib.sha256(strip_bearer(storage_token).encode('utf-8')).digest()
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -99,7 +99,10 @@ def create_keboola_lifespan(
         - it could handle OAuth token, client access, Redis database connection for storing sessions, access
         to the Relational DB, etc.
         """
-        yield server_state
+        try:
+            yield server_state
+        finally:
+            await server_state.aclose()
 
     return keboola_lifespan
 

--- a/src/keboola_mcp_server/tools/project.py
+++ b/src/keboola_mcp_server/tools/project.py
@@ -534,7 +534,7 @@ async def get_accessible_projects(
         scoped_project_ids=scoped_ids,
         read_only=scope.read_only if scoped_ids is not None else None,
         scope_token=(
-            scope.to_token(resolve_scope_key(server_state.config), aad=resolve_scope_binding_aad(client.token))
+            scope.to_token(resolve_scope_key(server_state.config), aad=resolve_scope_binding_aad(client.bearer_token))
             if scoped_ids is not None and not is_persisted
             else None
         ),
@@ -632,7 +632,7 @@ async def set_project_scope(
     scope_token = (
         None
         if persisted
-        else scope.to_token(resolve_scope_key(server_state.config), aad=resolve_scope_binding_aad(client.token))
+        else scope.to_token(resolve_scope_key(server_state.config), aad=resolve_scope_binding_aad(client.bearer_token))
     )
     resend_instruction = (
         'The server persists this scope server-side for the rest of the conversation -- no need to resend it.'

--- a/src/keboola_mcp_server/workspace.py
+++ b/src/keboola_mcp_server/workspace.py
@@ -443,7 +443,9 @@ class _Workspace(abc.ABC):
             raise RuntimeError('Cannot determine the default branch ID')
 
         # Prefer bearer token over storage token for Query Service
-        token = f'Bearer {self._client.bearer_token}' if self._client.bearer_token else self._client.token
+        token = (
+            f'Bearer {self._client.bearer_token}' if self._client.bearer_token else self._client.legacy_storage_token
+        )
 
         return QueryServiceClient.create(
             root_url=urlunparse(('https', f'query.{self._client.hostname_suffix}', '', '', '', '')),

--- a/tests/clients/test_auth_bridge.py
+++ b/tests/clients/test_auth_bridge.py
@@ -68,6 +68,34 @@ async def test_resolve_success_sends_expected_request(sa_token_file: Path) -> No
     assert rq.headers['X-Subject-Token'] == 'Bearer kbc_pat_abc'
 
 
+@pytest.mark.asyncio
+async def test_resolve_reuses_one_client_across_calls(sa_token_file: Path) -> None:
+    # PSGO-280 (P1): a resolver is held for the life of the server and reused across an
+    # N-project fan-out, so it must pool one connection rather than handshaking per resolve.
+    seen_clients = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(HTTPStatus.OK, json={'storageToken': 'legacy-token'})
+
+    resolver = _resolver(sa_token_file, handler)
+
+    for _ in range(3):
+        seen_clients.append(resolver._client())
+        await resolver.resolve(subject_token='kbc_at_abc', project_id=1)
+
+    assert len({id(c) for c in seen_clients}) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_creates_a_new_client_after_aclose(sa_token_file: Path) -> None:
+    resolver = _resolver(sa_token_file, lambda rq: httpx.Response(HTTPStatus.OK, json={'storageToken': 'x'}))
+    first = resolver._client()
+
+    await resolver.aclose()
+
+    assert resolver._client() is not first
+
+
 @pytest.mark.parametrize('status', [HTTPStatus.BAD_REQUEST, HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN])
 @pytest.mark.asyncio
 async def test_resolve_passes_through_client_errors(sa_token_file: Path, status: HTTPStatus) -> None:

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from pytest_mock import MockerFixture
 
+from keboola_mcp_server.clients.auth_bridge import StorageTokenExchangeError, StorageTokenResolver
 from keboola_mcp_server.clients.base import RawKeboolaClient
 from keboola_mcp_server.clients.client import KeboolaClient, get_metadata_property
 from keboola_mcp_server.clients.storage import AsyncStorageClient
@@ -17,7 +18,7 @@ from keboola_mcp_server.mcp import build_tracing_headers
 
 @pytest.fixture
 def keboola_client() -> KeboolaClient:
-    return KeboolaClient(storage_api_url='https://connection.test.keboola.com', storage_api_token='test-token')
+    return KeboolaClient(storage_api_url='https://connection.test.keboola.com', legacy_storage_token='test-token')
 
 
 @pytest.fixture
@@ -347,7 +348,7 @@ class TestKeboolaClient:
     def keboola_client_with_headers(self, runtime_config: ServerRuntimeInfo) -> KeboolaClient:
         headers = build_tracing_headers(runtime_config)
         return KeboolaClient(
-            storage_api_url='https://connection.test.keboola.com', storage_api_token='test-token', headers=headers
+            storage_api_url='https://connection.test.keboola.com', legacy_storage_token='test-token', headers=headers
         )
 
     @pytest.mark.asyncio
@@ -410,7 +411,7 @@ class TestKeboolaClient:
     def test_metastore_client_url_derivation(self) -> None:
         client = KeboolaClient(
             storage_api_url='https://connection.canary-orion.keboola.dev',
-            storage_api_token='sapi_token_456',
+            legacy_storage_token='sapi_token_456',
         )
 
         assert client.metastore_client.raw_client.base_api_url == 'https://metastore.canary-orion.keboola.dev'
@@ -443,7 +444,7 @@ class TestKeboolaClient:
         """Clients use the bearer token when available, falling back to the storage token."""
         client = KeboolaClient(
             storage_api_url='https://connection.keboola.com',
-            storage_api_token=storage_token,
+            legacy_storage_token=storage_token,
             bearer_token=bearer_token,
         )
 
@@ -470,7 +471,7 @@ class TestKeboolaClient:
         """
         client = KeboolaClient(
             storage_api_url='https://connection.keboola.com',
-            storage_api_token='sapi_token_456',
+            legacy_storage_token='sapi_token_456',
             bearer_token='oauth_bearer_123',
         )
 
@@ -483,7 +484,7 @@ class TestKeboolaClient:
 def test_flow_schema_cache_roundtrip():
     client = KeboolaClient(
         storage_api_url='https://connection.keboola.com',
-        storage_api_token='dummy-token',
+        legacy_storage_token='dummy-token',
     )
     assert client.get_cached_flow_schema('keboola.flow') is None
     schema = {'type': 'object'}
@@ -724,6 +725,160 @@ def test_get_metadata_property(
     assert result == expected
 
 
+class TestKeboolaClientCreate:
+    """`KeboolaClient.create` classifies a raw caller credential into `legacy_storage_token` /
+    `bearer_token` and, for a programmatic token narrowed to one project, exchanges it for that
+    project's legacy Storage token via the auth-bridge -- the one place PSGO-280's fix lives,
+    replacing the near-identical logic that used to be duplicated in `create_session_state`
+    (mcp.py) and `client_for_project` (multiproject.py)."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_token_passes_through_untouched(self) -> None:
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com', storage_token='sapi_token_456'
+        )
+
+        assert client.legacy_storage_token == 'sapi_token_456'
+        assert client.bearer_token is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_token_with_separate_oauth_bearer(self) -> None:
+        # An OAuth session: a legacy Storage token plus a separately-supplied bearer. Neither is
+        # programmatic-shaped, so no resolver call is attempted even when one is available.
+        resolver = AsyncMock(spec=StorageTokenResolver)
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com',
+            storage_token='sapi_token_456',
+            bearer_token='oauth_bearer_123',
+            project_id='42',
+            token_resolver=resolver,
+        )
+
+        assert client.legacy_storage_token == 'sapi_token_456'
+        assert client.bearer_token == 'oauth_bearer_123'
+        resolver.resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('project_id', [None, '42', 42], ids=['no_project', 'str_project', 'int_project'])
+    async def test_programmatic_token_without_resolver_is_untouched(self, project_id) -> None:
+        # No token_resolver at all (e.g. a local/non-deployed server) -- never attempt an exchange,
+        # regardless of whether a project is known.
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id=project_id
+        )
+
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.legacy_storage_token == 'kbc_at_abc'
+
+    @pytest.mark.asyncio
+    async def test_programmatic_token_without_project_id_skips_resolve(self) -> None:
+        # A resolver is available, but with no project known yet (e.g. before
+        # get_accessible_projects/set_project_scope) there is nothing to resolve against.
+        resolver = AsyncMock(spec=StorageTokenResolver)
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', token_resolver=resolver
+        )
+
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.legacy_storage_token == 'kbc_at_abc'
+        resolver.resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_programmatic_token_strips_bearer_scheme_before_resolving(self) -> None:
+        resolver = AsyncMock(spec=StorageTokenResolver)
+        resolver.resolve = AsyncMock(return_value='legacy-project-42-token')
+
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com',
+            storage_token='Bearer kbc_at_abc',
+            project_id='42',
+            token_resolver=resolver,
+        )
+
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.legacy_storage_token == 'legacy-project-42-token'
+        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
+
+    @pytest.mark.asyncio
+    async def test_programmatic_token_resolves_legacy_token_for_the_given_project(self) -> None:
+        resolver = AsyncMock(spec=StorageTokenResolver)
+        resolver.resolve = AsyncMock(return_value='legacy-project-42-token')
+
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com',
+            storage_token='kbc_at_abc',
+            project_id='42',
+            token_resolver=resolver,
+        )
+
+        # The Bearer form (Storage/data-science/scheduler/metastore) still carries the original
+        # programmatic token; only legacy_storage_token (queue/AI-service/sync-actions) is swapped.
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.legacy_storage_token == 'legacy-project-42-token'
+        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'error',
+        [
+            StorageTokenExchangeError('resolver rejected', status_code=403),
+            OSError('token file missing'),
+            ValueError('token file empty'),
+        ],
+        ids=['exchange_error', 'os_error', 'value_error'],
+    )
+    async def test_falls_back_to_raw_token_when_resolve_fails(self, error: Exception) -> None:
+        resolver = AsyncMock(spec=StorageTokenResolver)
+        resolver.resolve = AsyncMock(side_effect=error)
+
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com',
+            storage_token='kbc_at_abc',
+            project_id='42',
+            token_resolver=resolver,
+        )
+
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.legacy_storage_token == 'kbc_at_abc'
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_project_id_degrades_to_fallback_not_500(self) -> None:
+        # project_id can come straight off the caller-supplied X-KBC-ProjectId header -- a
+        # malformed value must degrade like any other resolver failure, not crash the request.
+        resolver = AsyncMock(spec=StorageTokenResolver)
+
+        client = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com',
+            storage_token='kbc_at_abc',
+            project_id='not-a-number',
+            token_resolver=resolver,
+        )
+
+        assert client.legacy_storage_token == 'kbc_at_abc'
+        resolver.resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_branch_id_is_applied(self, mocker) -> None:
+        mocker.patch.object(KeboolaClient, 'with_branch_id', AsyncMock(return_value='branched'))
+
+        result = await KeboolaClient.create(
+            storage_api_url='https://connection.keboola.com', storage_token='sapi_token_456', branch_id='123'
+        )
+
+        assert result == 'branched'
+        KeboolaClient.with_branch_id.assert_awaited_once_with('123')
+
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_storage_api_url(self) -> None:
+        with pytest.raises(ValueError, match='Storage API URL'):
+            await KeboolaClient.create(storage_api_url='', storage_token='sapi_token_456')
+
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_storage_token(self) -> None:
+        with pytest.raises(ValueError, match='Storage API token'):
+            await KeboolaClient.create(storage_api_url='https://connection.keboola.com', storage_token='')
+
+
 class TestStepUpStorageClient:
     """
     KeboolaClient.step_up_storage_client builds the Kubernetes step-up Storage client.
@@ -750,7 +905,7 @@ class TestStepUpStorageClient:
         token_file.write_text('sa-jwt\n')
         client = KeboolaClient(
             storage_api_url=self.OWN_STACK_URL,
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             headers={'User-Agent': 'test'},
             own_stack_storage_api_url=own_stack_storage_api_url,
         )
@@ -772,7 +927,7 @@ class TestStepUpStorageClient:
         token_file.write_text('sa-jwt')
         client = KeboolaClient(
             storage_api_url='https://connection.keboola.com',
-            storage_api_token='kbc_at_abc',
+            legacy_storage_token='kbc_at_abc',
             bearer_token='kbc_at_abc',
         )
 
@@ -791,7 +946,7 @@ class TestStepUpStorageClient:
         token_file.write_text('sa-jwt')
         client = KeboolaClient(
             storage_api_url=self.OWN_STACK_URL,
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             readonly=readonly,
             own_stack_storage_api_url=self.OWN_STACK_URL,
         )
@@ -808,7 +963,7 @@ class TestStepUpStorageClient:
         token_file.write_text('sa-jwt')
         client = KeboolaClient(
             storage_api_url=self.OWN_STACK_URL,
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             branch_id='999',
             own_stack_storage_api_url=self.OWN_STACK_URL,
         )
@@ -832,7 +987,7 @@ class TestStepUpStorageClient:
         # to a dev branch. See the "Security hardening" RFC increment.
         client = KeboolaClient(
             storage_api_url='https://connection.keboola.com',
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             branch_id='999',
             readonly=readonly,
         )
@@ -848,7 +1003,7 @@ class TestStepUpStorageClient:
         token_file.write_text('  \n')
         client = KeboolaClient(
             storage_api_url=self.OWN_STACK_URL,
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             own_stack_storage_api_url=self.OWN_STACK_URL,
         )
 
@@ -858,7 +1013,7 @@ class TestStepUpStorageClient:
     def test_fails_loudly_on_missing_token_file(self, tmp_path):
         client = KeboolaClient(
             storage_api_url=self.OWN_STACK_URL,
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             own_stack_storage_api_url=self.OWN_STACK_URL,
         )
 
@@ -885,7 +1040,7 @@ class TestStepUpStorageClient:
         token_file.write_text('sa-jwt')
         client = KeboolaClient(
             storage_api_url=storage_api_url,
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             own_stack_storage_api_url=own_stack_storage_api_url,
         )
 
@@ -910,7 +1065,7 @@ class TestStepUpStorageClient:
         with pytest.raises(ValueError, match='Invalid Keboola Storage API URL'):
             KeboolaClient(
                 storage_api_url=lookalike_url,
-                storage_api_token='user-token',
+                legacy_storage_token='user-token',
                 own_stack_storage_api_url=self.OWN_STACK_URL,
             )
 
@@ -921,7 +1076,7 @@ class TestStepUpStorageClient:
         token_file.write_text('sa-jwt')
         client = KeboolaClient(
             storage_api_url='https://connection.other.keboola.com',
-            storage_api_token='user-token',
+            legacy_storage_token='user-token',
             readonly=True,
             own_stack_storage_api_url=self.OWN_STACK_URL,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def keboola_client(mocker) -> KeboolaClient:
     client = mocker.AsyncMock(KeboolaClient)
     client.storage_api_url = 'https://connection.test.keboola.com'
     client.branch_id = None
-    client.token = 'test-token'
+    client.legacy_storage_token = 'test-token'
     client.bearer_token = None  # Default to no bearer token
     client.hostname_suffix = 'test.keboola.com'
     client.headers = {}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -487,7 +487,7 @@ async def test_event_step_up_header_only_for_own_stack(
     # stack is the one it was configured with when it started (see `ServerState.own_stack_storage_api_url`).
     client = KeboolaClient(
         storage_api_url=session_storage_api_url,
-        storage_api_token='user-token',
+        legacy_storage_token='user-token',
         own_stack_storage_api_url='https://connection.keboola.com',
     )
     empty_context.session.state[KeboolaClient.STATE_KEY] = client

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1282,16 +1282,17 @@ class TestReadPersistedKaiScope:
 
 
 class TestProgrammaticTokenForwarding:
-    """A programmatic token (kbc_at_/kbc_pat_) is always forwarded downstream as a Bearer (PSGO-261).
-
-    KeboolaClient already sends a Bearer token to every service it wraps (Storage, Queue, AI,
-    etc.), so no legacy per-project Storage token needs to be minted via the auth-bridge resolver
-    -- that resolver call was removed entirely; see git history for the prior
-    `_exchange_programmatic_token`/`StorageTokenResolver` code this replaced.
+    """A programmatic token (kbc_at_/kbc_pat_) is forwarded downstream as a Bearer for
+    Storage/data-science/scheduler/metastore (PSGO-261). Jobs-queue/AI-service/sync-actions don't
+    accept that Bearer (INC-02580), so once a project is known, `create_session_state` resolves the
+    real per-project Storage token for `KeboolaClient.token` via the auth-bridge (`StorageTokenResolver`)
+    -- see the `TestLegacyTokenResolutionForQueueBackedClients` class below for that behavior.
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize('kubernetes_token_path', [None, '/var/run/secrets/token'], ids=['local', 'deployed'])
+    @pytest.mark.parametrize(
+        'kubernetes_token_path', [None, '/var/run/secrets/missing-token'], ids=['local', 'deployed']
+    )
     @pytest.mark.parametrize('project_id', [None, '42'], ids=['no_project_id', 'with_project_id'])
     async def test_forwards_bearer_regardless_of_deployment_or_project_id(
         self, monkeypatch, kubernetes_token_path: str | None, project_id: str | None
@@ -1312,8 +1313,62 @@ class TestProgrammaticTokenForwarding:
 
         client = state[KeboolaClient.STATE_KEY]
         assert client.bearer_token == 'kbc_at_abc'
+        # kubernetes_token_path points at a file that doesn't exist here, so the auth-bridge
+        # resolve attempt (when project_id is set) fails and falls back to the raw token untouched.
         assert client.token == 'kbc_at_abc'
         assert client.headers.get('X-KBC-ProjectId') == project_id
+
+
+class TestLegacyTokenResolutionForQueueBackedClients:
+    """`create_session_state` resolves a legacy per-project Storage token via the auth-bridge
+    (`StorageTokenResolver`) for a programmatic-token, project-scoped, deployed session, and uses
+    it (not the raw kbc_at_/kbc_pat_ token) as `KeboolaClient.token` -- the credential jobs-queue/
+    AI-service/sync-actions actually receive (INC-02580 / client.py's `self._token`).
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolves_legacy_token_when_deployed_and_project_scoped(self, monkeypatch) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id='42')
+        runtime_info = ServerRuntimeInfo(transport='http')
+
+        resolver = AsyncMock()
+        resolver.resolve = AsyncMock(return_value='legacy-storage-token-789')
+        with (
+            patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
+            patch('keboola_mcp_server.mcp.StorageTokenResolver', return_value=resolver),
+        ):
+            state = await SessionStateMiddleware.create_session_state(
+                config, runtime_info, own_stack_storage_api_url=None
+            )
+
+        client = state[KeboolaClient.STATE_KEY]
+        # The Bearer form (Storage/data-science/scheduler/metastore) still carries the original
+        # programmatic token; only the raw `.token` (queue/AI-service/sync-actions) is swapped.
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.token == 'legacy-storage-token-789'
+        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_raw_token_when_resolver_fails(self, monkeypatch) -> None:
+        from keboola_mcp_server.clients.auth_bridge import StorageTokenExchangeError
+
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id='42')
+        runtime_info = ServerRuntimeInfo(transport='http')
+
+        resolver = AsyncMock()
+        resolver.resolve = AsyncMock(side_effect=StorageTokenExchangeError('resolver rejected', status_code=403))
+        with (
+            patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
+            patch('keboola_mcp_server.mcp.StorageTokenResolver', return_value=resolver),
+        ):
+            state = await SessionStateMiddleware.create_session_state(
+                config, runtime_info, own_stack_storage_api_url=None
+            )
+
+        client = state[KeboolaClient.STATE_KEY]
+        assert client.token == 'kbc_at_abc'
 
 
 class TestMaybeUseStoredSession:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -13,6 +13,7 @@ from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from pydantic import BaseModel, Field
 from starlette.requests import Request
 
+from keboola_mcp_server.clients.auth_bridge import StorageTokenResolver
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
 from keboola_mcp_server.mcp import (
@@ -440,6 +441,30 @@ class TestToolsFilteringMiddleware:
         assert {t.name for t in result} == {'get_tables', 'create_flow', 'get_semantic_context'}
 
     @pytest.mark.asyncio
+    async def test_list_tools_skips_verify_for_a_resolved_project_scoped_session(self, mcp_context_client) -> None:
+        # Regression (PSGO-280): the guard must check client.bearer_token, not
+        # client.legacy_storage_token. On a deployed, project-scoped programmatic session,
+        # legacy_storage_token has already been swapped for a server-minted per-project legacy
+        # Storage token (no kbc_at_/kbc_pat_ prefix) by KeboolaClient.create, while bearer_token
+        # still carries the original programmatic token -- checking the wrong one would
+        # re-enable verify_token here and risk the exact tools/list 401-and-disconnect regression
+        # the surrounding comment says this guard exists to prevent.
+        client = KeboolaClient.from_state(mcp_context_client.session.state)
+        client.bearer_token = 'kbc_at_abc'
+        client.legacy_storage_token = 'legacy-storage-token-for-active-project'
+        client.storage_client.verify_token = AsyncMock(side_effect=AssertionError('verify must not run'))
+
+        tools = [_tool('get_tables', read_only=True), _tool('create_flow')]
+
+        async def call_next(_):
+            return tools
+
+        context = SimpleNamespace(fastmcp_context=mcp_context_client)
+        result = await ToolsFilteringMiddleware().on_list_tools(context, call_next)
+
+        assert {t.name for t in result} == {'get_tables', 'create_flow'}
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ('token_role', 'bearer_token', 'hidden_tools', 'visible_tools'),
         [
@@ -707,6 +732,47 @@ class TestToolsFilteringMiddleware:
             assert result is expected
 
 
+class TestServerStateStorageTokenResolver:
+    """`ServerState.storage_token_resolver` -- PSGO-280 (P1): a fanned-out multi-project call, and
+    every request after it, must reuse one pooled resolver/connection per stack URL rather than
+    handshaking TLS on every single resolve."""
+
+    def test_returns_none_when_not_deployed(self, monkeypatch) -> None:
+        monkeypatch.delenv('KBC_KUBERNETES_TOKEN_PATH', raising=False)
+        server_state = ServerState(config=Config(), runtime_info=ServerRuntimeInfo(transport='stdio'))
+
+        assert server_state.storage_token_resolver('https://connection.keboola.com') is None
+
+    def test_returns_none_without_a_storage_api_url(self, monkeypatch) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        server_state = ServerState(config=Config(), runtime_info=ServerRuntimeInfo(transport='http'))
+
+        assert server_state.storage_token_resolver(None) is None
+
+    def test_memoizes_one_resolver_per_stack_url(self, monkeypatch) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        server_state = ServerState(config=Config(), runtime_info=ServerRuntimeInfo(transport='http'))
+
+        a1 = server_state.storage_token_resolver('https://connection.keboola.com')
+        a2 = server_state.storage_token_resolver('https://connection.keboola.com')
+        b = server_state.storage_token_resolver('https://connection.other.keboola.com')
+
+        assert a1 is a2
+        assert a1 is not b
+
+    @pytest.mark.asyncio
+    async def test_aclose_closes_every_held_resolver(self, monkeypatch, mocker) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        server_state = ServerState(config=Config(), runtime_info=ServerRuntimeInfo(transport='http'))
+        resolver = server_state.storage_token_resolver('https://connection.keboola.com')
+        mocker.patch.object(resolver, 'aclose', mocker.AsyncMock())
+
+        await server_state.aclose()
+
+        resolver.aclose.assert_awaited_once()
+        assert server_state.storage_token_resolver('https://connection.keboola.com') is not resolver
+
+
 class TestSessionStateMiddleware:
     def test_apply_request_config_never_logs_header_values(self, mocker) -> None:
         # Authorization (a live programmatic bearer token) and X-Storage-Api-Token must never
@@ -762,7 +828,9 @@ class TestSessionStateMiddleware:
         captured_configs: list[Config] = []
         captured_own_stack_urls: list[str | None] = []
 
-        async def fake_create_session_state(cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url):
+        async def fake_create_session_state(
+            cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url, token_resolver=None
+        ):
             captured_configs.append(cfg)
             captured_own_stack_urls.append(own_stack_storage_api_url)
             return {'fake': 'state'}
@@ -781,6 +849,60 @@ class TestSessionStateMiddleware:
         # The session's client is told which stack is the server's own one, so that it can decide
         # whether the Kubernetes step-up header may be sent.
         assert captured_own_stack_urls == ['https://connection.test.keboola.com']
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('method', 'expect_resolver'),
+        [
+            ('tools/list', False),
+            ('resources/list', False),
+            ('prompts/list', False),
+            ('tools/call', True),
+        ],
+        ids=['tools_list', 'resources_list', 'prompts_list', 'tools_call'],
+    )
+    async def test_on_request_gates_token_resolver_by_is_list(
+        self, monkeypatch, method: str, expect_resolver: bool
+    ) -> None:
+        # PSGO-280 (P1): capability-discovery requests (/list) must add no Connection auth
+        # round-trips (see the is_list comment in on_request) -- no resolver means no auth-bridge
+        # exchange when KeboolaClient.create later builds the client.
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        config = Config(storage_api_url='https://connection.test.keboola.com', storage_token='kbc_at_abc')
+        runtime_info = ServerRuntimeInfo(transport='stdio')
+        server_state = ServerState(config=config, runtime_info=runtime_info)
+
+        session = SimpleNamespace(state={})
+        ctx = MagicMock(spec=Context)
+        ctx.session = session
+        ctx.request_context.lifespan_context = server_state
+
+        context = SimpleNamespace(message=SimpleNamespace(), method=method, fastmcp_context=ctx)
+
+        async def call_next(_):
+            return object()
+
+        captured_resolvers: list[StorageTokenResolver | None] = []
+
+        async def fake_create_session_state(
+            cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url, token_resolver=None
+        ):
+            captured_resolvers.append(token_resolver)
+            return {'fake': 'state'}
+
+        middleware = SessionStateMiddleware()
+
+        with (
+            patch.object(middleware, 'create_session_state', side_effect=fake_create_session_state),
+            patch('keboola_mcp_server.mcp.get_http_request_or_none', return_value=None),
+        ):
+            await middleware.on_request(context, call_next)
+
+        assert len(captured_resolvers) == 1
+        if expect_resolver:
+            assert isinstance(captured_resolvers[0], StorageTokenResolver)
+        else:
+            assert captured_resolvers[0] is None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -809,7 +931,9 @@ class TestSessionStateMiddleware:
 
         captured_readonly = []
 
-        async def fake_create_session_state(cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url):
+        async def fake_create_session_state(
+            cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url, token_resolver=None
+        ):
             captured_readonly.append(readonly)
             return {}
 
@@ -1116,7 +1240,9 @@ class TestSessionStateMiddleware:
 
         captured_scopes = []
 
-        async def fake_create_session_state(cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url):
+        async def fake_create_session_state(
+            cfg, _runtime_info, readonly=None, *, own_stack_storage_api_url, token_resolver=None
+        ):
             return {}
 
         async def call_next(_):
@@ -1281,94 +1407,90 @@ class TestReadPersistedKaiScope:
         store.get.assert_not_awaited()
 
 
-class TestProgrammaticTokenForwarding:
-    """A programmatic token (kbc_at_/kbc_pat_) is forwarded downstream as a Bearer for
-    Storage/data-science/scheduler/metastore (PSGO-261). Jobs-queue/AI-service/sync-actions don't
-    accept that Bearer (INC-02580), so once a project is known, `create_session_state` resolves the
-    real per-project Storage token for `KeboolaClient.token` via the auth-bridge (`StorageTokenResolver`)
-    -- see the `TestLegacyTokenResolutionForQueueBackedClients` class below for that behavior.
+class TestCreateSessionStateTokenResolutionWiring:
+    """`create_session_state` no longer performs credential classification or the auth-bridge
+    exchange itself (PSGO-280 follow-up) -- that all moved into `KeboolaClient.create`, which has
+    its own exhaustive coverage in `tests/clients/test_client.py::TestKeboolaClientCreate`. What's
+    left to test here is the wiring: which `project_id`/headers `create_session_state` computes
+    from `config`, and that it forwards whatever `token_resolver` it is given through unchanged.
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        'kubernetes_token_path', [None, '/var/run/secrets/missing-token'], ids=['local', 'deployed']
-    )
     @pytest.mark.parametrize('project_id', [None, '42'], ids=['no_project_id', 'with_project_id'])
-    async def test_forwards_bearer_regardless_of_deployment_or_project_id(
-        self, monkeypatch, kubernetes_token_path: str | None, project_id: str | None
-    ) -> None:
-        if kubernetes_token_path:
-            monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', kubernetes_token_path)
-        else:
-            monkeypatch.delenv('KBC_KUBERNETES_TOKEN_PATH', raising=False)
+    async def test_project_id_and_header_only_set_for_a_programmatic_token(self, project_id: str | None) -> None:
         config = Config(
             storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id=project_id
         )
         runtime_info = ServerRuntimeInfo(transport='http')
 
-        with patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')):
+        with (
+            patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
+            patch('keboola_mcp_server.mcp.KeboolaClient.create', AsyncMock(wraps=KeboolaClient.create)) as create,
+        ):
             state = await SessionStateMiddleware.create_session_state(
                 config, runtime_info, own_stack_storage_api_url=None
             )
 
+        assert create.await_args.kwargs['project_id'] == project_id
         client = state[KeboolaClient.STATE_KEY]
-        assert client.bearer_token == 'kbc_at_abc'
-        # kubernetes_token_path points at a file that doesn't exist here, so the auth-bridge
-        # resolve attempt (when project_id is set) fails and falls back to the raw token untouched.
-        assert client.token == 'kbc_at_abc'
         assert client.headers.get('X-KBC-ProjectId') == project_id
 
-
-class TestLegacyTokenResolutionForQueueBackedClients:
-    """`create_session_state` resolves a legacy per-project Storage token via the auth-bridge
-    (`StorageTokenResolver`) for a programmatic-token, project-scoped, deployed session, and uses
-    it (not the raw kbc_at_/kbc_pat_ token) as `KeboolaClient.token` -- the credential jobs-queue/
-    AI-service/sync-actions actually receive (INC-02580 / client.py's `self._token`).
-    """
-
     @pytest.mark.asyncio
-    async def test_resolves_legacy_token_when_deployed_and_project_scoped(self, monkeypatch) -> None:
-        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
-        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id='42')
+    async def test_project_id_and_header_omitted_for_a_legacy_token(self) -> None:
+        # A legacy project-bound Storage token derives its project from the token itself and must
+        # not get X-KBC-ProjectId -- even if config.project_id happens to be set.
+        config = Config(
+            storage_api_url='https://connection.keboola.com', storage_token='sapi_token_456', project_id='42'
+        )
         runtime_info = ServerRuntimeInfo(transport='http')
 
-        resolver = AsyncMock()
+        with (
+            patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
+            patch('keboola_mcp_server.mcp.KeboolaClient.create', AsyncMock(wraps=KeboolaClient.create)) as create,
+        ):
+            state = await SessionStateMiddleware.create_session_state(
+                config, runtime_info, own_stack_storage_api_url=None
+            )
+
+        assert create.await_args.kwargs['project_id'] is None
+        client = state[KeboolaClient.STATE_KEY]
+        assert 'X-KBC-ProjectId' not in (client.headers or {})
+
+    @pytest.mark.asyncio
+    async def test_forwards_the_given_token_resolver_unchanged(self) -> None:
+        config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id='42')
+        runtime_info = ServerRuntimeInfo(transport='http')
+        resolver = AsyncMock(spec=StorageTokenResolver)
         resolver.resolve = AsyncMock(return_value='legacy-storage-token-789')
+
         with (
             patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
-            patch('keboola_mcp_server.mcp.StorageTokenResolver', return_value=resolver),
+            patch('keboola_mcp_server.mcp.KeboolaClient.create', AsyncMock(wraps=KeboolaClient.create)) as create,
         ):
-            state = await SessionStateMiddleware.create_session_state(
-                config, runtime_info, own_stack_storage_api_url=None
+            await SessionStateMiddleware.create_session_state(
+                config, runtime_info, own_stack_storage_api_url=None, token_resolver=resolver
             )
 
-        client = state[KeboolaClient.STATE_KEY]
-        # The Bearer form (Storage/data-science/scheduler/metastore) still carries the original
-        # programmatic token; only the raw `.token` (queue/AI-service/sync-actions) is swapped.
-        assert client.bearer_token == 'kbc_at_abc'
-        assert client.token == 'legacy-storage-token-789'
-        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
+        assert create.await_args.kwargs['token_resolver'] is resolver
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_raw_token_when_resolver_fails(self, monkeypatch) -> None:
-        from keboola_mcp_server.clients.auth_bridge import StorageTokenExchangeError
-
-        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+    async def test_end_to_end_resolves_legacy_token_when_a_resolver_is_given(self) -> None:
+        # One true integration-style test (no mocking KeboolaClient.create itself) confirming the
+        # wiring and the factory actually compose end to end.
         config = Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_abc', project_id='42')
         runtime_info = ServerRuntimeInfo(transport='http')
+        resolver = AsyncMock(spec=StorageTokenResolver)
+        resolver.resolve = AsyncMock(return_value='legacy-storage-token-789')
 
-        resolver = AsyncMock()
-        resolver.resolve = AsyncMock(side_effect=StorageTokenExchangeError('resolver rejected', status_code=403))
-        with (
-            patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
-            patch('keboola_mcp_server.mcp.StorageTokenResolver', return_value=resolver),
-        ):
+        with patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')):
             state = await SessionStateMiddleware.create_session_state(
-                config, runtime_info, own_stack_storage_api_url=None
+                config, runtime_info, own_stack_storage_api_url=None, token_resolver=resolver
             )
 
         client = state[KeboolaClient.STATE_KEY]
-        assert client.token == 'kbc_at_abc'
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.legacy_storage_token == 'legacy-storage-token-789'
+        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=42)
 
 
 class TestMaybeUseStoredSession:

--- a/tests/test_multiproject.py
+++ b/tests/test_multiproject.py
@@ -673,3 +673,63 @@ class TestActiveProjectReadOnlyGuard:
 
         await MultiProjectMiddleware().on_call_tool(context, call_next)
         assert captured_readonly == [True]
+
+
+class TestClientForProject:
+    """`client_for_project` resolves a legacy per-project Storage token via the auth-bridge for a
+    deployed session, so jobs-queue/AI-service/sync-actions calls against a fanned-out (non-active)
+    project don't 401 the same way the primary session client's used to (INC-02580 / PSGO-261)."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_legacy_token_when_deployed(self, monkeypatch, mocker) -> None:
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        server_state = ServerState(
+            config=Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_x'),
+            runtime_info=ServerRuntimeInfo(transport='http'),
+        )
+        resolver = AsyncMock()
+        resolver.resolve = AsyncMock(return_value='legacy-storage-token-789')
+        mocker.patch('keboola_mcp_server.multiproject.StorageTokenResolver', return_value=resolver)
+
+        client = await MultiProjectMiddleware.client_for_project(
+            server_state, 'https://connection.keboola.com', 'kbc_at_abc', 11, False
+        )
+
+        assert client.bearer_token == 'kbc_at_abc'
+        assert client.token == 'legacy-storage-token-789'
+        resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=11)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_raw_token_when_resolver_fails(self, monkeypatch, mocker) -> None:
+        from keboola_mcp_server.clients.auth_bridge import StorageTokenExchangeError
+
+        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+        server_state = ServerState(
+            config=Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_x'),
+            runtime_info=ServerRuntimeInfo(transport='http'),
+        )
+        resolver = AsyncMock()
+        resolver.resolve = AsyncMock(side_effect=StorageTokenExchangeError('resolver rejected', status_code=403))
+        mocker.patch('keboola_mcp_server.multiproject.StorageTokenResolver', return_value=resolver)
+
+        client = await MultiProjectMiddleware.client_for_project(
+            server_state, 'https://connection.keboola.com', 'kbc_at_abc', 11, False
+        )
+
+        assert client.token == 'kbc_at_abc'
+
+    @pytest.mark.asyncio
+    async def test_keeps_raw_token_when_not_deployed(self, monkeypatch, mocker) -> None:
+        monkeypatch.delenv('KBC_KUBERNETES_TOKEN_PATH', raising=False)
+        server_state = ServerState(
+            config=Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_x'),
+            runtime_info=ServerRuntimeInfo(transport='stdio'),
+        )
+        resolver_cls = mocker.patch('keboola_mcp_server.multiproject.StorageTokenResolver')
+
+        client = await MultiProjectMiddleware.client_for_project(
+            server_state, 'https://connection.keboola.com', 'kbc_at_abc', 11, False
+        )
+
+        resolver_cls.assert_not_called()
+        assert client.token == 'kbc_at_abc'

--- a/tests/test_multiproject.py
+++ b/tests/test_multiproject.py
@@ -306,6 +306,65 @@ class TestMultiProjectMiddleware:
             assert call.kwargs.get('kubernetes_token_path') == '/var/run/secrets/token'
 
     @pytest.mark.asyncio
+    async def test_fan_out_uses_bearer_token_not_active_project_resolved_token(self) -> None:
+        # No scoped_token (auto-leased scope, or set_project_scope's exchange-failure fallback) with
+        # a real active client whose .token has been narrowed to the active project's resolved legacy
+        # Storage token by create_session_state, while .bearer_token stays the whole-stack subject
+        # token. Fanning out to a DIFFERENT project must use .bearer_token, never that narrowed
+        # .token -- reusing it would run the fanned-out call against the WRONG project (PSGO-280).
+        scope = SessionScope(project_ids=[11, 22], confirmed=True)
+        context, state = self._ctx(scope, 'get_tables', read_only=True)
+        state[KeboolaClient.STATE_KEY] = KeboolaClient(
+            storage_api_url='https://connection.keboola.com',
+            storage_api_token='legacy-project-11-token',
+            bearer_token='kbc_at_whole_stack',
+        )
+        seen_tokens: list = []
+
+        async def fake_client_for_project(_ss, _url, token, pid, _ro):
+            seen_tokens.append(token)
+            return f'client-{pid}'
+
+        async def call_next(_):
+            return self._result('rows')
+
+        with (
+            patch.object(MultiProjectMiddleware, 'client_for_project', AsyncMock(side_effect=fake_client_for_project)),
+            patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
+        ):
+            await MultiProjectMiddleware().on_call_tool(context, call_next)
+
+        assert seen_tokens == ['kbc_at_whole_stack', 'kbc_at_whole_stack']
+
+    @pytest.mark.asyncio
+    async def test_single_target_dispatch_uses_bearer_token_not_active_project_resolved_token(self) -> None:
+        # Same hazard as above, for the write/get_project_info single-target dispatch path.
+        scope = SessionScope(project_ids=[11, 22], confirmed=True)
+        context, state = self._ctx(scope, 'update_config', read_only=False, arguments={'project_id': '22'})
+        state[KeboolaClient.STATE_KEY] = KeboolaClient(
+            storage_api_url='https://connection.keboola.com',
+            storage_api_token='legacy-project-11-token',
+            bearer_token='kbc_at_whole_stack',
+        )
+        seen_tokens: list = []
+
+        async def call_next(_):
+            return self._result('updated')
+
+        with (
+            patch.object(
+                MultiProjectMiddleware,
+                'client_for_project',
+                AsyncMock(side_effect=lambda _ss, _url, token, pid, _ro: seen_tokens.append(token) or f'client-{pid}'),
+            ),
+            patch.object(WorkspaceManager, 'create', AsyncMock(return_value='wsm')),
+        ):
+            result = await MultiProjectMiddleware().on_call_tool(context, call_next)
+
+        assert seen_tokens == ['kbc_at_whole_stack']
+        assert result.content[0].text == 'updated'
+
+    @pytest.mark.asyncio
     async def test_query_data_targets_single_project_workspace(self) -> None:
         # query_data is no longer excluded: with the project_ids filter it runs once against that
         # project's own workspace, so the user can query any scoped project without re-scoping.

--- a/tests/test_multiproject.py
+++ b/tests/test_multiproject.py
@@ -9,6 +9,7 @@ from fastmcp.tools.tool import ToolResult
 from mcp import types as mt
 from pydantic import ValidationError as PydanticValidationError
 
+from keboola_mcp_server.clients.auth_bridge import StorageTokenResolver
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
 from keboola_mcp_server.mcp import ServerState
@@ -281,7 +282,7 @@ class TestMultiProjectMiddleware:
         context, state = self._ctx(scope, 'get_tables', read_only=True)
         # server_state.config carries a different (stale/absent) URL than the active request client.
         state[KeboolaClient.STATE_KEY] = KeboolaClient(
-            storage_api_url='https://connection.request.keboola.com', storage_api_token='kbc_at_s'
+            storage_api_url='https://connection.request.keboola.com', legacy_storage_token='kbc_at_s'
         )
         seen_calls: list = []
 
@@ -308,15 +309,16 @@ class TestMultiProjectMiddleware:
     @pytest.mark.asyncio
     async def test_fan_out_uses_bearer_token_not_active_project_resolved_token(self) -> None:
         # No scoped_token (auto-leased scope, or set_project_scope's exchange-failure fallback) with
-        # a real active client whose .token has been narrowed to the active project's resolved legacy
-        # Storage token by create_session_state, while .bearer_token stays the whole-stack subject
-        # token. Fanning out to a DIFFERENT project must use .bearer_token, never that narrowed
-        # .token -- reusing it would run the fanned-out call against the WRONG project (PSGO-280).
+        # a real active client whose .legacy_storage_token has been narrowed to the active project's
+        # resolved legacy Storage token by KeboolaClient.create, while .bearer_token stays the
+        # whole-stack subject token. Fanning out to a DIFFERENT project must use .bearer_token,
+        # never that narrowed .legacy_storage_token -- reusing it would run the fanned-out call
+        # against the WRONG project (PSGO-280).
         scope = SessionScope(project_ids=[11, 22], confirmed=True)
         context, state = self._ctx(scope, 'get_tables', read_only=True)
         state[KeboolaClient.STATE_KEY] = KeboolaClient(
             storage_api_url='https://connection.keboola.com',
-            storage_api_token='legacy-project-11-token',
+            legacy_storage_token='legacy-project-11-token',
             bearer_token='kbc_at_whole_stack',
         )
         seen_tokens: list = []
@@ -343,7 +345,7 @@ class TestMultiProjectMiddleware:
         context, state = self._ctx(scope, 'update_config', read_only=False, arguments={'project_id': '22'})
         state[KeboolaClient.STATE_KEY] = KeboolaClient(
             storage_api_url='https://connection.keboola.com',
-            storage_api_token='legacy-project-11-token',
+            legacy_storage_token='legacy-project-11-token',
             bearer_token='kbc_at_whole_stack',
         )
         seen_tokens: list = []
@@ -679,7 +681,7 @@ class TestActiveProjectReadOnlyGuard:
     def _ctx_with_client(scope: SessionScope, tool_name: str, read_only_tool: bool, client_readonly) -> tuple:
         client = MagicMock(spec=KeboolaClient)
         client.readonly = client_readonly
-        client.token = 'kbc_at_x'
+        client.legacy_storage_token = 'kbc_at_x'
         client.storage_api_url = 'https://connection.keboola.com'
         state: dict = {KeboolaClient.STATE_KEY: client, SCOPE_KEY: scope}
         ctx = MagicMock(spec=Context)
@@ -735,60 +737,40 @@ class TestActiveProjectReadOnlyGuard:
 
 
 class TestClientForProject:
-    """`client_for_project` resolves a legacy per-project Storage token via the auth-bridge for a
-    deployed session, so jobs-queue/AI-service/sync-actions calls against a fanned-out (non-active)
-    project don't 401 the same way the primary session client's used to (INC-02580 / PSGO-261)."""
+    """`client_for_project` just asks `ServerState.storage_token_resolver` for the (possibly-None)
+    auth-bridge resolver and hands it to `KeboolaClient.create` -- the resolve-success/failure/
+    no-resolver behavior itself is covered once, in
+    tests/clients/test_client.py::TestKeboolaClientCreate."""
 
     @pytest.mark.asyncio
-    async def test_resolves_legacy_token_when_deployed(self, monkeypatch, mocker) -> None:
-        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+    async def test_uses_the_resolver_server_state_provides(self, mocker) -> None:
         server_state = ServerState(
             config=Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_x'),
             runtime_info=ServerRuntimeInfo(transport='http'),
         )
-        resolver = AsyncMock()
+        resolver = AsyncMock(spec=StorageTokenResolver)
         resolver.resolve = AsyncMock(return_value='legacy-storage-token-789')
-        mocker.patch('keboola_mcp_server.multiproject.StorageTokenResolver', return_value=resolver)
+        get_resolver = mocker.patch.object(ServerState, 'storage_token_resolver', return_value=resolver)
 
         client = await MultiProjectMiddleware.client_for_project(
             server_state, 'https://connection.keboola.com', 'kbc_at_abc', 11, False
         )
 
         assert client.bearer_token == 'kbc_at_abc'
-        assert client.token == 'legacy-storage-token-789'
+        assert client.legacy_storage_token == 'legacy-storage-token-789'
         resolver.resolve.assert_awaited_once_with(subject_token='kbc_at_abc', project_id=11)
+        get_resolver.assert_called_once_with('https://connection.keboola.com')
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_raw_token_when_resolver_fails(self, monkeypatch, mocker) -> None:
-        from keboola_mcp_server.clients.auth_bridge import StorageTokenExchangeError
-
-        monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
-        server_state = ServerState(
-            config=Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_x'),
-            runtime_info=ServerRuntimeInfo(transport='http'),
-        )
-        resolver = AsyncMock()
-        resolver.resolve = AsyncMock(side_effect=StorageTokenExchangeError('resolver rejected', status_code=403))
-        mocker.patch('keboola_mcp_server.multiproject.StorageTokenResolver', return_value=resolver)
-
-        client = await MultiProjectMiddleware.client_for_project(
-            server_state, 'https://connection.keboola.com', 'kbc_at_abc', 11, False
-        )
-
-        assert client.token == 'kbc_at_abc'
-
-    @pytest.mark.asyncio
-    async def test_keeps_raw_token_when_not_deployed(self, monkeypatch, mocker) -> None:
+    async def test_no_resolver_when_not_deployed(self, monkeypatch) -> None:
         monkeypatch.delenv('KBC_KUBERNETES_TOKEN_PATH', raising=False)
         server_state = ServerState(
             config=Config(storage_api_url='https://connection.keboola.com', storage_token='kbc_at_x'),
             runtime_info=ServerRuntimeInfo(transport='stdio'),
         )
-        resolver_cls = mocker.patch('keboola_mcp_server.multiproject.StorageTokenResolver')
 
         client = await MultiProjectMiddleware.client_for_project(
             server_state, 'https://connection.keboola.com', 'kbc_at_abc', 11, False
         )
 
-        resolver_cls.assert_not_called()
-        assert client.token == 'kbc_at_abc'
+        assert client.legacy_storage_token == 'kbc_at_abc'

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -923,7 +923,7 @@ class TestPreviewConfigDiff:
         # Mock the KeboolaClient
         mock_client = mocker.AsyncMock(KeboolaClient)
         _configure_preview_auth(mock_client, mocker)  # admin/main default; overridden below where needed
-        mock_client.token = 'test-token'
+        mock_client.legacy_storage_token = 'test-token'
         mock_client.storage_api_url = 'https://connection.test.keboola.com'
 
         async def mock_config_detail(**kwargs):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -260,7 +260,7 @@ async def test_with_session_state(config: Config, envs: dict[str, Any], mocker):
 
         keboola_client = KeboolaClient.from_state(ctx.session.state)
         assert keboola_client is not None
-        assert keboola_client.token == 'SAPI_1234'
+        assert keboola_client.legacy_storage_token == 'SAPI_1234'
 
         workspace_manager = WorkspaceManager.from_state(ctx.session.state)
         assert workspace_manager is not None
@@ -386,7 +386,7 @@ async def test_keboola_injection_and_lifespan(
         server_state = ServerState.from_context(ctx)
         assert asdict(server_state.config) == asdict(config) | os_environ_params
 
-        assert client.token == expected_params['storage_token']
+        assert client.legacy_storage_token == expected_params['storage_token']
         assert workspace._workspace_schema == expected_params['workspace_schema']
 
         return param

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -33,7 +33,7 @@ async def test_query_client_token_selection(bearer_token: str | None, storage_to
     """Test QueryServiceClient uses bearer token when available, falls back to storage token."""
     # Create mock KeboolaClient with different token configurations
     mock_client = Mock(spec=KeboolaClient)
-    mock_client.token = storage_token
+    mock_client.legacy_storage_token = storage_token
     mock_client.bearer_token = bearer_token
     mock_client.hostname_suffix = 'keboola.com'
     mock_client.branch_id = '12345'
@@ -72,7 +72,7 @@ async def test_query_client_token_selection_with_branch_lookup():
     """Test QueryServiceClient token selection when branch_id needs to be looked up."""
     # Create mock KeboolaClient with bearer token but no branch_id
     mock_client = Mock(spec=KeboolaClient)
-    mock_client.token = 'sapi_token_456'
+    mock_client.legacy_storage_token = 'sapi_token_456'
     mock_client.bearer_token = 'oauth_bearer_123'
     mock_client.hostname_suffix = 'keboola.com'
     mock_client.branch_id = None  # No branch_id, will trigger lookup

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -9,10 +9,11 @@ from pytest_mock import MockerFixture
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, MetadataField, ServerRuntimeInfo
 from keboola_mcp_server.links import Link
-from keboola_mcp_server.mcp import ServerState
+from keboola_mcp_server.mcp import ServerState, SessionStateMiddleware
 from keboola_mcp_server.scope import (
     OAUTH_SESSION_ID_KEY,
     SCOPE_KEY,
+    SCOPE_TOKEN_ARG,
     SessionScope,
     resolve_scope_binding_aad,
     resolve_scope_key,
@@ -475,7 +476,9 @@ async def test_set_project_scope_binds_scope_token_to_caller_on_deployed_server(
     mcp_context_client: Context, mocker: MockerFixture, monkeypatch
 ) -> None:
     # The replay fix: on a deployed server, the returned scope_token must only decrypt alongside
-    # the same caller's own storage token (client.token) it was minted for -- see
+    # the same caller's own bearer token (client.bearer_token, the un-narrowed whole-stack subject
+    # token -- see PSGO-280: it must NOT be client.legacy_storage_token, which on a project-scoped
+    # session can be a server-minted, per-project token) it was minted for -- see
     # resolve_scope_binding_aad. A different caller's token must fail, even with the right key.
     monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
     mcp_context_client.request_context.lifespan_context = ServerState(
@@ -489,9 +492,45 @@ async def test_set_project_scope_binds_scope_token_to_caller_on_deployed_server(
 
     scope = mcp_context_client.session.state[SCOPE_KEY]
     key = resolve_scope_key(Config())
-    assert SessionScope.from_token(result.scope_token, key, aad=resolve_scope_binding_aad('test-token')) == scope
+    assert SessionScope.from_token(result.scope_token, key, aad=resolve_scope_binding_aad('kbc_at_parent')) == scope
     with pytest.raises(Exception, match='.+'):
         SessionScope.from_token(result.scope_token, key, aad=resolve_scope_binding_aad('kbc_at_someone_else'))
+
+
+@pytest.mark.asyncio
+async def test_set_project_scope_token_round_trips_through_read_scope_from_request(
+    mcp_context_client: Context, mocker: MockerFixture, monkeypatch
+) -> None:
+    """Regression (PSGO-280): the scope_token minted by set_project_scope must actually decrypt
+    on the very next request via `SessionStateMiddleware._read_scope_from_request` -- not just
+    against a hand-picked AAD in isolation (see the test above). That method seals with
+    `config.storage_token` -- the caller's raw presented credential -- which on a deployed,
+    project-scoped programmatic session is NOT the same string as `client.legacy_storage_token`
+    (the server-minted, per-project legacy Storage token). Sealing with the wrong one here would
+    silently evaporate every confirmed scope on the next call.
+    """
+    monkeypatch.setenv('KBC_KUBERNETES_TOKEN_PATH', '/var/run/secrets/token')
+    mcp_context_client.request_context.lifespan_context = ServerState(
+        Config(), ServerRuntimeInfo(transport='http-compat/streamable-http', stateless_http=True)
+    )
+    client = _prep_client(mcp_context_client, mocker)
+    # Simulate a resolved session: the caller presented 'kbc_at_parent', but the active project's
+    # legacy_storage_token has already been swapped for a server-minted per-project token by
+    # KeboolaClient.create -- a different string from the caller's own credential.
+    client.legacy_storage_token = 'legacy-storage-token-for-active-project'
+    minted = SimpleNamespace(access_token='kbc_at_scoped', expires_at=time.time() + 3600, read_only=False)
+    mocker.patch('keboola_mcp_server.tools.project.exchange_scoped_token', new=mocker.AsyncMock(return_value=minted))
+
+    result = await set_project_scope(mcp_context_client, project_ids=[18, 83])
+    scope = mcp_context_client.session.state[SCOPE_KEY]
+
+    # The next request presents the same raw credential the caller always had.
+    config = Config(storage_token='kbc_at_parent')
+    context = SimpleNamespace(
+        message=SimpleNamespace(name='get_tables', arguments={SCOPE_TOKEN_ARG: result.scope_token}),
+        method='tools/call',
+    )
+    assert SessionStateMiddleware._read_scope_from_request(context, config) == scope
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.78.2"
+version = "1.78.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: [PSGO-280](https://linear.app/keboola/issue/PSGO-280/run-job-queue-api-401s-for-oauth-session-programmatic-token-multi)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`run_job` (and any jobs-queue/AI-service/sync-actions call) has been 401ing with "Invalid access
token" for deployed, project-scoped, programmatic-token (`kbc_at_`/`kbc_pat_`) OAuth-session
users — e.g. the multi-project AWS US MCP session.

Root cause, found by tracing two prior fixes against each other:
- `fix(PSGO-261): drop the auth-bridge resolve-storage-token exchange for programmatic tokens`
  (78a0bf6e) removed the only code path that minted a legacy per-project Storage token for a
  programmatic session, because the exchange endpoint hit a 403 in live testing (missing Manage
  API scope grant on that dev stack at the time).
- `fix(INC-02580): keep the Storage token on jobs-queue/AI-service/sync-actions` (d2dfbd41),
  three weeks later, routed those three clients back onto the raw session token, on the
  assumption that `create_session_state` still put an exchanged legacy token into
  `storage_token` for programmatic sessions. That assumption was stale — the exchange had
  already been removed — so the "raw Storage token" these three clients got was actually the
  raw `kbc_at_/kbc_pat_` string, which Queue's `NewJobFactory` forwards to Storage as a legacy
  `X-StorageApi-Token` and gets rejected.

Fix: re-wire the dormant `StorageTokenResolver` (already written in `clients/auth_bridge.py`,
never called) back into `SessionStateMiddleware.create_session_state` and
`MultiProjectMiddleware.client_for_project`. Once a project id is known on a deployed session,
resolve the real per-project legacy Storage token via the auth-bridge and use it — instead of
the raw token — for jobs-queue/AI-service/sync-actions, leaving the Bearer form used by
Storage/data-science/scheduler/metastore untouched. On resolver failure (e.g. that Manage-scope
grant still isn't in place on some stack), falls back to the raw token with a logged warning
instead of breaking session creation.


## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Not tested end-to-end against a live deployed OAuth-session stack (would need the auth-bridge's
Manage scope grant confirmed there first, and a real multi-project programmatic session). Added
unit test coverage instead: `tests/test_mcp.py::TestLegacyTokenResolutionForQueueBackedClients`
and `tests/test_multiproject.py::TestClientForProject` cover the resolve-success, resolve-failure
(fallback), and not-deployed (no-op) cases for both `create_session_state` and
`client_for_project`. Full suite + ruff + check-tools-docs run clean (one pre-existing, unrelated
flake in `tests/test_server.py::test_json_logging`, reproduced identically on `main` before this
change).

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)

[PSGO-280]: https://keboola.atlassian.net/browse/PSGO-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ