### PR TITLE
fix(PSGO-280): auto-confirm OAuth project scope and guide toward it on a real 401

### DIFF
--- a/feature_spec/pat_token_support/RFC.md
+++ b/feature_spec/pat_token_support/RFC.md
@@ -1154,3 +1154,47 @@ against both a minimal repro and FastMCP's actual app-construction shape):
 **Explicitly not fixed here:** the deployed `KeboolaClient`'s own request path has nothing to do
 with Postgres (Storage API calls don't touch this server's session database), so it needs no
 equivalent guard.
+
+## Extension: multi-project OAuth sessions never auto-confirmed (increment 16)
+
+Increment 8's premise -- "this server's OAuth grant is always whole-stack (`claudai projectless`
+scope), so introspection's count there is just the user's real total org membership, not evidence
+of a prior scoping choice" -- predates the league's `/oauth/consent` screen letting the user
+themselves pick "all projects" or freeze access to a specific subset (checkboxes per org/project,
+screenshot reviewed in the reporting conversation). That screen *is* the scoping decision; by the
+time `exchange_authorization_code` runs, the user has already made it, whether they kept "All
+projects" or picked a subset. Auto-confirming only when introspection returned exactly one project
+left every other session -- including a deliberate 2-of-N pick -- stuck at `confirmed=False`, so
+the ask-first gate in `multiproject.py` 401'd every data-tool call in `main` until the agent called
+`set_project_scope` again for a choice the user had already made once.
+
+**Fix:** `oauth.py`'s `_auto_confirm_single_project_scope` (renamed
+`_auto_confirm_project_scope`) drops the `len(introspection.projects) != 1` guard and confirms the
+scope to whatever the freshly-exchanged token can reach, at any count -- mirroring
+`set_project_scope`'s own "omit/null project_ids -> introspect and scope to everything returned"
+behavior in `tools/project.py`. Still best-effort and still a no-op on zero reachable projects
+(nothing to scope to); an explicit `set_project_scope` call still works afterwards to re-scope
+mid-conversation.
+
+## Extension: a real 401 gave the agent no reason to try scoping (increment 17)
+
+Companion fix to increment 16, prompted by a reproduced example in the reporting conversation: an
+agent hit a genuine `401 Unauthorized` from a Storage-backed call (not the `multiproject.py`
+ask-first `ToolError`, an actual HTTP 401 propagating from `RawKeboolaClient._raise_for_status`)
+and, with nothing in the error text pointing at scoping, told the user their connector's token had
+expired and to reconnect it -- the wrong diagnosis when the real fix is `get_accessible_projects`
++ `set_project_scope`. The message an agent sees for any 401 is genuinely ambiguous between "bad
+credential" and "no/stale project scope" -- this server can't tell which from inside
+`_raise_for_status` (it has no view of `SessionScope`), so the fix nudges towards the
+usually-cheaper, usually-right hypothesis rather than leaving the agent to guess.
+
+**Fix:** `clients/base.py`'s `RawKeboolaClient._raise_for_status` appends a fixed hint to the
+raised `HTTPStatusError`'s message whenever `response.status_code == 401`, naming
+`get_accessible_projects`/`set_project_scope` explicitly and saying this is a common cause of a
+401 that doesn't necessarily mean the credential itself is invalid. Unconditional -- every
+Keboola-API-backed client (`storage`, `jobs_queue`, `ai_service`, `sync_actions`, `scheduler`,
+`data_science`, `metastore`, `query`) shares this one `_raise_for_status`, so the hint applies
+everywhere a 401 can surface, regardless of session type. Harmless when scoping genuinely doesn't
+apply to the session (e.g. a deployed session pinned to one project via `X-KBC-ProjectId`): those
+two tools just report that no programmatic token is present, which is itself useful signal that
+the 401 has some other cause.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.78.3"
+version = "1.78.4"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/base.py
+++ b/src/keboola_mcp_server/clients/base.py
@@ -133,6 +133,19 @@ class RawKeboolaClient:
                 except Exception:
                     LOG.debug('Failed to read response.text while building the error message.', exc_info=True)
 
+            if response.status_code == HTTPStatus.UNAUTHORIZED:
+                # A 401 here is often a project scope that was never confirmed (or has gone stale),
+                # not an actually-invalid credential -- steer the agent toward the tools that fix
+                # that instead of telling the user to re-authenticate. Harmless to suggest even when
+                # scoping doesn't apply to this session (e.g. a single pinned project): those tools
+                # just say so.
+                message_parts.append(
+                    'If this session\'s Keboola project scope may be unset or stale, call '
+                    '"get_accessible_projects" to see which project(s) this session can reach, then '
+                    '"set_project_scope" to (re-)confirm which one(s) to work with -- this is a common '
+                    'cause of a 401 here and does not necessarily mean the credential itself is invalid.'
+                )
+
             raise httpx.HTTPStatusError('\n'.join(message_parts), request=response.request, response=response) from e
 
     async def get(

--- a/src/keboola_mcp_server/errors.py
+++ b/src/keboola_mcp_server/errors.py
@@ -261,6 +261,7 @@ class ValidationErrorMiddleware(fmw.Middleware):
         context: MiddlewareContext[mt.CallToolRequestParams],
         call_next: CallNext[mt.CallToolRequestParams, mt.CallToolResult],
     ) -> mt.CallToolResult:
+        await self._coerce_empty_string_arrays(context)
         try:
             return await call_next(context)
         except ValidationError as e:
@@ -271,3 +272,27 @@ class ValidationErrorMiddleware(fmw.Middleware):
             if isinstance(e.__cause__, ValidationError):
                 raise ToolError(prettify_validation_error(e.__cause__)) from e
             raise
+
+    @staticmethod
+    async def _coerce_empty_string_arrays(context: MiddlewareContext[mt.CallToolRequestParams]) -> None:
+        """Some tool-calling clients send `""` instead of omitting/`[]` for an unset array-typed
+        argument (observed live: `get_configs` called with `component_types=""`,
+        `component_ids=""`), which pydantic-core always rejects for a `Sequence[...]` field
+        ("'str' instances are not allowed as a Sequence value") -- a plain string is never a valid
+        value for an argument the tool's own schema declares as `array`, so there's no legitimate
+        case this coercion could clobber. Mutates ``context.message.arguments`` in place before
+        ``call_next`` so the tool never sees the invalid input at all, rather than just prettifying
+        the resulting error.
+        """
+        ctx = context.fastmcp_context
+        args = getattr(context.message, 'arguments', None)
+        if ctx is None or not isinstance(args, dict):
+            return
+        try:
+            tool = await ctx.fastmcp.get_tool(context.message.name)
+        except Exception:
+            return
+        props = (tool.parameters or {}).get('properties', {}) if tool else {}
+        for key, value in args.items():
+            if value == '' and props.get(key, {}).get('type') == 'array':
+                args[key] = []

--- a/src/keboola_mcp_server/multiproject.py
+++ b/src/keboola_mcp_server/multiproject.py
@@ -173,6 +173,19 @@ class MultiProjectMiddleware(fmw.Middleware):
                     # every project, so fanning out would emit N identical copies plus a confusing
                     # "failed for all N projects" aggregate. Abort and surface the single clean error.
                     raise
+                except ToolError as e:
+                    # ValidationErrorMiddleware sits inner of this middleware (see server.py's
+                    # registration order) and already converted a FastMCPValidationError raised
+                    # during argument validation into a ToolError -- via `raise ToolError(...) from
+                    # e` -- before it ever reaches the except clause above, so that clause never
+                    # actually fires for this case in practice. Detect it the same way
+                    # ValidationErrorMiddleware itself does (its `from e` sets `__cause__`) and
+                    # re-raise for the same reason: the same bad arguments fail identically in
+                    # every project.
+                    if isinstance(e.__cause__, FastMCPValidationError):
+                        raise
+                    LOG.warning(f'Fan-out call failed for project {project_id}: {e}', exc_info=True)
+                    errors.append((project_id, str(e)))
                 except Exception as e:
                     LOG.warning(f'Fan-out call failed for project {project_id}: {e}', exc_info=True)
                     errors.append((project_id, str(e)))

--- a/src/keboola_mcp_server/oauth.py
+++ b/src/keboola_mcp_server/oauth.py
@@ -481,17 +481,23 @@ class SimpleOAuthProvider(OAuthProvider):
             kbc_refresh_token=token_set.refresh_token,
             kbc_access_expires_at=datetime.fromtimestamp(token_set.expires_at, tz=timezone.utc),
         )
-        await self._auto_confirm_single_project_scope(session.id, token_set.access_token)
+        await self._auto_confirm_project_scope(session.id, token_set.access_token)
         return self._oauth_token(access_token, refresh_token, authorization_code.scopes)
 
-    async def _auto_confirm_single_project_scope(self, session_id: str, subject_token: str) -> None:
-        """If this freshly-created session's token can reach exactly one project, there's no real
-        scoping choice for the user to make -- confirm it immediately so the session is usable
-        without ever calling ``set_project_scope`` (mirrors the local ``login``/``login --pat``
-        flow, which does the same for the same reason -- see the "Security hardening" RFC
-        increment). Any project count other than 1 is left untouched: this server's OAuth grant is
-        always whole-stack (``claudai projectless`` scope), so introspection's count there is just
-        the user's real total org membership, not a scoping decision to defer to.
+    async def _auto_confirm_project_scope(self, session_id: str, subject_token: str) -> None:
+        """The league consent screen (`/oauth/consent`) already makes the user pick "all projects"
+        or a specific subset before this code path ever runs -- there is no separate scoping
+        decision left for the MCP session to defer to via ``set_project_scope``. Confirm the scope
+        immediately to whatever the freshly-exchanged token can reach, so the session is usable
+        right away (mirrors the local ``login``/``login --pat`` flow, which does the same for the
+        same reason -- see the "Security hardening" RFC increment).
+
+        This used to only auto-confirm when introspection returned exactly one project, on the
+        assumption that this server's OAuth grant was always whole-stack (``claudai projectless``
+        scope) and any other count was just the user's total org membership, not a deliberate
+        choice. That assumption no longer holds now that the consent screen itself lets the user
+        freeze access to a specific subset -- see the "increment 8" extension in the RFC and its
+        follow-up note.
 
         Best-effort: introspection/exchange failures here just leave the session unconfirmed, same
         as before this method existed -- an explicit ``set_project_scope`` call still works.
@@ -499,30 +505,30 @@ class SimpleOAuthProvider(OAuthProvider):
         try:
             introspection = await introspect_token(self._storage_api_url, subject_token=subject_token)
         except Exception as e:
-            LOG.warning(f'Could not introspect new OAuth session for single-project auto-scope: {e}', exc_info=True)
+            LOG.warning(f'Could not introspect new OAuth session for scope auto-confirm: {e}', exc_info=True)
             return
-        if len(introspection.projects) != 1:
+        if not introspection.projects:
             return
-        project_id = introspection.projects[0].id
+        project_ids = [p.id for p in introspection.projects]
         scoped_token: str | None = None
         scoped_expires_at: datetime | None = None
         try:
             minted = await exchange_scoped_token(
-                self._storage_api_url, subject_token=subject_token, project_ids=[project_id], read_only=False
+                self._storage_api_url, subject_token=subject_token, project_ids=project_ids, read_only=False
             )
             scoped_token = minted.access_token
             scoped_expires_at = datetime.fromtimestamp(minted.expires_at, tz=timezone.utc)
         except Exception as e:
-            LOG.warning(f'Scoped-token exchange failed while auto-confirming single project: {e}', exc_info=True)
+            LOG.warning(f'Scoped-token exchange failed while auto-confirming project scope: {e}', exc_info=True)
         await self._session_store.update_scope(
             session_id,
-            project_ids=[project_id],
+            project_ids=project_ids,
             read_only=False,
             confirmed=True,
             scoped_token=scoped_token,
             scoped_expires_at=scoped_expires_at,
         )
-        LOG.info(f'Session {session_id} auto-confirmed to its only accessible project ({project_id}).')
+        LOG.info(f'Session {session_id} auto-confirmed to its accessible project(s) {project_ids}.')
 
     async def load_access_token(self, token: str) -> AccessToken | None:
         """

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -60,6 +60,21 @@ def mock_http_response_404(mock_http_request: httpx.Request) -> httpx.Response:
     return response
 
 
+@pytest.fixture
+def mock_http_response_401(mock_http_request: httpx.Request) -> httpx.Response:
+    """Create a mock HTTP response with 401 status."""
+    response = Mock(spec=httpx.Response)
+    response.status_code = 401
+    response.reason_phrase = 'Unauthorized'
+    response.url = 'https://api.example.com/test'
+    response.request = mock_http_request
+    response.is_error = True
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        message=f"{response.reason_phrase} for url '{response.url}'", request=mock_http_request, response=response
+    )
+    return response
+
+
 class TestRawKeboolaClient:
     """Test suite for enhanced HTTP client error handling."""
 
@@ -132,6 +147,19 @@ class TestRawKeboolaClient:
         )
         with pytest.raises(httpx.HTTPStatusError, match=match):
             raw_client._raise_for_status(mock_http_response_404)
+
+    def test_raise_for_status_401_suggests_project_scope_tools(
+        self, raw_client: RawKeboolaClient, mock_http_response_401: httpx.Response
+    ):
+        """A 401 often means the session's project scope was never confirmed or has gone stale --
+        the error message should steer the agent to get_accessible_projects/set_project_scope
+        instead of implying the credential itself is invalid."""
+
+        mock_http_response_401.json.return_value = {'error': 'Invalid access token', 'code': 'storage.tokenInvalid'}
+
+        with pytest.raises(httpx.HTTPStatusError, match='get_accessible_projects') as exc_info:
+            raw_client._raise_for_status(mock_http_response_401)
+        assert 'set_project_scope' in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_get_method_integration_with_enhanced_error_handling(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+from collections.abc import Sequence
 from importlib.metadata import distribution
 from unittest.mock import ANY
 
@@ -363,6 +364,50 @@ class TestPydanticValidationErrors:
             assert len(lines) > 0, 'Empty error message'
             assert lines[0] == 'MCP tool "foo" call failed. ToolError: Found 1 validation error(s) for TableColumnInfo'
             assert expected_error_details == yaml.safe_load('\n'.join(lines[1:]))
+
+    @staticmethod
+    @tool_errors()
+    async def echo_ids(_ctx: Context, ids: Sequence[str] = ()) -> list[str]:
+        return list(ids)
+
+    @pytest.mark.asyncio
+    async def test_empty_string_array_argument_is_coerced_to_empty_list(self, mocker, mcp_server: FastMCP):
+        # Some tool-calling clients send `""` instead of omitting/`[]` an unset array-typed
+        # argument (observed live against `get_configs`'s `component_types`/`component_ids`),
+        # which pydantic-core always rejects for a `Sequence[...]` field. The declared `array`
+        # schema type means `""` is never a legitimate value, so it's coerced to `[]` before the
+        # tool ever sees it, rather than surfacing a validation error at all.
+        mocker.patch(
+            'keboola_mcp_server.clients.base.KeboolaServiceClient.get',
+            return_value={'owner': {'id': '123'}},
+        )
+        mocker.patch(
+            'keboola_mcp_server.clients.base.KeboolaServiceClient.post',
+            return_value={'id': '13008826', 'uuid': '01958f48-b1fc-7f05-b9b9-8a4a7b385bc3'},
+        )
+        mcp_server.add_tool(FunctionTool.from_function(self.echo_ids))
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool('echo_ids', arguments={'ids': ''})
+
+        assert result.structured_content == {'result': []}
+
+    @pytest.mark.asyncio
+    async def test_non_empty_array_argument_is_untouched(self, mocker, mcp_server: FastMCP):
+        mocker.patch(
+            'keboola_mcp_server.clients.base.KeboolaServiceClient.get',
+            return_value={'owner': {'id': '123'}},
+        )
+        mocker.patch(
+            'keboola_mcp_server.clients.base.KeboolaServiceClient.post',
+            return_value={'id': '13008826', 'uuid': '01958f48-b1fc-7f05-b9b9-8a4a7b385bc3'},
+        )
+        mcp_server.add_tool(FunctionTool.from_function(self.echo_ids))
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool('echo_ids', arguments={'ids': ['keboola.ex-db-mysql']})
+
+        assert result.structured_content == {'result': ['keboola.ex-db-mysql']}
 
 
 @pytest.mark.asyncio

--- a/tests/test_multiproject.py
+++ b/tests/test_multiproject.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.tools.tool import ToolResult
 from mcp import types as mt
 from pydantic import ValidationError as PydanticValidationError
@@ -655,6 +656,45 @@ class TestMultiProjectMiddleware:
 
         # Aborted after the first project; not retried across the rest.
         assert calls == ['client-11']
+
+    @pytest.mark.asyncio
+    async def test_fan_out_validation_error_wrapped_in_tool_error_raised_once(self) -> None:
+        # In practice, `ValidationErrorMiddleware` (registered inner of this middleware -- see
+        # server.py's registration order) converts a FastMCPValidationError raised during argument
+        # validation into a ToolError (`raise ToolError(...) from e`) before it ever reaches this
+        # middleware's except clauses, so the bare-PydanticValidationError case covered by
+        # test_fan_out_validation_error_raised_once_not_per_project never actually happens on a
+        # real server (reproduced live: `get_configs` called with `component_types=""`). This must
+        # still surface as ONE clean error, not N duplicated copies + a confusing aggregate.
+        scope = SessionScope(project_ids=[120, 512], scoped_token='kbc_at_s', confirmed=True)
+        context, state = self._ctx(scope, 'get_tables', read_only=True)
+        calls = []
+
+        async def call_next(_):
+            calls.append(state[KeboolaClient.STATE_KEY])
+            cause = FastMCPValidationError('Found 2 validation error(s) for call[get_configs]')
+            cause.__cause__ = PydanticValidationError.from_exception_data('get_configs', [])
+            err = ToolError('Found 2 validation error(s) for call[get_configs]')
+            err.__cause__ = cause
+            raise err
+
+        with (
+            patch.object(
+                MultiProjectMiddleware,
+                'client_for_project',
+                AsyncMock(side_effect=lambda _ss, _url, _token, pid, _ro: f'client-{pid}'),
+            ),
+            patch.object(
+                WorkspaceManager,
+                'create',
+                AsyncMock(side_effect=lambda client, _schema, kubernetes_token_path=None: f'wsm-{client}'),
+            ),
+            pytest.raises(ToolError, match=r'^Found 2 validation error\(s\) for call\[get_configs\]$'),
+        ):
+            await MultiProjectMiddleware().on_call_tool(context, call_next)
+
+        # Aborted after the first project; not retried (and duplicated) across the rest.
+        assert calls == ['client-120']
 
     def test_merge_large_degrades_to_count_first(self, monkeypatch) -> None:
         # Lower the cap so a modest result trips the count-first path.

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -439,9 +439,11 @@ class TestSimpleOAuthProvider:
         monkeypatch.setattr(oauth_module, 'deployed_sa_token_path', lambda: '/tmp/sa-token')
         captured: dict[str, Any] = {}
         self._stub_exchanger(monkeypatch, captured)
-        # Two reachable projects: not the single-project auto-confirm case, so the session should
-        # stay unconfirmed exactly as before that feature existed. Also proves introspection failures
-        # here are non-fatal to login -- see test_exchange_authorization_code_introspection_failure_is_non_fatal.
+        # Two reachable projects: the consent screen already made this the user's deliberate choice
+        # (whether "all projects" or a picked subset), so the session should still auto-confirm --
+        # see test_exchange_authorization_code_auto_confirms_multiple_projects. Also proves
+        # introspection failures here are non-fatal to login -- see
+        # test_exchange_authorization_code_introspection_failure_is_non_fatal.
         monkeypatch.setattr(
             oauth_module,
             'introspect_token',
@@ -450,6 +452,9 @@ class TestSimpleOAuthProvider:
                     user_id=1, user_email=None, user_name=None, projects=[_project(1), _project(2)]
                 )
             ),
+        )
+        monkeypatch.setattr(
+            oauth_module, 'exchange_scoped_token', mock.AsyncMock(side_effect=httpx.ConnectError('unreachable'))
         )
 
         client = _OAuthClientInformationFull(redirect_uris=[AnyHttpUrl('http://foo')], client_id='foo-client-id')
@@ -472,7 +477,10 @@ class TestSimpleOAuthProvider:
         # forced-relogin window tied to the (1h) Keboola access token's lifetime.
         assert loaded.expires_at is None
         assert loaded_refresh.expires_at is None
-        assert loaded.scope_confirmed is False
+        # Still confirmed even though the scoped-token exchange itself failed (best-effort fallback).
+        assert loaded.scope_confirmed is True
+        assert loaded.scope_project_ids == [1, 2]
+        assert loaded.scope_scoped_token is None
 
     @pytest.mark.asyncio
     async def test_exchange_authorization_code_auto_confirms_single_project(
@@ -510,6 +518,49 @@ class TestSimpleOAuthProvider:
         assert loaded is not None
         assert loaded.scope_confirmed is True
         assert loaded.scope_project_ids == [42]
+        assert loaded.scope_read_only is False
+        assert loaded.scope_scoped_token == 'kbc_at_scoped'
+
+    @pytest.mark.asyncio
+    async def test_exchange_authorization_code_auto_confirms_multiple_projects(
+        self, oauth_provider: SimpleOAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The league consent screen already lets the user pick "all projects" or freeze access to a
+        # specific subset -- either way that's the user's deliberate scoping choice, made before this
+        # code path ever runs, so a session reaching more than one project must still auto-confirm
+        # instead of making the agent ask the user again via set_project_scope.
+        from keboola_mcp_server import oauth as oauth_module
+
+        monkeypatch.setattr(oauth_module, 'deployed_sa_token_path', lambda: '/tmp/sa-token')
+        captured: dict[str, Any] = {}
+        self._stub_exchanger(monkeypatch, captured)
+        monkeypatch.setattr(
+            oauth_module,
+            'introspect_token',
+            mock.AsyncMock(
+                return_value=Introspection(
+                    user_id=1, user_email=None, user_name=None, projects=[_project(1), _project(2)]
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            oauth_module,
+            'exchange_scoped_token',
+            mock.AsyncMock(
+                return_value=ScopedToken(
+                    access_token='kbc_at_scoped', expires_at=time.time() + 3600, project_ids=[1, 2], read_only=False
+                )
+            ),
+        )
+
+        client = _OAuthClientInformationFull(redirect_uris=[AnyHttpUrl('http://foo')], client_id='foo-client-id')
+        auth_code = _ExtendedAuthorizationCode.model_validate(self.authorization_code())
+        oauth_token = await oauth_provider.exchange_authorization_code(client, auth_code)
+
+        loaded = await oauth_provider.load_access_token(oauth_token.access_token)
+        assert loaded is not None
+        assert loaded.scope_confirmed is True
+        assert loaded.scope_project_ids == [1, 2]
         assert loaded.scope_read_only is False
         assert loaded.scope_scoped_token == 'kbc_at_scoped'
 

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.78.3"
+version = "1.78.4"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: [PSGO-280](https://linear.app/keboola/issue/PSGO-280)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Users authorizing via the league `/oauth/consent` screen can now pick "all projects" or freeze
access to a specific subset (checkboxes per org/project) before this server ever sees the
resulting token. That click *is* the scoping decision — but `_auto_confirm_single_project_scope`
only ever auto-confirmed a session when introspection returned exactly one project, on the old
assumption that this server's OAuth grant was always whole-stack. Every other session (including a
deliberate 2-of-N pick, e.g. `demo1` + `demo2`) was left `confirmed=False`, so the ask-first gate
in `multiproject.py` blocked every data tool call (`list configurations`, etc.) until the agent
called `set_project_scope` again for a choice the user had already made once at login.

- `oauth.py`: renamed `_auto_confirm_single_project_scope` → `_auto_confirm_project_scope`;
  drops the "exactly one project" restriction and auto-confirms the scope to whatever the
  freshly-exchanged token can reach, at any count — mirroring `set_project_scope`'s own
  "omit `project_ids` → introspect and scope to everything returned" behavior. Still best-effort
  (introspection/exchange failures just leave the session unconfirmed, same as before).
- `clients/base.py`: `RawKeboolaClient._raise_for_status` now appends a hint to any real
  `401 Unauthorized` it raises, pointing the agent at `get_accessible_projects`/
  `set_project_scope` — a stale/unset scope is a common cause of a 401 here and shouldn't be
  mistaken by the agent for an invalid/expired credential (reproduced live: an agent hit exactly
  this and told the user to "reconnect the connector" instead).

**Follow-up, found while testing the above against a real dev-stack build:** once a session
actually reaches multi-project mode, the first `get_configs` call arrived with
`component_types=""`/`component_ids=""` (some tool-calling clients send `""` instead of
omitting/`[]` an unset array-typed argument) — pydantic-core always rejects a bare string for a
`Sequence[...]` field, and `MultiProjectMiddleware`'s fan-out loop then duplicated that same
validation failure once per scoped project into a confusing "The tool failed for all N scoped
project(s)" aggregate instead of one clean error.

- `errors.py`: `ValidationErrorMiddleware` now coerces an empty-string argument to `[]` before
  `call_next` whenever the tool's own schema declares that parameter as an `array` — a bare string
  is never a legitimate value there, so this can't clobber real input. Fixes the failure itself
  rather than just prettifying its message.
- `multiproject.py`: the fan-out loop's "abort and surface once, don't duplicate per project"
  special case only matched a bare `FastMCPValidationError`/`PydanticValidationError`. In practice
  `ValidationErrorMiddleware` (registered inner of `MultiProjectMiddleware`) already converts that
  into a `ToolError` before it reaches this except clause, so the special case never actually fired
  for this exact scenario. Now also recognizes a `ToolError` whose `__cause__` is a
  `FastMCPValidationError`.
- `feature_spec/pat_token_support/RFC.md`: documents all of the above as increments 16–17.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Not yet manually tested end-to-end against a real OAuth consent flow from this environment. The
OAuth auto-confirm + 401-guidance fix (commit `a56a5e42`) was verified via a `dev-v1.78.4-dev.1`
tag build deployed to a testing stack, where the reported multi-project OAuth session did reach
`get_configs` — which is what surfaced the `component_types=""`/`component_ids=""` follow-up bug
fixed in commit `a1783d44` (not separately re-verified against a fresh dev build; covered by unit
tests only). Full `tox` (pytest 2112 passed / 24 skipped, ruff, check-tools-docs) is green;
`tests/test_server.py::test_json_logging` fails the same way on `main` (pre-existing, unrelated
subprocess/env flake).

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)

[PSGO-280]: https://keboola.atlassian.net/browse/PSGO-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ