### PR TITLE
SUPPORT-17480: Add Project Settings link to project info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.78.5"
+version = "1.78.6"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/links.py
+++ b/src/keboola_mcp_server/links.py
@@ -102,8 +102,11 @@ class ProjectLinksManager:
     def get_project_detail_link(self) -> Link:
         return Link.detail(title='Project Dashboard', url=self._url(''))
 
+    def get_project_settings_link(self) -> Link:
+        return Link.detail(title='Project Settings', url=self._url('project-settings'))
+
     def get_project_links(self) -> list[Link]:
-        return [self.get_project_detail_link()]
+        return [self.get_project_detail_link(), self.get_project_settings_link()]
 
     # --- Flows ---
     def get_flow_detail_link(self, flow_id: str | int, flow_name: str, flow_type: FlowType) -> Link:

--- a/tests/tools/test_project.py
+++ b/tests/tools/test_project.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, MetadataField, ServerRuntimeInfo
-from keboola_mcp_server.links import Link
+from keboola_mcp_server.links import Link, ProjectLinksManager
 from keboola_mcp_server.mcp import ServerState, SessionStateMiddleware
 from keboola_mcp_server.scope import (
     OAUTH_SESSION_ID_KEY,
@@ -31,6 +31,22 @@ from keboola_mcp_server.tools.project import (
 from keboola_mcp_server.workspace import WorkspaceManager
 
 STACK = 'https://connection.test.keboola.com'
+
+
+@pytest.mark.parametrize(
+    ('branch_id', 'project_base_url'),
+    [
+        (None, f'{STACK}/admin/projects/proj-123'),
+        ('456', f'{STACK}/admin/projects/proj-123/branch/456'),
+    ],
+)
+def test_get_project_links(branch_id: str | None, project_base_url: str) -> None:
+    links_manager = ProjectLinksManager(base_url=STACK, project_id='proj-123', branch_id=branch_id)
+
+    assert links_manager.get_project_links() == [
+        Link.detail(title='Project Dashboard', url=f'{project_base_url}/'),
+        Link.detail(title='Project Settings', url=f'{project_base_url}/project-settings'),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.78.5"
+version = "1.78.6"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: SUPPORT-17480

### Change Type  

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Add the canonical Project Settings URL to `ProjectLinksManager.get_project_links()`, so `get_project_info` supplies agents with `/project-settings` instead of requiring the model to infer the route. The link follows the existing project and development-branch URL context; the Project Dashboard link remains unchanged. No Features link is added.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)
- `tox` (2,258 unit tests, Ruff, and generated tool documentation check)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable)

Link to Devin session: https://app.devin.ai/sessions/afc824e204a54d6dbb8111ff08902c05
Open in Devin Desktop: https://app.devin.ai/desktop/session/afc824e204a54d6dbb8111ff08902c05?variant=devin
Requested by: @ZoraJel