### PR TITLE
fix(oauth): allowlist ai.euromedia.cz redirect_uri [AI-3797]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.79.0"
+version = "1.79.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/oauth.py
+++ b/src/keboola_mcp_server/oauth.py
@@ -63,6 +63,7 @@ _ALLOWED_DOMAINS = {
         # and flags its wildcards as a subdomain-takeover risk, so don't add another one (AI-3773).
         re.compile(r'^agnes\.keboola\.systems$', re.IGNORECASE),  # no subdomains allowed
         re.compile(r'^librechat\.glami-ml\.com$', re.IGNORECASE),  # no subdomains allowed
+        re.compile(r'^ai\.euromedia\.cz$', re.IGNORECASE),  # Kofola/Euromedia Open WebUI (AI-3797), no subdomains
         re.compile(r'^(.*\.)?make\.com$', re.IGNORECASE),
         re.compile(r'^api\.devin\.ai$', re.IGNORECASE),  # devin.ai API domain
         re.compile(r'^cloud\.onyx\.app$', re.IGNORECASE),  # onyx.app OAuth callback

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -325,6 +325,12 @@ class TestSimpleOAuthProvider:
             (AnyUrl('https://librechat.glami-ml.com'), True),
             (AnyUrl('https://librechat.glami-ml.com/api/mcp/keboola/oauth/callback'), True),
             (AnyUrl('https://foo.librechat.glami-ml.com/bar'), False),  # no subdomains allowed
+            # Kofola/Euromedia Open WebUI (exact host only, no subdomains) [AI-3797]
+            (AnyUrl('https://ai.euromedia.cz'), True),
+            (AnyUrl('https://ai.euromedia.cz/oauth/clients/mcp:keboola/callback'), True),
+            (AnyUrl('https://ai.euromedia.cz/oauth/clients/mcp%3Akeboola/callback'), True),
+            (AnyUrl('https://foo.ai.euromedia.cz/bar'), False),  # no subdomains allowed
+            (AnyUrl('https://euromedia.cz/callback'), False),  # must be ai.euromedia.cz
             # Make.com (subdomain optional)
             (AnyUrl('https://make.com'), True),
             (AnyUrl('https://foo.make.com/bar'), True),

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.79.0"
+version = "1.79.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: [AI-3797](https://linear.app/keboola/issue/AI-3797/support-17488-request-to-allowlist-aieuromediacz-for-keboola-mcp-oauth) (SUPPORT-17488)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

Kofola/Euromedia's Open WebUI instance at `ai.euromedia.cz` was hitting `Invalid redirect_uri` on `/authorize` — their host wasn't on the hardcoded OAuth redirect_uri domain allowlist (`_ALLOWED_DOMAINS` in `src/keboola_mcp_server/oauth.py`). Dynamic Client Registration against `/register` already succeeds; only the redirect_uri check at `/authorize` was rejecting them.

Adds `ai.euromedia.cz` as an exact-host entry, same pattern as the prior `AI-3773` fix for `agnes.keboola.systems`: exact host, no subdomain wildcard, since `AI-3591` is retiring this whole hardcoded list in favour of Connection's real OAuth client registry (tracked separately, not part of this PR).

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

Verified locally: `tox -e py310 -- tests/test_oauth.py` (116 passed), `tox -e ruff` (format + lint clean).

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [ ] Documentation updated (if applicable)