### PR TITLE
fix: allow keboola.cloud hosts in Storage API URL allowlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.78.1"
+version = "1.78.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/base.py
+++ b/src/keboola_mcp_server/clients/base.py
@@ -20,11 +20,12 @@ JsonStruct = Union[JsonDict, JsonList]  # noqa: UP007
 LOG = logging.getLogger(__name__)
 
 # A genuine Keboola stack host: a `connection.` label, any number of region/cloud-provider
-# subdomain labels, ending in `.keboola.com` or `.keboola.dev`. `hostname.startswith('connection.')`
-# alone is not a domain allowlist -- `connection.attacker.tld` would satisfy it -- see the
-# "Security hardening" RFC increment. Mirrors the domain-allowlist pattern `oauth.py`'s
-# `_ALLOWED_DOMAINS` already uses for redirect URIs, scoped to this server's own kind of host.
-_STORAGE_API_HOST_RE = re.compile(r'^connection\.(?:[a-z0-9-]+\.)*keboola\.(?:com|dev)$', re.IGNORECASE)
+# subdomain labels, ending in `.keboola.com`/`.keboola.dev` (multi-tenant stacks) or `.keboola.cloud`
+# (single-tenant stacks). `hostname.startswith('connection.')` alone is not a domain allowlist --
+# `connection.attacker.tld` would satisfy it -- see the "Security hardening" RFC increment. Mirrors
+# the domain-allowlist pattern `oauth.py`'s `_ALLOWED_DOMAINS` already uses for redirect URIs,
+# scoped to this server's own kind of host.
+_STORAGE_API_HOST_RE = re.compile(r'^connection\.(?:[a-z0-9-]+\.)*keboola\.(?:com|dev|cloud)$', re.IGNORECASE)
 
 
 def normalize_storage_api_url(storage_api_url: str) -> str:

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -24,6 +24,8 @@ class TestNormalizeStorageApiUrl:
             ('https://connection.canary-orion.keboola.dev', 'https://connection.canary-orion.keboola.dev'),
             ('https://connection.keboola.com:443', 'https://connection.keboola.com'),
             ('https://connection.keboola.com/v2/storage', 'https://connection.keboola.com'),
+            ('https://connection.acme.keboola.cloud', 'https://connection.acme.keboola.cloud'),
+            ('https://connection.example-tenant.keboola.cloud', 'https://connection.example-tenant.keboola.cloud'),
         ],
     )
     def test_accepts_genuine_keboola_stack_hosts(self, url: str, expected: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.78.1"
+version = "1.78.2"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: N/A — hotfix for a regression reported internally (mcp-server-agent rejecting all single-tenant Storage API hosts)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`normalize_storage_api_url()` was hardened in #605 (PSGO-261) to require a genuine `connection.*.keboola.(com|dev)` host, closing a lookalike-domain bypass. That regex missed single-tenant stacks, which live under `.keboola.cloud`, so every login against a single-tenant stack started failing with `Invalid Keboola Storage API URL`. This adds `cloud` to the allowed suffix alternation alongside `com`/`dev`.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Ran `pytest tests/clients/test_base.py tests/clients/test_client.py` locally (83 passed), including new cases for generic `*.keboola.cloud` single-tenant hosts.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)