### PR TITLE
RLS: row-level security query tool (pilot, do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,32 @@ docker run \
 > **Note**: The server will use the Streamable HTTP transport and listen on `localhost:8000` for incoming connections at `/mcp`.
 > You can change `-p` to map the container's port somewhere else.
 
+### Row-Level Security (pilot)
+
+Restrict what each user can read from a shared table by giving the server a YAML rules file and
+starting it with `--rls-rules-path <file>` (or `KBC_RLS_RULES_PATH=<file>`). When set, the server
+exposes `query_data_rls` **instead of** `query_data`; the unrestricted tool is not registered at all.
+
+```yaml
+# rls.yaml -- table -> user -> SQL predicate (workspace dialect, inserted into WHERE verbatim)
+tables:
+  invoices:
+    petr: "country = 'CZ'"
+    monika: "country = 'DE'"
+    admin: "TRUE"              # unrestricted access must be written explicitly
+  in.c-crm.orders:             # <bucket>.<table> key takes precedence over a bare table name
+    petr: "country = 'CZ' AND status <> 'draft'"
+```
+
+`query_data_rls(sql_query, query_name, user)` rewrites every table in the SELECT to
+`(SELECT * FROM <table> WHERE <predicate>)` for that user, runs it, and reports the applied rules in
+`applied_rules`. It is fail-closed: a table without a rule for the user, a non-SELECT statement, or an
+unparseable query is refused and nothing is executed. The file is validated at startup; a broken file
+stops the server.
+
+Limitation: the `user` argument is supplied by the MCP client / model and is not verified by the server
+(same trust level as the `X-*` request headers). Suitable for a pilot behind a trusted client.
+
 ### Do I Need to Start the Server Myself?
 
 | Scenario | Need to Run Manually? | Use This Setup |

--- a/README.md
+++ b/README.md
@@ -381,7 +381,9 @@ docker run \
 ### Row-Level Security (pilot)
 
 Restrict what each user can read from a shared table by giving the server a YAML rules file and
-starting it with `--rls-rules-path <file>` (or `KBC_RLS_RULES_PATH=<file>`). When set, the server
+starting it with `--rls-rules-path <file>` (or `KBC_RLS_RULES_PATH=<file>`), plus
+`--rls-principal-source header|argument` (or `KBC_RLS_PRINCIPAL_SOURCE`) to say where the identity
+comes from — see [Who is the principal?](#who-is-the-principal) below. When set, the server
 exposes `query_data_rls` **instead of** `query_data`; the unrestricted tool is not registered at all.
 
 ```yaml
@@ -396,8 +398,8 @@ tables:
     petr: "country = 'CZ' AND status <> 'draft'"
 ```
 
-`query_data_rls(sql_query, query_name, user)` rewrites every table in the SELECT to
-`(SELECT * FROM <table> WHERE <predicate>)` for that user, runs it, and reports which tables were
+`query_data_rls(sql_query, query_name, principal)` rewrites every table in the SELECT to
+`(SELECT * FROM <table> WHERE <predicate>)` for that principal, runs it, and reports which tables were
 filtered in `applied_rules`. That list holds table keys only — the predicates themselves are never
 returned to the caller, since the filter is the admin's policy and disclosing it tells the reader
 what was withheld; failures that involve a predicate say only which rule could not be applied, with
@@ -416,18 +418,54 @@ both backends. Key matching follows each backend's own name resolution: case-ins
 Snowflake, case-**sensitive** on BigQuery, where `in_c_crm.Invoices` really is a different table
 from `in_c_crm.invoices`.
 
-Limitations:
+`query_data_rls` refuses any query longer than 20,000 characters, and any query too deeply nested for
+the rewriter to parse, before it reaches the workspace. The rewrite itself runs off the event loop, so
+a pathological query slows down only the session that sent it.
 
-- The `user` argument is supplied by the MCP client / model and is not verified by the server
-  (same trust level as the `X-*` request headers). Suitable for a pilot behind a trusted client.
-- Other tool docstrings and the bundled project prompt still refer to `query_data`; in RLS mode the
-  model must use `query_data_rls` instead. This is a known pilot limitation.
+A server started with `--rls-rules-path` is read-only as a whole: it exposes, and accepts calls to,
+only tools annotated `readOnlyHint=True`. Write tools such as `run_job`, `create_config`,
+`create_sql_transformation` or `deploy_data_app` are absent from `tools/list` and are refused if
+called, regardless of `X-Allowed-Tools` or the token role.
+
+#### Who is the principal?
+
+The principal is the identity the rules are keyed by. Where it comes from is a deployment decision,
+made once with `--rls-principal-source` / `KBC_RLS_PRINCIPAL_SOURCE`; a server with a rules file and
+no source refuses to start, because neither mode is a safe default for the other's deployment.
+
+- **`header`** (production shape) — the principal is the `X-RLS-Principal` request header. The
+  `principal` tool argument must be omitted; passing it is refused rather than ignored, and a request
+  without the header is refused too. The model can neither choose nor override the identity.
+- **`argument`** (pilot/demo) — the principal is the `principal` tool argument, supplied by the MCP
+  client or the model and not verified by anything. An `X-RLS-Principal` header is ignored in this
+  mode, with a warning in the log.
+
+The wrapper architecture behind `header` mode: an application authenticates its own end users
+(Active Directory, Google, Okta, its own session cookie — the MCP server has no opinion). That
+application is the only client of this MCP server, and it asserts the authenticated user on every
+request in the `X-RLS-Principal` header. The server does **not** verify the header — it trusts the
+wrapper — so the MCP endpoint must be reachable only from that application, never directly from an
+LLM, an end user's MCP client, or the public internet.
+
+Rule keys are therefore whatever strings the calling application asserts: e-mail addresses
+(`petr@example.com`), IdP subject ids (`a1b2c3-...`), or group names (`sales-cz`) all work equally
+well, as long as the rules file uses the very same strings the wrapper sends. Every query is logged
+with `outcome=`, `principal=` and `source=header|argument`, so a deployment that is meant to be
+header-bound can be audited for calls that were not.
 
 To try the feature by hand, [`examples/rls-demo/`](examples/rls-demo/) is a small Node.js app that
-starts the server in RLS mode and lets you pick a user, type SQL, see the rewritten statement live
-and compare the result across users — plus edit the rules file and reload it. It is an example only:
-it is not part of the server and nothing in `src/` depends on it. See its
-[README](examples/rls-demo/README.md) for the prerequisites and configuration.
+plays the wrapper role: it runs the server in RLS header mode, offers a mock sign-in, and lets you
+type SQL, see the rewritten statement live and compare the result across sign-ins — plus edit the
+rules file and reload it. It is an example only: it is not part of the server and nothing in `src/`
+depends on it. See its [README](examples/rls-demo/README.md) for the prerequisites and configuration.
+
+Limitations:
+
+- The server never verifies the principal itself. In `header` mode that trust is placed in the
+  calling application (which must be the only client able to reach the server); in `argument` mode it
+  is placed in the MCP client / model, which is suitable only for a pilot behind a trusted client.
+- Other tool docstrings and the bundled project prompt still refer to `query_data`; in RLS mode the
+  model must use `query_data_rls` instead. This is a known pilot limitation.
 
 ### Do I Need to Start the Server Myself?
 

--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ exposes `query_data_rls` **instead of** `query_data`; the unrestricted tool is n
 
 ```yaml
 # rls.yaml -- table -> user -> SQL predicate (workspace dialect, inserted into WHERE verbatim)
+dialect: snowflake             # required: snowflake or bigquery; predicates are never transpiled
 tables:
   invoices:
     petr: "country = 'CZ'"
@@ -399,7 +400,8 @@ tables:
 `(SELECT * FROM <table> WHERE <predicate>)` for that user, runs it, and reports the applied rules in
 `applied_rules`. It is fail-closed: a table without a rule for the user, a non-SELECT statement, or an
 unparseable query is refused and nothing is executed. The file is validated at startup; a broken file
-stops the server.
+stops the server. `dialect` pins the workspace backend the predicates are written for: every predicate
+is parsed in that dialect at startup, and a query against a workspace of any other dialect is refused.
 
 A bare key such as `invoices` matches a table of that name in every schema/bucket; use the
 `<bucket>.<table>` form to scope a rule.

--- a/README.md
+++ b/README.md
@@ -401,8 +401,15 @@ tables:
 unparseable query is refused and nothing is executed. The file is validated at startup; a broken file
 stops the server.
 
-Limitation: the `user` argument is supplied by the MCP client / model and is not verified by the server
-(same trust level as the `X-*` request headers). Suitable for a pilot behind a trusted client.
+A bare key such as `invoices` matches a table of that name in every schema/bucket; use the
+`<bucket>.<table>` form to scope a rule.
+
+Limitations:
+
+- The `user` argument is supplied by the MCP client / model and is not verified by the server
+  (same trust level as the `X-*` request headers). Suitable for a pilot behind a trusted client.
+- Other tool docstrings and the bundled project prompt still refer to `query_data`; in RLS mode the
+  model must use `query_data_rls` instead. This is a known pilot limitation.
 
 ### Do I Need to Start the Server Myself?
 

--- a/README.md
+++ b/README.md
@@ -397,8 +397,11 @@ tables:
 ```
 
 `query_data_rls(sql_query, query_name, user)` rewrites every table in the SELECT to
-`(SELECT * FROM <table> WHERE <predicate>)` for that user, runs it, and reports the applied rules in
-`applied_rules`. It is fail-closed: a table without a rule for the user, a non-SELECT statement, or an
+`(SELECT * FROM <table> WHERE <predicate>)` for that user, runs it, and reports which tables were
+filtered in `applied_rules`. That list holds table keys only — the predicates themselves are never
+returned to the caller, since the filter is the admin's policy and disclosing it tells the reader
+what was withheld; failures that involve a predicate say only which rule could not be applied, with
+the detail in the server log. It is fail-closed: a table without a rule for the user, a non-SELECT statement, or an
 unparseable query is refused and nothing is executed. The file is validated at startup; a broken file
 stops the server. `dialect` pins the workspace backend the predicates are written for: every predicate
 is parsed in that dialect at startup, and a query against a workspace of any other dialect is refused.

--- a/README.md
+++ b/README.md
@@ -388,11 +388,11 @@ exposes `query_data_rls` **instead of** `query_data`; the unrestricted tool is n
 # rls.yaml -- table -> user -> SQL predicate (workspace dialect, inserted into WHERE verbatim)
 dialect: snowflake             # required: snowflake or bigquery; predicates are never transpiled
 tables:
-  invoices:
+  in.c-crm.invoices:           # keys are always <bucket>.<table>
     petr: "country = 'CZ'"
     monika: "country = 'DE'"
     admin: "TRUE"              # unrestricted access must be written explicitly
-  in.c-crm.orders:             # <bucket>.<table> key takes precedence over a bare table name
+  in.c-crm.orders:
     petr: "country = 'CZ' AND status <> 'draft'"
 ```
 
@@ -403,8 +403,13 @@ unparseable query is refused and nothing is executed. The file is validated at s
 stops the server. `dialect` pins the workspace backend the predicates are written for: every predicate
 is parsed in that dialect at startup, and a query against a workspace of any other dialect is refused.
 
-A bare key such as `invoices` matches a table of that name in every schema/bucket; use the
-`<bucket>.<table>` form to scope a rule.
+Every key is `<bucket>.<table>` — the table name is the part after the last dot, since bucket names
+contain dots of their own. There is no bare-name form, and a query must name the bucket too
+(`"in.c-crm"."orders"` on Snowflake, `` `in_c_crm`.`orders` `` on BigQuery): an unqualified table
+reference is refused. A database/project name in front of the bucket is ignored — the workspace can
+only reach its own project. On BigQuery the bucket part of a key is normalised the way the server
+names datasets (`in.c-crm` → `in_c_crm`), so the rules file is written in Keboola bucket names for
+both backends.
 
 Limitations:
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,9 @@ contain dots of their own. There is no bare-name form, and a query must name the
 reference is refused. A database/project name in front of the bucket is ignored — the workspace can
 only reach its own project. On BigQuery the bucket part of a key is normalised the way the server
 names datasets (`in.c-crm` → `in_c_crm`), so the rules file is written in Keboola bucket names for
-both backends.
+both backends. Key matching follows each backend's own name resolution: case-insensitive on
+Snowflake, case-**sensitive** on BigQuery, where `in_c_crm.Invoices` really is a different table
+from `in_c_crm.invoices`.
 
 Limitations:
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,12 @@ Limitations:
 - Other tool docstrings and the bundled project prompt still refer to `query_data`; in RLS mode the
   model must use `query_data_rls` instead. This is a known pilot limitation.
 
+To try the feature by hand, [`examples/rls-demo/`](examples/rls-demo/) is a small Node.js app that
+starts the server in RLS mode and lets you pick a user, type SQL, see the rewritten statement live
+and compare the result across users — plus edit the rules file and reload it. It is an example only:
+it is not part of the server and nothing in `src/` depends on it. See its
+[README](examples/rls-demo/README.md) for the prerequisites and configuration.
+
 ### Do I Need to Start the Server Myself?
 
 | Scenario | Need to Run Manually? | Use This Setup |

--- a/examples/rls-demo/.gitignore
+++ b/examples/rls-demo/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+logs/
+rls.yaml
+rls.yaml.bak
+.env

--- a/examples/rls-demo/.gitignore
+++ b/examples/rls-demo/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 logs/
 rls.yaml
 rls.yaml.bak
+demo.json
 .env

--- a/examples/rls-demo/README.md
+++ b/examples/rls-demo/README.md
@@ -57,6 +57,7 @@ invented defaults.
 | `RLS_DEMO_MCP_PORT` | no | `8788` | Port the spawned MCP server listens on (always bound to `127.0.0.1`) |
 | `KEBOOLA_MCP_COMMAND` | no | `keboola_mcp_server` | The server executable. Point it at a checkout with `/path/to/mcp-server/.venv/bin/keboola_mcp_server` |
 | `RLS_DEMO_PYTHON` | no | `python3` | Interpreter for the rewrite preview and the rules validation. Must be a Python where `keboola_mcp_server` is importable, e.g. `/path/to/mcp-server/.venv/bin/python` |
+| `RLS_DEMO_CONFIG_PATH` | no | `./demo.json` | Persona descriptions + example queries shown in the UI, relative to this directory. See "Customising the demo" below. |
 
 ## Rules
 
@@ -64,8 +65,34 @@ invented defaults.
 `in.c-sales.deals`) and users (`alice`, `bob`, `carol`, `dave`, `admin`). On first start the app
 copies it to the configured rules file (`rls.yaml` by default, git-ignored) and logs that it did.
 Edit that copy — in a text editor or in the app's Rules panel — and replace the table keys with
-tables that exist in your own project. The example queries in `public/index.html` reference the same
-placeholder tables, so change them together.
+tables that exist in your own project. The example queries in `demo.json` (see below) reference the
+same placeholder tables, so change them together.
+
+## Customising the demo
+
+The persona descriptions shown next to each sign-in button, and the queries in the "Examples"
+dropdown, are **not** hardcoded in `public/index.html` — they come from `demo.json`, served by the
+app via `GET /api/config`. On first start the app copies the shipped `demo.example.json` template to
+the configured path (`demo.json` by default, git-ignored, see `RLS_DEMO_CONFIG_PATH`), the same way
+`rls.example.yaml` seeds `rls.yaml`. Edit that copy to match your own users and tables:
+
+```json
+{
+  "personas": { "alice": "Czech market only", "bob": "..." },
+  "examples": [{ "label": "Rows per country — invoices", "sql": "SELECT ... LIMIT 20" }]
+}
+```
+
+- `personas` maps a user name (matched case-insensitively against the rules file's principals) to a
+  one-line description. A user with no entry here still signs in fine — the UI shows a muted
+  "no description" instead.
+- `examples` is the list backing the "Examples" dropdown, in order.
+
+The file is validated on load (`personas` must be a string → string map, `examples` an array of
+`{label, sql}` string pairs); an invalid file makes the app print a clear error and exit — there is
+no silent fallback to a half-broken config. If `demo.json` cannot be found or seeded at all, the app
+falls back to the generic built-in personas/examples baked into `config.mjs` (the same content as
+`demo.example.json`) and logs that it did so.
 
 ## Run
 
@@ -113,12 +140,13 @@ lists the tools and refuses to start if `query_data_rls` is missing or `query_da
 | `server.mjs` | HTTP server + mock sign-in + per-principal MCP HTTP clients + rewrite-preview helper. |
 | `public/index.html` | Single-file UI (inline CSS/JS). |
 | `rls.example.yaml` | Rules template, copied to the rules file on first start. |
+| `demo.example.json` | Personas + example queries template, copied to the demo config file on first start. |
 
 ## API
 
 | Endpoint | Result |
 | --- | --- |
-| `GET /api/config` | `{ui}` — UI-only constants, no secrets |
+| `GET /api/config` | `{ui, personas, examples}` — UI-only constants plus deployment-specific personas/examples from `demo.json`, no secrets |
 | `GET /api/session` | `{principal}` — the current sign-in, or `null` |
 | `POST /api/login` `{principal}` | `{ok: true, principal}` + session cookie, or `{ok: false, error}` (400) |
 | `POST /api/logout` | `{ok: true, principal: null}` and the cookie is cleared |

--- a/examples/rls-demo/README.md
+++ b/examples/rls-demo/README.md
@@ -1,0 +1,134 @@
+# RLS demo — Keboola MCP Server
+
+A small Node.js app for trying out the row-level-security pilot by hand: pick a user, type SQL, and
+see exactly what the server's `query_data_rls` tool returns for that user against a real Keboola
+project.
+
+This is an **example / manual test harness**. It is not part of the MCP server, it is not shipped
+with it, and nothing in `src/` depends on it.
+
+The MCP server is started in RLS mode (`--rls-rules-path <file>`), so it registers `query_data_rls`
+and does **not** register the unrestricted `query_data`. Every query is rewritten server-side: each
+referenced table becomes `(SELECT * FROM <table> WHERE <predicate>)`. It is fail-closed — a table
+with no rule for the user is refused, and so is anything that is not a single plain `SELECT`.
+
+## Prerequisites
+
+- Node.js 20 or newer.
+- A Python environment where `keboola_mcp_server` is installed and importable — the same environment
+  that runs the server. A checkout works: `uv sync` in the repository root gives you
+  `.venv/bin/keboola_mcp_server` and `.venv/bin/python`.
+- A Keboola project with a Storage API token, and tables to point the rules at.
+
+## Configuration
+
+Everything is configured through environment variables. Put them in the real environment or in a
+local `.env` file in this directory (`KEY=VALUE` lines) — `.env` is git-ignored and must never be
+committed. Missing required variables abort the start with a message naming them; there are no
+invented defaults.
+
+| Variable | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `KBC_STORAGE_API_URL` | yes | — | Keboola stack URL, e.g. `https://connection.north-europe.azure.keboola.com` |
+| `KBC_STORAGE_TOKEN` | yes | — | Storage API token for that project |
+| `KBC_WORKSPACE_ID` | no | — | Existing workspace to query in; when unset, the MCP server manages its own |
+| `RLS_RULES_PATH` | no | `./rls.yaml` | Rules file, relative to this directory |
+| `RLS_DEMO_PORT` | no | `8787` | HTTP port |
+| `RLS_DEMO_HOST` | no | `127.0.0.1` | Listen address — leave it local, there is no authentication |
+| `KEBOOLA_MCP_COMMAND` | no | `keboola_mcp_server` | The server executable. Point it at a checkout with `/path/to/mcp-server/.venv/bin/keboola_mcp_server` |
+| `RLS_DEMO_PYTHON` | no | `python3` | Interpreter for the rewrite preview and the rules validation. Must be a Python where `keboola_mcp_server` is importable, e.g. `/path/to/mcp-server/.venv/bin/python` |
+
+## Rules
+
+`rls.example.yaml` is a template with generic tables (`in.c-crm.invoices`, `in.c-crm.orders`,
+`in.c-sales.deals`) and users (`alice`, `bob`, `carol`, `dave`, `admin`). On first start the app
+copies it to the configured rules file (`rls.yaml` by default, git-ignored) and logs that it did.
+Edit that copy — in a text editor or in the app's Rules panel — and replace the table keys with
+tables that exist in your own project. The example queries in `public/index.html` reference the same
+placeholder tables, so change them together.
+
+## Run
+
+```
+npm install
+npm start
+```
+
+Then open <http://127.0.0.1:8787/>.
+
+On startup the app spawns one stdio MCP session, lists the tools and refuses to start if
+`query_data_rls` is missing or `query_data` is present.
+
+## The UI
+
+- **Users** — a strip of persona chips at the top; the selected one is highlighted.
+- **Query** — two columns. Left: the SQL as the user writes it. Right: **Rewritten SQL for `<user>`**,
+  a read-only view that refreshes automatically (debounced) whenever the SQL or the selected user
+  changes. It shows the applied-rule chips and the rewritten statement, pretty-printed in the browser
+  by a small keyword-based formatter. A refusal is shown in red in the same panel. Below 900 px the
+  two columns stack.
+- **Result** — tabbed. *Run as `<user>`* produces a single tab; **Run for all users** produces a
+  **Summary** tab (the comparison table, active by default) plus one tab per user with that user's
+  full result — applied-rule chips, message and data table, or the red refusal callout. Tabs are
+  `role="tab"` buttons with `aria-selected`, reachable by Tab and navigable with the arrow keys.
+- **Rules** — full width, editable, with a **Grid** / **YAML** segmented control.
+  - *Grid*: rows are tables (bucket prefix in grey, table name in bold), columns are users, and each
+    cell is an input holding the predicate. An empty cell means *no rule* and is shown in red.
+    **Add user** and **Add table** prompt for a name; the small `×` removes a row or a column.
+  - *YAML*: the raw file, comments included. Saving from the grid regenerates the YAML with a short
+    header comment explaining the format.
+  - **Save and reload rules** validates the YAML, rewrites the rules file (keeping the previous
+    version next to it as `<rules file>.bak`) and restarts the MCP server process — the product has
+    no hot reload, so the stdio session is torn down and started again. **Discard changes** reverts
+    to the saved file.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.mjs` | Environment-driven configuration, `.env` reader, fail-fast validation. No secrets in the file. |
+| `server.mjs` | HTTP server + MCP stdio client + rewrite-preview helper. |
+| `public/index.html` | Single-file UI (inline CSS/JS). |
+| `rls.example.yaml` | Rules template, copied to the rules file on first start. |
+
+## API
+
+| Endpoint | Result |
+| --- | --- |
+| `GET /api/config` | `{ui}` — UI-only constants, no secrets |
+| `GET /api/rules` | `{users, tables, yaml}` — parsed rules plus the raw file text |
+| `PUT /api/rules` `{yaml}` | `{ok: true, users, tables, yaml, tools}` or `{ok: false, error}` |
+| `GET /api/tools` | tool names reported by the MCP server |
+| `POST /api/query` `{user, sql, query_name?}` | `{ok: true, applied_rules, csv_data, message}` or `{ok: false, error}` |
+| `POST /api/rewrite` `{user, sql}` | `{ok: true, sql, applied_rules}` — the rewritten SQL, not executed |
+
+A refusal is a normal outcome of this demo, so it comes back as HTTP 200 with `ok: false` and the
+verbatim `RLS: ...` message.
+
+### `PUT /api/rules`
+
+1. The candidate YAML is written to a **temp file** and validated by the MCP server's own
+   `RlsRules.load()`, run through `RLS_DEMO_PYTHON` with the temp path passed as `argv[1]` (never
+   interpolated into the script). A bad predicate — say `country = = 1` — comes back as
+   `{ok: false, error}` with the verbatim `RlsError` message, and **nothing is written**.
+2. Only then is the rules file replaced, after copying the previous version to `<rules file>.bak`.
+3. The stdio MCP session is closed (which kills the spawned server process), a new one is spawned
+   with the same environment and `listTools` is run again, so the new rules take effect.
+
+Steps 2 and 3 run inside the same queue as the tool calls, so a query never hits a half-restarted
+server.
+
+## Security
+
+- **Local use only.** The app binds to `127.0.0.1` by default and has no authentication: anything
+  that can reach the port can run queries as any user and rewrite the rules file. Do not expose it.
+- The Storage API token is read from the environment, kept in memory and handed only to the spawned
+  MCP server process as an environment variable. It is never logged, never written to disk by this
+  app and never returned in an HTTP response.
+- **Trust boundary.** The `user` argument is supplied by the caller — here, the browser — and is not
+  verified by the server. That is the documented pilot limitation of `query_data_rls`, and this demo
+  exists precisely to make it visible.
+
+## Status
+
+Pilot demo. Not production code: single shared MCP session, no authentication, no user identity.

--- a/examples/rls-demo/README.md
+++ b/examples/rls-demo/README.md
@@ -1,16 +1,35 @@
 # RLS demo — Keboola MCP Server
 
-A small Node.js app for trying out the row-level-security pilot by hand: pick a user, type SQL, and
-see exactly what the server's `query_data_rls` tool returns for that user against a real Keboola
-project.
+A small Node.js app for trying out the row-level-security pilot by hand: sign in as a user, type
+SQL, and see exactly what the server's `query_data_rls` tool returns for that user against a real
+Keboola project.
 
 This is an **example / manual test harness**. It is not part of the MCP server, it is not shipped
 with it, and nothing in `src/` depends on it.
 
+## The wrapper role
+
+The demo plays the part the RLS design expects of a real application:
+
+1. **It authenticates its own users.** Here that is a mock sign-in — clicking a persona *is* the
+   login. In a real deployment this would be Active Directory, Google, Okta, or the app's own
+   session; the MCP server has no opinion about which.
+2. **It is the only client of the MCP server.** The MCP server is started by this app as a local
+   streamable-HTTP server bound to `127.0.0.1` (`RLS_DEMO_MCP_PORT`, default 8788), with
+   `KBC_RLS_PRINCIPAL_SOURCE=header`.
+3. **It asserts the signed-in user on every call** in the `X-RLS-Principal` request header. The
+   server does not verify that header — it trusts this app — which is exactly why the MCP port must
+   not be reachable by anyone else.
+
+The identity is therefore never a tool argument: the browser sends only SQL, and `/api/query`
+refuses outright when nobody is signed in. A `principal` tool argument would be refused by the
+server anyway in header mode.
+
 The MCP server is started in RLS mode (`--rls-rules-path <file>`), so it registers `query_data_rls`
-and does **not** register the unrestricted `query_data`. Every query is rewritten server-side: each
-referenced table becomes `(SELECT * FROM <table> WHERE <predicate>)`. It is fail-closed — a table
-with no rule for the user is refused, and so is anything that is not a single plain `SELECT`.
+and does **not** register the unrestricted `query_data` — and the whole server is read-only, so no
+write tool is registered either. Every query is rewritten server-side: each referenced table becomes
+`(SELECT * FROM <table> WHERE <predicate>)`. It is fail-closed — a table with no rule for the
+principal is refused, and so is anything that is not a single plain `SELECT`.
 
 ## Prerequisites
 
@@ -33,8 +52,9 @@ invented defaults.
 | `KBC_STORAGE_TOKEN` | yes | — | Storage API token for that project |
 | `KBC_WORKSPACE_ID` | no | — | Existing workspace to query in; when unset, the MCP server manages its own |
 | `RLS_RULES_PATH` | no | `./rls.yaml` | Rules file, relative to this directory |
-| `RLS_DEMO_PORT` | no | `8787` | HTTP port |
-| `RLS_DEMO_HOST` | no | `127.0.0.1` | Listen address — leave it local, there is no authentication |
+| `RLS_DEMO_PORT` | no | `8787` | HTTP port of this app |
+| `RLS_DEMO_HOST` | no | `127.0.0.1` | Listen address of this app — leave it local, the sign-in is a mock |
+| `RLS_DEMO_MCP_PORT` | no | `8788` | Port the spawned MCP server listens on (always bound to `127.0.0.1`) |
 | `KEBOOLA_MCP_COMMAND` | no | `keboola_mcp_server` | The server executable. Point it at a checkout with `/path/to/mcp-server/.venv/bin/keboola_mcp_server` |
 | `RLS_DEMO_PYTHON` | no | `python3` | Interpreter for the rewrite preview and the rules validation. Must be a Python where `keboola_mcp_server` is importable, e.g. `/path/to/mcp-server/.venv/bin/python` |
 
@@ -56,18 +76,21 @@ npm start
 
 Then open <http://127.0.0.1:8787/>.
 
-On startup the app spawns one stdio MCP session, lists the tools and refuses to start if
-`query_data_rls` is missing or `query_data` is present.
+On startup the app spawns the MCP server on `RLS_DEMO_MCP_PORT`, waits for its `/health-check`,
+lists the tools and refuses to start if `query_data_rls` is missing or `query_data` is present.
 
 ## The UI
 
-- **Users** — a strip of persona chips at the top; the selected one is highlighted.
+- **Sign in** — a strip of persona chips: clicking one signs you in (mock IdP) and the header line
+  says *Signed in as `<name>` (mock IdP)*, with a **Sign out** button. Nothing can be run while
+  signed out.
 - **Query** — two columns. Left: the SQL as the user writes it. Right: **Rewritten SQL for `<user>`**,
-  a read-only view that refreshes automatically (debounced) whenever the SQL or the selected user
+  a read-only view that refreshes automatically (debounced) whenever the SQL or the sign-in
   changes. It shows the applied-rule chips and the rewritten statement, pretty-printed in the browser
   by a small keyword-based formatter. A refusal is shown in red in the same panel. Below 900 px the
   two columns stack.
-- **Result** — tabbed. *Run as `<user>`* produces a single tab; **Run for all users** produces a
+- **Result** — tabbed. *Run as `<user>`* produces a single tab; **Run for all users** — an
+  admin-style comparison the app runs server-side, one sign-in at a time — produces a
   **Summary** tab (the comparison table, active by default) plus one tab per user with that user's
   full result — applied-rule chips, message and data table, or the red refusal callout. Tabs are
   `role="tab"` buttons with `aria-selected`, reachable by Tab and navigable with the arrow keys.
@@ -79,7 +102,7 @@ On startup the app spawns one stdio MCP session, lists the tools and refuses to 
     header comment explaining the format.
   - **Save and reload rules** validates the YAML, rewrites the rules file (keeping the previous
     version next to it as `<rules file>.bak`) and restarts the MCP server process — the product has
-    no hot reload, so the stdio session is torn down and started again. **Discard changes** reverts
+    no hot reload, so the server process is stopped and started again. **Discard changes** reverts
     to the saved file.
 
 ## Files
@@ -87,7 +110,7 @@ On startup the app spawns one stdio MCP session, lists the tools and refuses to 
 | File | Purpose |
 | --- | --- |
 | `config.mjs` | Environment-driven configuration, `.env` reader, fail-fast validation. No secrets in the file. |
-| `server.mjs` | HTTP server + MCP stdio client + rewrite-preview helper. |
+| `server.mjs` | HTTP server + mock sign-in + per-principal MCP HTTP clients + rewrite-preview helper. |
 | `public/index.html` | Single-file UI (inline CSS/JS). |
 | `rls.example.yaml` | Rules template, copied to the rules file on first start. |
 
@@ -96,14 +119,23 @@ On startup the app spawns one stdio MCP session, lists the tools and refuses to 
 | Endpoint | Result |
 | --- | --- |
 | `GET /api/config` | `{ui}` — UI-only constants, no secrets |
+| `GET /api/session` | `{principal}` — the current sign-in, or `null` |
+| `POST /api/login` `{principal}` | `{ok: true, principal}` + session cookie, or `{ok: false, error}` (400) |
+| `POST /api/logout` | `{ok: true, principal: null}` and the cookie is cleared |
 | `GET /api/rules` | `{users, tables, yaml}` — parsed rules plus the raw file text |
 | `PUT /api/rules` `{yaml}` | `{ok: true, users, tables, yaml, tools}` or `{ok: false, error}` |
 | `GET /api/tools` | tool names reported by the MCP server |
-| `POST /api/query` `{user, sql, query_name?}` | `{ok: true, applied_rules, csv_data, message}` or `{ok: false, error}` |
-| `POST /api/rewrite` `{user, sql}` | `{ok: true, sql, applied_rules}` — the rewritten SQL, not executed |
+| `POST /api/query` `{sql, query_name?}` | `{ok: true, applied_rules, csv_data, message}` or `{ok: false, error}` |
+| `POST /api/query-all` `{sql, query_name?}` | `{ok: true, results: [{principal, result}]}` — the same query as every principal |
+| `POST /api/rewrite` `{sql}` | `{ok: true, sql, applied_rules}` — the rewritten SQL, not executed |
 
-A refusal is a normal outcome of this demo, so it comes back as HTTP 200 with `ok: false` and the
-verbatim `RLS: ...` message.
+**No endpoint takes a principal for a query.** `/api/query`, `/api/query-all` and `/api/rewrite`
+read it from the mock sign-in session (an `HttpOnly` cookie) and answer **401** when there is none.
+`/api/login` is the only place a name is accepted, and it only accepts principals that the rules
+file mentions.
+
+A refusal by the MCP server is a normal outcome of this demo, so it comes back as HTTP 200 with
+`ok: false` and the verbatim `RLS: ...` message.
 
 ### `PUT /api/rules`
 
@@ -112,23 +144,27 @@ verbatim `RLS: ...` message.
    interpolated into the script). A bad predicate — say `country = = 1` — comes back as
    `{ok: false, error}` with the verbatim `RlsError` message, and **nothing is written**.
 2. Only then is the rules file replaced, after copying the previous version to `<rules file>.bak`.
-3. The stdio MCP session is closed (which kills the spawned server process), a new one is spawned
-   with the same environment and `listTools` is run again, so the new rules take effect.
+3. Every per-principal MCP client is closed and the spawned server process is stopped (SIGTERM, then
+   SIGKILL after a timeout), a new one is spawned with the same environment and `listTools` is run
+   again, so the new rules take effect.
 
 Steps 2 and 3 run inside the same queue as the tool calls, so a query never hits a half-restarted
 server.
 
 ## Security
 
-- **Local use only.** The app binds to `127.0.0.1` by default and has no authentication: anything
-  that can reach the port can run queries as any user and rewrite the rules file. Do not expose it.
+- **Local use only.** The sign-in is a *mock*: anyone who can reach this app's port can sign in as
+  anybody and rewrite the rules file. Both this app and the MCP server it spawns bind to
+  `127.0.0.1`. Do not expose either.
 - The Storage API token is read from the environment, kept in memory and handed only to the spawned
   MCP server process as an environment variable. It is never logged, never written to disk by this
   app and never returned in an HTTP response.
-- **Trust boundary.** The `user` argument is supplied by the caller — here, the browser — and is not
-  verified by the server. That is the documented pilot limitation of `query_data_rls`, and this demo
-  exists precisely to make it visible.
+- **Trust boundary.** The MCP server does not verify `X-RLS-Principal` — it trusts whatever this app
+  asserts. That is the whole architecture: the wrapper authenticates, the MCP server enforces. It
+  only holds as long as the MCP port is reachable from the wrapper alone, which is why it is bound to
+  loopback here and must be equally fenced off in any real deployment.
 
 ## Status
 
-Pilot demo. Not production code: single shared MCP session, no authentication, no user identity.
+Pilot demo. Not production code: the sign-in is a mock, sessions live in memory, and rules are
+edited by anyone who can open the page.

--- a/examples/rls-demo/config.mjs
+++ b/examples/rls-demo/config.mjs
@@ -20,6 +20,7 @@ const REQUIRED_ENV = ['KBC_STORAGE_API_URL', 'KBC_STORAGE_TOKEN'];
 /** Defaults for the optional variables. Required ones deliberately have none. */
 const DEFAULTS = {
   RLS_RULES_PATH: './rls.yaml',
+  RLS_DEMO_CONFIG_PATH: './demo.json',
   RLS_DEMO_PORT: '8787',
   RLS_DEMO_HOST: '127.0.0.1',
   // The MCP server is started as a local streamable-HTTP server so this app can assert the signed-in
@@ -92,6 +93,7 @@ if (mcpPort === port) {
 }
 
 const rulesPath = path.resolve(APP_DIR, env('RLS_RULES_PATH'));
+const demoConfigPath = path.resolve(APP_DIR, env('RLS_DEMO_CONFIG_PATH'));
 
 export const config = {
   appDir: APP_DIR,
@@ -105,6 +107,13 @@ export const config = {
     token: process.env.KBC_STORAGE_TOKEN,
     // Optional: when unset, the MCP server manages its own workspace.
     workspaceId: String(process.env.KBC_WORKSPACE_ID ?? '').trim() || null,
+  },
+  demo: {
+    // Personas + example queries shown in the UI. When this file does not exist, `loadDemoConfig()`
+    // falls back to `BUILTIN_DEMO_CONFIG` below (after `ensureDemoConfigFile()` in server.mjs has had
+    // a chance to seed it from `exampleConfigPath`, the same way the rules file is seeded).
+    configPath: demoConfigPath,
+    exampleConfigPath: path.join(APP_DIR, 'demo.example.json'),
   },
   mcp: {
     // The Keboola MCP Server executable. Defaults to the CLI on PATH; point it at a checkout with
@@ -155,3 +164,130 @@ export const config = {
     idpLabel: 'mock IdP',
   },
 };
+
+// --- demo.json (personas + example queries) ---------------------------------------------------
+//
+// Deployment-specific content that used to be hardcoded in public/index.html: the one-line persona
+// descriptions shown next to each sign-in button, and the example queries in the "Examples"
+// dropdown. Kept here (not in public/index.html) so a deployment can swap them without touching
+// code — see demo.example.json and README.md.
+
+/**
+ * Generic content used only when `config.demo.configPath` does not exist AND could not be seeded
+ * from `config.demo.exampleConfigPath` (see `ensureDemoConfigFile()` in server.mjs). Mirrors
+ * demo.example.json exactly.
+ */
+export const BUILTIN_DEMO_CONFIG = {
+  personas: {
+    alice: 'Czech market only',
+    bob: 'Poland + Slovakia',
+    carol: 'DACH + Benelux (DE, AT, NL, BE)',
+    dave: 'Southern markets (ES, IT, FR), no in.c-sales.deals',
+    admin: 'Sees everything',
+  },
+  examples: [
+    {
+      label: 'Rows per country — invoices',
+      sql: 'SELECT country, COUNT(*) AS n\nFROM "in.c-crm"."invoices"\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 20',
+    },
+    {
+      label: 'Top 10 invoices by amount',
+      sql: 'SELECT id, country, amount\nFROM "in.c-crm"."invoices"\nORDER BY amount DESC\nLIMIT 10',
+    },
+    {
+      label: 'Orders by country and status',
+      sql:
+        'SELECT country, status, COUNT(*) AS n\nFROM "in.c-crm"."orders"\nWHERE status IS NOT NULL\n' +
+        'GROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25',
+    },
+    {
+      label: 'Join invoices and orders per country',
+      sql:
+        'SELECT i.country, COUNT(*) AS matched_rows, COUNT(DISTINCT o.id) AS orders\n' +
+        'FROM "in.c-crm"."invoices" AS i\nJOIN "in.c-crm"."orders" AS o ON o.customer_id = i.customer_id\n' +
+        'GROUP BY 1\nORDER BY 2 DESC\nLIMIT 20',
+    },
+    {
+      label: 'Deals by stage — in.c-sales.deals (refused for dave)',
+      sql: 'SELECT country, stage, COUNT(*) AS n\nFROM "in.c-sales"."deals"\nGROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25',
+    },
+    {
+      label: 'Refused — RESULT_SCAN escape attempt',
+      sql: 'SELECT *\nFROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))\nLIMIT 10',
+    },
+    {
+      label: 'Refused — non-SELECT statement',
+      sql: "DELETE FROM \"in.c-crm\".\"invoices\"\nWHERE country = 'CZ'",
+    },
+  ],
+};
+
+/**
+ * Validate the shape of a candidate demo config object. Throws with a clear, specific message on
+ * the first problem found — never silently coerces or drops bad data.
+ * @param {unknown} data
+ * @returns {{personas: Record<string, string>, examples: {label: string, sql: string}[]}}
+ */
+export function validateDemoConfig(data) {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('demo config must be a JSON object with "personas" and "examples" fields');
+  }
+  const { personas, examples } = /** @type {Record<string, unknown>} */ (data);
+
+  if (personas === null || typeof personas !== 'object' || Array.isArray(personas)) {
+    throw new Error('demo config "personas" must be an object mapping user name -> description string');
+  }
+  for (const [user, desc] of Object.entries(personas)) {
+    if (typeof desc !== 'string') {
+      throw new Error(`demo config "personas.${user}" must be a string, got ${typeof desc}`);
+    }
+  }
+
+  if (!Array.isArray(examples)) {
+    throw new Error('demo config "examples" must be an array of {label, sql} objects');
+  }
+  examples.forEach((entry, i) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`demo config "examples[${i}]" must be an object with "label" and "sql" strings`);
+    }
+    const { label, sql } = /** @type {Record<string, unknown>} */ (entry);
+    if (typeof label !== 'string' || !label.trim()) {
+      throw new Error(`demo config "examples[${i}].label" must be a non-empty string`);
+    }
+    if (typeof sql !== 'string' || !sql.trim()) {
+      throw new Error(`demo config "examples[${i}].sql" must be a non-empty string`);
+    }
+  });
+
+  return {
+    personas: /** @type {Record<string, string>} */ (personas),
+    examples: /** @type {{label: string, sql: string}[]} */ (examples),
+  };
+}
+
+/**
+ * Load and validate the demo config from `filePath`. When `filePath` does not exist, resolves to
+ * `BUILTIN_DEMO_CONFIG` with `source: 'built-in'`. An existing-but-invalid file is a fatal error —
+ * the caller is expected to print it and exit(1), never to fall back silently.
+ * @param {string} filePath
+ * @returns {Promise<{source: string, personas: Record<string, string>, examples: {label: string, sql: string}[]}>}
+ */
+export async function loadDemoConfig(filePath) {
+  if (!existsSync(filePath)) {
+    return { source: 'built-in', personas: BUILTIN_DEMO_CONFIG.personas, examples: BUILTIN_DEMO_CONFIG.examples };
+  }
+  let raw;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (e) {
+    throw new Error(`cannot read demo config ${filePath}: ${e?.message ?? e}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`${filePath} is not valid JSON: ${e?.message ?? e}`);
+  }
+  const validated = validateDemoConfig(parsed);
+  return { source: filePath, ...validated };
+}

--- a/examples/rls-demo/config.mjs
+++ b/examples/rls-demo/config.mjs
@@ -22,6 +22,9 @@ const DEFAULTS = {
   RLS_RULES_PATH: './rls.yaml',
   RLS_DEMO_PORT: '8787',
   RLS_DEMO_HOST: '127.0.0.1',
+  // The MCP server is started as a local streamable-HTTP server so this app can assert the signed-in
+  // principal in a per-request header. It listens on loopback only — see `mcp.host` below.
+  RLS_DEMO_MCP_PORT: '8788',
   KEBOOLA_MCP_COMMAND: 'keboola_mcp_server',
   RLS_DEMO_PYTHON: 'python3',
 };
@@ -71,9 +74,20 @@ function env(name) {
   return resolved;
 }
 
-const port = Number(env('RLS_DEMO_PORT'));
-if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-  console.error(`[rls-demo] FATAL: RLS_DEMO_PORT must be a TCP port number, got "${env('RLS_DEMO_PORT')}"`);
+/** @param {string} name */
+function portFromEnv(name) {
+  const value = Number(env(name));
+  if (!Number.isInteger(value) || value <= 0 || value > 65535) {
+    console.error(`[rls-demo] FATAL: ${name} must be a TCP port number, got "${env(name)}"`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const port = portFromEnv('RLS_DEMO_PORT');
+const mcpPort = portFromEnv('RLS_DEMO_MCP_PORT');
+if (mcpPort === port) {
+  console.error('[rls-demo] FATAL: RLS_DEMO_PORT and RLS_DEMO_MCP_PORT must differ');
   process.exit(1);
 }
 
@@ -106,18 +120,38 @@ export const config = {
     rulesBackupPath: `${rulesPath}.bak`,
     clientName: 'rls-demo',
     clientVersion: '1.0.0',
-    // The rewrite preview and every tool call go through the same single stdio session.
+    // The MCP server is spawned as a local streamable-HTTP server, bound to loopback: it trusts the
+    // X-RLS-Principal header this app sends, so nothing but this app may be able to reach it.
+    host: '127.0.0.1',
+    port: mcpPort,
+    url: `http://127.0.0.1:${mcpPort}/mcp`,
+    healthUrl: `http://127.0.0.1:${mcpPort}/health-check`,
+    // The MCP server takes the principal from this header (KBC_RLS_PRINCIPAL_SOURCE=header), never
+    // from a tool argument. Both are set in one place so the demo cannot drift from the server.
+    principalHeader: 'X-RLS-Principal',
+    principalSource: 'header',
     dialect: 'snowflake',
     expectedTool: 'query_data_rls',
     forbiddenTool: 'query_data',
     startupTimeoutMs: 60000,
+    // How long to wait for the spawned server's /health-check to answer, and how often to retry.
+    readyTimeoutMs: 60000,
+    readyPollIntervalMs: 250,
+    // How long to wait for the spawned server to exit on SIGTERM before sending SIGKILL.
+    shutdownTimeoutMs: 10000,
     callTimeoutMs: 180000,
     rewriteTimeoutMs: 30000,
     validateTimeoutMs: 30000,
+  },
+  session: {
+    // Mock sign-in cookie. This stands in for whatever a real wrapper application uses (an AD /
+    // Google / Okta session, its own JWT); the demo keeps the mapping in memory only.
+    cookieName: 'rls_demo_session',
   },
   ui: {
     defaultQueryName: 'RLS demo query',
     // Debounce for the live "Rewritten SQL" panel in the browser.
     rewriteDebounceMs: 400,
+    idpLabel: 'mock IdP',
   },
 };

--- a/examples/rls-demo/config.mjs
+++ b/examples/rls-demo/config.mjs
@@ -1,0 +1,123 @@
+// Configuration for the RLS pilot demo.
+//
+// Everything that depends on the machine comes from environment variables — there are no hardcoded
+// paths, project ids or credentials in this directory. A local `.env` file (never committed, see
+// .gitignore) is read first, so `npm start` works without exporting anything by hand.
+//
+// SECURITY: `keboola.token` holds the Storage API token in memory only. It is handed to the spawned
+// MCP server process as an environment variable and is never logged, never written to disk and never
+// returned in an HTTP response.
+
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APP_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Environment variables that must be present; the process exits 1 when any is missing. */
+const REQUIRED_ENV = ['KBC_STORAGE_API_URL', 'KBC_STORAGE_TOKEN'];
+
+/** Defaults for the optional variables. Required ones deliberately have none. */
+const DEFAULTS = {
+  RLS_RULES_PATH: './rls.yaml',
+  RLS_DEMO_PORT: '8787',
+  RLS_DEMO_HOST: '127.0.0.1',
+  KEBOOLA_MCP_COMMAND: 'keboola_mcp_server',
+  RLS_DEMO_PYTHON: 'python3',
+};
+
+/**
+ * Minimal `.env` reader: `KEY=VALUE` lines, `#` comments, optional surrounding quotes.
+ * Deliberately dependency-free. Values already present in the real environment win.
+ * @param {string} filePath
+ */
+function loadDotEnv(filePath) {
+  if (!existsSync(filePath)) return;
+  for (const rawLine of readFileSync(filePath, 'utf8').split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+loadDotEnv(path.join(APP_DIR, '.env'));
+
+const missing = REQUIRED_ENV.filter((name) => !String(process.env[name] ?? '').trim());
+if (missing.length) {
+  // Fail fast with a clear message — no invented defaults for required configuration.
+  console.error(
+    `[rls-demo] FATAL: missing required environment variable(s): ${missing.join(', ')}\n` +
+      '[rls-demo] Set them in the environment or in a local .env file in this directory.\n' +
+      '[rls-demo] See README.md for the full configuration table.'
+  );
+  process.exit(1);
+}
+
+/** @param {string} name */
+function env(name) {
+  const value = process.env[name];
+  const resolved = value === undefined || value === '' ? DEFAULTS[name] : value;
+  if (resolved === undefined) throw new Error(`No value and no default for ${name}`);
+  return resolved;
+}
+
+const port = Number(env('RLS_DEMO_PORT'));
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  console.error(`[rls-demo] FATAL: RLS_DEMO_PORT must be a TCP port number, got "${env('RLS_DEMO_PORT')}"`);
+  process.exit(1);
+}
+
+const rulesPath = path.resolve(APP_DIR, env('RLS_RULES_PATH'));
+
+export const config = {
+  appDir: APP_DIR,
+  http: {
+    // Local-use demo: there is no authentication, so it never binds to a public interface.
+    host: env('RLS_DEMO_HOST'),
+    port,
+  },
+  keboola: {
+    stackUrl: process.env.KBC_STORAGE_API_URL,
+    token: process.env.KBC_STORAGE_TOKEN,
+    // Optional: when unset, the MCP server manages its own workspace.
+    workspaceId: String(process.env.KBC_WORKSPACE_ID ?? '').trim() || null,
+  },
+  mcp: {
+    // The Keboola MCP Server executable. Defaults to the CLI on PATH; point it at a checkout with
+    // KEBOOLA_MCP_COMMAND=/path/to/mcp-server/.venv/bin/keboola_mcp_server.
+    command: env('KEBOOLA_MCP_COMMAND'),
+    // Python interpreter used for the rewrite preview and the rules validation. It must be an
+    // environment where `keboola_mcp_server` is importable.
+    pythonPath: env('RLS_DEMO_PYTHON'),
+    rulesPath,
+    // Shipped template, copied to rulesPath on first start when the rules file does not exist.
+    exampleRulesPath: path.join(APP_DIR, 'rls.example.yaml'),
+    // Single backup of the previous rules file, rewritten on every successful save.
+    rulesBackupPath: `${rulesPath}.bak`,
+    clientName: 'rls-demo',
+    clientVersion: '1.0.0',
+    // The rewrite preview and every tool call go through the same single stdio session.
+    dialect: 'snowflake',
+    expectedTool: 'query_data_rls',
+    forbiddenTool: 'query_data',
+    startupTimeoutMs: 60000,
+    callTimeoutMs: 180000,
+    rewriteTimeoutMs: 30000,
+    validateTimeoutMs: 30000,
+  },
+  ui: {
+    defaultQueryName: 'RLS demo query',
+    // Debounce for the live "Rewritten SQL" panel in the browser.
+    rewriteDebounceMs: 400,
+  },
+};

--- a/examples/rls-demo/demo.example.json
+++ b/examples/rls-demo/demo.example.json
@@ -1,0 +1,39 @@
+{
+  "personas": {
+    "alice": "Czech market only",
+    "bob": "Poland + Slovakia",
+    "carol": "DACH + Benelux (DE, AT, NL, BE)",
+    "dave": "Southern markets (ES, IT, FR), no in.c-sales.deals",
+    "admin": "Sees everything"
+  },
+  "examples": [
+    {
+      "label": "Rows per country — invoices",
+      "sql": "SELECT country, COUNT(*) AS n\nFROM \"in.c-crm\".\"invoices\"\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 20"
+    },
+    {
+      "label": "Top 10 invoices by amount",
+      "sql": "SELECT id, country, amount\nFROM \"in.c-crm\".\"invoices\"\nORDER BY amount DESC\nLIMIT 10"
+    },
+    {
+      "label": "Orders by country and status",
+      "sql": "SELECT country, status, COUNT(*) AS n\nFROM \"in.c-crm\".\"orders\"\nWHERE status IS NOT NULL\nGROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25"
+    },
+    {
+      "label": "Join invoices and orders per country",
+      "sql": "SELECT i.country, COUNT(*) AS matched_rows, COUNT(DISTINCT o.id) AS orders\nFROM \"in.c-crm\".\"invoices\" AS i\nJOIN \"in.c-crm\".\"orders\" AS o ON o.customer_id = i.customer_id\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 20"
+    },
+    {
+      "label": "Deals by stage — in.c-sales.deals (refused for dave)",
+      "sql": "SELECT country, stage, COUNT(*) AS n\nFROM \"in.c-sales\".\"deals\"\nGROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25"
+    },
+    {
+      "label": "Refused — RESULT_SCAN escape attempt",
+      "sql": "SELECT *\nFROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))\nLIMIT 10"
+    },
+    {
+      "label": "Refused — non-SELECT statement",
+      "sql": "DELETE FROM \"in.c-crm\".\"invoices\"\nWHERE country = 'CZ'"
+    }
+  ]
+}

--- a/examples/rls-demo/package-lock.json
+++ b/examples/rls-demo/package-lock.json
@@ -1,0 +1,1215 @@
+{
+  "name": "rls-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rls-demo",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/rls-demo/package.json
+++ b/examples/rls-demo/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rls-demo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Keboola MCP Server row-level-security pilot demo app",
+  "type": "module",
+  "main": "server.mjs",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "yaml": "^2.9.0"
+  }
+}

--- a/examples/rls-demo/public/index.html
+++ b/examples/rls-demo/public/index.html
@@ -653,53 +653,25 @@
     </footer>
 
     <script>
-      // One-line persona descriptions, matching the comments in rls.example.yaml. Users that are
-      // not listed here still work — they simply render without a description.
-      const USER_DESCRIPTIONS = {
-        alice: 'Czech market only',
-        bob: 'Poland + Slovakia',
-        carol: 'DACH + Benelux (DE, AT, NL, BE)',
-        dave: 'Southern markets (ES, IT, FR), no in.c-sales.deals',
-        admin: 'Sees everything',
-      };
+      // Persona descriptions and example queries are deployment-specific content served by the
+      // server from demo.json (see /api/config) — never hardcoded here. Populated by init() before
+      // anything below reads them. A user with no matching entry in USER_DESCRIPTIONS still works —
+      // it simply renders with a muted "no description".
+      let USER_DESCRIPTIONS = {};
       const USER_ORDER = ['alice', 'bob', 'carol', 'dave', 'admin'];
-      // Buckets used by the example queries. They match the keys in rls.example.yaml — point them
-      // at your own buckets together with the rules.
-      const CRM = '"in.c-crm"';
-      const SALES = '"in.c-sales"';
-
-      const EXAMPLES = [
-        {
-          label: 'Rows per country — invoices',
-          sql: `SELECT country, COUNT(*) AS n\nFROM ${CRM}."invoices"\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 20`,
-        },
-        {
-          label: 'Top 10 invoices by amount',
-          sql: `SELECT id, country, amount\nFROM ${CRM}."invoices"\nORDER BY amount DESC\nLIMIT 10`,
-        },
-        {
-          label: 'Orders by country and status',
-          sql: `SELECT country, status, COUNT(*) AS n\nFROM ${CRM}."orders"\nWHERE status IS NOT NULL\nGROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25`,
-        },
-        {
-          label: 'Join invoices and orders per country',
-          sql: `SELECT i.country, COUNT(*) AS matched_rows, COUNT(DISTINCT o.id) AS orders\nFROM ${CRM}."invoices" AS i\nJOIN ${CRM}."orders" AS o ON o.customer_id = i.customer_id\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 20`,
-        },
-        {
-          label: 'Deals by stage — in.c-sales.deals (refused for dave)',
-          sql: `SELECT country, stage, COUNT(*) AS n\nFROM ${SALES}."deals"\nGROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25`,
-        },
-        {
-          label: 'Refused — RESULT_SCAN escape attempt',
-          sql: `SELECT *\nFROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))\nLIMIT 10`,
-        },
-        {
-          label: 'Refused — non-SELECT statement',
-          sql: `DELETE FROM ${CRM}."invoices"\nWHERE country = 'CZ'`,
-        },
-      ];
+      let EXAMPLES = [];
 
       const $ = (id) => document.getElementById(id);
+
+      /** Case-insensitive lookup into USER_DESCRIPTIONS, since rules users are matched
+          case-insensitively server-side too. */
+      function personaDescription(user) {
+        const needle = String(user ?? '').toLowerCase();
+        for (const [name, desc] of Object.entries(USER_DESCRIPTIONS)) {
+          if (name.toLowerCase() === needle) return desc;
+        }
+        return null;
+      }
 
       /** The signed-in principal, or null. Set only by the server's /api/session and /api/login —
           the page never picks an identity for a query, it only asks to be signed in as one. */
@@ -887,11 +859,14 @@
         const order = userOrder(rules.users);
         $('users').innerHTML = order
           .map((u) => {
-            const desc = USER_DESCRIPTIONS[u] ?? 'no description';
+            const desc = personaDescription(u);
+            const descHtml = desc
+              ? `<span class="desc">${esc(desc)}</span>`
+              : '<span class="desc" style="opacity:.55;font-style:italic">no description</span>';
             return (
-              `<button type="button" class="persona" data-user="${esc(u)}" title="${esc(desc)}" ` +
+              `<button type="button" class="persona" data-user="${esc(u)}" title="${esc(desc ?? 'no description')}" ` +
               `aria-pressed="${u === currentUser}">` +
-              `<span class="name">${esc(u)}</span><span class="desc">${esc(desc)}</span></button>`
+              `<span class="name">${esc(u)}</span>${descHtml}</button>`
             );
           })
           .join('');
@@ -1350,11 +1325,13 @@
       }
 
       async function init() {
-        renderExamples();
-        $('sql').value = EXAMPLES[0].sql;
-
         const cfg = await (await fetch('/api/config')).json();
         uiConfig = cfg.ui;
+        USER_DESCRIPTIONS = cfg.personas ?? {};
+        EXAMPLES = cfg.examples ?? [];
+
+        renderExamples();
+        if (EXAMPLES.length) $('sql').value = EXAMPLES[0].sql;
 
         // Who the server says we are (a page reload keeps the mock sign-in cookie).
         currentUser = (await (await fetch('/api/session')).json()).principal ?? null;

--- a/examples/rls-demo/public/index.html
+++ b/examples/rls-demo/public/index.html
@@ -1,0 +1,1324 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Keboola MCP — Row-Level Security demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --ground: #eef1f5;
+        --card: #ffffff;
+        --ink: #1b2330;
+        --ink-soft: #5a6676;
+        --ink-faint: #8b96a5;
+        --line: #dde3ea;
+        --line-strong: #c6d0da;
+        --accent: #1f5fd8;
+        --accent-soft: #e8f0fe;
+        --danger: #c02b2b;
+        --danger-soft: #fdecec;
+        --ok: #1d7a4c;
+        --ok-soft: #e6f4ec;
+        --radius: 6px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--ground);
+        color: var(--ink);
+        font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      code,
+      pre,
+      textarea,
+      .mono {
+        font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      header {
+        background: var(--card);
+        border-bottom: 1px solid var(--line);
+        padding: 14px 24px;
+        display: flex;
+        align-items: baseline;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+      header h1 {
+        font-size: 16px;
+        font-weight: 600;
+        margin: 0;
+        letter-spacing: -0.01em;
+      }
+      header .sub {
+        color: var(--ink-soft);
+        font-size: 12.5px;
+      }
+      header .status {
+        margin-left: auto;
+        font-size: 12px;
+        color: var(--ink-soft);
+      }
+      header .status .dot {
+        display: inline-block;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--ink-faint);
+        margin-right: 6px;
+        vertical-align: middle;
+      }
+      header .status.up .dot {
+        background: var(--ok);
+      }
+      header .status.down .dot {
+        background: var(--danger);
+      }
+      main {
+        padding: 18px 24px 40px;
+      }
+      .card {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        margin-bottom: 18px;
+      }
+      .card > h2 {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--ink-soft);
+        font-weight: 600;
+        margin: 0;
+        padding: 11px 14px;
+        border-bottom: 1px solid var(--line);
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .card > h2 .h2-right {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        text-transform: none;
+        letter-spacing: 0;
+      }
+      .card > .body {
+        padding: 14px;
+      }
+      .card > .body.flush {
+        padding: 0;
+      }
+
+      /* Users strip */
+      .strip {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .persona {
+        border: 1px solid var(--line-strong);
+        border-radius: var(--radius);
+        background: #fff;
+        padding: 7px 12px;
+        cursor: pointer;
+        font: inherit;
+        color: inherit;
+        text-align: left;
+        min-width: 150px;
+      }
+      .persona:hover {
+        border-color: var(--accent);
+      }
+      .persona[aria-pressed='true'] {
+        background: var(--accent-soft);
+        border-color: var(--accent);
+      }
+      .persona .name {
+        display: block;
+        font-weight: 600;
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 13px;
+      }
+      .persona .desc {
+        display: block;
+        color: var(--ink-soft);
+        font-size: 11.5px;
+        line-height: 1.35;
+      }
+
+      /* Query: editor + rewritten SQL side by side */
+      .split {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: 16px;
+        align-items: start;
+      }
+      @media (max-width: 900px) {
+        .split {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+      .pane-title {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--ink-soft);
+        font-weight: 600;
+        margin-bottom: 7px;
+      }
+      textarea#sql {
+        width: 100%;
+        min-height: 190px;
+        resize: vertical;
+        border: 1px solid var(--line-strong);
+        border-radius: var(--radius);
+        padding: 10px 12px;
+        font-size: 12.5px;
+        line-height: 1.6;
+        color: var(--ink);
+        background: #fcfdfe;
+      }
+      textarea#sql:focus {
+        outline: 2px solid var(--accent-soft);
+        border-color: var(--accent);
+      }
+      #rewrite-pane {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: #f6f8fb;
+        padding: 10px 12px;
+        min-height: 190px;
+      }
+      select,
+      input[type='text'] {
+        font: inherit;
+        font-size: 13px;
+        padding: 6px 8px;
+        border: 1px solid var(--line-strong);
+        border-radius: var(--radius);
+        background: #fff;
+        color: var(--ink);
+      }
+      .row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .row.gap-t {
+        margin-top: 12px;
+      }
+      label.inline {
+        font-size: 12px;
+        color: var(--ink-soft);
+      }
+      button.btn {
+        font: inherit;
+        font-size: 13px;
+        font-weight: 500;
+        padding: 7px 14px;
+        border-radius: var(--radius);
+        border: 1px solid var(--line-strong);
+        background: #fff;
+        color: var(--ink);
+        cursor: pointer;
+      }
+      button.btn:hover:not(:disabled) {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      button.btn.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
+      button.btn.primary:hover:not(:disabled) {
+        background: #1a51ba;
+        color: #fff;
+      }
+      button.btn.small {
+        font-size: 12px;
+        padding: 5px 10px;
+      }
+      button.btn:disabled {
+        opacity: 0.55;
+        cursor: default;
+      }
+
+      /* Tabs */
+      .tabs {
+        display: flex;
+        gap: 2px;
+        flex-wrap: wrap;
+        border-bottom: 1px solid var(--line);
+        padding: 0 14px;
+      }
+      button.tab {
+        font: inherit;
+        font-size: 12.5px;
+        font-weight: 500;
+        background: transparent;
+        border: 0;
+        border-bottom: 2px solid transparent;
+        padding: 9px 12px;
+        margin-bottom: -1px;
+        color: var(--ink-soft);
+        cursor: pointer;
+      }
+      button.tab:hover {
+        color: var(--ink);
+      }
+      button.tab[aria-selected='true'] {
+        color: var(--accent);
+        border-bottom-color: var(--accent);
+      }
+      button.tab:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
+      }
+      button.tab .badge {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 10.5px;
+        color: var(--ink-faint);
+        margin-left: 6px;
+      }
+      button.tab .badge.bad {
+        color: var(--danger);
+      }
+
+      /* Segmented control */
+      .seg {
+        display: inline-flex;
+        border: 1px solid var(--line-strong);
+        border-radius: var(--radius);
+        overflow: hidden;
+      }
+      .seg button {
+        font: inherit;
+        font-size: 12px;
+        font-weight: 500;
+        padding: 5px 12px;
+        border: 0;
+        background: #fff;
+        color: var(--ink-soft);
+        cursor: pointer;
+      }
+      .seg button + button {
+        border-left: 1px solid var(--line-strong);
+      }
+      .seg button[aria-pressed='true'] {
+        background: var(--accent-soft);
+        color: var(--accent);
+      }
+
+      /* Rules editor */
+      table.grid {
+        border-collapse: collapse;
+        font-size: 11.5px;
+      }
+      table.grid th,
+      table.grid td {
+        border: 1px solid var(--line);
+        padding: 5px 7px;
+        text-align: left;
+        vertical-align: middle;
+      }
+      table.grid th {
+        background: #f6f8fb;
+        font-weight: 600;
+        color: var(--ink-soft);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        white-space: nowrap;
+      }
+      table.grid th.rowhead {
+        font-family: 'IBM Plex Mono', monospace;
+        text-transform: none;
+        letter-spacing: 0;
+        font-size: 11.5px;
+        white-space: nowrap;
+        font-weight: 400;
+      }
+      table.grid th.rowhead .bucket {
+        color: var(--ink-faint);
+      }
+      table.grid th.rowhead .tname {
+        font-weight: 600;
+        color: var(--ink);
+      }
+      .colhead {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .colhead .uname {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 11.5px;
+        text-transform: none;
+        letter-spacing: 0;
+        color: var(--ink);
+        font-weight: 600;
+      }
+      button.rm {
+        font: inherit;
+        font-size: 12px;
+        line-height: 1;
+        border: 1px solid var(--line-strong);
+        background: #fff;
+        color: var(--ink-faint);
+        border-radius: 4px;
+        padding: 1px 5px;
+        cursor: pointer;
+      }
+      button.rm:hover {
+        color: var(--danger);
+        border-color: var(--danger);
+      }
+      input.cell {
+        width: 100%;
+        min-width: 210px;
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 11.5px;
+        padding: 5px 7px;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        background: #fff;
+        color: var(--ink);
+      }
+      input.cell:hover {
+        border-color: var(--line);
+      }
+      input.cell:focus {
+        outline: none;
+        border-color: var(--accent);
+        background: #fcfdfe;
+      }
+      input.cell.empty {
+        background: var(--danger-soft);
+      }
+      input.cell::placeholder {
+        color: var(--danger);
+        opacity: 1;
+      }
+      textarea#yaml {
+        width: 100%;
+        min-height: 340px;
+        resize: vertical;
+        border: 1px solid var(--line-strong);
+        border-radius: var(--radius);
+        padding: 10px 12px;
+        font-size: 12.5px;
+        line-height: 1.55;
+        color: var(--ink);
+        background: #fcfdfe;
+      }
+      .dirty {
+        font-size: 11.5px;
+        color: var(--danger);
+      }
+      #rules-status {
+        font-size: 12px;
+        color: var(--ink-soft);
+      }
+      #rules-status.bad {
+        color: var(--danger);
+      }
+      #rules-status.good {
+        color: var(--ok);
+      }
+
+      /* Results */
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-bottom: 10px;
+      }
+      .chip {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 11.5px;
+        background: var(--ok-soft);
+        color: var(--ok);
+        border: 1px solid #bfe0cd;
+        border-radius: 999px;
+        padding: 2px 10px;
+      }
+      .callout {
+        border-radius: var(--radius);
+        padding: 10px 12px;
+        font-size: 12.5px;
+      }
+      .callout.error {
+        background: var(--danger-soft);
+        border: 1px solid #f0c2c2;
+        color: var(--danger);
+      }
+      .callout.error .mono {
+        display: block;
+        margin-top: 4px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .callout.info {
+        background: #f6f8fb;
+        border: 1px solid var(--line);
+        color: var(--ink-soft);
+      }
+      .meta {
+        font-size: 12px;
+        color: var(--ink-soft);
+        margin-bottom: 8px;
+      }
+      pre.sqlout {
+        background: transparent;
+        border: 0;
+        padding: 0;
+        font-size: 12px;
+        line-height: 1.55;
+        overflow-x: auto;
+        margin: 0;
+        white-space: pre;
+      }
+      table.data {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 12px;
+      }
+      table.data th,
+      table.data td {
+        border-bottom: 1px solid var(--line);
+        padding: 5px 10px;
+        text-align: left;
+        white-space: nowrap;
+      }
+      table.data th {
+        background: #f6f8fb;
+        position: sticky;
+        top: 0;
+        font-weight: 600;
+        color: var(--ink-soft);
+        font-size: 11px;
+      }
+      table.data tr:hover td {
+        background: #fafbfd;
+      }
+      .tablewrap {
+        max-height: 460px;
+        overflow: auto;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+      }
+      .cmp td.refusal {
+        color: var(--danger);
+        white-space: normal;
+        font-size: 11px;
+      }
+      .cmp td.rules {
+        white-space: normal;
+        color: var(--ok);
+        font-size: 11px;
+        font-family: 'IBM Plex Mono', monospace;
+      }
+      .scrollx {
+        overflow-x: auto;
+      }
+      .spinner {
+        font-size: 12.5px;
+        color: var(--ink-soft);
+      }
+      footer {
+        padding: 0 24px 30px;
+        color: var(--ink-faint);
+        font-size: 11.5px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Keboola MCP Server — Row-Level Security</h1>
+      <span class="sub">pilot demo · local only · read-only queries</span>
+      <span class="status" id="status"><span class="dot"></span><span id="status-text">connecting…</span></span>
+    </header>
+
+    <main>
+      <section class="card">
+        <h2>Users</h2>
+        <div class="body">
+          <div class="strip" id="users"></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Query</h2>
+        <div class="body">
+          <div class="row" style="margin-bottom: 12px">
+            <label class="inline" for="examples">Examples</label>
+            <select id="examples" style="flex: 1; max-width: 520px"></select>
+          </div>
+          <div class="split">
+            <div>
+              <div class="pane-title">SQL as the user writes it</div>
+              <textarea id="sql" spellcheck="false"></textarea>
+              <div class="row gap-t">
+                <button class="btn primary" id="btn-run">Run</button>
+                <button class="btn" id="btn-all">Run for all users</button>
+                <span class="spinner" id="busy"></span>
+              </div>
+            </div>
+            <div>
+              <div class="pane-title" id="rewrite-title">Rewritten SQL</div>
+              <div id="rewrite-pane">
+                <div class="callout info">Type a query to see how it is rewritten.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Result</h2>
+        <div class="tabs" id="result-tabs" role="tablist" aria-label="Result per user" hidden></div>
+        <div class="body" id="result">
+          <div class="callout info">Pick a user, choose or type a query, then run it.</div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>
+          Rules
+          <span class="h2-right">
+            <span class="dirty" id="rules-dirty" hidden>unsaved changes</span>
+            <span class="seg" id="rules-view">
+              <button type="button" data-view="grid" aria-pressed="true">Grid</button>
+              <button type="button" data-view="yaml" aria-pressed="false">YAML</button>
+            </span>
+          </span>
+        </h2>
+        <div class="body">
+          <div id="rules-grid" class="scrollx"></div>
+          <div id="rules-yaml" hidden>
+            <textarea id="yaml" spellcheck="false"></textarea>
+          </div>
+          <div class="row gap-t">
+            <button class="btn small" id="btn-add-user">Add user</button>
+            <button class="btn small" id="btn-add-table">Add table</button>
+            <span style="flex: 1"></span>
+            <button class="btn" id="btn-discard">Discard changes</button>
+            <button class="btn primary" id="btn-save">Save and reload rules</button>
+            <span id="rules-status"></span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      Every query is rewritten server-side: each referenced table becomes
+      <span class="mono">(SELECT * FROM table WHERE &lt;predicate&gt;)</span>. Fail-closed — a table without a rule for
+      the user is refused. Saving rules rewrites the rules file (keeping a
+      <span class="mono">.bak</span> copy) and restarts the MCP server process.
+    </footer>
+
+    <script>
+      // One-line persona descriptions, matching the comments in rls.example.yaml. Users that are
+      // not listed here still work — they simply render without a description.
+      const USER_DESCRIPTIONS = {
+        alice: 'Czech market only',
+        bob: 'Poland + Slovakia',
+        carol: 'DACH + Benelux (DE, AT, NL, BE)',
+        dave: 'Southern markets (ES, IT, FR), no in.c-sales.deals',
+        admin: 'Sees everything',
+      };
+      const USER_ORDER = ['alice', 'bob', 'carol', 'dave', 'admin'];
+      // Buckets used by the example queries. They match the keys in rls.example.yaml — point them
+      // at your own buckets together with the rules.
+      const CRM = '"in.c-crm"';
+      const SALES = '"in.c-sales"';
+
+      const EXAMPLES = [
+        {
+          label: 'Rows per country — invoices',
+          sql: `SELECT country, COUNT(*) AS n\nFROM ${CRM}."invoices"\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 20`,
+        },
+        {
+          label: 'Top 10 invoices by amount',
+          sql: `SELECT id, country, amount\nFROM ${CRM}."invoices"\nORDER BY amount DESC\nLIMIT 10`,
+        },
+        {
+          label: 'Orders by country and status',
+          sql: `SELECT country, status, COUNT(*) AS n\nFROM ${CRM}."orders"\nWHERE status IS NOT NULL\nGROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25`,
+        },
+        {
+          label: 'Join invoices and orders per country',
+          sql: `SELECT i.country, COUNT(*) AS matched_rows, COUNT(DISTINCT o.id) AS orders\nFROM ${CRM}."invoices" AS i\nJOIN ${CRM}."orders" AS o ON o.customer_id = i.customer_id\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 20`,
+        },
+        {
+          label: 'Deals by stage — in.c-sales.deals (refused for dave)',
+          sql: `SELECT country, stage, COUNT(*) AS n\nFROM ${SALES}."deals"\nGROUP BY 1, 2\nORDER BY 3 DESC\nLIMIT 25`,
+        },
+        {
+          label: 'Refused — RESULT_SCAN escape attempt',
+          sql: `SELECT *\nFROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))\nLIMIT 10`,
+        },
+        {
+          label: 'Refused — non-SELECT statement',
+          sql: `DELETE FROM ${CRM}."invoices"\nWHERE country = 'CZ'`,
+        },
+      ];
+
+      const $ = (id) => document.getElementById(id);
+
+      // Replaced by the first user from the rules file if this one is not present there.
+      let currentUser = 'alice';
+      /** Rules as last loaded from the server: {users, tables, yaml}. */
+      let rules = { users: [], tables: {}, yaml: '' };
+      /** Editable copy driving the Rules panel. */
+      let draft = { users: [], tables: {} };
+      let rulesView = 'grid';
+      let uiConfig = null;
+
+      const esc = (s) =>
+        String(s ?? '').replace(
+          /[&<>"']/g,
+          (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
+        );
+
+      /** Minimal RFC4180 CSV parser: handles quoted fields, embedded commas, quotes and newlines. */
+      function parseCsv(text) {
+        const rows = [];
+        let row = [];
+        let field = '';
+        let inQuotes = false;
+        for (let i = 0; i < text.length; i++) {
+          const ch = text[i];
+          if (inQuotes) {
+            if (ch === '"') {
+              if (text[i + 1] === '"') {
+                field += '"';
+                i++;
+              } else inQuotes = false;
+            } else field += ch;
+            continue;
+          }
+          if (ch === '"') inQuotes = true;
+          else if (ch === ',') {
+            row.push(field);
+            field = '';
+          } else if (ch === '\n') {
+            row.push(field);
+            rows.push(row);
+            row = [];
+            field = '';
+          } else if (ch !== '\r') field += ch;
+        }
+        if (field !== '' || row.length) {
+          row.push(field);
+          rows.push(row);
+        }
+        return rows.filter((r) => !(r.length === 1 && r[0] === ''));
+      }
+
+      // --- SQL pretty printer ------------------------------------------------------------------
+      // Keyword-based, deliberately dependency-free: it only inserts line breaks (and indents by
+      // parenthesis depth) before the clause keywords below. Quoted strings and quoted identifiers
+      // are copied verbatim so a keyword inside a literal never triggers a break.
+      const SQL_BREAK_KEYWORDS = [
+        'LEFT OUTER JOIN',
+        'RIGHT OUTER JOIN',
+        'FULL OUTER JOIN',
+        'NATURAL JOIN',
+        'CROSS JOIN',
+        'INNER JOIN',
+        'LEFT JOIN',
+        'RIGHT JOIN',
+        'FULL JOIN',
+        'GROUP BY',
+        'ORDER BY',
+        'JOIN',
+        'FROM',
+        'WHERE',
+        'HAVING',
+        'LIMIT',
+      ];
+
+      function formatSql(sql) {
+        const text = String(sql ?? '')
+          .replace(/\s+/g, ' ')
+          .trim();
+        let out = '';
+        let depth = 0;
+        let i = 0;
+        while (i < text.length) {
+          const ch = text[i];
+          if (ch === "'" || ch === '"') {
+            out += ch;
+            i++;
+            while (i < text.length) {
+              out += text[i];
+              if (text[i] === ch) {
+                if (text[i + 1] === ch) {
+                  out += text[i + 1];
+                  i += 2;
+                  continue;
+                }
+                i++;
+                break;
+              }
+              i++;
+            }
+            continue;
+          }
+          if (ch === '(') {
+            depth++;
+            out += ch;
+            i++;
+            continue;
+          }
+          if (ch === ')') {
+            depth = Math.max(0, depth - 1);
+            out += ch;
+            i++;
+            continue;
+          }
+          const atBoundary = out === '' || /[\s(]$/.test(out);
+          if (atBoundary) {
+            const rest = text.slice(i);
+            const kw = SQL_BREAK_KEYWORDS.find((k) => {
+              if (rest.slice(0, k.length).toUpperCase() !== k) return false;
+              const next = rest[k.length];
+              return next === undefined || !/[A-Za-z0-9_$]/.test(next);
+            });
+            if (kw) {
+              out = out.replace(/ +$/, '');
+              if (out !== '') out += '\n' + '  '.repeat(depth);
+              out += rest.slice(0, kw.length);
+              i += kw.length;
+              continue;
+            }
+          }
+          out += ch;
+          i++;
+        }
+        return out;
+      }
+
+      // --- shared rendering helpers ------------------------------------------------------------
+
+      function refusalHtml(msg) {
+        return `<div class="callout error"><strong>Refused</strong><span class="mono">${esc(msg)}</span></div>`;
+      }
+
+      function chipsHtml(appliedRules) {
+        if (!appliedRules || !appliedRules.length) return '';
+        return `<div class="chips">${appliedRules.map((r) => `<span class="chip">${esc(r)}</span>`).join('')}</div>`;
+      }
+
+      function csvTableHtml(csv) {
+        const rows = parseCsv(csv || '');
+        if (!rows.length) return '<div class="callout info">No rows returned.</div>';
+        const [header, ...data] = rows;
+        const thead = `<tr>${header.map((h) => `<th>${esc(h)}</th>`).join('')}</tr>`;
+        const tbody = data
+          .map((r) => `<tr>${header.map((_, i) => `<td>${esc(r[i] ?? '')}</td>`).join('')}</tr>`)
+          .join('');
+        return (
+          `<div class="meta">${data.length} row${data.length === 1 ? '' : 's'} · ${header.length} column${
+            header.length === 1 ? '' : 's'
+          }</div>` + `<div class="tablewrap"><table class="data">${thead}${tbody}</table></div>`
+        );
+      }
+
+      /** Full result panel for one user — the same markup for a single run and for a tab. */
+      function singleResultHtml(user, r) {
+        const head = `<div class="meta">Result for <strong>${esc(user)}</strong></div>`;
+        if (!r.ok) return head + refusalHtml(r.error);
+        return (
+          head +
+          chipsHtml(r.applied_rules) +
+          (r.message ? `<div class="callout info" style="margin-bottom:10px">${esc(r.message)}</div>` : '') +
+          csvTableHtml(r.csv_data)
+        );
+      }
+
+      function userOrder(list) {
+        const known = USER_ORDER.filter((u) => list.includes(u));
+        return known.concat(list.filter((u) => !USER_ORDER.includes(u)));
+      }
+
+      // --- users strip -------------------------------------------------------------------------
+
+      function renderUsers() {
+        const order = userOrder(rules.users);
+        $('users').innerHTML = order
+          .map((u) => {
+            const desc = USER_DESCRIPTIONS[u] ?? 'no description';
+            return (
+              `<button type="button" class="persona" data-user="${esc(u)}" title="${esc(desc)}" ` +
+              `aria-pressed="${u === currentUser}">` +
+              `<span class="name">${esc(u)}</span><span class="desc">${esc(desc)}</span></button>`
+            );
+          })
+          .join('');
+        for (const el of $('users').querySelectorAll('.persona')) {
+          el.addEventListener('click', () => {
+            currentUser = el.dataset.user;
+            renderUsers();
+            $('btn-run').textContent = `Run as ${currentUser}`;
+            scheduleRewrite();
+          });
+        }
+        if (!order.includes(currentUser) && order.length) {
+          currentUser = order[0];
+          $('btn-run').textContent = `Run as ${currentUser}`;
+          renderUsers();
+        }
+      }
+
+      // --- rewrite panel (live, debounced) -----------------------------------------------------
+
+      let rewriteTimer = null;
+      let rewriteToken = 0;
+
+      function scheduleRewrite() {
+        clearTimeout(rewriteTimer);
+        const delay = uiConfig?.rewriteDebounceMs;
+        if (typeof delay !== 'number') {
+          throw new Error('UI config is missing rewriteDebounceMs');
+        }
+        rewriteTimer = setTimeout(runRewrite, delay);
+      }
+
+      async function runRewrite() {
+        const sql = $('sql').value.trim();
+        $('rewrite-title').textContent = `Rewritten SQL for ${currentUser}`;
+        if (!sql) {
+          $('rewrite-pane').innerHTML = '<div class="callout info">Type a query to see how it is rewritten.</div>';
+          return;
+        }
+        const token = ++rewriteToken;
+        try {
+          const r = await postJson('/api/rewrite', { user: currentUser, sql });
+          if (token !== rewriteToken) return; // a newer request already won
+          $('rewrite-pane').innerHTML = r.ok
+            ? chipsHtml(r.applied_rules) + `<pre class="sqlout">${esc(formatSql(r.sql))}</pre>`
+            : refusalHtml(r.error);
+        } catch (e) {
+          if (token !== rewriteToken) return;
+          $('rewrite-pane').innerHTML = refusalHtml(`Rewrite preview failed: ${e.message}`);
+        }
+      }
+
+      // --- result tabs -------------------------------------------------------------------------
+
+      /** @type {{key: string, label: string, badge?: string, bad?: boolean, html: string}[]} */
+      let resultTabs = [];
+      let activeTab = 0;
+
+      function renderResultTabs() {
+        const bar = $('result-tabs');
+        if (resultTabs.length < 2) {
+          bar.hidden = true;
+          bar.innerHTML = '';
+        } else {
+          bar.hidden = false;
+          bar.innerHTML = resultTabs
+            .map(
+              (t, i) =>
+                `<button type="button" class="tab" role="tab" id="tab-${esc(t.key)}" ` +
+                `aria-selected="${i === activeTab}" aria-controls="result" tabindex="${i === activeTab ? 0 : -1}" ` +
+                `data-index="${i}">${esc(t.label)}` +
+                (t.badge ? `<span class="badge${t.bad ? ' bad' : ''}">${esc(t.badge)}</span>` : '') +
+                '</button>'
+            )
+            .join('');
+          for (const el of bar.querySelectorAll('.tab')) {
+            el.addEventListener('click', () => selectTab(Number(el.dataset.index)));
+            el.addEventListener('keydown', (ev) => {
+              if (ev.key !== 'ArrowRight' && ev.key !== 'ArrowLeft') return;
+              ev.preventDefault();
+              const step = ev.key === 'ArrowRight' ? 1 : -1;
+              const next = (Number(el.dataset.index) + step + resultTabs.length) % resultTabs.length;
+              selectTab(next);
+              bar.querySelectorAll('.tab')[next].focus();
+            });
+          }
+        }
+        $('result').innerHTML = resultTabs.length ? resultTabs[activeTab].html : '';
+      }
+
+      function selectTab(index) {
+        activeTab = index;
+        renderResultTabs();
+      }
+
+      function showResult(tabs) {
+        resultTabs = tabs;
+        activeTab = 0;
+        renderResultTabs();
+      }
+
+      // --- running queries ---------------------------------------------------------------------
+
+      async function postJson(path, body, method) {
+        const res = await fetch(path, {
+          method: method || 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        return res.json();
+      }
+
+      function setBusy(on, text) {
+        $('busy').textContent = on ? text || 'working…' : '';
+        for (const id of ['btn-run', 'btn-all']) $(id).disabled = on;
+      }
+
+      async function doRun() {
+        const sql = $('sql').value.trim();
+        if (!sql) return;
+        setBusy(true, `running as ${currentUser}…`);
+        try {
+          const r = await postJson('/api/query', { user: currentUser, sql });
+          showResult([{ key: currentUser, label: currentUser, html: singleResultHtml(currentUser, r) }]);
+        } finally {
+          setBusy(false);
+        }
+      }
+
+      async function doRunAll() {
+        const sql = $('sql').value.trim();
+        if (!sql) return;
+        const order = userOrder(rules.users);
+        const results = [];
+        setBusy(true, 'running for all users…');
+        try {
+          for (const user of order) {
+            $('busy').textContent = `running as ${user}…`;
+            const r = await postJson('/api/query', { user, sql });
+            results.push({ user, r });
+          }
+          const rows = results
+            .map(({ user, r }) => {
+              if (!r.ok) {
+                return `<tr><th class="rowhead">${esc(user)}</th><td class="refusal" colspan="2">${esc(
+                  r.error
+                )}</td></tr>`;
+              }
+              const parsed = parseCsv(r.csv_data || '');
+              const n = Math.max(parsed.length - 1, 0);
+              return (
+                `<tr><th class="rowhead">${esc(user)}</th>` +
+                `<td class="rules">${(r.applied_rules || []).map(esc).join('<br>')}</td>` +
+                `<td>${n} row${n === 1 ? '' : 's'}</td></tr>`
+              );
+            })
+            .join('');
+          const summary =
+            `<div class="meta">Same query, ${results.length} user${results.length === 1 ? '' : 's'}</div>` +
+            '<div class="scrollx"><table class="grid cmp">' +
+            '<tr><th>User</th><th>Applied rules</th><th>Outcome</th></tr>' +
+            rows +
+            '</table></div>';
+          showResult(
+            [{ key: 'summary', label: 'Summary', html: summary }].concat(
+              results.map(({ user, r }) => ({
+                key: user,
+                label: user,
+                badge: r.ok ? `${Math.max(parseCsv(r.csv_data || '').length - 1, 0)}` : 'refused',
+                bad: !r.ok,
+                html: singleResultHtml(user, r),
+              }))
+            )
+          );
+        } finally {
+          setBusy(false);
+        }
+      }
+
+      // --- rules editor ------------------------------------------------------------------------
+
+      function draftFromRules() {
+        return {
+          users: userOrder(rules.users),
+          tables: Object.fromEntries(
+            Object.entries(rules.tables).map(([t, perUser]) => [t, { ...(perUser ?? {}) }])
+          ),
+        };
+      }
+
+      /** Serialise the draft back to YAML, with a short header explaining the format. */
+      function draftToYaml(d) {
+        const quote = (s) => `"${String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+        const lines = [
+          '# Row-level security rules for the RLS pilot demo (Keboola MCP Server).',
+          '#',
+          '# table -> user -> SQL predicate. Each predicate is inserted verbatim into',
+          '#   SELECT * FROM <table> WHERE <predicate>',
+          '# and must be valid SQL in the workspace dialect (Snowflake here).',
+          '#',
+          '# Fail-closed: a table with no rule for the user is refused. Unrestricted access must be',
+          '# written explicitly as TRUE. Keys use the <bucket>.<table> form; user names are matched',
+          '# case-insensitively.',
+          '#',
+          '# Written by the RLS demo rules editor.',
+          '',
+          'tables:',
+        ];
+        for (const [table, perUser] of Object.entries(d.tables)) {
+          lines.push(`  ${table}:`);
+          for (const user of d.users) {
+            const pred = (perUser?.[user] ?? '').trim();
+            if (pred) lines.push(`    ${user}: ${quote(pred)}`);
+          }
+          lines.push('');
+        }
+        return lines.join('\n');
+      }
+
+      function currentYamlFromView() {
+        return rulesView === 'yaml' ? $('yaml').value : draftToYaml(draft);
+      }
+
+      function isDirty() {
+        return rulesView === 'yaml' ? $('yaml').value !== rules.yaml : draftToYaml(draft) !== draftToYaml(draftFromRules());
+      }
+
+      function markDirty() {
+        $('rules-dirty').hidden = !isDirty();
+      }
+
+      function renderRulesGrid() {
+        const users = draft.users;
+        const head =
+          '<tr><th>Table</th>' +
+          users
+            .map(
+              (u) =>
+                `<th><span class="colhead"><span class="uname">${esc(u)}</span>` +
+                `<button type="button" class="rm" data-rm-user="${esc(u)}" title="Remove user ${esc(
+                  u
+                )}">&times;</button></span></th>`
+            )
+            .join('') +
+          '</tr>';
+        const body = Object.entries(draft.tables)
+          .map(([table, perUser]) => {
+            const dot = table.lastIndexOf('.');
+            const bucket = dot >= 0 ? table.slice(0, dot + 1) : '';
+            const shortName = dot >= 0 ? table.slice(dot + 1) : table;
+            const cells = users
+              .map((u) => {
+                const pred = perUser?.[u] ?? '';
+                return (
+                  `<td><input class="cell${pred ? '' : ' empty'}" type="text" spellcheck="false" ` +
+                  `data-table="${esc(table)}" data-user="${esc(u)}" value="${esc(pred)}" ` +
+                  `placeholder="no rule" aria-label="${esc(u)} on ${esc(table)}" /></td>`
+                );
+              })
+              .join('');
+            return (
+              `<tr><th class="rowhead" title="${esc(table)}">` +
+              `<button type="button" class="rm" data-rm-table="${esc(table)}" title="Remove table ${esc(
+                table
+              )}">&times;</button> ` +
+              `<span class="bucket">${esc(bucket)}</span><span class="tname">${esc(shortName)}</span></th>${cells}</tr>`
+            );
+          })
+          .join('');
+        $('rules-grid').innerHTML = `<table class="grid">${head}${body}</table>`;
+
+        for (const input of $('rules-grid').querySelectorAll('input.cell')) {
+          input.addEventListener('input', () => {
+            const { table, user } = input.dataset;
+            const value = input.value;
+            if (value.trim()) draft.tables[table][user] = value;
+            else delete draft.tables[table][user];
+            input.classList.toggle('empty', !value.trim());
+            markDirty();
+          });
+        }
+        for (const btn of $('rules-grid').querySelectorAll('[data-rm-user]')) {
+          btn.addEventListener('click', () => {
+            const user = btn.dataset.rmUser;
+            draft.users = draft.users.filter((u) => u !== user);
+            for (const perUser of Object.values(draft.tables)) delete perUser[user];
+            renderRulesGrid();
+            markDirty();
+          });
+        }
+        for (const btn of $('rules-grid').querySelectorAll('[data-rm-table]')) {
+          btn.addEventListener('click', () => {
+            delete draft.tables[btn.dataset.rmTable];
+            renderRulesGrid();
+            markDirty();
+          });
+        }
+      }
+
+      function setRulesView(view) {
+        // Carry edits across the switch: grid -> YAML regenerates the text, YAML -> grid re-parses.
+        if (view === 'yaml' && rulesView === 'grid') $('yaml').value = draftToYaml(draft);
+        rulesView = view;
+        for (const b of $('rules-view').querySelectorAll('button')) {
+          b.setAttribute('aria-pressed', String(b.dataset.view === view));
+        }
+        $('rules-grid').hidden = view !== 'grid';
+        $('rules-yaml').hidden = view !== 'yaml';
+        markDirty();
+      }
+
+      function setRulesStatus(text, kind) {
+        $('rules-status').textContent = text;
+        $('rules-status').className = kind || '';
+      }
+
+      function applyRules(payload) {
+        rules = { users: payload.users, tables: payload.tables, yaml: payload.yaml ?? '' };
+        draft = draftFromRules();
+        $('yaml').value = rules.yaml;
+        renderUsers();
+        renderRulesGrid();
+        markDirty();
+      }
+
+      async function saveRules() {
+        const yamlText = currentYamlFromView();
+        setRulesStatus('validating and restarting the MCP server…');
+        for (const id of ['btn-save', 'btn-discard', 'btn-add-user', 'btn-add-table', 'btn-run', 'btn-all'])
+          $(id).disabled = true;
+        try {
+          const r = await postJson('/api/rules', { yaml: yamlText }, 'PUT');
+          if (!r.ok) {
+            setRulesStatus(r.error, 'bad');
+            return;
+          }
+          applyRules(r);
+          setRulesStatus('saved · rules file rewritten · MCP server restarted', 'good');
+          await refreshStatus();
+          scheduleRewrite();
+        } catch (e) {
+          setRulesStatus(`Save failed: ${e.message}`, 'bad');
+        } finally {
+          for (const id of ['btn-save', 'btn-discard', 'btn-add-user', 'btn-add-table', 'btn-run', 'btn-all'])
+            $(id).disabled = false;
+        }
+      }
+
+      function discardRules() {
+        draft = draftFromRules();
+        $('yaml').value = rules.yaml;
+        renderRulesGrid();
+        markDirty();
+        setRulesStatus('');
+      }
+
+      function addUser() {
+        const name = (prompt('New user name (lower-case, e.g. erin)') || '').trim().toLowerCase();
+        if (!name) return;
+        if (draft.users.includes(name)) {
+          setRulesStatus(`User "${name}" already exists.`, 'bad');
+          return;
+        }
+        draft.users.push(name);
+        setRulesView('grid');
+        renderRulesGrid();
+        markDirty();
+        setRulesStatus('');
+      }
+
+      function addTable() {
+        const key = (prompt('New table key in the <bucket>.<table> form') || '').trim();
+        if (!key) return;
+        if (draft.tables[key]) {
+          setRulesStatus(`Table "${key}" already exists.`, 'bad');
+          return;
+        }
+        draft.tables[key] = {};
+        setRulesView('grid');
+        renderRulesGrid();
+        markDirty();
+        setRulesStatus('');
+      }
+
+      // --- header status -----------------------------------------------------------------------
+
+      async function refreshStatus() {
+        try {
+          const t = await (await fetch('/api/tools')).json();
+          const tools = t.tools || [];
+          const hasRls = tools.includes('query_data_rls');
+          const hasPlain = tools.includes('query_data');
+          $('status').className = 'status ' + (hasRls && !hasPlain ? 'up' : 'down');
+          $('status-text').textContent =
+            `MCP connected · ${tools.length} tools · query_data_rls ${hasRls ? 'registered' : 'MISSING'}` +
+            ` · query_data ${hasPlain ? 'REGISTERED' : 'not registered'}`;
+          $('status').title = tools.join(', ');
+        } catch (e) {
+          $('status').className = 'status down';
+          $('status-text').textContent = 'MCP server unreachable';
+        }
+      }
+
+      // --- init --------------------------------------------------------------------------------
+
+      function renderExamples() {
+        $('examples').innerHTML =
+          '<option value="">— choose an example —</option>' +
+          EXAMPLES.map((e, i) => `<option value="${i}">${esc(e.label)}</option>`).join('');
+        $('examples').addEventListener('change', (ev) => {
+          const i = ev.target.value;
+          if (i !== '') {
+            $('sql').value = EXAMPLES[Number(i)].sql;
+            scheduleRewrite();
+          }
+        });
+      }
+
+      async function init() {
+        renderExamples();
+        $('sql').value = EXAMPLES[0].sql;
+
+        const cfg = await (await fetch('/api/config')).json();
+        uiConfig = cfg.ui;
+
+        applyRules(await (await fetch('/api/rules')).json());
+
+        $('btn-run').textContent = `Run as ${currentUser}`;
+        $('btn-run').addEventListener('click', doRun);
+        $('btn-all').addEventListener('click', doRunAll);
+        $('sql').addEventListener('input', scheduleRewrite);
+        $('yaml').addEventListener('input', markDirty);
+        $('btn-save').addEventListener('click', saveRules);
+        $('btn-discard').addEventListener('click', discardRules);
+        $('btn-add-user').addEventListener('click', addUser);
+        $('btn-add-table').addEventListener('click', addTable);
+        for (const b of $('rules-view').querySelectorAll('button')) {
+          b.addEventListener('click', () => setRulesView(b.dataset.view));
+        }
+
+        await refreshStatus();
+        runRewrite();
+      }
+
+      init();
+    </script>
+  </body>
+</html>

--- a/examples/rls-demo/public/index.html
+++ b/examples/rls-demo/public/index.html
@@ -1080,6 +1080,8 @@
           '#',
           '# Written by the RLS demo rules editor.',
           '',
+          'dialect: snowflake',
+          '',
           'tables:',
         ];
         for (const [table, perUser] of Object.entries(d.tables)) {

--- a/examples/rls-demo/public/index.html
+++ b/examples/rls-demo/public/index.html
@@ -126,11 +126,24 @@
         padding: 0;
       }
 
-      /* Users strip */
+      /* Sign-in strip */
       .strip {
         display: flex;
         gap: 8px;
         flex-wrap: wrap;
+      }
+      .signed-in {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 12px;
+        font-size: 12.5px;
+        color: var(--ink-soft);
+      }
+      .signed-in .who {
+        font-family: 'IBM Plex Mono', monospace;
+        font-weight: 600;
+        color: var(--ink);
       }
       .persona {
         border: 1px solid var(--line-strong);
@@ -555,14 +568,15 @@
   <body>
     <header>
       <h1>Keboola MCP Server — Row-Level Security</h1>
-      <span class="sub">pilot demo · local only · read-only queries</span>
+      <span class="sub">pilot demo · authenticating wrapper · local only · read-only queries</span>
       <span class="status" id="status"><span class="dot"></span><span id="status-text">connecting…</span></span>
     </header>
 
     <main>
       <section class="card">
-        <h2>Users</h2>
+        <h2>Sign in</h2>
         <div class="body">
+          <div class="signed-in" id="signed-in"></div>
           <div class="strip" id="users"></div>
         </div>
       </section>
@@ -598,7 +612,7 @@
         <h2>Result</h2>
         <div class="tabs" id="result-tabs" role="tablist" aria-label="Result per user" hidden></div>
         <div class="body" id="result">
-          <div class="callout info">Pick a user, choose or type a query, then run it.</div>
+          <div class="callout info">Sign in, choose or type a query, then run it.</div>
         </div>
       </section>
 
@@ -631,10 +645,11 @@
     </main>
 
     <footer>
-      Every query is rewritten server-side: each referenced table becomes
-      <span class="mono">(SELECT * FROM table WHERE &lt;predicate&gt;)</span>. Fail-closed — a table without a rule for
-      the user is refused. Saving rules rewrites the rules file (keeping a
-      <span class="mono">.bak</span> copy) and restarts the MCP server process.
+      This page never names the user: the demo signs you in and asserts that principal to the MCP server in the
+      <span class="mono">X-RLS-Principal</span> header on every call. Every query is then rewritten server-side —
+      each referenced table becomes <span class="mono">(SELECT * FROM table WHERE &lt;predicate&gt;)</span>.
+      Fail-closed — a table without a rule for the principal is refused. Saving rules rewrites the rules file
+      (keeping a <span class="mono">.bak</span> copy) and restarts the MCP server process.
     </footer>
 
     <script>
@@ -686,8 +701,9 @@
 
       const $ = (id) => document.getElementById(id);
 
-      // Replaced by the first user from the rules file if this one is not present there.
-      let currentUser = 'alice';
+      /** The signed-in principal, or null. Set only by the server's /api/session and /api/login —
+          the page never picks an identity for a query, it only asks to be signed in as one. */
+      let currentUser = null;
       /** Rules as last loaded from the server: {users, tables, yaml}. */
       let rules = { users: [], tables: {}, yaml: '' };
       /** Editable copy driving the Rules panel. */
@@ -863,7 +879,9 @@
         return known.concat(list.filter((u) => !USER_ORDER.includes(u)));
       }
 
-      // --- users strip -------------------------------------------------------------------------
+      // --- mock sign-in ------------------------------------------------------------------------
+      // Choosing a persona IS the login: it posts to /api/login, which is where the demo (playing
+      // the wrapper application) decides who the user is. From then on the browser sends only SQL.
 
       function renderUsers() {
         const order = userOrder(rules.users);
@@ -878,18 +896,41 @@
           })
           .join('');
         for (const el of $('users').querySelectorAll('.persona')) {
-          el.addEventListener('click', () => {
-            currentUser = el.dataset.user;
-            renderUsers();
-            $('btn-run').textContent = `Run as ${currentUser}`;
-            scheduleRewrite();
-          });
+          el.addEventListener('click', () => signIn(el.dataset.user));
         }
-        if (!order.includes(currentUser) && order.length) {
-          currentUser = order[0];
-          $('btn-run').textContent = `Run as ${currentUser}`;
-          renderUsers();
+        renderSignedIn();
+      }
+
+      function renderSignedIn() {
+        const idp = uiConfig?.idpLabel ?? 'mock IdP';
+        $('signed-in').innerHTML = currentUser
+          ? `Signed in as <span class="who">${esc(currentUser)}</span> (${esc(idp)}) ` +
+            '<button type="button" class="btn small" id="btn-signout">Sign out</button>'
+          : `<span>Not signed in — choose a user below to sign in (${esc(idp)}).</span>`;
+        const out = $('btn-signout');
+        if (out) out.addEventListener('click', signOut);
+        $('btn-run').textContent = currentUser ? `Run as ${currentUser}` : 'Run';
+        $('btn-run').disabled = !currentUser;
+        $('btn-all').disabled = !currentUser;
+      }
+
+      async function signIn(principal) {
+        const r = await postJson('/api/login', { principal });
+        if (!r.ok) {
+          $('result').innerHTML = refusalHtml(r.error);
+          return;
         }
+        currentUser = r.principal;
+        renderUsers();
+        scheduleRewrite();
+      }
+
+      async function signOut() {
+        await postJson('/api/logout', {});
+        currentUser = null;
+        renderUsers();
+        $('rewrite-pane').innerHTML = '<div class="callout info">Sign in to see how a query is rewritten.</div>';
+        $('rewrite-title').textContent = 'Rewritten SQL';
       }
 
       // --- rewrite panel (live, debounced) -----------------------------------------------------
@@ -908,6 +949,11 @@
 
       async function runRewrite() {
         const sql = $('sql').value.trim();
+        if (!currentUser) {
+          $('rewrite-title').textContent = 'Rewritten SQL';
+          $('rewrite-pane').innerHTML = '<div class="callout info">Sign in to see how a query is rewritten.</div>';
+          return;
+        }
         $('rewrite-title').textContent = `Rewritten SQL for ${currentUser}`;
         if (!sql) {
           $('rewrite-pane').innerHTML = '<div class="callout info">Type a query to see how it is rewritten.</div>';
@@ -915,7 +961,7 @@
         }
         const token = ++rewriteToken;
         try {
-          const r = await postJson('/api/rewrite', { user: currentUser, sql });
+          const r = await postJson('/api/rewrite', { sql });
           if (token !== rewriteToken) return; // a newer request already won
           $('rewrite-pane').innerHTML = r.ok
             ? chipsHtml(r.applied_rules) + `<pre class="sqlout">${esc(formatSql(r.sql))}</pre>`
@@ -988,15 +1034,17 @@
 
       function setBusy(on, text) {
         $('busy').textContent = on ? text || 'working…' : '';
-        for (const id of ['btn-run', 'btn-all']) $(id).disabled = on;
+        // Signed out is also "cannot run": the run buttons stay disabled until there is a principal.
+        for (const id of ['btn-run', 'btn-all']) $(id).disabled = on || !currentUser;
       }
 
       async function doRun() {
         const sql = $('sql').value.trim();
-        if (!sql) return;
+        if (!sql || !currentUser) return;
         setBusy(true, `running as ${currentUser}…`);
         try {
-          const r = await postJson('/api/query', { user: currentUser, sql });
+          // No principal in the body: the server takes it from the session it signed us into.
+          const r = await postJson('/api/query', { sql });
           showResult([{ key: currentUser, label: currentUser, html: singleResultHtml(currentUser, r) }]);
         } finally {
           setBusy(false);
@@ -1005,16 +1053,17 @@
 
       async function doRunAll() {
         const sql = $('sql').value.trim();
-        if (!sql) return;
-        const order = userOrder(rules.users);
-        const results = [];
+        if (!sql || !currentUser) return;
         setBusy(true, 'running for all users…');
         try {
-          for (const user of order) {
-            $('busy').textContent = `running as ${user}…`;
-            const r = await postJson('/api/query', { user, sql });
-            results.push({ user, r });
+          // Admin-style comparison: the server iterates the sign-ins, so the browser still never
+          // names a principal.
+          const all = await postJson('/api/query-all', { sql });
+          if (!all.ok) {
+            showResult([{ key: 'error', label: 'Error', html: refusalHtml(all.error) }]);
+            return;
           }
+          const results = all.results.map(({ principal, result }) => ({ user: principal, r: result }));
           const rows = results
             .map(({ user, r }) => {
               if (!r.ok) {
@@ -1070,13 +1119,17 @@
         const lines = [
           '# Row-level security rules for the RLS pilot demo (Keboola MCP Server).',
           '#',
-          '# table -> user -> SQL predicate. Each predicate is inserted verbatim into',
+          '# table -> principal -> SQL predicate. Each predicate is inserted verbatim into',
           '#   SELECT * FROM <table> WHERE <predicate>',
           '# and must be valid SQL in the workspace dialect (Snowflake here).',
           '#',
-          '# Fail-closed: a table with no rule for the user is refused. Unrestricted access must be',
-          '# written explicitly as TRUE. Keys use the <bucket>.<table> form; user names are matched',
-          '# case-insensitively.',
+          '# The principals are whatever strings the calling application asserts in X-RLS-Principal',
+          '# (here: the demo\'s mock sign-in). E-mail addresses, IdP subject ids and group names all',
+          '# work, as long as they match what the application sends.',
+          '#',
+          '# Fail-closed: a table with no rule for the principal is refused. Unrestricted access must',
+          '# be written explicitly as TRUE. Keys use the <bucket>.<table> form; principals are',
+          '# matched case-insensitively.',
           '#',
           '# Written by the RLS demo rules editor.',
           '',
@@ -1221,6 +1274,8 @@
         } finally {
           for (const id of ['btn-save', 'btn-discard', 'btn-add-user', 'btn-add-table', 'btn-run', 'btn-all'])
             $(id).disabled = false;
+          // ... except the run buttons, which stay disabled while signed out.
+          renderSignedIn();
         }
       }
 
@@ -1301,9 +1356,11 @@
         const cfg = await (await fetch('/api/config')).json();
         uiConfig = cfg.ui;
 
+        // Who the server says we are (a page reload keeps the mock sign-in cookie).
+        currentUser = (await (await fetch('/api/session')).json()).principal ?? null;
+
         applyRules(await (await fetch('/api/rules')).json());
 
-        $('btn-run').textContent = `Run as ${currentUser}`;
         $('btn-run').addEventListener('click', doRun);
         $('btn-all').addEventListener('click', doRunAll);
         $('sql').addEventListener('input', scheduleRewrite);

--- a/examples/rls-demo/public/index.html
+++ b/examples/rls-demo/public/index.html
@@ -884,9 +884,14 @@
           : `<span>Not signed in — choose a user below to sign in (${esc(idp)}).</span>`;
         const out = $('btn-signout');
         if (out) out.addEventListener('click', signOut);
-        $('btn-run').textContent = currentUser ? `Run as ${currentUser}` : 'Run';
+        // Nothing runs without a principal: the wrapper never sends a query on behalf of "nobody",
+        // so the buttons say why they are disabled instead of just greying out.
+        const hint = `Sign in above (${idp}) first — every query runs as someone.`;
+        $('btn-run').textContent = currentUser ? `Run as ${currentUser}` : 'Sign in to run';
         $('btn-run').disabled = !currentUser;
+        $('btn-run').title = currentUser ? '' : hint;
         $('btn-all').disabled = !currentUser;
+        $('btn-all').title = currentUser ? '' : hint;
       }
 
       async function signIn(principal) {

--- a/examples/rls-demo/rls.example.yaml
+++ b/examples/rls-demo/rls.example.yaml
@@ -22,6 +22,10 @@
 #
 # The tables below are placeholders: replace them with tables that exist in your own project.
 
+# Required: the workspace backend these predicates are written for. Predicates are never
+# transpiled, so the server refuses to apply this file to a workspace of any other dialect.
+dialect: snowflake
+
 tables:
   in.c-crm.invoices:
     alice: "country = 'CZ'"

--- a/examples/rls-demo/rls.example.yaml
+++ b/examples/rls-demo/rls.example.yaml
@@ -4,14 +4,18 @@
 # (RLS_RULES_PATH, `rls.yaml` by default), which is git-ignored — edit that copy, or edit the rules
 # in the UI, and this template stays untouched.
 #
-# table -> user -> SQL predicate. Predicates are inserted verbatim into
+# table -> principal -> SQL predicate. Predicates are inserted verbatim into
 #   SELECT * FROM <table> WHERE <predicate>
 # and must be written in the workspace dialect (Snowflake here). Fail-closed:
-# a table without a rule for the user, or a user without a rule on a table, is refused.
+# a table without a rule for the principal, or a principal without a rule on a table, is refused.
 # Unrestricted access must be written explicitly as TRUE.
 #
+# The principals are whatever strings the calling application asserts in the X-RLS-Principal header
+# (here: the demo's mock sign-in). E-mail addresses, IdP subject ids or group names work just as
+# well as the short names below — they only have to match what the application sends.
+#
 # Keys are always <bucket>.<table>, so a rule only ever covers that one table in that one
-# bucket; a query must name the bucket too. User names are matched case-insensitively.
+# bucket; a query must name the bucket too. Principals are matched case-insensitively.
 #
 # Demo personas (the tables are assumed to have a `country` column):
 #   alice - Czech market only

--- a/examples/rls-demo/rls.example.yaml
+++ b/examples/rls-demo/rls.example.yaml
@@ -10,8 +10,8 @@
 # a table without a rule for the user, or a user without a rule on a table, is refused.
 # Unrestricted access must be written explicitly as TRUE.
 #
-# Keys use the <bucket>.<table> form so they only match tables in that bucket.
-# User names are matched case-insensitively.
+# Keys are always <bucket>.<table>, so a rule only ever covers that one table in that one
+# bucket; a query must name the bucket too. User names are matched case-insensitively.
 #
 # Demo personas (the tables are assumed to have a `country` column):
 #   alice - Czech market only

--- a/examples/rls-demo/rls.example.yaml
+++ b/examples/rls-demo/rls.example.yaml
@@ -1,0 +1,45 @@
+# Example row-level security rules for the RLS pilot demo (Keboola MCP Server).
+#
+# This file is a TEMPLATE. On first start the demo copies it to the configured rules file
+# (RLS_RULES_PATH, `rls.yaml` by default), which is git-ignored — edit that copy, or edit the rules
+# in the UI, and this template stays untouched.
+#
+# table -> user -> SQL predicate. Predicates are inserted verbatim into
+#   SELECT * FROM <table> WHERE <predicate>
+# and must be written in the workspace dialect (Snowflake here). Fail-closed:
+# a table without a rule for the user, or a user without a rule on a table, is refused.
+# Unrestricted access must be written explicitly as TRUE.
+#
+# Keys use the <bucket>.<table> form so they only match tables in that bucket.
+# User names are matched case-insensitively.
+#
+# Demo personas (the tables are assumed to have a `country` column):
+#   alice - Czech market only
+#   bob   - Poland + Slovakia
+#   carol - DACH + Benelux (DE, AT, NL, BE)
+#   dave  - southern markets (ES, IT, FR), no access to in.c-sales.deals at all
+#   admin - sees everything (TRUE)
+#
+# The tables below are placeholders: replace them with tables that exist in your own project.
+
+tables:
+  in.c-crm.invoices:
+    alice: "country = 'CZ'"
+    bob:   "country IN ('PL', 'SK')"
+    carol: "country IN ('DE', 'AT', 'NL', 'BE')"
+    dave:  "country IN ('ES', 'IT', 'FR')"
+    admin: "TRUE"
+
+  in.c-crm.orders:
+    alice: "country = 'CZ'"
+    bob:   "country IN ('PL', 'SK')"
+    carol: "country IN ('DE', 'AT', 'NL', 'BE')"
+    dave:  "country IN ('ES', 'IT', 'FR')"
+    admin: "TRUE"
+
+  in.c-sales.deals:
+    alice: "country = 'CZ'"
+    bob:   "country IN ('PL', 'SK')"
+    carol: "country IN ('DE', 'AT', 'NL', 'BE')"
+    # dave intentionally has no rule here -> any query touching in.c-sales.deals is refused for him
+    admin: "TRUE"

--- a/examples/rls-demo/server.mjs
+++ b/examples/rls-demo/server.mjs
@@ -1,13 +1,22 @@
-// RLS demo server.
+// RLS demo server — an *authenticating wrapper* around the Keboola MCP Server.
 //
-// Boots a single stdio MCP session against the Keboola MCP Server running in RLS mode and exposes a
-// tiny HTTP API for the browser UI:
+// This app plays the role the row-level-security design expects of a real application: it
+// authenticates its own users (here: a mock sign-in standing in for AD / Google / Okta / an app
+// session), and it is the only client of the MCP server. The MCP server is started in RLS mode with
+// KBC_RLS_PRINCIPAL_SOURCE=header and listens on loopback; this app asserts the signed-in user on
+// every call in the `X-RLS-Principal` header. The identity is therefore never a tool argument, and
+// neither the browser nor a model can choose it.
+//
 //   GET  /              -> public/index.html
 //   GET  /api/config    -> UI-only constants (no secrets, no paths)
+//   GET  /api/session   -> {principal} of the current sign-in, or {principal: null}
+//   POST /api/login     -> mock IdP: sign in as one of the principals in the rules file
+//   POST /api/logout    -> sign out
 //   GET  /api/rules     -> {users, tables, yaml} parsed from the rules file
 //   PUT  /api/rules     -> validates + writes the rules file, then restarts the MCP process
 //   GET  /api/tools     -> tool names reported by the MCP server
-//   POST /api/query     -> runs query_data_rls for a user
+//   POST /api/query     -> runs query_data_rls as the signed-in principal
+//   POST /api/query-all -> admin comparison: runs the same query as every principal, server-side
 //   POST /api/rewrite   -> shows the rewritten SQL without executing it
 //
 // SECURITY: the Keboola Storage API token comes from the environment (see config.mjs) and is passed
@@ -17,13 +26,14 @@
 import http from 'node:http';
 import { readFile, writeFile, copyFile, mkdtemp, rm, access } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import YAML from 'yaml';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 import { config } from './config.mjs';
 
@@ -143,7 +153,7 @@ function validateRulesFile(filePath) {
  * Validate, persist and activate a new rules file.
  *
  * Nothing is written unless `RlsRules.load()` accepts the candidate YAML. The MCP server reads its
- * rules once at startup (there is deliberately no hot reload), so the stdio process is restarted —
+ * rules once at startup (there is deliberately no hot reload), so the server process is restarted —
  * inside the call queue, so no query ever runs against a half-restarted server.
  *
  * @param {string} yamlText
@@ -183,12 +193,15 @@ async function saveRules(yamlText) {
 
 // --- MCP session -----------------------------------------------------------------------------
 
-/** @type {Client | null} */
-let mcpClient = null;
+/** The spawned Keboola MCP Server process (streamable-HTTP, RLS header mode). */
+let mcpProcess = null;
+/** One client (and thus one transport, carrying one `X-RLS-Principal` value) per principal. */
+const mcpClients = new Map();
 /** @type {string[]} */
 let toolNames = [];
 
-// The stdio client is a single session: serialise every tool call behind one promise chain.
+// Rules reloads restart the MCP process, so every call is serialised behind one promise chain and a
+// restart runs inside it: no query can hit a half-restarted server.
 let callChain = Promise.resolve();
 
 /**
@@ -213,63 +226,135 @@ function mcpEnv() {
     ...process.env,
     KBC_STORAGE_API_URL: config.keboola.stackUrl,
     KBC_STORAGE_TOKEN: config.keboola.token,
+    // The whole point of this demo: the server takes the principal from the header this app sets,
+    // and refuses a `principal` tool argument outright.
+    KBC_RLS_PRINCIPAL_SOURCE: config.mcp.principalSource,
   };
   if (config.keboola.workspaceId) env.KBC_WORKSPACE_ID = config.keboola.workspaceId;
   else delete env.KBC_WORKSPACE_ID;
   return env;
 }
 
-async function startMcp() {
-  const transport = new StdioClientTransport({
-    command: config.mcp.command,
-    args: ['--transport', 'stdio', '--rls-rules-path', config.mcp.rulesPath],
-    env: mcpEnv(),
-    stderr: 'inherit',
+/** Resolve once the spawned server answers its health check, or reject with why it did not. */
+async function waitForMcpReady() {
+  const deadline = Date.now() + config.mcp.readyTimeoutMs;
+  for (;;) {
+    if (mcpProcess === null || mcpProcess.exitCode !== null || mcpProcess.signalCode !== null) {
+      throw new Error('the MCP server process exited during startup (see its log output above)');
+    }
+    try {
+      const res = await fetch(config.mcp.healthUrl);
+      if (res.ok) return;
+    } catch {
+      /* not listening yet */
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`the MCP server did not become ready within ${config.mcp.readyTimeoutMs} ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, config.mcp.readyPollIntervalMs));
+  }
+}
+
+/**
+ * The MCP client for one principal, created on first use.
+ *
+ * One client per principal, because the principal is a *transport* property here: the header is set
+ * on the transport's `requestInit` and therefore travels with every request that client makes. The
+ * server runs stateless (its default), so per-request headers are honoured on every call.
+ * @param {string} principal
+ * @returns {Promise<Client>}
+ */
+async function clientFor(principal) {
+  const existing = mcpClients.get(principal);
+  if (existing) return existing;
+  const transport = new StreamableHTTPClientTransport(new URL(config.mcp.url), {
+    requestInit: { headers: { [config.mcp.principalHeader]: principal } },
   });
   const client = new Client(
     { name: config.mcp.clientName, version: config.mcp.clientVersion },
     { capabilities: {} }
   );
   await client.connect(transport, { timeout: config.mcp.startupTimeoutMs });
-  const listed = await client.listTools();
-  mcpClient = client;
+  mcpClients.set(principal, client);
+  return client;
+}
+
+async function startMcp() {
+  mcpProcess = spawn(
+    config.mcp.command,
+    [
+      '--transport',
+      'streamable-http',
+      '--host',
+      config.mcp.host,
+      '--port',
+      String(config.mcp.port),
+      '--rls-rules-path',
+      config.mcp.rulesPath,
+    ],
+    { env: mcpEnv(), stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  mcpProcess.on('exit', (code, signal) => {
+    console.log(`[rls-demo] the MCP server process exited (code=${code}, signal=${signal})`);
+  });
+  await waitForMcpReady();
+  // Tool discovery needs no principal: `tools/list` is not an RLS-guarded call.
+  const listed = await (await clientFor('')).listTools();
   toolNames = (listed.tools ?? []).map((t) => t.name).sort();
   return toolNames;
 }
 
+/** Close every per-principal client and stop the spawned MCP server process. */
+async function stopMcp() {
+  for (const [principal, client] of mcpClients) {
+    try {
+      await client.close();
+    } catch (e) {
+      console.error(`[rls-demo] closing the MCP client for "${principal}" failed: ${e?.message ?? e}`);
+    }
+  }
+  mcpClients.clear();
+  toolNames = [];
+  const child = mcpProcess;
+  mcpProcess = null;
+  if (!child || child.exitCode !== null) return;
+  await new Promise((resolve) => {
+    const timer = setTimeout(() => child.kill('SIGKILL'), config.mcp.shutdownTimeoutMs);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.kill('SIGTERM');
+  });
+}
+
 /**
- * Tear the stdio session down and start a fresh one, so the MCP server re-reads the rules file.
- * Call it from inside `serialise()` — a query must never see a half-restarted session.
+ * Stop the MCP server and start a fresh one, so it re-reads the rules file.
+ * Call it from inside `serialise()` — a query must never see a half-restarted server.
  * @returns {Promise<string[]>}
  */
 async function restartMcp() {
-  const old = mcpClient;
-  mcpClient = null;
-  toolNames = [];
-  if (old) {
-    try {
-      // Closing the client closes the transport, which kills the spawned server process.
-      await old.close();
-    } catch (e) {
-      console.error(`[rls-demo] closing the old MCP session failed: ${e?.message ?? e}`);
-    }
-  }
+  await stopMcp();
   return startMcp();
 }
 
 /**
- * Call `query_data_rls` for one user.
- * @param {{user: string, sql: string, queryName: string}} args
+ * Call `query_data_rls` on behalf of one principal.
+ *
+ * The principal is NOT passed as a tool argument — in header mode the server refuses that. It is
+ * asserted in the `X-RLS-Principal` header of the client we picked for it.
+ * @param {{principal: string, sql: string, queryName: string}} args
  */
-async function callQueryDataRls({ user, sql, queryName }) {
+async function callQueryDataRls({ principal, sql, queryName }) {
   return serialise(async () => {
-    if (!mcpClient) {
-      return { ok: false, error: 'The MCP session is not running — a rules reload may have failed.' };
+    if (!mcpProcess) {
+      return { ok: false, error: 'The MCP server is not running — a rules reload may have failed.' };
     }
-    const result = await mcpClient.callTool(
+    const client = await clientFor(principal);
+    const result = await client.callTool(
       {
         name: config.mcp.expectedTool,
-        arguments: { sql_query: sql, query_name: queryName, user },
+        arguments: { sql_query: sql, query_name: queryName },
       },
       undefined,
       { timeout: config.mcp.callTimeoutMs }
@@ -321,10 +406,13 @@ except Exception as e:
 `;
 
 /**
- * Rewrite the SQL without executing it.
- * @param {{user: string, sql: string}} args
+ * Rewrite the SQL without executing it, for the signed-in principal.
+ *
+ * This calls the server's own rewrite function directly (no MCP round-trip), so the principal is an
+ * argument here — it comes from the demo session, never from the browser's request body.
+ * @param {{principal: string, sql: string}} args
  */
-function rewritePreview({ user, sql }) {
+function rewritePreview({ principal, sql }) {
   return new Promise((resolve) => {
     const child = spawn(config.mcp.pythonPath, ['-c', REWRITE_SCRIPT], {
       // The rewrite needs no Keboola credentials at all — it is a pure SQL transformation.
@@ -360,16 +448,46 @@ function rewritePreview({ user, sql }) {
       }
     });
     child.stdin.end(
-      JSON.stringify({ rules_path: config.mcp.rulesPath, sql, user, dialect: config.mcp.dialect })
+      JSON.stringify({ rules_path: config.mcp.rulesPath, sql, user: principal, dialect: config.mcp.dialect })
     );
   });
 }
 
+// --- mock sign-in ------------------------------------------------------------------------------
+//
+// Stands in for whatever a real wrapper application already has: an Active Directory / Google /
+// Okta login, or its own session cookie. Nothing here is a security mechanism — the point is only
+// that the *application* decides who the user is, and the browser never names the principal for a
+// query. Sessions live in memory and die with the process.
+
+/** @type {Map<string, string>} sessionId -> principal */
+const sessions = new Map();
+
+/** @param {import('node:http').IncomingMessage} req */
+function sessionIdFromRequest(req) {
+  for (const part of String(req.headers.cookie ?? '').split(';')) {
+    const eq = part.indexOf('=');
+    if (eq <= 0) continue;
+    if (part.slice(0, eq).trim() === config.session.cookieName) return part.slice(eq + 1).trim();
+  }
+  return null;
+}
+
+/**
+ * The principal of the current sign-in, or null when the caller is not signed in.
+ * @param {import('node:http').IncomingMessage} req
+ * @returns {string | null}
+ */
+function principalFromRequest(req) {
+  const sid = sessionIdFromRequest(req);
+  return sid ? (sessions.get(sid) ?? null) : null;
+}
+
 // --- HTTP ------------------------------------------------------------------------------------
 
-function sendJson(res, status, body) {
+function sendJson(res, status, body, headers) {
   const payload = JSON.stringify(body);
-  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', ...(headers ?? {}) });
   res.end(payload);
 }
 
@@ -413,6 +531,46 @@ async function handle(req, res) {
     return;
   }
 
+  if (req.method === 'GET' && url.pathname === '/api/session') {
+    sendJson(res, 200, { principal: principalFromRequest(req) });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/login') {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (e) {
+      sendJson(res, 400, { ok: false, error: `Invalid JSON body: ${e.message}` });
+      return;
+    }
+    const principal = typeof body.principal === 'string' ? body.principal.trim() : '';
+    // The mock IdP only knows the principals the rules file mentions. A real wrapper would accept
+    // whatever its identity provider returns and let the MCP server refuse an unknown principal.
+    if (!principal || !rules.users.includes(principal)) {
+      sendJson(res, 400, { ok: false, error: 'Unknown user — pick one of the principals in the rules file.' });
+      return;
+    }
+    const sid = randomUUID();
+    sessions.set(sid, principal);
+    console.log(`[rls-demo] mock sign-in: ${principal}`);
+    sendJson(res, 200, { ok: true, principal }, {
+      // Local demo over plain HTTP, so no `Secure`; `HttpOnly` keeps the page's own scripts (and
+      // anything injected into them) from reading the session id.
+      'set-cookie': `${config.session.cookieName}=${sid}; HttpOnly; SameSite=Strict; Path=/`,
+    });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/logout') {
+    const sid = sessionIdFromRequest(req);
+    if (sid) sessions.delete(sid);
+    sendJson(res, 200, { ok: true, principal: null }, {
+      'set-cookie': `${config.session.cookieName}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0`,
+    });
+    return;
+  }
+
   if (req.method === 'GET' && url.pathname === '/api/rules') {
     sendJson(res, 200, rules);
     return;
@@ -445,7 +603,14 @@ async function handle(req, res) {
     return;
   }
 
-  if (req.method === 'POST' && url.pathname === '/api/query') {
+  if (req.method === 'POST' && (url.pathname === '/api/query' || url.pathname === '/api/query-all')) {
+    // The principal comes from the demo's own session, never from the request body: this app
+    // authenticated the user, so this app — not the page, and not the model — says who they are.
+    const principal = principalFromRequest(req);
+    if (!principal) {
+      sendJson(res, 401, { ok: false, error: 'Not signed in — sign in first, queries always run as someone.' });
+      return;
+    }
     let body;
     try {
       body = await readJsonBody(req);
@@ -453,20 +618,25 @@ async function handle(req, res) {
       sendJson(res, 400, { ok: false, error: `Invalid JSON body: ${e.message}` });
       return;
     }
-    const user = typeof body.user === 'string' ? body.user.trim() : '';
     const sql = typeof body.sql === 'string' ? body.sql.trim() : '';
-    if (!user || !sql) {
-      sendJson(res, 400, { ok: false, error: 'Both "user" and "sql" are required.' });
+    if (!sql) {
+      sendJson(res, 400, { ok: false, error: '"sql" is required.' });
       return;
     }
     const queryName =
       typeof body.query_name === 'string' && body.query_name.trim()
         ? body.query_name.trim()
         : config.ui.defaultQueryName;
+    // "Run for all users" is an admin-style comparison: the sign-ins are iterated here, server-side,
+    // so the browser still never names a principal.
+    const principals = url.pathname === '/api/query-all' ? rules.users : [principal];
     try {
       // A refusal is a normal outcome of this demo, so it comes back as 200 with ok:false.
-      const result = await callQueryDataRls({ user, sql, queryName });
-      sendJson(res, 200, result);
+      const results = [];
+      for (const p of principals) {
+        results.push({ principal: p, result: await callQueryDataRls({ principal: p, sql, queryName }) });
+      }
+      sendJson(res, 200, url.pathname === '/api/query-all' ? { ok: true, results } : results[0].result);
     } catch (e) {
       sendJson(res, 200, { ok: false, error: String(e?.message ?? e) });
     }
@@ -474,6 +644,11 @@ async function handle(req, res) {
   }
 
   if (req.method === 'POST' && url.pathname === '/api/rewrite') {
+    const principal = principalFromRequest(req);
+    if (!principal) {
+      sendJson(res, 401, { ok: false, error: 'Not signed in — the rewrite is always for someone.' });
+      return;
+    }
     let body;
     try {
       body = await readJsonBody(req);
@@ -481,13 +656,12 @@ async function handle(req, res) {
       sendJson(res, 400, { ok: false, error: `Invalid JSON body: ${e.message}` });
       return;
     }
-    const user = typeof body.user === 'string' ? body.user.trim() : '';
     const sql = typeof body.sql === 'string' ? body.sql.trim() : '';
-    if (!user || !sql) {
-      sendJson(res, 400, { ok: false, error: 'Both "user" and "sql" are required.' });
+    if (!sql) {
+      sendJson(res, 400, { ok: false, error: '"sql" is required.' });
       return;
     }
-    sendJson(res, 200, await rewritePreview({ user, sql }));
+    sendJson(res, 200, await rewritePreview({ principal, sql }));
     return;
   }
 
@@ -500,22 +674,28 @@ async function main() {
   await ensureRulesFile();
   rules = await loadRules();
   console.log(`[rls-demo] rules loaded from ${config.mcp.rulesPath}: users = ${rules.users.join(', ')}`);
-  console.log(`[rls-demo] starting the Keboola MCP Server (stdio, RLS mode) via "${config.mcp.command}"...`);
+  console.log(
+    `[rls-demo] starting the Keboola MCP Server (streamable-http on ${config.mcp.host}:${config.mcp.port}, ` +
+      `RLS mode, principal from the ${config.mcp.principalHeader} header) via "${config.mcp.command}"...`
+  );
 
   let tools;
   try {
     tools = await startMcp();
   } catch (e) {
     console.error(`[rls-demo] FATAL: the MCP server failed to start: ${e?.message ?? e}`);
+    await stopMcp();
     process.exit(1);
   }
   console.log(`[rls-demo] MCP tools: ${tools.join(', ')}`);
   if (!tools.includes(config.mcp.expectedTool)) {
     console.error(`[rls-demo] FATAL: ${config.mcp.expectedTool} is not registered — is --rls-rules-path in effect?`);
+    await stopMcp();
     process.exit(1);
   }
   if (tools.includes(config.mcp.forbiddenTool)) {
     console.error(`[rls-demo] FATAL: ${config.mcp.forbiddenTool} is registered — RLS mode is not active.`);
+    await stopMcp();
     process.exit(1);
   }
   console.log(
@@ -536,7 +716,7 @@ async function main() {
   const shutdown = async () => {
     server.close();
     try {
-      await mcpClient?.close();
+      await stopMcp();
     } catch {
       /* ignore */
     }

--- a/examples/rls-demo/server.mjs
+++ b/examples/rls-demo/server.mjs
@@ -35,7 +35,7 @@ import YAML from 'yaml';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
-import { config } from './config.mjs';
+import { config, loadDemoConfig } from './config.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PUBLIC_DIR = path.join(HERE, 'public');
@@ -56,6 +56,36 @@ async function ensureRulesFile() {
   await copyFile(config.mcp.exampleRulesPath, config.mcp.rulesPath);
   console.log(
     `[rls-demo] ${config.mcp.rulesPath} did not exist — seeded it from ${config.mcp.exampleRulesPath}`
+  );
+}
+
+// --- demo config (personas + example queries) -------------------------------------------------
+
+/**
+ * Copy the shipped `demo.example.json` to the configured demo config path when that file does not
+ * exist yet, same pattern as `ensureRulesFile()`. When the example itself is missing (should not
+ * happen in a checkout), this is a no-op — `loadDemoConfig()` then falls back to the built-in
+ * generic content baked into config.mjs.
+ */
+async function ensureDemoConfigFile() {
+  try {
+    await access(config.demo.configPath);
+    return;
+  } catch {
+    /* not there yet — fall through and try to seed it */
+  }
+  try {
+    await access(config.demo.exampleConfigPath);
+  } catch {
+    console.warn(
+      `[rls-demo] ${config.demo.exampleConfigPath} not found — cannot seed ${config.demo.configPath}; ` +
+        'falling back to the built-in generic personas/examples.'
+    );
+    return;
+  }
+  await copyFile(config.demo.exampleConfigPath, config.demo.configPath);
+  console.log(
+    `[rls-demo] ${config.demo.configPath} did not exist — seeded it from ${config.demo.exampleConfigPath}`
   );
 }
 
@@ -90,6 +120,9 @@ async function loadRules() {
 
 /** Current rules, replaced in place by a successful `PUT /api/rules`. */
 let rules = { users: [], tables: {}, yaml: '' };
+
+/** Personas + example queries served via `GET /api/config`. Loaded once at startup. */
+let demoConfig = { personas: {}, examples: [] };
 
 // Validation runs in the MCP server's Python environment against a TEMP copy of the candidate YAML.
 // The path is passed as argv[1] — never interpolated into the script — so no file name can become
@@ -527,7 +560,7 @@ async function handle(req, res) {
 
   if (req.method === 'GET' && url.pathname === '/api/config') {
     // UI-only constants (no secrets, no paths) so index.html hardcodes nothing.
-    sendJson(res, 200, { ui: config.ui });
+    sendJson(res, 200, { ui: config.ui, personas: demoConfig.personas, examples: demoConfig.examples });
     return;
   }
 
@@ -674,6 +707,20 @@ async function main() {
   await ensureRulesFile();
   rules = await loadRules();
   console.log(`[rls-demo] rules loaded from ${config.mcp.rulesPath}: users = ${rules.users.join(', ')}`);
+
+  await ensureDemoConfigFile();
+  try {
+    demoConfig = await loadDemoConfig(config.demo.configPath);
+  } catch (e) {
+    // Fail fast: an existing-but-invalid demo config is a configuration error, never silently
+    // ignored or replaced with an invented default.
+    console.error(`[rls-demo] FATAL: invalid demo config at ${config.demo.configPath}: ${e?.message ?? e}`);
+    process.exit(1);
+  }
+  console.log(
+    `[rls-demo] demo config: ${demoConfig.source === 'built-in' ? 'built-in generic content' : demoConfig.source} ` +
+      `(${Object.keys(demoConfig.personas).length} personas, ${demoConfig.examples.length} examples)`
+  );
   console.log(
     `[rls-demo] starting the Keboola MCP Server (streamable-http on ${config.mcp.host}:${config.mcp.port}, ` +
       `RLS mode, principal from the ${config.mcp.principalHeader} header) via "${config.mcp.command}"...`

--- a/examples/rls-demo/server.mjs
+++ b/examples/rls-demo/server.mjs
@@ -1,0 +1,552 @@
+// RLS demo server.
+//
+// Boots a single stdio MCP session against the Keboola MCP Server running in RLS mode and exposes a
+// tiny HTTP API for the browser UI:
+//   GET  /              -> public/index.html
+//   GET  /api/config    -> UI-only constants (no secrets, no paths)
+//   GET  /api/rules     -> {users, tables, yaml} parsed from the rules file
+//   PUT  /api/rules     -> validates + writes the rules file, then restarts the MCP process
+//   GET  /api/tools     -> tool names reported by the MCP server
+//   POST /api/query     -> runs query_data_rls for a user
+//   POST /api/rewrite   -> shows the rewritten SQL without executing it
+//
+// SECURITY: the Keboola Storage API token comes from the environment (see config.mjs) and is passed
+// only as an environment variable to the spawned MCP server process. It is never logged, never
+// returned in an HTTP response and never written to disk by this app.
+
+import http from 'node:http';
+import { readFile, writeFile, copyFile, mkdtemp, rm, access } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import YAML from 'yaml';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+import { config } from './config.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PUBLIC_DIR = path.join(HERE, 'public');
+
+// --- rules -----------------------------------------------------------------------------------
+
+/**
+ * Copy the shipped `rls.example.yaml` to the configured rules path when that file does not exist,
+ * so a fresh checkout starts with a working (generic) set of rules.
+ */
+async function ensureRulesFile() {
+  try {
+    await access(config.mcp.rulesPath);
+    return;
+  } catch {
+    /* not there yet — fall through and seed it */
+  }
+  await copyFile(config.mcp.exampleRulesPath, config.mcp.rulesPath);
+  console.log(
+    `[rls-demo] ${config.mcp.rulesPath} did not exist — seeded it from ${config.mcp.exampleRulesPath}`
+  );
+}
+
+/**
+ * Parse rules YAML text into `{users, tables, yaml}`.
+ * `yaml` is the verbatim source text so the UI can show the file with its comments.
+ * @param {string} raw
+ * @returns {{users: string[], tables: Record<string, Record<string, string>>, yaml: string}}
+ */
+function parseRules(raw) {
+  const doc = YAML.parse(raw);
+  const tables = doc?.tables;
+  if (!tables || typeof tables !== 'object') {
+    throw new Error(`${config.mcp.rulesPath} has no top-level "tables" mapping`);
+  }
+  const users = [];
+  for (const perUser of Object.values(tables)) {
+    for (const user of Object.keys(perUser ?? {})) {
+      if (!users.includes(user)) users.push(user);
+    }
+  }
+  return { users, tables, yaml: raw };
+}
+
+/**
+ * Load the rules file from disk.
+ * @returns {Promise<{users: string[], tables: Record<string, Record<string, string>>, yaml: string}>}
+ */
+async function loadRules() {
+  return parseRules(await readFile(config.mcp.rulesPath, 'utf8'));
+}
+
+/** Current rules, replaced in place by a successful `PUT /api/rules`. */
+let rules = { users: [], tables: {}, yaml: '' };
+
+// Validation runs in the MCP server's Python environment against a TEMP copy of the candidate YAML.
+// The path is passed as argv[1] — never interpolated into the script — so no file name can become
+// Python code.
+const VALIDATE_SCRIPT = `
+import json, sys
+from keboola_mcp_server.rls import RlsRules, RlsError
+
+try:
+    rules = RlsRules.load(sys.argv[1])
+    print(json.dumps({"ok": True, "tables": len(rules.tables)}))
+except RlsError as e:
+    print(json.dumps({"ok": False, "error": str(e)}))
+except Exception as e:
+    print(json.dumps({"ok": False, "error": f"{type(e).__name__}: {e}"}))
+`;
+
+/**
+ * Run `RlsRules.load()` from the MCP server's own Python environment against `filePath`.
+ * @param {string} filePath
+ * @returns {Promise<{ok: true} | {ok: false, error: string}>}
+ */
+function validateRulesFile(filePath) {
+  return new Promise((resolve) => {
+    const child = spawn(config.mcp.pythonPath, ['-c', VALIDATE_SCRIPT, filePath], {
+      // Validation is a pure file parse — it needs no Keboola credentials.
+      env: { ...process.env, KBC_STORAGE_TOKEN: '', PYTHONWARNINGS: 'ignore' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let err = '';
+    const timer = setTimeout(() => child.kill('SIGKILL'), config.mcp.validateTimeoutMs);
+    child.stdout.on('data', (d) => {
+      out += d;
+    });
+    child.stderr.on('data', (d) => {
+      err += d;
+    });
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      resolve({ ok: false, error: `Cannot run the rules validator: ${e.message}` });
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const line = out.trim().split('\n').filter(Boolean).pop();
+      if (!line) {
+        resolve({ ok: false, error: `Rules validator exited with code ${code}: ${err.trim().slice(0, 500)}` });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        resolve(parsed.ok ? { ok: true } : { ok: false, error: parsed.error });
+      } catch {
+        resolve({ ok: false, error: `Rules validator produced unparseable output: ${line.slice(0, 500)}` });
+      }
+    });
+  });
+}
+
+/**
+ * Validate, persist and activate a new rules file.
+ *
+ * Nothing is written unless `RlsRules.load()` accepts the candidate YAML. The MCP server reads its
+ * rules once at startup (there is deliberately no hot reload), so the stdio process is restarted —
+ * inside the call queue, so no query ever runs against a half-restarted server.
+ *
+ * @param {string} yamlText
+ * @returns {Promise<{ok: true, users: string[], tables: object, yaml: string, tools: string[]} | {ok: false, error: string}>}
+ */
+async function saveRules(yamlText) {
+  // 1) Shape check in Node first — a cheap, clearer error than the Python one for an empty body.
+  let candidate;
+  try {
+    candidate = parseRules(yamlText);
+  } catch (e) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+
+  // 2) Validate with the real thing: the MCP server's own RlsRules.load(), against a temp file.
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'rls-demo-rules-'));
+  const tempPath = path.join(dir, 'rls.yaml');
+  let verdict;
+  try {
+    await writeFile(tempPath, yamlText, 'utf8');
+    verdict = await validateRulesFile(tempPath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+  if (!verdict.ok) return verdict;
+
+  // 3) Write, keeping a single backup of the previous version, then restart the MCP session.
+  return serialise(async () => {
+    await copyFile(config.mcp.rulesPath, config.mcp.rulesBackupPath);
+    await writeFile(config.mcp.rulesPath, yamlText, 'utf8');
+    rules = candidate;
+    const tools = await restartMcp();
+    console.log(`[rls-demo] rules saved and MCP restarted: users = ${rules.users.join(', ')}`);
+    return { ok: true, users: rules.users, tables: rules.tables, yaml: rules.yaml, tools };
+  });
+}
+
+// --- MCP session -----------------------------------------------------------------------------
+
+/** @type {Client | null} */
+let mcpClient = null;
+/** @type {string[]} */
+let toolNames = [];
+
+// The stdio client is a single session: serialise every tool call behind one promise chain.
+let callChain = Promise.resolve();
+
+/**
+ * Queue `fn` so only one MCP call is in flight at a time.
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+function serialise(fn) {
+  const result = callChain.then(fn, fn);
+  // Keep the chain alive even when a call rejects.
+  callChain = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
+/** Environment handed to the spawned MCP server process. The token lives only here. */
+function mcpEnv() {
+  const env = {
+    ...process.env,
+    KBC_STORAGE_API_URL: config.keboola.stackUrl,
+    KBC_STORAGE_TOKEN: config.keboola.token,
+  };
+  if (config.keboola.workspaceId) env.KBC_WORKSPACE_ID = config.keboola.workspaceId;
+  else delete env.KBC_WORKSPACE_ID;
+  return env;
+}
+
+async function startMcp() {
+  const transport = new StdioClientTransport({
+    command: config.mcp.command,
+    args: ['--transport', 'stdio', '--rls-rules-path', config.mcp.rulesPath],
+    env: mcpEnv(),
+    stderr: 'inherit',
+  });
+  const client = new Client(
+    { name: config.mcp.clientName, version: config.mcp.clientVersion },
+    { capabilities: {} }
+  );
+  await client.connect(transport, { timeout: config.mcp.startupTimeoutMs });
+  const listed = await client.listTools();
+  mcpClient = client;
+  toolNames = (listed.tools ?? []).map((t) => t.name).sort();
+  return toolNames;
+}
+
+/**
+ * Tear the stdio session down and start a fresh one, so the MCP server re-reads the rules file.
+ * Call it from inside `serialise()` — a query must never see a half-restarted session.
+ * @returns {Promise<string[]>}
+ */
+async function restartMcp() {
+  const old = mcpClient;
+  mcpClient = null;
+  toolNames = [];
+  if (old) {
+    try {
+      // Closing the client closes the transport, which kills the spawned server process.
+      await old.close();
+    } catch (e) {
+      console.error(`[rls-demo] closing the old MCP session failed: ${e?.message ?? e}`);
+    }
+  }
+  return startMcp();
+}
+
+/**
+ * Call `query_data_rls` for one user.
+ * @param {{user: string, sql: string, queryName: string}} args
+ */
+async function callQueryDataRls({ user, sql, queryName }) {
+  return serialise(async () => {
+    if (!mcpClient) {
+      return { ok: false, error: 'The MCP session is not running — a rules reload may have failed.' };
+    }
+    const result = await mcpClient.callTool(
+      {
+        name: config.mcp.expectedTool,
+        arguments: { sql_query: sql, query_name: queryName, user },
+      },
+      undefined,
+      { timeout: config.mcp.callTimeoutMs }
+    );
+    const text = (result.content ?? [])
+      .filter((c) => c.type === 'text')
+      .map((c) => c.text)
+      .join('\n');
+    if (result.isError) {
+      return { ok: false, error: text || 'The MCP tool returned an error without a message.' };
+    }
+    let payload = result.structuredContent;
+    if (!payload || typeof payload !== 'object' || !('csv_data' in payload)) {
+      // Fall back to the text content, which carries the JSON-serialised output model.
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        return { ok: false, error: `Unexpected tool result: ${text.slice(0, 500)}` };
+      }
+    }
+    return {
+      ok: true,
+      applied_rules: payload.applied_rules ?? [],
+      csv_data: payload.csv_data ?? '',
+      message: payload.message ?? null,
+    };
+  });
+}
+
+// --- rewrite preview -------------------------------------------------------------------------
+
+// Runs in the MCP server's Python environment; input arrives as JSON on stdin so nothing is
+// shell-interpolated.
+const REWRITE_SCRIPT = `
+import json, sys
+from keboola_mcp_server.rls import RlsRules, rewrite_query, RlsError
+
+payload = json.load(sys.stdin)
+try:
+    rules = RlsRules.load(payload["rules_path"])
+    rewritten = rewrite_query(
+        payload["sql"], user=payload["user"], dialect=payload["dialect"], rules=rules
+    )
+    print(json.dumps({"sql": rewritten.sql, "applied_rules": list(rewritten.applied_rules)}))
+except RlsError as e:
+    print(json.dumps({"error": str(e)}))
+except Exception as e:
+    print(json.dumps({"error": f"{type(e).__name__}: {e}"}))
+`;
+
+/**
+ * Rewrite the SQL without executing it.
+ * @param {{user: string, sql: string}} args
+ */
+function rewritePreview({ user, sql }) {
+  return new Promise((resolve) => {
+    const child = spawn(config.mcp.pythonPath, ['-c', REWRITE_SCRIPT], {
+      // The rewrite needs no Keboola credentials at all — it is a pure SQL transformation.
+      env: { ...process.env, KBC_STORAGE_TOKEN: '', PYTHONWARNINGS: 'ignore' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let err = '';
+    const timer = setTimeout(() => child.kill('SIGKILL'), config.mcp.rewriteTimeoutMs);
+    child.stdout.on('data', (d) => {
+      out += d;
+    });
+    child.stderr.on('data', (d) => {
+      err += d;
+    });
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      resolve({ ok: false, error: `Cannot run the rewrite helper: ${e.message}` });
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const line = out.trim().split('\n').filter(Boolean).pop();
+      if (!line) {
+        resolve({ ok: false, error: `Rewrite helper exited with code ${code}: ${err.trim().slice(0, 500)}` });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed.error) resolve({ ok: false, error: parsed.error });
+        else resolve({ ok: true, sql: parsed.sql, applied_rules: parsed.applied_rules ?? [] });
+      } catch {
+        resolve({ ok: false, error: `Rewrite helper produced unparseable output: ${line.slice(0, 500)}` });
+      }
+    });
+    child.stdin.end(
+      JSON.stringify({ rules_path: config.mcp.rulesPath, sql, user, dialect: config.mcp.dialect })
+    );
+  });
+}
+
+// --- HTTP ------------------------------------------------------------------------------------
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(payload);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    req.on('data', (c) => {
+      size += c.length;
+      if (size > 1_000_000) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+async function readJsonBody(req) {
+  const raw = await readBody(req);
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+async function handle(req, res) {
+  const url = new URL(req.url, `http://${config.http.host}:${config.http.port}`);
+
+  if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
+    const html = await readFile(path.join(PUBLIC_DIR, 'index.html'), 'utf8');
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(html);
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/config') {
+    // UI-only constants (no secrets, no paths) so index.html hardcodes nothing.
+    sendJson(res, 200, { ui: config.ui });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/rules') {
+    sendJson(res, 200, rules);
+    return;
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/rules') {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (e) {
+      sendJson(res, 400, { ok: false, error: `Invalid JSON body: ${e.message}` });
+      return;
+    }
+    const yamlText = typeof body.yaml === 'string' ? body.yaml : '';
+    if (!yamlText.trim()) {
+      sendJson(res, 400, { ok: false, error: 'A non-empty "yaml" field is required.' });
+      return;
+    }
+    try {
+      // An invalid rules file is a normal outcome here, so it is 200 with ok:false.
+      sendJson(res, 200, await saveRules(yamlText));
+    } catch (e) {
+      sendJson(res, 200, { ok: false, error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/tools') {
+    sendJson(res, 200, { tools: toolNames });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/query') {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (e) {
+      sendJson(res, 400, { ok: false, error: `Invalid JSON body: ${e.message}` });
+      return;
+    }
+    const user = typeof body.user === 'string' ? body.user.trim() : '';
+    const sql = typeof body.sql === 'string' ? body.sql.trim() : '';
+    if (!user || !sql) {
+      sendJson(res, 400, { ok: false, error: 'Both "user" and "sql" are required.' });
+      return;
+    }
+    const queryName =
+      typeof body.query_name === 'string' && body.query_name.trim()
+        ? body.query_name.trim()
+        : config.ui.defaultQueryName;
+    try {
+      // A refusal is a normal outcome of this demo, so it comes back as 200 with ok:false.
+      const result = await callQueryDataRls({ user, sql, queryName });
+      sendJson(res, 200, result);
+    } catch (e) {
+      sendJson(res, 200, { ok: false, error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/rewrite') {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (e) {
+      sendJson(res, 400, { ok: false, error: `Invalid JSON body: ${e.message}` });
+      return;
+    }
+    const user = typeof body.user === 'string' ? body.user.trim() : '';
+    const sql = typeof body.sql === 'string' ? body.sql.trim() : '';
+    if (!user || !sql) {
+      sendJson(res, 400, { ok: false, error: 'Both "user" and "sql" are required.' });
+      return;
+    }
+    sendJson(res, 200, await rewritePreview({ user, sql }));
+    return;
+  }
+
+  sendJson(res, 404, { ok: false, error: 'Not found' });
+}
+
+// --- startup ---------------------------------------------------------------------------------
+
+async function main() {
+  await ensureRulesFile();
+  rules = await loadRules();
+  console.log(`[rls-demo] rules loaded from ${config.mcp.rulesPath}: users = ${rules.users.join(', ')}`);
+  console.log(`[rls-demo] starting the Keboola MCP Server (stdio, RLS mode) via "${config.mcp.command}"...`);
+
+  let tools;
+  try {
+    tools = await startMcp();
+  } catch (e) {
+    console.error(`[rls-demo] FATAL: the MCP server failed to start: ${e?.message ?? e}`);
+    process.exit(1);
+  }
+  console.log(`[rls-demo] MCP tools: ${tools.join(', ')}`);
+  if (!tools.includes(config.mcp.expectedTool)) {
+    console.error(`[rls-demo] FATAL: ${config.mcp.expectedTool} is not registered — is --rls-rules-path in effect?`);
+    process.exit(1);
+  }
+  if (tools.includes(config.mcp.forbiddenTool)) {
+    console.error(`[rls-demo] FATAL: ${config.mcp.forbiddenTool} is registered — RLS mode is not active.`);
+    process.exit(1);
+  }
+  console.log(
+    `[rls-demo] smoke test OK: ${config.mcp.expectedTool} present, ${config.mcp.forbiddenTool} absent.`
+  );
+
+  const server = http.createServer((req, res) => {
+    handle(req, res).catch((e) => {
+      console.error(`[rls-demo] request failed: ${e?.message ?? e}`);
+      if (!res.headersSent) sendJson(res, 500, { ok: false, error: 'Internal server error' });
+      else res.end();
+    });
+  });
+  server.listen(config.http.port, config.http.host, () => {
+    console.log(`[rls-demo] listening on http://${config.http.host}:${config.http.port}/`);
+  });
+
+  const shutdown = async () => {
+    server.close();
+    try {
+      await mcpClient?.close();
+    } catch {
+      /* ignore */
+    }
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch((e) => {
+  console.error(`[rls-demo] FATAL: ${e?.message ?? e}`);
+  process.exit(1);
+});

--- a/feature_spec/rls_query_tool/PLAN.md
+++ b/feature_spec/rls_query_tool/PLAN.md
@@ -1,0 +1,978 @@
+# RLS Query Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `query_data_rls` MCP tool that rewrites a user's SELECT so every table is replaced by a filtered subquery taken from a YAML rules file, and make the server register *only* that tool (never the unrestricted `query_data`) when the rules file is configured.
+
+**Architecture:** A new pure module `keboola_mcp_server/rls.py` owns rules loading/validation and the sqlglot AST rewrite (no I/O beyond reading the YAML at startup). `tools/sql.py` gains a thin tool that calls the rewrite and reuses the existing query-execution path. `Config`/CLI gain one deployment-level field for the rules path; `create_server()` loads the rules into `ServerState` and picks which SQL tool to register.
+
+**Tech Stack:** Python 3.10, FastMCP, `sqlglot ~= 30.0` (already a dependency), `pyyaml ~= 6.0` (already a dependency), pytest + pytest-asyncio + pytest-mock.
+
+**Spec:** `feature_spec/rls_query_tool/RFC.md`
+
+## Global Constraints
+
+- Work on branch `feat/rls-query-tool`; open a **draft** PR; do **not** merge.
+- No new dependencies. No hardcoded paths/defaults: the rules path comes only from `KBC_RLS_RULES_PATH` env or `--rls-rules-path` CLI, never from an HTTP header.
+- Fail-closed everywhere: any load/parse/lookup failure raises; no SQL reaches the workspace unrewritten.
+- `query_data` behaviour is unchanged when no rules path is configured (`tests/test_server.py::TestServer::test_list_tools` must keep passing untouched).
+- Code, comments, docstrings, commit messages in English. No emoji.
+- Style: ruff (`tox -m cs-fix` auto-fixes). Single quotes, 120-column lines (see existing code). Parametrized tests declare names as a tuple `('a', 'b')`.
+- Tests run with `.venv/bin/python -m pytest <path> -q -p no:cacheprovider`. Pre-existing failure on clean `main`: `tests/test_server.py::test_json_logging` (`FileNotFoundError`, environment-specific) — ignore it.
+- Commit messages: `RLS: <what>` (no Linear issue assigned yet; no Co-Authored-By trailer).
+- Version bump: `1.79.2` → `1.80.0` (new tool = minor) in Task 5 only, followed by `uv lock`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/keboola_mcp_server/rls.py` (new) | `RlsRules` (load + validate YAML, case-insensitive lookup), `RlsError`, `rewrite_query()` (sqlglot AST rewrite, fail-closed) |
+| `tests/test_rls.py` (new) | Unit tests for loading, lookup and rewrite |
+| `src/keboola_mcp_server/config.py` | New field `rls_rules_path` (deployment-level, not header-eligible) |
+| `src/keboola_mcp_server/cli.py` | `--rls-rules-path` flag wired into `Config(...)` |
+| `tests/test_config.py` | Field reachable from env/CLI, unreachable from headers |
+| `src/keboola_mcp_server/tools/sql.py` | Shared `_execute_and_serialize()` helper, `RlsQueryDataOutput`, `query_data_rls` tool, `add_sql_tools(mcp, rls_rules=None)` swap |
+| `tests/tools/test_sql.py` | Tool tests for `query_data_rls` |
+| `src/keboola_mcp_server/mcp.py` | `ServerState.rls_rules: RlsRules \| None` |
+| `src/keboola_mcp_server/server.py` | Load rules in `create_server()` when configured; pass to `add_sql_tools` |
+| `tests/test_server.py` | Swap test: exactly one of the two SQL tools is registered |
+| `README.md` | "Row-Level Security (pilot)" section |
+| `pyproject.toml`, `uv.lock` | Version bump |
+
+**Parallelism:** Tasks 1 and 2 are independent — run them in parallel. Tasks 3 and 4 both depend on Task 1's interface (and Task 4 on Task 2's field); they can run in parallel with each other once 1 and 2 are merged into the branch. Task 5 is sequential at the end.
+
+---
+
+### Task 1: `rls.py` — rules loading and SQL rewrite
+
+**Files:**
+- Create: `src/keboola_mcp_server/rls.py`
+- Create: `tests/test_rls.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces (used by Tasks 3 and 4):
+
+```python
+class RlsError(ValueError):
+    """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means 'no data'."""
+
+@dataclasses.dataclass(frozen=True)
+class RlsRules:
+    tables: Mapping[str, Mapping[str, str]]   # lower-cased table key -> lower-cased user -> predicate
+
+    @classmethod
+    def load(cls, path: str) -> 'RlsRules': ...          # raises RlsError
+    def predicate_for(self, *, table_name: str, schema: str | None, user: str) -> tuple[str, str]: ...
+        # returns (matched_key, predicate); raises RlsError
+
+@dataclasses.dataclass(frozen=True)
+class RewrittenQuery:
+    sql: str
+    applied_rules: list[str]                             # e.g. ["invoices: country = 'CZ'"]
+
+def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> RewrittenQuery: ...
+    # dialect: 'snowflake' | 'bigquery' (lower-case sqlglot dialect name); raises RlsError
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_rls.py
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from keboola_mcp_server.rls import RewrittenQuery, RlsError, RlsRules, rewrite_query
+
+VALID_YAML = textwrap.dedent(
+    """
+    tables:
+      invoices:
+        petr: "country = 'CZ'"
+        Monika: "country = 'DE'"
+        admin: "TRUE"
+      in.c-crm.orders:
+        petr: "country = 'CZ' AND status <> 'draft'"
+      orders:
+        petr: "FALSE"
+    """
+)
+
+
+@pytest.fixture
+def rules(tmp_path: Path) -> RlsRules:
+    path = tmp_path / 'rls.yaml'
+    path.write_text(VALID_YAML)
+    return RlsRules.load(str(path))
+
+
+class TestLoad:
+    def test_load_normalizes_keys(self, rules: RlsRules) -> None:
+        assert rules.tables['invoices']['monika'] == "country = 'DE'"
+        assert rules.tables['in.c-crm.orders']['petr'] == "country = 'CZ' AND status <> 'draft'"
+
+    @pytest.mark.parametrize(
+        ('content', 'match'),
+        [
+            ('', 'empty'),
+            ('tables: {}', 'no tables'),
+            ('foo: bar', "'tables'"),
+            ('tables:\n  invoices: "not a mapping"', "'invoices'"),
+            ('tables:\n  invoices:\n    petr: 42', "'petr'"),
+            ('tables:\n  invoices:\n    petr: "country = = 1"', 'petr'),
+            ('tables:\n  invoices:\n    petr: ""', 'petr'),
+            ('tables: [\n', 'YAML'),
+        ],
+    )
+    def test_load_rejects_invalid_file(self, tmp_path: Path, content: str, match: str) -> None:
+        path = tmp_path / 'rls.yaml'
+        path.write_text(content)
+        with pytest.raises(RlsError, match=match):
+            RlsRules.load(str(path))
+
+    def test_load_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(RlsError, match='not found'):
+            RlsRules.load(str(tmp_path / 'nope.yaml'))
+
+
+class TestPredicateFor:
+    @pytest.mark.parametrize(
+        ('table_name', 'schema', 'user', 'expected'),
+        [
+            ('invoices', None, 'petr', ('invoices', "country = 'CZ'")),
+            ('INVOICES', None, 'PETR', ('invoices', "country = 'CZ'")),
+            ('invoices', 'in.c-main', 'monika', ('invoices', "country = 'DE'")),  # falls back to bare name
+            ('orders', 'in.c-crm', 'petr', ('in.c-crm.orders', "country = 'CZ' AND status <> 'draft'")),
+            ('orders', None, 'petr', ('orders', 'FALSE')),
+        ],
+    )
+    def test_lookup(self, rules: RlsRules, table_name, schema, user, expected) -> None:
+        assert rules.predicate_for(table_name=table_name, schema=schema, user=user) == expected
+
+    @pytest.mark.parametrize(
+        ('table_name', 'schema', 'user', 'match'),
+        [
+            ('customers', None, 'petr', "table 'customers'"),
+            ('invoices', None, 'nobody', "user 'nobody'"),
+            ('orders', 'in.c-crm', 'monika', "user 'monika'"),  # qualified key wins even if bare key has no user
+        ],
+    )
+    def test_lookup_denied(self, rules: RlsRules, table_name, schema, user, match) -> None:
+        with pytest.raises(RlsError, match=match):
+            rules.predicate_for(table_name=table_name, schema=schema, user=user)
+
+
+class TestRewriteQuery:
+    @pytest.mark.parametrize(
+        ('sql', 'dialect', 'expected_sql', 'expected_rules'),
+        [
+            (
+                'SELECT COUNT(*) FROM invoices',
+                'snowflake',
+                "SELECT COUNT(*) FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT i.id FROM invoices i JOIN "in.c-crm"."orders" AS o ON o.id = i.id',
+                'snowflake',
+                "SELECT i.id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS i "
+                "JOIN (SELECT * FROM \"in.c-crm\".\"orders\" WHERE country = 'CZ' AND status <> 'draft') AS \"o\" "
+                'ON o.id = i.id',
+                ["invoices: country = 'CZ'", "in.c-crm.orders: country = 'CZ' AND status <> 'draft'"],
+            ),
+            (
+                'WITH x AS (SELECT * FROM invoices) SELECT * FROM x',
+                'snowflake',
+                "WITH x AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) SELECT * FROM x",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT * FROM (SELECT id FROM invoices) sub',
+                'snowflake',
+                "SELECT * FROM (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) AS sub",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT id FROM invoices UNION ALL SELECT id FROM orders',
+                'snowflake',
+                "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders',
+                ["invoices: country = 'CZ'", 'orders: FALSE'],
+            ),
+            (
+                'SELECT COUNT(*) FROM `proj.ds.invoices`',
+                'bigquery',
+                "SELECT COUNT(*) FROM (SELECT * FROM `proj`.`ds`.`invoices` WHERE country = 'CZ') AS `invoices`",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT COUNT(*) FROM `ds`.`invoices` LIMIT 10',
+                'bigquery',
+                "SELECT COUNT(*) FROM (SELECT * FROM `ds`.`invoices` WHERE country = 'CZ') AS `invoices` LIMIT 10",
+                ["invoices: country = 'CZ'"],
+            ),
+        ],
+    )
+    def test_rewrite(self, rules: RlsRules, sql, dialect, expected_sql, expected_rules) -> None:
+        out = rewrite_query(sql, user='petr', dialect=dialect, rules=rules)
+        assert out == RewrittenQuery(sql=expected_sql, applied_rules=expected_rules)
+
+    @pytest.mark.parametrize(
+        ('sql', 'user', 'match'),
+        [
+            ('DELETE FROM invoices', 'petr', 'SELECT'),
+            ('INSERT INTO invoices SELECT * FROM orders', 'petr', 'SELECT'),
+            ('SELECT 1; SELECT 2', 'petr', 'one statement'),
+            ('SELCT nonsense', 'petr', 'SELECT'),
+            ('SELECT * FROM customers', 'petr', "table 'customers'"),
+            ('SELECT * FROM invoices', 'nobody', "user 'nobody'"),
+            # A CTE named like a protected table would shadow it inside its own body -- refuse.
+            ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'CTE'),
+            ('', 'petr', 'one statement'),
+        ],
+    )
+    def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, match) -> None:
+        with pytest.raises(RlsError, match=match):
+            rewrite_query(sql, user=user, dialect='snowflake', rules=rules)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_rls.py -q -p no:cacheprovider`
+Expected: FAIL with `ModuleNotFoundError: No module named 'keboola_mcp_server.rls'`
+
+- [ ] **Step 3: Implement `rls.py`**
+
+```python
+# src/keboola_mcp_server/rls.py
+"""Row-level security (RLS) for the `query_data_rls` tool.
+
+Rules are data, not code: a YAML file maps `table -> user -> SQL predicate`. `rewrite_query()`
+replaces every table referenced by a SELECT with `(SELECT * FROM <table> WHERE <predicate>)`, so
+the caller can only ever see the slice the admin wrote down for them. Everything here is
+fail-closed: a missing rule, an unsupported statement or an unparseable query raises `RlsError`
+and no SQL is executed. See `feature_spec/rls_query_tool/RFC.md`.
+"""
+
+import dataclasses
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+
+import sqlglot
+import yaml
+from sqlglot import exp
+
+LOG = logging.getLogger(__name__)
+
+
+class RlsError(ValueError):
+    """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means "no data"."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RewrittenQuery:
+    sql: str
+    applied_rules: list[str]
+    """Human-readable disclosure, one entry per rewritten table: `"<table key>: <predicate>"`."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RlsRules:
+    """RLS rules keyed by lower-cased table key, then lower-cased user name.
+
+    A table key is either a bare table name (`invoices`) or `<schema>.<name>` (`in.c-crm.invoices`);
+    the qualified form takes precedence during lookup.
+    """
+
+    tables: Mapping[str, Mapping[str, str]]
+
+    @classmethod
+    def load(cls, path: str) -> 'RlsRules':
+        """Read and validate the YAML rules file. Raises `RlsError` on any problem."""
+        file = Path(path)
+        if not file.is_file():
+            raise RlsError(f'RLS rules file not found: {path}')
+        try:
+            raw = yaml.safe_load(file.read_text())
+        except yaml.YAMLError as e:
+            raise RlsError(f'RLS rules file {path} is not valid YAML: {e}') from e
+        if raw is None:
+            raise RlsError(f'RLS rules file {path} is empty')
+        if not isinstance(raw, Mapping) or 'tables' not in raw:
+            raise RlsError(f"RLS rules file {path} must have a top-level 'tables' mapping")
+        tables_raw = raw['tables']
+        if not isinstance(tables_raw, Mapping) or not tables_raw:
+            raise RlsError(f'RLS rules file {path} has no tables defined')
+
+        tables: dict[str, dict[str, str]] = {}
+        for table_key, users_raw in tables_raw.items():
+            if not isinstance(users_raw, Mapping) or not users_raw:
+                raise RlsError(f"RLS rules for table '{table_key}' must be a non-empty mapping of user -> predicate")
+            users: dict[str, str] = {}
+            for user, predicate in users_raw.items():
+                if not isinstance(predicate, str) or not predicate.strip():
+                    raise RlsError(f"RLS predicate for table '{table_key}', user '{user}' must be a non-empty string")
+                try:
+                    # Dialect-agnostic parse: we only check the predicate is a well-formed condition.
+                    sqlglot.parse_one(predicate, into=exp.Condition)
+                except sqlglot.errors.ParseError as e:
+                    raise RlsError(f"RLS predicate for table '{table_key}', user '{user}' is not valid SQL: {e}") from e
+                users[str(user).lower()] = predicate
+            tables[str(table_key).lower()] = users
+
+        LOG.info(f'Loaded RLS rules for {len(tables)} table(s) from {path}')
+        return cls(tables=tables)
+
+    def predicate_for(self, *, table_name: str, schema: str | None, user: str) -> tuple[str, str]:
+        """Return `(matched_key, predicate)` for the table/user, or raise `RlsError`.
+
+        The `<schema>.<name>` key is tried first, then the bare name. When a key matches but has
+        no entry for `user`, that is a denial -- we do not fall through to a less specific key.
+        """
+        candidates: list[str] = []
+        if schema:
+            candidates.append(f'{schema}.{table_name}'.lower())
+        candidates.append(table_name.lower())
+        for key in candidates:
+            users = self.tables.get(key)
+            if users is None:
+                continue
+            predicate = users.get(user.lower())
+            if predicate is None:
+                raise RlsError(f"RLS: no rule for user '{user.lower()}' on table '{key}'")
+            return key, predicate
+        raise RlsError(f"RLS: no rule for table '{table_name}'")
+
+
+def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> RewrittenQuery:
+    """Rewrite a single SELECT so every referenced table becomes a filtered subquery.
+
+    :param sql: the caller's SQL, in the workspace dialect
+    :param user: identity used to select rules; case-insensitive
+    :param dialect: sqlglot dialect name (`'snowflake'` / `'bigquery'`)
+    :param rules: loaded rules
+    :raises RlsError: on anything other than one SELECT statement whose every table has a rule
+    """
+    try:
+        statements = sqlglot.parse(sql, dialect=dialect)
+    except sqlglot.errors.ParseError as e:
+        raise RlsError(f'RLS: cannot parse SQL: {e}') from e
+    if len(statements) != 1 or statements[0] is None:
+        raise RlsError('RLS: exactly one statement is allowed')
+    tree = statements[0]
+    if not isinstance(tree, (exp.Select, exp.Union)):
+        raise RlsError(f'RLS: only SELECT statements are allowed, got {type(tree).__name__}')
+
+    cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+    # A CTE named like a protected table would shadow the real table inside its own body and let
+    # the reference through unfiltered. Refuse instead of trying to be clever (fail-closed).
+    if collisions := sorted(cte_names & set(rules.tables)):
+        raise RlsError(f'RLS: CTE name(s) collide with protected table(s): {", ".join(collisions)}')
+
+    applied: list[str] = []
+
+    def _transform(node: exp.Expression) -> exp.Expression:
+        if not isinstance(node, exp.Table):
+            return node
+        if not node.db and node.name.lower() in cte_names:
+            return node  # reference to a CTE defined in this statement, not a real table
+        key, predicate = rules.predicate_for(table_name=node.name, schema=node.db or None, user=user)
+        applied.append(f'{key}: {predicate}')
+        alias = node.alias or node.name
+        inner = exp.Table(this=node.this, db=node.args.get('db'), catalog=node.args.get('catalog'))
+        filtered = exp.select('*').from_(inner).where(sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition))
+        # Returning a new node stops `transform` from descending into it, so the inner table is
+        # not wrapped a second time.
+        return exp.Subquery(
+            this=filtered, alias=exp.TableAlias(this=exp.to_identifier(alias, quoted=node.this.quoted))
+        )
+
+    rewritten = tree.transform(_transform, copy=True)
+    return RewrittenQuery(sql=rewritten.sql(dialect=dialect), applied_rules=applied)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_rls.py -q -p no:cacheprovider`
+Expected: all PASS. If an `expected_sql` string differs only in whitespace/quoting emitted by sqlglot, fix the **test expectation** to the actual output *only if* the output is semantically the same filtered subquery; never loosen the fail-closed assertions.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+.venv/bin/ruff format src/keboola_mcp_server/rls.py tests/test_rls.py
+.venv/bin/ruff check --fix src/keboola_mcp_server/rls.py tests/test_rls.py
+git add src/keboola_mcp_server/rls.py tests/test_rls.py
+git commit -m "RLS: add rules loading and sqlglot-based SELECT rewrite"
+```
+
+---
+
+### Task 2: `Config.rls_rules_path` + `--rls-rules-path`
+
+**Files:**
+- Modify: `src/keboola_mcp_server/config.py:76-103`
+- Modify: `src/keboola_mcp_server/cli.py:58-63` (argparse) and `cli.py:559-564` (`Config(...)`)
+- Modify: `tests/test_config.py:238-247`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Config.rls_rules_path: str | None` (used by Task 4). Env var `KBC_RLS_RULES_PATH` works automatically through `Config._read_options`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `'rls_rules_path'` to the parametrize list of `TestConfigHeaderAllowlist::test_deployment_level_fields_are_unreachable` (the list at `tests/test_config.py:~230-237`; keep the existing entries). Then add a new test to the same class:
+
+```python
+    def test_rls_rules_path_from_env_and_cli(self) -> None:
+        # Deployment-level: reachable from env / CLI (trusted), never from a header (Task 2 above).
+        assert Config().replace_by({'KBC_RLS_RULES_PATH': '/etc/rls.yaml'}).rls_rules_path == '/etc/rls.yaml'
+        assert Config(rls_rules_path='/opt/rls.yaml').rls_rules_path == '/opt/rls.yaml'
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_config.py -q -p no:cacheprovider -k "rls_rules_path or deployment_level"`
+Expected: FAIL — `TypeError: Config.__init__() got an unexpected keyword argument 'rls_rules_path'` and the header test fails for the `rls_rules_path` parameter.
+
+- [ ] **Step 3: Add the field**
+
+In `config.py`, after the `project_id` field (line ~81), add:
+
+```python
+    rls_rules_path: str | None = None
+    """Path to the YAML row-level-security rules file (feature_spec/rls_query_tool/RFC.md).
+
+    When set, the server registers the `query_data_rls` tool instead of `query_data`. Deployment-level:
+    maps `KBC_RLS_RULES_PATH` / `--rls-rules-path` only and is deliberately absent from
+    `_HEADER_ELIGIBLE_FIELDS` so a caller can never point the server at a different rules file."""
+```
+
+Do **not** touch `_HEADER_ELIGIBLE_FIELDS`.
+
+- [ ] **Step 4: Add the CLI flag**
+
+In `cli.py` after the `--workspace-id` argument (line ~60):
+
+```python
+    parser.add_argument(
+        '--rls-rules-path',
+        metavar='PATH',
+        help='YAML file with row-level-security rules. When set, only the query_data_rls tool is registered.',
+    )
+```
+
+and in the `Config(...)` constructor at `cli.py:~559`:
+
+```python
+        config = Config(
+            storage_api_url=parsed_args.api_url,
+            storage_token=parsed_args.storage_token,
+            workspace_schema=parsed_args.workspace_schema,
+            workspace_id=parsed_args.workspace_id,
+            rls_rules_path=parsed_args.rls_rules_path,
+        ).replace_by(os.environ)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_config.py tests/test_cli.py -q -p no:cacheprovider`
+Expected: PASS (if `tests/test_cli.py` does not exist, run only `tests/test_config.py`).
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+.venv/bin/ruff format src/keboola_mcp_server/config.py src/keboola_mcp_server/cli.py tests/test_config.py
+.venv/bin/ruff check --fix src/keboola_mcp_server/config.py src/keboola_mcp_server/cli.py tests/test_config.py
+git add src/keboola_mcp_server/config.py src/keboola_mcp_server/cli.py tests/test_config.py
+git commit -m "RLS: add rls_rules_path config field and --rls-rules-path flag"
+```
+
+---
+
+### Task 3: `query_data_rls` tool in `tools/sql.py`
+
+**Files:**
+- Modify: `src/keboola_mcp_server/tools/sql.py:215-357`
+- Modify: `tests/tools/test_sql.py` (append after `test_query_data`, line ~88)
+
+**Interfaces:**
+- Consumes (Task 1): `from keboola_mcp_server.rls import RlsError, RlsRules, rewrite_query`; `ServerState.rls_rules` (Task 4 adds the field — until then the tests below set it via `dataclasses.replace`, so add the field in `mcp.py` here if Task 4 has not landed yet: `rls_rules: 'RlsRules | None' = None` right after `kai_scope_store` in `ServerState`, with `from keboola_mcp_server.rls import RlsRules` at the top of `mcp.py`).
+- Produces (used by Task 4):
+
+```python
+class RlsQueryDataOutput(QueryDataOutput):
+    applied_rules: list[str]
+
+def add_sql_tools(mcp: FastMCP, *, rls_rules: RlsRules | None = None) -> None
+async def query_data_rls(sql_query: str, query_name: str, user: str, ctx: Context) -> RlsQueryDataOutput
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/tools/test_sql.py` (add the imports at the top of the file: `import dataclasses`, `from keboola_mcp_server.mcp import ServerState, ServerRuntimeInfo` if not present, `from keboola_mcp_server.config import Config` if not present, `from keboola_mcp_server.rls import RlsRules`, and extend the existing `from keboola_mcp_server.tools.sql import ...` with `RlsQueryDataOutput, add_sql_tools, query_data_rls`; also `from fastmcp import FastMCP`):
+
+```python
+@pytest.fixture
+def rls_context(mcp_context_client: Context, mocker) -> tuple[Context, WorkspaceManager]:
+    """`mcp_context_client` with RLS rules in the server state and a Snowflake workspace mock."""
+    rules = RlsRules(tables={'invoices': {'petr': "country = 'CZ'"}})
+    state = mcp_context_client.request_context.lifespan_context
+    mcp_context_client.request_context.lifespan_context = dataclasses.replace(state, rls_rules=rules)
+    manager = mocker.AsyncMock(WorkspaceManager)
+    manager.get_sql_dialect.return_value = 'Snowflake'
+    manager.execute_query.return_value = QueryResult(
+        status='ok', data=SqlSelectData(columns=['n'], rows=[{'n': 3}]), message=None
+    )
+    mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+    return mcp_context_client, manager
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_rewrites_and_discloses(rls_context) -> None:
+    ctx, manager = rls_context
+
+    result = await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', 'Petr', ctx)
+
+    assert isinstance(result, RlsQueryDataOutput)
+    assert result.csv_data == 'n\r\n3\r\n'
+    assert result.applied_rules == ["invoices: country = 'CZ'"]
+    sent_sql = manager.execute_query.call_args.args[0]
+    assert sent_sql == "SELECT COUNT(*) AS n FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('sql', 'user', 'match'),
+    [
+        ('SELECT * FROM invoices', 'nobody', "user 'nobody'"),
+        ('SELECT * FROM customers', 'petr', "table 'customers'"),
+        ('DELETE FROM invoices', 'petr', 'SELECT'),
+    ],
+)
+async def test_query_data_rls_fails_closed(rls_context, sql: str, user: str, match: str) -> None:
+    ctx, manager = rls_context
+
+    with pytest.raises(ValueError, match=match):
+        await query_data_rls(sql, 'Bad Query', user, ctx)
+
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_requires_rules_in_state(mcp_context_client: Context) -> None:
+    # Defensive: the tool is only registered when rules exist, but never run unfiltered if they are missing.
+    with pytest.raises(ValueError, match='RLS rules'):
+        await query_data_rls('SELECT 1', 'No Rules', 'petr', mcp_context_client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('rls_rules', 'expected_tools'),
+    [
+        (None, ['query_data']),
+        (RlsRules(tables={'invoices': {'petr': 'TRUE'}}), ['query_data_rls']),
+    ],
+)
+async def test_add_sql_tools_registers_exactly_one_query_tool(rls_rules, expected_tools) -> None:
+    mcp = FastMCP('test')
+    add_sql_tools(mcp, rls_rules=rls_rules)
+    tools = await mcp.list_tools(run_middleware=False)
+    assert sorted(t.name for t in tools) == expected_tools
+    assert all(t.annotations is not None and t.annotations.readOnlyHint is True for t in tools)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/tools/test_sql.py -q -p no:cacheprovider -k rls`
+Expected: FAIL with `ImportError: cannot import name 'RlsQueryDataOutput'`.
+
+- [ ] **Step 3: Refactor `query_data` body into a shared helper and add the RLS tool**
+
+In `tools/sql.py`:
+
+1. Add imports: `from keboola_mcp_server.mcp import ServerState, get_http_request_or_none` (replace the existing `get_http_request_or_none` import line) and `from keboola_mcp_server.rls import RlsRules, rewrite_query`.
+2. After `QueryDataOutput` add:
+
+```python
+class RlsQueryDataOutput(QueryDataOutput):
+    """Output of `query_data_rls`: the data plus a disclosure of which RLS rules shaped it."""
+
+    applied_rules: list[str] = Field(
+        description='RLS rules applied to the query, one per table, as "<table>: <predicate>". '
+        'The result is a filtered slice of the data, never the whole table.'
+    )
+```
+
+3. Replace `add_sql_tools` with:
+
+```python
+def add_sql_tools(mcp: FastMCP, *, rls_rules: RlsRules | None = None) -> None:
+    """Add SQL tools to the MCP server.
+
+    With `rls_rules` the server exposes only `query_data_rls`; the unrestricted `query_data` is not
+    registered at all, so no per-request header (`X-Allowed-Tools`, ...) can bring it back.
+    """
+    if rls_rules is None:
+        tool = query_data
+    else:
+        tool = query_data_rls
+    mcp.add_tool(
+        FunctionTool.from_function(
+            tool,
+            annotations=ToolAnnotations(readOnlyHint=True),
+            tags={SQL_TOOLS_TAG},
+        )
+    )
+    LOG.info(f'SQL tools added to the MCP server: {tool.__name__}.')
+```
+
+4. Move the body of `query_data` (everything from `workspace_manager = ...` to the end, lines 310-356) into a module-level helper, and make `query_data` call it:
+
+```python
+async def _execute_and_serialize(sql_query: str, query_name: str, ctx: Context) -> tuple[SqlSelectData, str | None]:
+    """Run `sql_query` in the workspace and return `(data, message)`; raises `ValueError` on failure.
+
+    Shared by `query_data` and `query_data_rls` so progress notifications, disconnect watching and
+    error mapping live in exactly one place.
+    """
+    workspace_manager = WorkspaceManager.from_state(ctx.session.state)
+
+    progress_token = _client_progress_token(ctx)
+
+    async def _on_job_submitted(info: JobSubmittedInfo) -> None:
+        await _emit_job_submitted_progress(ctx, progress_token, info)
+
+    query_coro = workspace_manager.execute_query(
+        sql_query,
+        max_rows=MAX_ROWS,
+        max_chars=MAX_CHARS,
+        on_job_submitted=_on_job_submitted if progress_token is not None else None,
+    )
+    # (keep the existing comment about the disconnect race here)
+    request = get_http_request_or_none()
+    if request is None:
+        result = await query_coro
+    else:
+        result = await _execute_watching_disconnect(query_coro, request, query_name)
+    if result.is_ok:
+        LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
+        if result.data:
+            data = result.data
+        else:
+            # non-SELECT query, this should not really happen, because this tool is for running SELECT queries
+            data = SqlSelectData(columns=['message'], rows=[{'message': result.message}])
+        return data, result.message
+
+    # (keep the existing comment about cancellation here)
+    if result.message == 'Query was cancelled':
+        LOG.info(f'Query "{query_name}" was cancelled.')
+        raise ValueError('Query was cancelled')
+    LOG.warning(' '.join(filter(None, [f'Query "{query_name}" failed.', result.message])))
+    raise ValueError(f'Failed to run SQL query, error: {result.message}')
+
+
+def _to_csv(data: SqlSelectData) -> str:
+    output = StringIO()
+    writer = csv.DictWriter(output, fieldnames=data.columns)
+    writer.writeheader()
+    writer.writerows(data.rows)
+    return output.getvalue()
+```
+
+`query_data`'s body becomes:
+
+```python
+    data, message = await _execute_and_serialize(sql_query, query_name, ctx)
+    return QueryDataOutput(query_name=query_name, csv_data=_to_csv(data), message=message)
+```
+
+5. Add the new tool right after `query_data`:
+
+```python
+@tool_errors()
+async def query_data_rls(
+    sql_query: Annotated[str, Field(description='SQL SELECT query to run.')],
+    query_name: Annotated[
+        str,
+        Field(
+            description=(
+                'A concise, human-readable name for this query based on its purpose and what data it retrieves. '
+                'Use normal words with spaces (e.g., "Customer Orders Last Month", "Top Selling Products", '
+                '"User Activity Summary").'
+            )
+        ),
+    ],
+    user: Annotated[
+        str,
+        Field(
+            description=(
+                'Name of the user on whose behalf the query runs. Row-level-security rules are selected by this '
+                'name; every table in the query must have a rule for it, otherwise the query is refused.'
+            )
+        ),
+    ],
+    ctx: Context,
+) -> RlsQueryDataOutput:
+    """
+    Executes an SQL SELECT query with row-level security applied for the given user.
+
+    Every table referenced by the query is replaced by a filtered view defined by the server-side RLS
+    rules for `user`. The result is therefore a SLICE of the data, never the whole table; the
+    `applied_rules` field of the output says exactly which filters were applied — always tell the user.
+    Tables that have no rule for `user`, non-SELECT statements and multi-statement input are refused.
+
+    The SQL requirements below are identical to the `query_data` tool.
+
+    BEFORE QUERYING:
+    * Always verify the table has a non-null fullyQualifiedName from get_tables tool.
+      If it does not, the table is not SQL-accessible from this workspace — do not attempt the query and inform user.
+
+    CRITICAL SQL REQUIREMENTS:
+
+    * ALWAYS check the SQL dialect before constructing queries.
+    * Do not include any comments in the SQL code
+    * Use delimited identifiers and FQN format for the current SQL dialect.
+    * Always use the LIMIT clause in your SELECT statements when fetching data; the tool truncates
+      results beyond its row/character limits and a truncated result is a contiguous prefix, not a sample.
+    * Compute aggregates (COUNT, GROUP BY, SUM, AVG, etc.) in SQL rather than pulling raw rows.
+    """
+    rules = ServerState.from_context(ctx).rls_rules
+    if rules is None:
+        raise ValueError('RLS rules are not configured on this server.')
+    workspace_manager = WorkspaceManager.from_state(ctx.session.state)
+    dialect = (await workspace_manager.get_sql_dialect()).lower()
+    # Raises RlsError (a ValueError) before anything is sent to the workspace -- fail-closed.
+    rewritten = rewrite_query(sql_query, user=user, dialect=dialect, rules=rules)
+    LOG.info(f'RLS applied for user "{user}" in query "{query_name}": {rewritten.applied_rules}')
+
+    data, message = await _execute_and_serialize(rewritten.sql, query_name, ctx)
+    return RlsQueryDataOutput(
+        query_name=query_name, csv_data=_to_csv(data), message=message, applied_rules=rewritten.applied_rules
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/tools/test_sql.py -q -p no:cacheprovider`
+Expected: all PASS, including the pre-existing `test_query_data*` and progress/disconnect tests (the refactor must not change their behaviour).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+.venv/bin/ruff format src/keboola_mcp_server/tools/sql.py tests/tools/test_sql.py src/keboola_mcp_server/mcp.py
+.venv/bin/ruff check --fix src/keboola_mcp_server/tools/sql.py tests/tools/test_sql.py src/keboola_mcp_server/mcp.py
+git add src/keboola_mcp_server/tools/sql.py tests/tools/test_sql.py src/keboola_mcp_server/mcp.py
+git commit -m "RLS: add query_data_rls tool and swap it for query_data when rules are set"
+```
+
+---
+
+### Task 4: Server wiring, swap test and README
+
+**Files:**
+- Modify: `src/keboola_mcp_server/mcp.py:121-128` (`ServerState`) — skip if Task 3 already added the field
+- Modify: `src/keboola_mcp_server/server.py:255-260` and `:314`
+- Modify: `tests/test_server.py` (append)
+- Modify: `README.md` (after the "Option D: Using Docker" section, before "Do I Need to Start the Server Myself?")
+
+**Interfaces:**
+- Consumes: `Config.rls_rules_path` (Task 2), `RlsRules.load`, `RlsError` (Task 1), `add_sql_tools(mcp, rls_rules=...)` (Task 3).
+- Produces: `ServerState.rls_rules`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_server.py` (imports needed: `from keboola_mcp_server.rls import RlsError` plus `pytest`, `Config`, `ServerRuntimeInfo`, `create_server` which are already imported):
+
+```python
+@pytest.mark.asyncio
+async def test_rls_swaps_query_tool(tmp_path) -> None:
+    rules_file = tmp_path / 'rls.yaml'
+    rules_file.write_text("tables:\n  invoices:\n    petr: \"country = 'CZ'\"\n")
+
+    server = create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))
+    tool_names = {tool.name for tool in await server.list_tools(run_middleware=False)}
+
+    assert 'query_data_rls' in tool_names
+    assert 'query_data' not in tool_names
+
+
+def test_rls_invalid_rules_file_fails_startup(tmp_path) -> None:
+    rules_file = tmp_path / 'rls.yaml'
+    rules_file.write_text('tables:\n  invoices:\n    petr: ""\n')
+
+    with pytest.raises(RlsError, match='petr'):
+        create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))
+
+
+def test_rls_missing_rules_file_fails_startup(tmp_path) -> None:
+    with pytest.raises(RlsError, match='not found'):
+        create_server(
+            Config(rls_rules_path=str(tmp_path / 'missing.yaml')), runtime_info=ServerRuntimeInfo(transport='stdio')
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_server.py -q -p no:cacheprovider -k rls`
+Expected: FAIL — `query_data_rls` not in tool names / no `RlsError` raised.
+
+- [ ] **Step 3: Add `rls_rules` to `ServerState`** (only if Task 3 did not)
+
+In `mcp.py`, add `from keboola_mcp_server.rls import RlsRules` to the imports and, in `ServerState` after `kai_scope_store`:
+
+```python
+    rls_rules: RlsRules | None = None
+    """Row-level-security rules loaded at startup from `Config.rls_rules_path`; None = RLS disabled."""
+```
+
+- [ ] **Step 4: Load rules in `create_server()`**
+
+In `server.py`, add `from keboola_mcp_server.rls import RlsRules` and, just before `LOG.info(f'Creating server with config: {config}')` (line ~256):
+
+```python
+    # Row-level security (feature_spec/rls_query_tool/RFC.md): load and validate the rules once, at
+    # startup, so a broken file refuses to start the server instead of failing the first query.
+    rls_rules = RlsRules.load(config.rls_rules_path) if config.rls_rules_path else None
+```
+
+Pass it into `ServerState(...)`:
+
+```python
+    server_state = ServerState(
+        config=config,
+        runtime_info=runtime_info,
+        session_store=session_store,
+        kai_scope_store=kai_scope_store,
+        rls_rules=rls_rules,
+    )
+```
+
+and change line 314 to `add_sql_tools(mcp, rls_rules=rls_rules)`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_server.py -q -p no:cacheprovider`
+Expected: the three new tests PASS and `TestServer::test_list_tools` still PASSES unchanged (no RLS ⇒ `query_data` is still there). `test_json_logging` may fail for the pre-existing environment reason — ignore.
+
+- [ ] **Step 6: README section**
+
+Insert into `README.md` before the `### Do I Need to Start the Server Myself?` heading:
+
+````markdown
+### Row-Level Security (pilot)
+
+Restrict what each user can read from a shared table by giving the server a YAML rules file and
+starting it with `--rls-rules-path <file>` (or `KBC_RLS_RULES_PATH=<file>`). When set, the server
+exposes `query_data_rls` **instead of** `query_data`; the unrestricted tool is not registered at all.
+
+```yaml
+# rls.yaml -- table -> user -> SQL predicate (workspace dialect, inserted into WHERE verbatim)
+tables:
+  invoices:
+    petr: "country = 'CZ'"
+    monika: "country = 'DE'"
+    admin: "TRUE"              # unrestricted access must be written explicitly
+  in.c-crm.orders:             # <bucket>.<table> key takes precedence over a bare table name
+    petr: "country = 'CZ' AND status <> 'draft'"
+```
+
+`query_data_rls(sql_query, query_name, user)` rewrites every table in the SELECT to
+`(SELECT * FROM <table> WHERE <predicate>)` for that user, runs it, and reports the applied rules in
+`applied_rules`. It is fail-closed: a table without a rule for the user, a non-SELECT statement, or an
+unparseable query is refused and nothing is executed. The file is validated at startup; a broken file
+stops the server.
+
+Limitation: the `user` argument is supplied by the MCP client / model and is not verified by the server
+(same trust level as the `X-*` request headers). Suitable for a pilot behind a trusted client.
+````
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+.venv/bin/ruff format src/keboola_mcp_server/server.py src/keboola_mcp_server/mcp.py tests/test_server.py
+.venv/bin/ruff check --fix src/keboola_mcp_server/server.py src/keboola_mcp_server/mcp.py tests/test_server.py
+git add src/keboola_mcp_server/server.py src/keboola_mcp_server/mcp.py tests/test_server.py README.md
+git commit -m "RLS: load rules at startup, wire tool swap into create_server, document pilot"
+```
+
+---
+
+### Task 5: Version bump, full checks, draft PR
+
+**Files:**
+- Modify: `pyproject.toml:7`, `uv.lock`
+
+- [ ] **Step 1: Bump version and lock**
+
+Change `version = "1.79.2"` to `version = "1.80.0"` in `pyproject.toml`, then:
+
+```bash
+VIRTUAL_ENV=.venv uv lock
+```
+
+- [ ] **Step 2: Run the full gate**
+
+```bash
+.venv/bin/ruff format --check src tests && .venv/bin/ruff check src tests
+.venv/bin/python -m pytest tests -q -p no:cacheprovider
+.venv/bin/python -m keboola_mcp_server.generate_tool_docs && git diff --exit-code TOOLS.md
+```
+
+Expected: ruff clean; pytest all green except the pre-existing `test_json_logging`; `TOOLS.md` unchanged (the docs generator runs with a default `Config`, so it still documents `query_data` — `query_data_rls` is documented in the README only, by design for the pilot). If `TOOLS.md` did change, inspect the diff: only a *removal* of `query_data` would be a bug (it means the swap fired without rules).
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "RLS: bump version to 1.80.0"
+git push -u origin feat/rls-query-tool
+```
+
+- [ ] **Step 4: Open a draft PR**
+
+```bash
+gh pr create --draft --title "RLS: row-level security query tool (pilot)" --body-file - <<'EOF'
+## Description
+
+**Linear**: AI-XXX (pilot, no issue yet)
+
+### Change Type
+
+- [ ] Major (breaking changes, significant new features)
+- [x] Minor (new features, enhancements, backward compatible)
+- [ ] Patch (bug fixes, small improvements, no new features)
+
+### Summary
+
+Pilot of row-level security for SQL queries. RFC: `feature_spec/rls_query_tool/RFC.md`.
+
+- New `query_data_rls(sql_query, query_name, user)` tool: rewrites every table in a SELECT to
+  `(SELECT * FROM <table> WHERE <predicate>)` using rules from a YAML file (`--rls-rules-path` /
+  `KBC_RLS_RULES_PATH`), fail-closed, and discloses `applied_rules` in the output.
+- When the rules path is set the server registers **only** `query_data_rls`; `query_data` is not
+  registered, so it cannot be re-enabled via headers. Without the path nothing changes.
+- Rules are validated at startup; a broken file refuses to start the server.
+
+Not for merge as-is: `user` is client-supplied and unverified (documented limitation), no groups,
+no column masking, no hot reload.
+
+## Testing
+
+- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)
+
+## Checklist
+
+- [x] Self-review completed
+- [x] Unit tests added/updated (if applicable)
+- [ ] Integration tests added/updated (if applicable)
+- [x] Project version bumped according to the change type
+- [x] Documentation updated (if applicable)
+EOF
+```
+
+Report the PR URL.

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -1,0 +1,141 @@
+# RFC: Row-Level Security Query Tool (`query_data_rls`)
+
+Linear: _TBD — pilot; no Linear issue assigned yet_
+
+Status: **Draft / pilot** — this branch is not meant to be merged as-is.
+
+## Problem
+
+Today `query_data` runs whatever SQL the model produces against the Keboola workspace with the
+full privileges of the configured token. There is no way to expose a shared table to several
+users while letting each of them see only *their* slice (orders per country, invoices per
+cost-centre, ...). A model answering on a user's behalf must receive already-filtered data — it
+cannot be trusted to add the filter itself.
+
+Agnes (keboola/agnes-the-ai-analyst#1979) solves this with "Table Access Policies": a policy is
+data (a SQL `SELECT` attached to a table), the server substitutes it for the table on every read,
+enforcement is fail-closed, and every filtered response carries a disclosure. This RFC ports the
+*minimum* of that idea into the MCP server. Explicitly out of scope (KISS): groups, `$user_*`
+variables, column masking, mapping tables, transpilation between dialects, audit log, admin UI,
+hot reload.
+
+## Required Behavior
+
+### Rules file
+
+Rules live in a YAML file whose path is given by the `KBC_RLS_RULES_PATH` environment variable
+or the `--rls-rules-path` CLI flag. The path is deployment-level configuration: it is **never**
+read from an HTTP header (the `Config` field is not in `_HEADER_ELIGIBLE_FIELDS`).
+
+```yaml
+# table -> user -> SQL predicate (inserted into WHERE verbatim, in the workspace dialect)
+tables:
+  invoices:
+    petr: "country = 'CZ'"
+    monika: "country = 'DE'"
+    admin: "TRUE"                       # unrestricted access must be written explicitly
+  in.c-crm.orders:                      # bucket-qualified key, takes precedence over a bare name
+    petr: "country = 'CZ' AND status <> 'draft'"
+```
+
+- Table keys are matched case-insensitively against the table reference in the SQL. A
+  bucket-qualified key (`<bucket>.<table>`, i.e. `<schema>.<name>` in the workspace) is tried
+  first, then the bare table name.
+- User keys are matched case-insensitively.
+- The file is loaded and validated **once at server start**. Every predicate must parse as a SQL
+  condition (`sqlglot`, dialect-agnostic parse). An unreadable, malformed or empty file, or an
+  unparseable predicate, makes the server fail to start with a message naming the offending
+  table/user. No silent defaults.
+
+### SQL rewrite
+
+`rewrite_query(sql, user, dialect) -> (rewritten_sql, applied_rules)` in a new module
+`keboola_mcp_server/rls.py`:
+
+1. Parse `sql` with `sqlglot` using the workspace dialect (`snowflake` / `bigquery`, obtained via
+   `WorkspaceManager.get_sql_dialect()`).
+2. Reject (raise) if the input is not exactly one statement or the statement is not a `SELECT`
+   (CTEs and set operations on top of `SELECT` are allowed).
+3. Walk every `exp.Table` node that references a real table (names that are CTE aliases defined
+   in the same statement are skipped).
+4. For each such table look up the predicate for `user`. Missing table or missing user ⇒ raise
+   with the table name in the message. Never fall back to an unfiltered table.
+5. Replace the node with a subquery `(SELECT * FROM <original table> WHERE <predicate>)` aliased
+   to the original alias, or to the bare table name when there was no alias, so the rest of the
+   query keeps resolving.
+6. Generate SQL back in the same dialect and return it together with a human-readable list of
+   applied rules, e.g. `["invoices: country = 'CZ'"]`.
+
+Example — input `SELECT COUNT(*) FROM invoices` for user `petr` becomes
+`SELECT COUNT(*) FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices`.
+
+The whole path is fail-closed: any exception in parsing, lookup or rewriting propagates as a tool
+error and no SQL is sent to the workspace.
+
+### Tool
+
+```python
+async def query_data_rls(
+    sql_query: str,      # same semantics as query_data
+    query_name: str,     # same semantics as query_data
+    user: str,           # REQUIRED — identity used to select the RLS rules
+    ctx: Context,
+) -> RlsQueryDataOutput
+```
+
+`RlsQueryDataOutput` extends `QueryDataOutput` with `applied_rules: list[str]` so the model and
+the human always see that the result is a filtered slice (Agnes "disclosure"). The tool is
+annotated `readOnlyHint=True` and tagged `sql` like `query_data`. Its docstring reuses the SQL
+guidance from `query_data` and adds: which user to pass, that results are filtered, and that
+tables without a rule for the user are inaccessible.
+
+Query execution (progress notification, disconnect watching, CSV serialisation) is extracted from
+`query_data` into a shared private helper in `tools/sql.py`; both tools call it.
+
+### Server behaviour (tool swap)
+
+`add_sql_tools(mcp, rls_rules)`:
+
+- `rls_rules is None` (no path configured) ⇒ register `query_data` only — **no behaviour change**.
+- `rls_rules` present ⇒ register `query_data_rls` **only**; `query_data` is not registered at all,
+  so it cannot be re-enabled through `X-Allowed-Tools` or any other header.
+
+`create_server()` loads the rules when `config.rls_rules_path` is set and stores them in
+`ServerState` so the tool can read them from `ctx.request_context.lifespan_context`.
+
+### Trust boundary (documented limitation)
+
+The `user` argument is supplied by the MCP client / model; the server cannot verify it. This is
+the same trust level as today's `X-*` request headers and is acceptable for the pilot. A later
+iteration may bind the user from an authenticated HTTP header instead of a tool argument.
+
+## Scope and Constraints
+
+- Only `SELECT` statements; no DDL/DML through the RLS tool.
+- No new dependencies: `sqlglot` and `pyyaml` are already required.
+- Predicates are written by the admin in the workspace dialect; the server does not transpile.
+- No changes to `query_data` behaviour when RLS is not configured.
+- All configuration via `Config`; no hardcoded paths or defaults.
+
+## Testing
+
+Unit tests (`tests/test_rls.py`), parametrised where possible:
+
+- rules loading: valid file, missing file, empty file, missing `tables` key, unparseable
+  predicate → error names the table/user; case-insensitive lookup; bucket-qualified key
+  precedence.
+- rewrite: plain `SELECT`, table alias, two-table `JOIN`, `WITH` CTE referencing a real table
+  (CTE alias itself not rewritten), nested subquery, `UNION`, bucket-qualified table reference,
+  Snowflake and BigQuery quoting round-trip.
+- fail-closed: unknown table, unknown user, non-`SELECT`, multiple statements, unparseable SQL.
+
+Tool tests (`tests/tools/test_sql.py`): `query_data_rls` sends the rewritten SQL to
+`WorkspaceManager.execute_query` and returns `applied_rules`; error from rewrite never reaches the
+workspace.
+
+Config / server tests: new field reachable from env/CLI and unreachable from headers
+(`tests/test_config.py`); `add_sql_tools` registers exactly one of the two tools depending on the
+rules (`tests/test_server.py`).
+
+`TOOLS.md` regenerated (`tox -e check-tools-docs`). README gets a short "Row-Level Security
+(pilot)" section under the local setup.

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -86,10 +86,11 @@ error and no SQL is sent to the workspace.
 
 ```python
 async def query_data_rls(
-    sql_query: str,      # same semantics as query_data
-    query_name: str,     # same semantics as query_data
-    user: str,           # REQUIRED — identity used to select the RLS rules
+    sql_query: str,           # same semantics as query_data
+    query_name: str,          # same semantics as query_data
     ctx: Context,
+    principal: str | None,    # identity used to select the RLS rules; REQUIRED in `argument` mode
+                              # and REFUSED in `header` mode (see "Trust boundary")
 ) -> RlsQueryDataOutput
 ```
 
@@ -114,11 +115,29 @@ Query execution (progress notification, disconnect watching, CSV serialisation) 
 `create_server()` loads the rules when `config.rls_rules_path` is set and stores them in
 `ServerState` so the tool can read them from `ctx.request_context.lifespan_context`.
 
-### Trust boundary (documented limitation)
+### Trust boundary
 
-The `user` argument is supplied by the MCP client / model; the server cannot verify it. This is
-the same trust level as today's `X-*` request headers and is acceptable for the pilot. A later
-iteration may bind the user from an authenticated HTTP header instead of a tool argument.
+Where the principal comes from is a deployment decision, `config.rls_principal_source`
+(`KBC_RLS_PRINCIPAL_SOURCE` / `--rls-principal-source`), with no default: a server started with
+`rls_rules_path` and no source raises at startup, because neither mode is a safe default for the
+other's deployment.
+
+- `header` — the principal is the `X-RLS-Principal` request header (`Config.rls_principal`, the one
+  RLS field in `_HEADER_ELIGIBLE_FIELDS`; it is `header_only`, so no env var or CLI flag can pin it
+  server-wide). The `principal` tool argument must be omitted — passing it is refused, not ignored,
+  and a missing header is refused as well. The model can neither choose nor override the identity.
+- `argument` — the principal is the `principal` tool argument, supplied by the MCP client / model and
+  verified by nothing. A stray `X-RLS-Principal` header is ignored with a WARNING. This is the pilot
+  mode, acceptable only behind a trusted client.
+
+The intended production shape is a wrapper application: it authenticates its own end users (AD,
+Google, Okta, its own sessions), it is the only client of the MCP server, and it asserts the
+authenticated user in `X-RLS-Principal` on every request. The MCP server does not verify that header
+— it trusts the wrapper — so the MCP endpoint must be reachable only from the wrapper, never directly
+from an LLM, an end user's MCP client, or the public internet. Rule keys are consequently whatever
+strings the wrapper asserts: e-mail addresses, IdP subject ids or group names all work, provided the
+rules file spells them exactly as the wrapper sends them. Each call is logged with `source=` so a
+header-bound deployment can be audited for calls that were not.
 
 ### Fail-closed guards added after adversarial review
 

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -70,11 +70,13 @@ tables:
 5. Replace the node with a subquery `(SELECT * FROM <original table> WHERE <predicate>)` aliased
    to the original alias, or to the bare table name when there was no alias, so the rest of the
    query keeps resolving.
-6. Generate SQL back in the same dialect and return it together with a human-readable list of
-   applied rules, e.g. `["invoices: country = 'CZ'"]`.
+6. Generate SQL back in the same dialect and return it together with the list of table keys that
+   were filtered, e.g. `["in.c-crm.invoices"]`. Keys only: a predicate is the admin's policy, and
+   returning it to a model tells the reader the shape of the data withheld from them. Errors that
+   involve a predicate say only which rule could not be applied; the detail goes to the server log.
 
-Example — input `SELECT COUNT(*) FROM invoices` for user `petr` becomes
-`SELECT COUNT(*) FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices`.
+Example — input `SELECT COUNT(*) FROM "in.c-crm"."invoices"` for user `petr` becomes
+`SELECT COUNT(*) FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = 'CZ') AS "invoices"`.
 
 The whole path is fail-closed: any exception in parsing, lookup or rewriting propagates as a tool
 error and no SQL is sent to the workspace.
@@ -90,8 +92,9 @@ async def query_data_rls(
 ) -> RlsQueryDataOutput
 ```
 
-`RlsQueryDataOutput` extends `QueryDataOutput` with `applied_rules: list[str]` so the model and
-the human always see that the result is a filtered slice (Agnes "disclosure"). The tool is
+`RlsQueryDataOutput` extends `QueryDataOutput` with `applied_rules: list[str]` — the keys of the
+tables that were filtered — so the model and the human always see that the result is a filtered
+slice (Agnes "disclosure") without being told what the filter was. The tool is
 annotated `readOnlyHint=True` and tagged `sql` like `query_data`. Its docstring reuses the SQL
 guidance from `query_data` and adds: which user to pass, that results are filtered, and that
 tables without a rule for the user are inaccessible.

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -162,3 +162,6 @@ rules (`tests/test_server.py`).
 
 `TOOLS.md` regenerated (`tox -e check-tools-docs`). README gets a short "Row-Level Security
 (pilot)" section under the local setup.
+
+Manual/exploratory testing: `examples/rls-demo/` — a Node.js harness that runs the server in RLS
+mode against a real project and shows the rewrite, the applied rules and the refusals per user.

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -29,6 +29,7 @@ read from an HTTP header (the `Config` field is not in `_HEADER_ELIGIBLE_FIELDS`
 
 ```yaml
 # table -> user -> SQL predicate (inserted into WHERE verbatim, in the workspace dialect)
+dialect: snowflake                      # required: snowflake or bigquery
 tables:
   invoices:
     petr: "country = 'CZ'"
@@ -42,10 +43,13 @@ tables:
   bucket-qualified key (`<bucket>.<table>`, i.e. `<schema>.<name>` in the workspace) is tried
   first, then the bare table name.
 - User keys are matched case-insensitively.
+- The required top-level `dialect` key (`snowflake` or `bigquery`) pins the workspace backend the
+  predicates are written for. Predicates are never transpiled, so `rewrite_query` refuses to apply
+  the rules to a workspace of any other dialect.
 - The file is loaded and validated **once at server start**. Every predicate must parse as a SQL
-  condition (`sqlglot`, dialect-agnostic parse). An unreadable, malformed or empty file, or an
-  unparseable predicate, makes the server fail to start with a message naming the offending
-  table/user. No silent defaults.
+  condition (`sqlglot`, in the pinned dialect). An unreadable, malformed or empty file, a missing or
+  unknown `dialect`, or an unparseable predicate, makes the server fail to start with a message
+  naming the offending table/user. No silent defaults.
 
 ### SQL rewrite
 

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -109,6 +109,29 @@ The `user` argument is supplied by the MCP client / model; the server cannot ver
 the same trust level as today's `X-*` request headers and is acceptable for the pilot. A later
 iteration may bind the user from an authenticated HTTP header instead of a tool argument.
 
+### Fail-closed guards added after adversarial review
+
+The rewrite is the enforcement boundary, so it is closed-by-default rather than open-by-default. In
+addition to the rules above, `rewrite_query` refuses (with `RlsError`):
+
+- any FROM / JOIN / LATERAL source that is not a plain table, subquery, `VALUES`, `UNNEST` or a CTE
+  reference — in particular `TABLE(...)`, table functions, `RESULT_SCAN`, `EXTERNAL_QUERY`, stage
+  references (`@stage/...`) and `IDENTIFIER(...)`; a table name must be a plain identifier;
+- `SELECT ... INTO` (sqlglot generates `CREATE TABLE ... AS` for it);
+- table modifiers that the wrapper cannot preserve: `SAMPLE`/`TABLESAMPLE`, `AT`/`BEFORE`/`CHANGES`,
+  `PIVOT`/`UNPIVOT`, `FOR SYSTEM_TIME AS OF`, alias column lists (`AS x(a, b)`);
+- CTE names that shadow anything: a CTE may not share its name with any rules key (bare or qualified);
+  a table reference is treated as a CTE reference only when the CTE is declared in the reference's own
+  enclosing scope chain (earlier siblings included; self-reference only under `RECURSIVE`); quoted
+  identifiers are compared case-sensitively and a quoting mismatch between alias and reference is
+  refused.
+
+After generating the rewritten SQL the function re-parses it and asserts that it is still exactly one
+`SELECT`/set operation and that every real table sits inside a subquery the rewriter generated.
+`applied_rules` is de-duplicated. Predicates must be plain conditions over the table's own columns; a
+predicate that itself references another table is refused by the output check. These refusals are
+deliberate pilot limitations, not bugs to work around.
+
 ## Scope and Constraints
 
 - Only `SELECT` statements; no DDL/DML through the RLS tool.

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -39,9 +39,10 @@ tables:
     petr: "country = 'CZ' AND status <> 'draft'"
 ```
 
-- Table keys are always `<bucket>.<table>` (`<schema>.<name>` in the workspace) and are matched
-  case-insensitively against the table reference in the SQL. The table name is the part after the
-  last dot, because bucket names contain dots. There is no bare-name form and no fall-back to one:
+- Table keys are always `<bucket>.<table>` (`<schema>.<name>` in the workspace). The table name is
+  the part after the last dot, because bucket names contain dots. Matching follows the backend's own
+  name resolution: case-insensitive on Snowflake, case-sensitive on BigQuery (where dataset and
+  table names are case-sensitive, unlike CTE names). There is no bare-name form and no fall-back to one:
   a query that names a table without its bucket is refused. A database/project name in front of the
   bucket is ignored -- the workspace reaches only its own project database. On BigQuery the bucket
   part of a key is normalised to the dataset name the server uses (`in.c-crm` -> `in_c_crm`).
@@ -135,8 +136,10 @@ addition to the rules above, `rewrite_query` refuses (with `RlsError`):
   because a protected table is always referenced with its bucket and a CTE alias never carries one.
   What is refused is real shadowing: a table reference counts as a CTE reference only when the CTE is
   declared in the reference's own enclosing scope chain (earlier siblings included; self-reference
-  only under `RECURSIVE`); quoted identifiers are compared case-sensitively and a quoting mismatch
-  between alias and reference is refused.
+  only under `RECURSIVE`). How a CTE name is compared depends on the backend: on Snowflake quoted
+  identifiers are case-sensitive and a quoting mismatch between alias and reference is refused; on
+  BigQuery CTE names fold case and backticks around them mean nothing, so those shapes resolve as
+  CTE references instead of being refused.
 
 After generating the rewritten SQL the function re-parses it and asserts that it is still exactly one
 `SELECT`/set operation and that every real table sits inside a subquery the rewriter generated.

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -31,17 +31,20 @@ read from an HTTP header (the `Config` field is not in `_HEADER_ELIGIBLE_FIELDS`
 # table -> user -> SQL predicate (inserted into WHERE verbatim, in the workspace dialect)
 dialect: snowflake                      # required: snowflake or bigquery
 tables:
-  invoices:
+  in.c-crm.invoices:                    # keys are always <bucket>.<table>
     petr: "country = 'CZ'"
     monika: "country = 'DE'"
     admin: "TRUE"                       # unrestricted access must be written explicitly
-  in.c-crm.orders:                      # bucket-qualified key, takes precedence over a bare name
+  in.c-crm.orders:
     petr: "country = 'CZ' AND status <> 'draft'"
 ```
 
-- Table keys are matched case-insensitively against the table reference in the SQL. A
-  bucket-qualified key (`<bucket>.<table>`, i.e. `<schema>.<name>` in the workspace) is tried
-  first, then the bare table name.
+- Table keys are always `<bucket>.<table>` (`<schema>.<name>` in the workspace) and are matched
+  case-insensitively against the table reference in the SQL. The table name is the part after the
+  last dot, because bucket names contain dots. There is no bare-name form and no fall-back to one:
+  a query that names a table without its bucket is refused. A database/project name in front of the
+  bucket is ignored -- the workspace reaches only its own project database. On BigQuery the bucket
+  part of a key is normalised to the dataset name the server uses (`in.c-crm` -> `in_c_crm`).
 - User keys are matched case-insensitively.
 - The required top-level `dialect` key (`snowflake` or `bigquery`) pins the workspace backend the
   predicates are written for. Predicates are never transpiled, so `rewrite_query` refuses to apply

--- a/feature_spec/rls_query_tool/RFC.md
+++ b/feature_spec/rls_query_tool/RFC.md
@@ -127,11 +127,13 @@ addition to the rules above, `rewrite_query` refuses (with `RlsError`):
 - `SELECT ... INTO` (sqlglot generates `CREATE TABLE ... AS` for it);
 - table modifiers that the wrapper cannot preserve: `SAMPLE`/`TABLESAMPLE`, `AT`/`BEFORE`/`CHANGES`,
   `PIVOT`/`UNPIVOT`, `FOR SYSTEM_TIME AS OF`, alias column lists (`AS x(a, b)`);
-- CTE names that shadow anything: a CTE may not share its name with any rules key (bare or qualified);
-  a table reference is treated as a CTE reference only when the CTE is declared in the reference's own
-  enclosing scope chain (earlier siblings included; self-reference only under `RECURSIVE`); quoted
-  identifiers are compared case-sensitively and a quoting mismatch between alias and reference is
-  refused.
+- CTE references that cannot be resolved with certainty. A CTE *may* be named after a protected
+  table (`WITH orders AS (SELECT * FROM "in.c-crm"."orders" WHERE amount > 0)`) — it shadows nothing,
+  because a protected table is always referenced with its bucket and a CTE alias never carries one.
+  What is refused is real shadowing: a table reference counts as a CTE reference only when the CTE is
+  declared in the reference's own enclosing scope chain (earlier siblings included; self-reference
+  only under `RECURSIVE`); quoted identifiers are compared case-sensitively and a quoting mismatch
+  between alias and reference is refused.
 
 After generating the rewritten SQL the function re-parses it and asserts that it is still exactly one
 `SELECT`/set operation and that every real table sits inside a subquery the rewriter generated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.79.2"
+version = "1.80.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ dependencies = [
     "cryptography ~= 50.0",
     "asyncpg ~= 0.31",
     "pydantic ~= 2.13.0",
-    "sqlglot ~= 30.0",
+    # Pinned exactly: the RLS query rewriting (src/keboola_mcp_server/rls.py) allowlists sqlglot's
+    # node taxonomy, so a new expression type or a changed parse tree in a minor release can silently
+    # widen what the rewriter accepts. Upgrade deliberately and only with the adversarial RLS suite
+    # (tests/test_rls.py) green -- that suite is the tripwire for this pin.
+    "sqlglot == 30.17.0",
     "toon-format ~= 0.9.0b1",
     "pyyaml ~= 6.0",
 ]

--- a/src/keboola_mcp_server/authorization.py
+++ b/src/keboola_mcp_server/authorization.py
@@ -12,6 +12,9 @@ Authorization is configured via HTTP headers:
 Note: These headers are intended to be injected by infrastructure/proxy layers (e.g., API gateways,
 reverse proxies) rather than set directly by end clients. For direct client access control,
 use Storage API token permissions which provide the security layer.
+
+On top of the headers, a server started with row-level-security rules (`--rls-rules-path`) is
+restricted to read-only tools unconditionally -- see `ToolAuthorizationMiddleware.is_rls_mode()`.
 """
 
 import logging
@@ -23,7 +26,7 @@ from fastmcp.tools import Tool
 from mcp import types as mt
 from starlette.requests import Request
 
-from keboola_mcp_server.mcp import get_http_request_or_none, is_read_only_tool
+from keboola_mcp_server.mcp import ServerState, get_http_request_or_none, is_read_only_tool
 
 LOG = logging.getLogger(__name__)
 
@@ -43,30 +46,70 @@ class ToolAuthorizationMiddleware(fmw.Middleware):
     """
 
     @staticmethod
+    def is_rls_mode(server_state: 'ServerState | None') -> bool:
+        """Whether the server was started with row-level-security rules.
+
+        RLS mode is a server-wide, header-independent read-only mode. The whole point of RLS is that a
+        query can only ever return the slice the rules allow; that guarantee is worth nothing if the
+        same session can run a job, create a transformation or deploy a data app that copies the
+        unfiltered table somewhere the rules do not reach. So RLS mode restricts the server to
+        `readOnlyHint=True` tools no matter what the caller's headers or token role say.
+        """
+        return server_state is not None and server_state.rls_rules is not None
+
+    @staticmethod
+    def _server_state_or_none(context: MiddlewareContext) -> 'ServerState | None':
+        """The `ServerState` behind the current MCP request, or None when it cannot be reached.
+
+        The lifespan state is where RLS mode is recorded, and it is the only unforgeable input the
+        middleware has (headers are caller-controlled). Every server built by `create_server()` has
+        one; None here means there is no FastMCP request context at all (unit tests with mock
+        contexts), in which case there are no RLS rules to enforce either.
+        """
+        ctx = getattr(context, 'fastmcp_context', None)
+        if ctx is None:
+            return None
+        try:
+            return ServerState.from_context(ctx)
+        except Exception as e:
+            LOG.debug(f'Tool authorization: no ServerState in the request context: {e}')
+            return None
+
+    @staticmethod
     def _get_authorization_config(
         http_rq: Request | None = None,
+        server_state: 'ServerState | None' = None,
     ) -> tuple[set[str] | None, set[str] | None, bool]:
         """
-        Determines the authorization configuration for the current request based on HTTP headers.
+        Determines the authorization configuration for the current request based on HTTP headers
+        and on the server-wide RLS mode.
 
         Returns a tuple of (allowed_tools, disallowed_tools, read_only_mode):
         - allowed_tools: Set of allowed tool names, or None if all tools are allowed
         - disallowed_tools: Set of tool names to exclude, or None if no tools are explicitly disallowed
-        - read_only_mode: Whether X-Read-Only-Mode header is enabled
+        - read_only_mode: Whether X-Read-Only-Mode header is enabled, or the server runs in RLS mode
 
         :param http_rq: Explicit request to read headers from. Falls back to the FastMCP request
             context when omitted. Raw Starlette routes (e.g. /preview/configuration) must pass it
             explicitly because the FastMCP request contextvar is not populated for them.
+        :param server_state: The server's lifespan state, used to detect RLS mode. Callers that can
+            reach it must pass it; omitting it only means RLS mode is not enforced on that path.
         """
+        # RLS mode forces read-only regardless of headers, and it is decided before them so that a
+        # request with no HTTP headers at all (stdio, in-memory client) is still restricted.
+        rls_mode = ToolAuthorizationMiddleware.is_rls_mode(server_state)
+        if rls_mode:
+            LOG.debug('Tool authorization: RLS mode is on, restricting to read-only tools')
+
         if http_rq is None:
             http_rq = get_http_request_or_none()
         if not http_rq:
-            # No HTTP request means no authorization headers are present, so we do not apply any filters.
-            return None, None, False
+            # No HTTP request means no authorization headers are present, so we only apply RLS mode.
+            return None, None, rls_mode
 
         allowed_tools: set[str] | None = None
         disallowed_tools: set[str] | None = None
-        read_only_mode = False
+        read_only_mode = rls_mode
 
         # Check X-Allowed-Tools header for explicit tool list
         if header_tools := http_rq.headers.get('X-Allowed-Tools'):
@@ -129,7 +172,9 @@ class ToolAuthorizationMiddleware(fmw.Middleware):
         """Filters the tools list to only include authorized tools."""
         tools = await call_next(context)
 
-        allowed_tools, disallowed_tools, read_only_mode = self._get_authorization_config()
+        allowed_tools, disallowed_tools, read_only_mode = self._get_authorization_config(
+            server_state=self._server_state_or_none(context)
+        )
         if allowed_tools is None and not disallowed_tools and not read_only_mode:
             return tools
 
@@ -146,12 +191,21 @@ class ToolAuthorizationMiddleware(fmw.Middleware):
     ) -> mt.CallToolResult:
         """Blocks calls to unauthorized tools."""
         tool_name = context.message.name
-        allowed_tools, disallowed_tools, read_only_mode = self._get_authorization_config()
+        server_state = self._server_state_or_none(context)
+        allowed_tools, disallowed_tools, read_only_mode = self._get_authorization_config(server_state=server_state)
 
         # For on_call_tool, we need to get the tool to check its annotations
         tool = await context.fastmcp_context.fastmcp.get_tool(tool_name)
 
         if not self._is_tool_authorized(tool, allowed_tools, disallowed_tools, read_only_mode):
+            if self.is_rls_mode(server_state) and not is_read_only_tool(tool):
+                # Name the real reason: the tool is not hidden because of this client's headers, it
+                # cannot be called on this server at all while RLS mode is on.
+                LOG.info(f'Tool authorization denied: {tool_name} is not read-only and the server runs in RLS mode')
+                raise ToolError(
+                    f'Access denied: this server runs with row-level security (RLS) enabled, which allows '
+                    f'read-only tools only. The tool "{tool_name}" modifies data and cannot be called.'
+                )
             LOG.info(f'Tool authorization denied: {tool_name} not authorized')
             raise ToolError(
                 f'Access denied: The tool "{tool_name}" is not authorized for this client. '

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -58,6 +58,11 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--storage-token', metavar='STR', help='Keboola Storage API token.')
     parser.add_argument('--workspace-schema', metavar='STR', help='Keboola Storage API workspace schema.')
     parser.add_argument('--workspace-id', metavar='STR', help='Keboola Storage API workspace ID.')
+    parser.add_argument(
+        '--rls-rules-path',
+        metavar='PATH',
+        help='YAML file with row-level-security rules. When set, only the query_data_rls tool is registered.',
+    )
     parser.add_argument('--host', default='localhost', metavar='STR', help='The host to listen on.')
     parser.add_argument('--port', type=int, default=8000, metavar='INT', help='The port to listen on.')
     parser.add_argument(
@@ -561,6 +566,7 @@ async def run_server(args: list[str] | None = None) -> None:
             storage_token=parsed_args.storage_token,
             workspace_schema=parsed_args.workspace_schema,
             workspace_id=parsed_args.workspace_id,
+            rls_rules_path=parsed_args.rls_rules_path,
         ).replace_by(os.environ)
 
         # Local dev convenience, for stdio and streamable-http alike: with no token configured (CLI,

--- a/src/keboola_mcp_server/cli.py
+++ b/src/keboola_mcp_server/cli.py
@@ -63,6 +63,14 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         metavar='PATH',
         help='YAML file with row-level-security rules. When set, only the query_data_rls tool is registered.',
     )
+    parser.add_argument(
+        '--rls-principal-source',
+        choices=['header', 'argument'],
+        help='Where query_data_rls takes the RLS principal from: "header" (the X-RLS-Principal header '
+        'asserted by the calling application, which must be the only client able to reach this server) '
+        'or "argument" (the `principal` tool argument supplied by the MCP client/model -- pilot only). '
+        'Required whenever --rls-rules-path is set; there is no default.',
+    )
     parser.add_argument('--host', default='localhost', metavar='STR', help='The host to listen on.')
     parser.add_argument('--port', type=int, default=8000, metavar='INT', help='The port to listen on.')
     parser.add_argument(
@@ -567,6 +575,7 @@ async def run_server(args: list[str] | None = None) -> None:
             workspace_schema=parsed_args.workspace_schema,
             workspace_id=parsed_args.workspace_id,
             rls_rules_path=parsed_args.rls_rules_path,
+            rls_principal_source=parsed_args.rls_principal_source,
         ).replace_by(os.environ)
 
         # Local dev convenience, for stdio and streamable-http alike: with no token configured (CLI,

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -79,6 +79,12 @@ class Config:
     Maps the `X-KBC-ProjectId` HTTP header (via the alias) and the `KBC_PROJECT_ID` env var.
     Only consulted when the inbound Storage token is a Keboola programmatic token; the legacy
     project-bound Storage token derives its project from the token itself."""
+    rls_rules_path: str | None = None
+    """Path to the YAML row-level-security rules file (feature_spec/rls_query_tool/RFC.md).
+
+    When set, the server registers the `query_data_rls` tool instead of `query_data`. Deployment-level:
+    maps `KBC_RLS_RULES_PATH` / `--rls-rules-path` only and is deliberately absent from
+    `_HEADER_ELIGIBLE_FIELDS` so a caller can never point the server at a different rules file."""
 
     # Fields a per-request HTTP header may legitimately set (see `replace_by_headers`). Everything
     # else -- jwt_secret, postgres_dsn, session_encryption_key, oauth_client_id/secret,

--- a/src/keboola_mcp_server/config.py
+++ b/src/keboola_mcp_server/config.py
@@ -85,6 +85,27 @@ class Config:
     When set, the server registers the `query_data_rls` tool instead of `query_data`. Deployment-level:
     maps `KBC_RLS_RULES_PATH` / `--rls-rules-path` only and is deliberately absent from
     `_HEADER_ELIGIBLE_FIELDS` so a caller can never point the server at a different rules file."""
+    rls_principal: str | None = field(default=None, metadata={'empty_means_absent': True, 'header_only': True})
+    """The identity the row-level-security rules are selected by, asserted per request by the calling
+    application in the `X-RLS-Principal` header (`_normalize` folds the dashes and the case, so no
+    alias is needed). The server does not verify it -- it trusts the wrapper that authenticated the
+    end user, which is why the MCP endpoint must be reachable only from that wrapper.
+
+    Header-only (`header_only`): unlike every other field it is deliberately NOT readable from the
+    process environment or a CLI flag. A server-wide `KBC_RLS_PRINCIPAL` would answer every request
+    that carries no header with one operator-chosen identity, which is precisely the fail-open that
+    `rls_principal_source='header'` exists to prevent. `empty_means_absent` is set for the same
+    reason: an unset header template (`X-RLS-Principal:`) must read as "no principal" (refused), not
+    as the empty-string principal."""
+    rls_principal_source: str | None = None
+    """Where `query_data_rls` takes its principal from: `'header'` (the `X-RLS-Principal` header, set
+    by an authenticating wrapper application) or `'argument'` (the `principal` tool argument, chosen
+    by the model -- pilot/demo only).
+
+    Deployment-level: maps `KBC_RLS_PRINCIPAL_SOURCE` / `--rls-principal-source` only and is
+    deliberately absent from `_HEADER_ELIGIBLE_FIELDS`, since a caller who could set it to
+    `'argument'` could name themselves. There is no default: a server started with
+    `rls_rules_path` and no source refuses to start (see `create_server()`)."""
 
     # Fields a per-request HTTP header may legitimately set (see `replace_by_headers`). Everything
     # else -- jwt_secret, postgres_dsn, session_encryption_key, oauth_client_id/secret,
@@ -105,8 +126,12 @@ class Config:
             'bearer_token',
             'conversation_id',
             'project_id',
+            'rls_principal',
         }
     )
+
+    # Values the two RLS principal modes may take; see `rls_principal_source`.
+    RLS_PRINCIPAL_SOURCES: ClassVar[frozenset[str]] = frozenset({'header', 'argument'})
 
     def __post_init__(self) -> None:
         for f in dataclasses.fields(self):
@@ -134,6 +159,18 @@ class Config:
         if self.workspace_id is not None and not self.workspace_id.isdigit():
             raise ValueError(f'Invalid workspace_id: {self.workspace_id!r}')
 
+        if self.rls_principal_source is not None:
+            # Security-relevant deployment choice, so it is validated where it is set rather than
+            # where it is read: a typo ('headers', or an empty KBC_RLS_PRINCIPAL_SOURCE=) must stop
+            # the server, never fall through to some default mode at the first query.
+            normalized = self.rls_principal_source.strip().lower()
+            if normalized not in self.RLS_PRINCIPAL_SOURCES:
+                raise ValueError(
+                    f'Invalid rls_principal_source: {self.rls_principal_source!r}; '
+                    f'expected one of {sorted(self.RLS_PRINCIPAL_SOURCES)}'
+                )
+            object.__setattr__(self, 'rls_principal_source', normalized)
+
     @staticmethod
     def _normalize(name: str) -> str:
         """Removes dashes and underscores from the input string and turns it into lowercase."""
@@ -151,6 +188,11 @@ class Config:
         options: dict[str, Any] = {}
         for f in dataclasses.fields(cls):
             if allowed_fields is not None and f.name not in allowed_fields:
+                continue
+            # The mirror image of `allowed_fields`: a `header_only` field is skipped on the
+            # env/CLI path (`allowed_fields is None`), so it can only ever be set per request.
+            # See `rls_principal`, where an operator-set server-wide value would be a fail-open.
+            if allowed_fields is None and f.metadata.get('header_only', False):
                 continue
             field_names = [f.name] + f.metadata.get('aliases', [])
 

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -10,7 +10,7 @@ import dataclasses
 import logging
 import textwrap
 from collections.abc import Awaitable, Callable, Iterable
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 from unittest.mock import MagicMock
 
 import toon_format
@@ -58,6 +58,9 @@ from keboola_mcp_server.tools.constants import (
     UPDATE_FLOW_TOOL_NAME,
 )
 from keboola_mcp_server.workspace import WorkspaceManager
+
+if TYPE_CHECKING:
+    from keboola_mcp_server.rls import RlsRules
 
 LOG = logging.getLogger(__name__)
 CONVERSATION_ID = 'conversation_id'
@@ -123,6 +126,8 @@ class ServerState:
     runtime_info: ServerRuntimeInfo
     session_store: SessionStore | None = None
     kai_scope_store: KaiScopeStore | None = None
+    rls_rules: 'RlsRules | None' = None
+    """Row-level-security rules loaded at startup from `Config.rls_rules_path`; None = RLS disabled."""
     _token_resolvers: dict[str, StorageTokenResolver] = dataclasses.field(
         default_factory=dict, compare=False, repr=False
     )

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -64,6 +64,11 @@ if TYPE_CHECKING:
 
 LOG = logging.getLogger(__name__)
 CONVERSATION_ID = 'conversation_id'
+RLS_PRINCIPAL = 'rls_principal'
+"""Session-state key holding this request's `X-RLS-Principal` value (None when the header was
+absent). Written by `create_session_state` from the per-request `Config`, which is rebuilt from the
+request's headers on every single request -- so `query_data_rls` reads the principal of the call it
+is serving, never one left over from an earlier call on a persisted session."""
 
 R = TypeVar('R')
 T = TypeVar('T')
@@ -916,6 +921,10 @@ class SessionStateMiddleware(fmw.Middleware):
             raise
 
         state[CONVERSATION_ID] = config.conversation_id
+        # The RLS principal is per-request by construction (`Config.rls_principal` is header-only),
+        # so it is carried into the session state the same way as the conversation id -- the state
+        # dict is rebuilt for every request, so nothing here can outlive the call it belongs to.
+        state[RLS_PRINCIPAL] = config.rls_principal
         return state
 
 

--- a/src/keboola_mcp_server/preview.py
+++ b/src/keboola_mcp_server/preview.py
@@ -268,13 +268,19 @@ def _prepare_mutator(
 async def preview_config_diff(rq: Request) -> Response:
     preview_rq = PreviewConfigDiffRq.model_validate(await rq.json())
 
+    server_state = ServerState.from_starlette(rq.app)
+
     # This route is a raw Starlette route outside the FastMCP middleware chain, so the tool
     # authorization that ToolAuthorizationMiddleware applies to MCP tool calls does not run here.
     # Enforce the same X-Allowed-Tools / X-Disallowed-Tools / X-Read-Only-Mode headers explicitly
     # so a restricted client cannot drive the mutator-preview path for a tool it cannot call.
+    # Passing the server state also carries the RLS read-only restriction over to this route, so it
+    # cannot become a back door around it.
     read_only_tools = getattr(rq.app.state, 'mcp_read_only_tools', set())
     is_read_only = preview_rq.tool_name in read_only_tools
-    allowed, disallowed, read_only_mode = ToolAuthorizationMiddleware._get_authorization_config(rq)
+    allowed, disallowed, read_only_mode = ToolAuthorizationMiddleware._get_authorization_config(
+        rq, server_state=server_state
+    )
     if not ToolAuthorizationMiddleware._is_tool_name_authorized(
         preview_rq.tool_name, is_read_only, allowed, disallowed, read_only_mode
     ):
@@ -287,7 +293,6 @@ async def preview_config_diff(rq: Request) -> Response:
     # Log only non-sensitive metadata; tool_params can carry user-supplied secrets.
     LOG.info(f'[preview_config_diff] tool_name={preview_rq.tool_name} param_keys={sorted(preview_rq.tool_params)}')
 
-    server_state = ServerState.from_starlette(rq.app)
     # This route builds its own session state, so it must pin the Storage API URL to the server's
     # own stack the same way the MCP middleware chain does.
     own_stack_storage_api_url = server_state.own_stack_storage_api_url

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -1,0 +1,143 @@
+"""Row-level security (RLS) for the `query_data_rls` tool.
+
+Rules are data, not code: a YAML file maps `table -> user -> SQL predicate`. `rewrite_query()`
+replaces every table referenced by a SELECT with `(SELECT * FROM <table> WHERE <predicate>)`, so
+the caller can only ever see the slice the admin wrote down for them. Everything here is
+fail-closed: a missing rule, an unsupported statement or an unparseable query raises `RlsError`
+and no SQL is executed. See `feature_spec/rls_query_tool/RFC.md`.
+"""
+
+import dataclasses
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+
+import sqlglot
+import yaml
+from sqlglot import exp
+
+LOG = logging.getLogger(__name__)
+
+
+class RlsError(ValueError):
+    """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means "no data"."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RewrittenQuery:
+    sql: str
+    applied_rules: list[str]
+    """Human-readable disclosure, one entry per rewritten table: `"<table key>: <predicate>"`."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RlsRules:
+    """RLS rules keyed by lower-cased table key, then lower-cased user name.
+
+    A table key is either a bare table name (`invoices`) or `<schema>.<name>` (`in.c-crm.invoices`);
+    the qualified form takes precedence during lookup.
+    """
+
+    tables: Mapping[str, Mapping[str, str]]
+
+    @classmethod
+    def load(cls, path: str) -> 'RlsRules':
+        """Read and validate the YAML rules file. Raises `RlsError` on any problem."""
+        file = Path(path)
+        if not file.is_file():
+            raise RlsError(f'RLS rules file not found: {path}')
+        try:
+            raw = yaml.safe_load(file.read_text())
+        except yaml.YAMLError as e:
+            raise RlsError(f'RLS rules file {path} is not valid YAML: {e}') from e
+        if raw is None:
+            raise RlsError(f'RLS rules file {path} is empty')
+        if not isinstance(raw, Mapping) or 'tables' not in raw:
+            raise RlsError(f"RLS rules file {path} must have a top-level 'tables' mapping")
+        tables_raw = raw['tables']
+        if not isinstance(tables_raw, Mapping) or not tables_raw:
+            raise RlsError(f'RLS rules file {path} has no tables defined')
+
+        tables: dict[str, dict[str, str]] = {}
+        for table_key, users_raw in tables_raw.items():
+            if not isinstance(users_raw, Mapping) or not users_raw:
+                raise RlsError(f"RLS rules for table '{table_key}' must be a non-empty mapping of user -> predicate")
+            users: dict[str, str] = {}
+            for user, predicate in users_raw.items():
+                if not isinstance(predicate, str) or not predicate.strip():
+                    raise RlsError(f"RLS predicate for table '{table_key}', user '{user}' must be a non-empty string")
+                try:
+                    # Dialect-agnostic parse: we only check the predicate is a well-formed condition.
+                    sqlglot.parse_one(predicate, into=exp.Condition)
+                except sqlglot.errors.ParseError as e:
+                    raise RlsError(f"RLS predicate for table '{table_key}', user '{user}' is not valid SQL: {e}") from e
+                users[str(user).lower()] = predicate
+            tables[str(table_key).lower()] = users
+
+        LOG.info(f'Loaded RLS rules for {len(tables)} table(s) from {path}')
+        return cls(tables=tables)
+
+    def predicate_for(self, *, table_name: str, schema: str | None, user: str) -> tuple[str, str]:
+        """Return `(matched_key, predicate)` for the table/user, or raise `RlsError`.
+
+        The `<schema>.<name>` key is tried first, then the bare name. When a key matches but has
+        no entry for `user`, that is a denial -- we do not fall through to a less specific key.
+        """
+        candidates: list[str] = []
+        if schema:
+            candidates.append(f'{schema}.{table_name}'.lower())
+        candidates.append(table_name.lower())
+        for key in candidates:
+            users = self.tables.get(key)
+            if users is None:
+                continue
+            predicate = users.get(user.lower())
+            if predicate is None:
+                raise RlsError(f"RLS: no rule for user '{user.lower()}' on table '{key}'")
+            return key, predicate
+        raise RlsError(f"RLS: no rule for table '{table_name}'")
+
+
+def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> RewrittenQuery:
+    """Rewrite a single SELECT so every referenced table becomes a filtered subquery.
+
+    :param sql: the caller's SQL, in the workspace dialect
+    :param user: identity used to select rules; case-insensitive
+    :param dialect: sqlglot dialect name (`'snowflake'` / `'bigquery'`)
+    :param rules: loaded rules
+    :raises RlsError: on anything other than one SELECT statement whose every table has a rule
+    """
+    try:
+        statements = sqlglot.parse(sql, dialect=dialect)
+    except sqlglot.errors.ParseError as e:
+        raise RlsError(f'RLS: cannot parse SQL: {e}') from e
+    if len(statements) != 1 or statements[0] is None:
+        raise RlsError('RLS: exactly one statement is allowed')
+    tree = statements[0]
+    if not isinstance(tree, (exp.Select, exp.Union)):
+        raise RlsError(f'RLS: only SELECT statements are allowed, got {type(tree).__name__}')
+
+    cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+    # A CTE named like a protected table would shadow the real table inside its own body and let
+    # the reference through unfiltered. Refuse instead of trying to be clever (fail-closed).
+    if collisions := sorted(cte_names & set(rules.tables)):
+        raise RlsError(f'RLS: CTE name(s) collide with protected table(s): {", ".join(collisions)}')
+
+    applied: list[str] = []
+
+    def _transform(node: exp.Expression) -> exp.Expression:
+        if not isinstance(node, exp.Table):
+            return node
+        if not node.db and node.name.lower() in cte_names:
+            return node  # reference to a CTE defined in this statement, not a real table
+        key, predicate = rules.predicate_for(table_name=node.name, schema=node.db or None, user=user)
+        applied.append(f'{key}: {predicate}')
+        alias = node.alias or node.name
+        inner = exp.Table(this=node.this, db=node.args.get('db'), catalog=node.args.get('catalog'))
+        filtered = exp.select('*').from_(inner).where(sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition))
+        # Returning a new node stops `transform` from descending into it, so the inner table is
+        # not wrapped a second time.
+        return exp.Subquery(this=filtered, alias=exp.TableAlias(this=exp.to_identifier(alias, quoted=node.this.quoted)))
+
+    rewritten = tree.transform(_transform, copy=True)
+    return RewrittenQuery(sql=rewritten.sql(dialect=dialect), applied_rules=applied)

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -14,6 +14,7 @@ dialect-specific parse happens in `rewrite_query()` at rewrite time and is fail-
 """
 
 import dataclasses
+import itertools
 import logging
 from collections.abc import Mapping
 from pathlib import Path
@@ -23,6 +24,17 @@ import yaml
 from sqlglot import exp
 
 LOG = logging.getLogger(__name__)
+
+# FROM/JOIN sources the rewriter knows how to secure. This is an allowlist on purpose: sqlglot has
+# many node types that read like a table but carry no `exp.Table` to wrap -- `FROM TABLE(x)` parses
+# as `exp.TableFromRows`, table functions as `exp.Anonymous` -- and those would otherwise reach the
+# workspace unfiltered. `exp.Lateral` is allowed only as a container; its own source is checked too.
+_ALLOWED_FROM_SOURCES = (exp.Table, exp.Subquery, exp.Unnest, exp.Values, exp.Lateral)
+
+# `exp.Table` args the rewrite can faithfully reproduce. Anything else -- PIVOT/UNPIVOT, SAMPLE,
+# Snowflake AT()/BEFORE()/CHANGES(), BigQuery FOR SYSTEM_TIME AS OF, an alias column list -- would be
+# silently dropped when the table is rebuilt inside the wrapper, changing what the query means.
+_ALLOWED_TABLE_ARGS = frozenset({'this', 'db', 'catalog', 'alias'})
 
 
 class RlsError(ValueError):
@@ -41,7 +53,8 @@ class RlsRules:
     """RLS rules keyed by lower-cased table key, then lower-cased user name.
 
     A table key is either a bare table name (`invoices`) or `<schema>.<name>` (`in.c-crm.invoices`);
-    the qualified form takes precedence during lookup.
+    the qualified form takes precedence during lookup. A bare key such as `invoices` matches a table
+    of that name in every schema/bucket; use the `<bucket>.<table>` form to scope a rule.
     """
 
     tables: Mapping[str, Mapping[str, str]]
@@ -112,6 +125,52 @@ class RlsRules:
         raise RlsError(f"RLS: no rule for table '{table_name}'")
 
 
+def _check_from_sources(tree: exp.Expression) -> None:
+    """Refuse any FROM/JOIN/LATERAL source that is not on `_ALLOWED_FROM_SOURCES`.
+
+    Allowlist, not denylist: the rewrite can only protect what it recognises, so an unknown source
+    type means "no data", never "pass it through".
+    """
+    for clause in itertools.chain(tree.find_all(exp.From), tree.find_all(exp.Join), tree.find_all(exp.Lateral)):
+        source = clause.this
+        if not isinstance(source, _ALLOWED_FROM_SOURCES):
+            raise RlsError(f'RLS: unsupported FROM source: {type(source).__name__}')
+
+
+def _check_output(sql: str, *, dialect: str) -> None:
+    """Assert the generated SQL is still a plain SELECT over wrapped tables; raise `RlsError` if not.
+
+    This is the safety net: it re-parses the rewriter's own output and checks it from scratch, so a
+    bug or an unforeseen node type upstream cannot smuggle DDL, a second statement or an unfiltered
+    table past it. The only table shape the rewrite ever produces is
+    `(SELECT * FROM <table> WHERE <predicate>) AS <alias>`; anything else is a defect, not data.
+
+    Consequence worth knowing when authoring rules: a predicate that itself references another table
+    (`id IN (SELECT id FROM other)`) leaves a table outside a wrapper and is refused. Predicates must
+    be plain conditions over the protected table's own columns.
+    """
+    try:
+        statements = sqlglot.parse(sql, dialect=dialect)
+    except sqlglot.errors.SqlglotError as e:
+        raise RlsError(f'RLS: rewrite produced SQL that cannot be re-parsed: {e}') from e
+    if len(statements) != 1 or not isinstance(statements[0], (exp.Select, exp.SetOperation)):
+        raise RlsError('RLS: rewrite produced a non-SELECT statement')
+    tree = statements[0]
+
+    cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+    for table in tree.find_all(exp.Table):
+        if not table.db and table.name.lower() in cte_names:
+            continue  # reference to a CTE defined in this statement, not a real table
+        select = table.parent.parent if isinstance(table.parent, exp.From) else None
+        wrapped = (
+            isinstance(select, exp.Select)
+            and [type(e) for e in select.expressions] == [exp.Star]
+            and isinstance(select.parent, exp.Subquery)
+        )
+        if not wrapped:
+            raise RlsError(f'RLS: rewrite left an unwrapped table reference: {table.name}')
+
+
 def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> RewrittenQuery:
     """Rewrite a single SELECT so every referenced table becomes a filtered subquery.
 
@@ -132,14 +191,21 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     if len(statements) != 1 or statements[0] is None:
         raise RlsError('RLS: exactly one statement is allowed')
     tree = statements[0]
-    if not isinstance(tree, (exp.Select, exp.Union)):
+    # `exp.SetOperation` covers UNION, EXCEPT and INTERSECT alike.
+    if not isinstance(tree, (exp.Select, exp.SetOperation)):
         raise RlsError(f'RLS: only SELECT statements are allowed, got {type(tree).__name__}')
+    # `SELECT ... INTO t` is generated back as `CREATE TABLE t AS ...` -- DDL from a read-only tool.
+    # Every SELECT is checked, not just the outermost one: set operations nest them.
+    if any(select.args.get('into') is not None for select in tree.find_all(exp.Select)):
+        raise RlsError('RLS: SELECT INTO is not allowed')
 
     cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
     # A CTE named like a protected table would shadow the real table inside its own body and let
     # the reference through unfiltered. Refuse instead of trying to be clever (fail-closed).
     if collisions := sorted(cte_names & set(rules.tables)):
         raise RlsError(f'RLS: CTE name(s) collide with protected table(s): {", ".join(collisions)}')
+
+    _check_from_sources(tree)
 
     applied: list[str] = []
 
@@ -148,6 +214,17 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
             return node
         if not node.db and node.name.lower() in cte_names:
             return node  # reference to a CTE defined in this statement, not a real table
+        # The wrapper below rebuilds the table from name/db/catalog only, so any other modifier the
+        # node carries would vanish and change the query's meaning. Refuse rather than drop it.
+        extra_args = [
+            key
+            for key, value in node.args.items()
+            if key not in _ALLOWED_TABLE_ARGS and value is not None and value != []
+        ]
+        if (alias := node.args.get('alias')) is not None and alias.args.get('columns'):
+            extra_args.append('alias columns')
+        if extra_args:
+            raise RlsError(f'RLS: table modifiers are not supported on {node.name!r}: {sorted(extra_args)}')
         key, predicate = rules.predicate_for(table_name=node.name, schema=node.db or None, user=user)
         applied.append(f'{key}: {predicate}')
         # Reuse the original alias identifier as-is (preserving its own quoting) so references to
@@ -169,5 +246,8 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
         # not wrapped a second time.
         return exp.Subquery(this=filtered, alias=exp.TableAlias(this=alias_identifier))
 
-    rewritten = tree.transform(_transform, copy=True)
-    return RewrittenQuery(sql=rewritten.sql(dialect=dialect), applied_rules=applied)
+    rewritten_sql = tree.transform(_transform, copy=True).sql(dialect=dialect)
+    _check_output(rewritten_sql, dialect=dialect)
+    # `dict.fromkeys` deduplicates while preserving first-seen order: a table joined or unioned with
+    # itself is disclosed once.
+    return RewrittenQuery(sql=rewritten_sql, applied_rules=list(dict.fromkeys(applied)))

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -135,6 +135,92 @@ def _check_from_sources(tree: exp.Expression) -> None:
         source = clause.this
         if not isinstance(source, _ALLOWED_FROM_SOURCES):
             raise RlsError(f'RLS: unsupported FROM source: {type(source).__name__}')
+        if isinstance(source, exp.Table) and not isinstance(source.this, exp.Identifier):
+            # A table function (`FROM my_udtf(1)`) parses as an `exp.Table` wrapping an
+            # `exp.Anonymous`. It has no table name to look a rule up by, so it must be refused
+            # here rather than reach the workspace as an unrewritten source.
+            raise RlsError(f'RLS: unsupported table reference: {source.sql()}')
+
+
+def _cte_names(tree: exp.Expression) -> set[str]:
+    """Every CTE alias in `tree`, as raw identifier text lower-cased (quoting ignored).
+
+    Quoting is deliberately ignored on both sides of every comparison in this module: a
+    `WITH "orders"` declaration and an unquoted `ORDERS` reference are the same name for the
+    purpose of deciding whether something is dangerous.
+    """
+    return {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+
+
+def _cte_key(cte: exp.CTE) -> tuple[str, bool]:
+    """A CTE declaration as `(lower-cased alias, quoted)` -- the same shape a table reference is
+    reduced to in `_is_cte_reference`."""
+    alias = cte.args.get('alias')
+    identifier = alias.this if isinstance(alias, exp.TableAlias) else None
+    return cte.alias_or_name.lower(), isinstance(identifier, exp.Identifier) and identifier.quoted
+
+
+def _with_clause(node: exp.Expression) -> exp.With | None:
+    """The WITH clause `node` carries, if any.
+
+    Found by scanning the node's args rather than by key: sqlglot has renamed the argument
+    (`with` -> `with_`) between versions, and a silently missed WITH clause here would mean a
+    missed shadowing check.
+    """
+    for value in node.args.values():
+        if isinstance(value, exp.With):
+            return value
+    return None
+
+
+def _cte_names_in_scope(node: exp.Expression) -> set[tuple[str, bool]]:
+    """CTE aliases visible from `node`, as `(lower-cased name, quoted)` pairs.
+
+    Walks `node`'s own ancestor chain outwards: a statement's WITH clause is visible to that
+    statement's body, and inside a CTE body only that CTE and its earlier siblings are visible (the
+    CTE itself so `WITH RECURSIVE` works). A CTE declared in a nested or sibling scope is therefore
+    not reachable -- which is the whole point, see `_is_cte_reference`.
+
+    This is a scope *chain* walk, not full SQL name resolution; it never has to be more precise
+    than that because every name it fails to resolve is refused, not passed through.
+    """
+    names: set[tuple[str, bool]] = set()
+    child, parent = node, node.parent
+    while parent is not None:
+        if isinstance(parent, exp.With):
+            # `child` is the CTE whose body we are in: stop at it, later siblings are not visible.
+            for cte in parent.expressions:
+                names.add(_cte_key(cte))
+                if cte is child:
+                    break
+        elif (with_clause := _with_clause(parent)) is not None and with_clause is not child:
+            names.update(_cte_key(cte) for cte in with_clause.expressions)
+        child, parent = parent, parent.parent
+    return names
+
+
+def _is_cte_reference(node: exp.Table, cte_names: set[str]) -> bool:
+    """Whether `node` names a CTE declared in its own enclosing scope chain (and so is not a table).
+
+    `cte_names` is `_cte_names()` for the whole statement. Matching the whole-tree set is not
+    enough on its own: a CTE declared in a nested subquery or in the other branch of a UNION used
+    to make a top-level *real* table look like a CTE reference and sail through unfiltered.
+
+    Fail-closed: when the name matches a CTE that is out of scope, or matches one in scope but with
+    different quoting (so the engine and this rewriter could disagree about what it resolves to),
+    raise rather than guess.
+    """
+    if node.db or node.catalog or not isinstance(node.this, exp.Identifier):
+        return False  # a qualified or non-identifier source is never a CTE reference
+    name = node.name.lower()
+    if name not in cte_names:
+        return False
+    in_scope = _cte_names_in_scope(node)
+    if (name, node.this.quoted) in in_scope:
+        return True
+    if any(scoped_name == name for scoped_name, _ in in_scope):
+        raise RlsError(f'RLS: ambiguous CTE reference, quoting differs from the declaration: {node.name}')
+    raise RlsError(f'RLS: table reference shadowed by a CTE declared in another scope: {node.name}')
 
 
 def _check_output(sql: str, *, dialect: str) -> None:
@@ -157,10 +243,10 @@ def _check_output(sql: str, *, dialect: str) -> None:
         raise RlsError('RLS: rewrite produced a non-SELECT statement')
     tree = statements[0]
 
-    cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+    cte_names = _cte_names(tree)
     for table in tree.find_all(exp.Table):
-        if not table.db and table.name.lower() in cte_names:
-            continue  # reference to a CTE defined in this statement, not a real table
+        if _is_cte_reference(table, cte_names):
+            continue  # reference to a CTE in scope here, not a real table
         select = table.parent.parent if isinstance(table.parent, exp.From) else None
         wrapped = (
             isinstance(select, exp.Select)
@@ -199,10 +285,13 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     if any(select.args.get('into') is not None for select in tree.find_all(exp.Select)):
         raise RlsError('RLS: SELECT INTO is not allowed')
 
-    cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+    cte_names = _cte_names(tree)
     # A CTE named like a protected table would shadow the real table inside its own body and let
     # the reference through unfiltered. Refuse instead of trying to be clever (fail-closed).
-    if collisions := sorted(cte_names & set(rules.tables)):
+    # A CTE alias is always bare, so it is a rule key's bare table name it shadows: `in.c-crm.orders`
+    # is guarded by `orders`. The full keys are compared too, for a bare key like `invoices`.
+    rule_keys = {key.lower() for key in rules.tables}
+    if collisions := sorted(cte_names & (rule_keys | {key.rsplit('.', 1)[-1] for key in rule_keys})):
         raise RlsError(f'RLS: CTE name(s) collide with protected table(s): {", ".join(collisions)}')
 
     _check_from_sources(tree)
@@ -212,8 +301,12 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     def _transform(node: exp.Expression) -> exp.Expression:
         if not isinstance(node, exp.Table):
             return node
-        if not node.db and node.name.lower() in cte_names:
-            return node  # reference to a CTE defined in this statement, not a real table
+        if not isinstance(node.this, exp.Identifier):
+            # A table function has no name to look a rule up by -- `_check_from_sources` already
+            # refuses these; this is the same guard on the rewrite path itself.
+            raise RlsError(f'RLS: unsupported table reference: {node.sql()}')
+        if _is_cte_reference(node, cte_names):
+            return node  # reference to a CTE in scope here, not a real table
         # The wrapper below rebuilds the table from name/db/catalog only, so any other modifier the
         # node carries would vanish and change the query's meaning. Refuse rather than drop it.
         extra_args = [

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -17,6 +17,7 @@ is asked to rewrite for is not the dialect the rules were written for.
 import dataclasses
 import itertools
 import logging
+import re
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -40,9 +41,30 @@ _ALLOWED_TABLE_ARGS = frozenset({'this', 'db', 'catalog', 'alias'})
 # The workspace backends the RLS pilot supports. A rules file must pin exactly one of them.
 _SUPPORTED_DIALECTS = ('bigquery', 'snowflake')
 
+# Table and user keys in the rules file. Deliberately narrow: it is the set of characters a Keboola
+# bucket/table name or a user name actually uses, and it rejects the shapes that would make a key
+# mean something other than it looks like -- an empty string, embedded quotes, whitespace, a `*`
+# that reads like a wildcard but is not one, and (via the `str` check) YAML 1.1 scalars such as
+# `yes:`/`on:`/`42:` that never were strings.
+_RULE_KEY_RE = re.compile(r'^[A-Za-z0-9_.\-]+$')
+_RULE_KEY_HINT = 'keys must be non-empty strings of letters, digits, underscore, dot or hyphen'
+
+# Expression roots a predicate may have. `exp.Predicate` covers the comparison and membership
+# operators (`=`, `IN`, `LIKE`, `IS`, `BETWEEN`, ...); the rest are the boolean connectives and
+# literals sqlglot does not classify as predicates. Anything else -- a bare column, a literal, a
+# function call, a CASE expression -- is not a filter a rules author can reason about.
+_BOOLEAN_ROOTS = (exp.Predicate, exp.And, exp.Or, exp.Not, exp.Boolean)
+
 
 class RlsError(ValueError):
     """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means "no data"."""
+
+
+def _is_boolean_condition(node: exp.Expression) -> bool:
+    """Whether `node` is a boolean-valued condition, looking through any wrapping parentheses."""
+    while isinstance(node, exp.Paren):
+        node = node.this
+    return isinstance(node, _BOOLEAN_ROOTS)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -103,21 +125,46 @@ class RlsRules:
 
         tables: dict[str, dict[str, str]] = {}
         for table_key, users_raw in tables_raw.items():
+            if not isinstance(table_key, str) or not _RULE_KEY_RE.match(table_key):
+                raise RlsError(f'RLS rules file {path} has an invalid table key {table_key!r}: {_RULE_KEY_HINT}')
+            key = table_key.lower()
+            if key in tables:
+                # Only reachable when two YAML keys differ solely in case: the second would silently
+                # replace the first, so the admin would be reading a rule that is not in force.
+                raise RlsError(f"RLS rules file {path} has a duplicate table key '{key}'")
             if not isinstance(users_raw, Mapping) or not users_raw:
                 raise RlsError(f"RLS rules for table '{table_key}' must be a non-empty mapping of user -> predicate")
             users: dict[str, str] = {}
             for user, predicate in users_raw.items():
+                if not isinstance(user, str) or not _RULE_KEY_RE.match(user):
+                    raise RlsError(
+                        f"RLS rules for table '{table_key}' have an invalid user key {user!r}: {_RULE_KEY_HINT}"
+                    )
+                user_key = user.lower()
+                if user_key in users:
+                    raise RlsError(f"RLS rules for table '{table_key}' have a duplicate user key '{user_key}'")
                 if not isinstance(predicate, str) or not predicate.strip():
                     raise RlsError(f"RLS predicate for table '{table_key}', user '{user}' must be a non-empty string")
                 try:
                     # Parsed in the file's own pinned dialect, so this check is the real one.
-                    sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition)
+                    parsed = sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition)
                 except sqlglot.errors.ParseError as e:
                     raise RlsError(
                         f"RLS predicate for table '{table_key}', user '{user}' is not valid {dialect} SQL: {e}"
                     ) from e
-                users[str(user).lower()] = predicate
-            tables[str(table_key).lower()] = users
+                if not _is_boolean_condition(parsed):
+                    raise RlsError(
+                        f"RLS predicate for table '{table_key}', user '{user}' must be a boolean condition, "
+                        f'got {type(parsed).__name__}'
+                    )
+                if next(parsed.find_all(exp.Table, exp.Subquery, exp.Select), None) is not None:
+                    # Such a predicate leaves a table outside a wrapper; `_check_output` would refuse
+                    # it at query time anyway, but the admin should hear about it at startup.
+                    raise RlsError(
+                        f"RLS predicate for table '{table_key}', user '{user}' must not reference a table or subquery"
+                    )
+                users[user_key] = predicate
+            tables[key] = users
 
         LOG.info(f'Loaded RLS rules for {len(tables)} table(s) from {path} (dialect {dialect})')
         return cls(tables=tables, dialect=dialect)

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -146,6 +146,23 @@ def _normalize_schema(schema: str, dialect: str) -> str:
     return schema.replace('.', '_').replace('-', '_') if dialect == 'bigquery' else schema
 
 
+def _rule_key(schema: str, table: str, dialect: str) -> str:
+    """The rules-file key a `<schema>.<table>` reference is looked up under.
+
+    Case handling follows the backend's own object-name resolution, so a rule matches exactly the
+    table the engine would read:
+
+    * Snowflake folds unquoted names and the workspace hands out fully-qualified names quoted in the
+      storage case, so keys are compared case-insensitively -- `"IN.C-CRM"."INVOICES"` and
+      `"in.c-crm"."invoices"` name the same table there.
+    * BigQuery dataset and table names are case-SENSITIVE: `in_c_crm.Invoices` is a different table
+      from `in_c_crm.invoices`, so a rule for one must not cover the other. Keys keep their case and
+      a mismatch simply finds no rule -- which is a refusal.
+    """
+    key = f'{schema}.{table}'
+    return key if dialect == 'bigquery' else key.lower()
+
+
 def _is_boolean_condition(node: exp.Expression) -> bool:
     """Whether `node` is a boolean-valued condition, looking through any wrapping parentheses."""
     while isinstance(node, exp.Paren):
@@ -168,7 +185,7 @@ class RewrittenQuery:
 
 @dataclasses.dataclass(frozen=True)
 class RlsRules:
-    """RLS rules keyed by lower-cased table key, then lower-cased user name.
+    """RLS rules keyed by table key, then lower-cased user name.
 
     A table key is always `<bucket>.<table>` (`in.c-crm.invoices`) -- the table part is the text
     after the LAST dot, because a Keboola bucket name contains dots of its own. There is no bare-name
@@ -182,9 +199,11 @@ class RlsRules:
 
     `dialect` is the workspace backend the predicates were written for; it is not a default but a
     pin, and `rewrite_query()` refuses to run these rules against any other backend. It also decides
-    how the bucket part of a key is normalised: BigQuery datasets cannot contain dots or hyphens, so
-    the server names the dataset for bucket `in.c-crm` `in_c_crm`, and a key written the Keboola way
-    is normalised to match at load time.
+    two things about the keys, each following that backend's own name resolution: how the bucket part
+    is spelled (BigQuery datasets take neither dots nor hyphens, so bucket `in.c-crm` is dataset
+    `in_c_crm` -- normalised at load, see `_normalize_schema`) and whether case matters (it does on
+    BigQuery, where table and dataset names are case-sensitive; it does not on Snowflake -- see
+    `_rule_key`).
     """
 
     tables: Mapping[str, Mapping[str, str]]
@@ -233,7 +252,7 @@ class RlsRules:
                 raise RlsError(
                     f"RLS rules file {path} has an unqualified table key '{table_key}': keys must be <bucket>.<table>"
                 )
-            key = f'{_normalize_schema(bucket, dialect)}.{table}'.lower()
+            key = _rule_key(_normalize_schema(bucket, dialect), table, dialect)
             if key in tables:
                 # Only reachable when two YAML keys differ solely in case: the second would silently
                 # replace the first, so the admin would be reading a rule that is not in force.
@@ -285,7 +304,7 @@ class RlsRules:
         """
         if not schema:
             raise RlsError(f"RLS: table reference must be qualified as <bucket>.<table>: '{table_name}'")
-        key = f'{schema}.{table_name}'.lower()
+        key = _rule_key(schema, table_name, self.dialect)
         users = self.tables.get(key)
         if users is None:
             raise RlsError(f"RLS: no rule for table '{key}'")
@@ -323,26 +342,36 @@ def _cte_names(tree: exp.Expression) -> set[str]:
     return {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
 
 
-def _identifier_key(text: str, quoted: bool) -> tuple[str, bool]:
-    """Reduce an identifier to a comparison key that matches engine name resolution.
+def _identifier_key(text: str, quoted: bool, *, dialect: str) -> tuple[str, bool]:
+    """Reduce a CTE name to a comparison key that matches how the engine resolves it.
 
-    Snowflake and BigQuery fold unquoted identifiers to a canonical case but treat quoted ones as
-    literal, so `"secret"` and `"SECRET"` are two different names while `secret` and `SECRET` are
-    one. Comparing everything lower-cased would bind a quoted reference to a differently-cased
-    quoted CTE that the engine resolves to the *base table* -- and pass that table through
-    unfiltered. Quoted and unquoted forms of the same text stay distinct too (Ruling 14): the
-    caller decides whether that mismatch is a refusal or merely a non-match.
+    The two backends do not agree, and the difference decides whether a reference binds to the CTE
+    or falls through to the base table -- so it is keyed on the dialect rather than guessed:
+
+    * Snowflake folds unquoted identifiers to a canonical case but treats quoted ones literally, so
+      `"secret"` and `"SECRET"` are two different names while `secret` and `SECRET` are one.
+      Comparing everything lower-cased would bind a quoted reference to a differently-cased quoted
+      CTE that the engine resolves to the *base table* -- and pass that table through unfiltered.
+      Quoted and unquoted forms of the same text stay distinct too (Ruling 14); the caller decides
+      whether that mismatch is a refusal or merely a non-match.
+    * BigQuery resolves CTE names case-insensitively and backticks around one carry no meaning at
+      all (verified against a live workspace): `WITH secret AS (...) SELECT * FROM \\`SECRET\\`` reads the
+      CTE. Keeping Snowflake's rule there would refuse ordinary queries as "ambiguous" while
+      protecting nothing. (BigQuery *table* and *dataset* names are case-sensitive -- that is a
+      separate question, settled by the rules-key lookup, not here.)
     """
+    if dialect == 'bigquery':
+        return text.lower(), False
     return text if quoted else text.lower(), quoted
 
 
-def _cte_key(cte: exp.CTE) -> tuple[str, bool]:
+def _cte_key(cte: exp.CTE, *, dialect: str) -> tuple[str, bool]:
     """A CTE declaration as an `_identifier_key` -- the same shape a table reference is reduced to
     in `_is_cte_reference`."""
     alias = cte.args.get('alias')
     identifier = alias.this if isinstance(alias, exp.TableAlias) else None
     quoted = isinstance(identifier, exp.Identifier) and identifier.quoted
-    return _identifier_key(cte.alias_or_name, quoted)
+    return _identifier_key(cte.alias_or_name, quoted, dialect=dialect)
 
 
 def _with_clause(node: exp.Expression) -> exp.With | None:
@@ -358,7 +387,7 @@ def _with_clause(node: exp.Expression) -> exp.With | None:
     return None
 
 
-def _cte_names_in_scope(node: exp.Expression) -> set[tuple[str, bool]]:
+def _cte_names_in_scope(node: exp.Expression, *, dialect: str) -> set[tuple[str, bool]]:
     """CTE aliases visible from `node`, as `_identifier_key` pairs.
 
     Walks `node`'s own ancestor chain outwards: a statement's WITH clause is visible to that
@@ -379,16 +408,16 @@ def _cte_names_in_scope(node: exp.Expression) -> set[tuple[str, bool]]:
             for cte in parent.expressions:
                 if cte is child and not parent.args.get('recursive'):
                     break
-                names.add(_cte_key(cte))
+                names.add(_cte_key(cte, dialect=dialect))
                 if cte is child:
                     break
         elif (with_clause := _with_clause(parent)) is not None and with_clause is not child:
-            names.update(_cte_key(cte) for cte in with_clause.expressions)
+            names.update(_cte_key(cte, dialect=dialect) for cte in with_clause.expressions)
         child, parent = parent, parent.parent
     return names
 
 
-def _is_non_recursive_self_reference(node: exp.Table, key: tuple[str, bool]) -> bool:
+def _is_non_recursive_self_reference(node: exp.Table, key: tuple[str, bool], *, dialect: str) -> bool:
     """Whether `node` sits inside the body of a CTE named `key` whose WITH lacks `RECURSIVE`.
 
     Only used to explain a refusal: `_cte_names_in_scope` has already decided such a name is not a
@@ -400,14 +429,14 @@ def _is_non_recursive_self_reference(node: exp.Table, key: tuple[str, bool]) -> 
         if (
             isinstance(parent, exp.With)
             and not parent.args.get('recursive')
-            and any(cte is child and _cte_key(cte) == key for cte in parent.expressions)
+            and any(cte is child and _cte_key(cte, dialect=dialect) == key for cte in parent.expressions)
         ):
             return True
         child, parent = parent, parent.parent
     return False
 
 
-def _is_cte_reference(node: exp.Table, cte_names: set[str]) -> bool:
+def _is_cte_reference(node: exp.Table, cte_names: set[str], *, dialect: str) -> bool:
     """Whether `node` names a CTE declared in its own enclosing scope chain (and so is not a table).
 
     `cte_names` is `_cte_names()` for the whole statement. Matching the whole-tree set is not
@@ -422,13 +451,13 @@ def _is_cte_reference(node: exp.Table, cte_names: set[str]) -> bool:
         return False  # a qualified or non-identifier source is never a CTE reference
     if node.name.lower() not in cte_names:
         return False
-    key = _identifier_key(node.name, node.this.quoted)
-    in_scope = _cte_names_in_scope(node)
+    key = _identifier_key(node.name, node.this.quoted, dialect=dialect)
+    in_scope = _cte_names_in_scope(node, dialect=dialect)
     if key in in_scope:
         return True
     if any(scoped_name == key[0] for scoped_name, _ in in_scope):
         raise RlsError(f'RLS: ambiguous CTE reference, quoting differs from the declaration: {node.name}')
-    if _is_non_recursive_self_reference(node, key):
+    if _is_non_recursive_self_reference(node, key, dialect=dialect):
         raise RlsError(f'RLS: a CTE cannot reference itself without RECURSIVE: {node.name}')
     raise RlsError(f'RLS: table reference shadowed by a CTE declared in another scope: {node.name}')
 
@@ -452,7 +481,7 @@ def _function_name(node: exp.Expression) -> str:
     return node.sql_name() if isinstance(node, exp.Func) else type(node).__name__
 
 
-def _check_functions(tree: exp.Expression, cte_names: set[str]) -> None:
+def _check_functions(tree: exp.Expression, cte_names: set[str], *, dialect: str) -> None:
     """Refuse function calls that RLS cannot reason about; raise `RlsError` if any is present.
 
     Two bans, both allowlist-shaped where it matters:
@@ -474,7 +503,7 @@ def _check_functions(tree: exp.Expression, cte_names: set[str]) -> None:
     # CTE is refused with the reason it deserves ("declared in another scope") instead of being
     # counted as a non-table here and reported as a stray function call.
     for table in tree.find_all(exp.Table):
-        if not isinstance(table.this, exp.Identifier) or not _is_cte_reference(table, cte_names):
+        if not isinstance(table.this, exp.Identifier) or not _is_cte_reference(table, cte_names, dialect=dialect):
             return  # there is a real table here; the rewrite will filter it
 
     for node in tree.find_all(exp.Func):
@@ -486,11 +515,11 @@ def _check_functions(tree: exp.Expression, cte_names: set[str]) -> None:
         raise RlsError(f'RLS: function calls are not allowed in a query without FROM: {name}')
 
 
-def _matching_key(table: exp.Table, keys: Mapping[str, str]) -> str | None:
+def _matching_key(table: exp.Table, keys: Mapping[str, str], *, dialect: str) -> str | None:
     """The rules key `table` was wrapped under -- built exactly as `predicate_for` builds it."""
     if not table.db:
         return None
-    key = f'{table.db}.{table.name}'.lower()
+    key = _rule_key(table.db, table.name, dialect)
     return key if key in keys else None
 
 
@@ -527,7 +556,7 @@ def _check_output(sql: str, *, dialect: str, predicates: Mapping[str, str]) -> N
             # here it also stops such a node reaching the "is it wrapped?" test, which would report
             # it under an empty name.
             raise RlsError('RLS: rewrite left an unsupported table reference')
-        if _is_cte_reference(table, cte_names):
+        if _is_cte_reference(table, cte_names, dialect=dialect):
             continue  # reference to a CTE in scope here, not a real table
         select = table.parent.parent if isinstance(table.parent, exp.From) else None
         wrapped = (
@@ -541,7 +570,7 @@ def _check_output(sql: str, *, dialect: str, predicates: Mapping[str, str]) -> N
             LOG.warning(f'RLS: rewrite left an unwrapped table reference: {table.sql(dialect=dialect)}')
             raise RlsError('RLS: rewrite left an unwrapped table reference')
         assert isinstance(select, exp.Select)  # narrowed by `wrapped`
-        key = _matching_key(table, predicates)
+        key = _matching_key(table, predicates, dialect=dialect)
         if key is None:
             LOG.warning(f'RLS: rewrite wrapped a table no rule was looked up for: {table.sql(dialect=dialect)}')
             raise RlsError('RLS: rewrite wrapped a table no rule was looked up for')
@@ -609,7 +638,7 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     cte_names = _cte_names(tree)
 
     _check_from_sources(tree)
-    _check_functions(tree, cte_names)
+    _check_functions(tree, cte_names, dialect=dialect)
 
     applied: list[str] = []
     # The predicate the rewrite actually inserted for each matched key, handed to `_check_output` so
@@ -623,7 +652,7 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
             # A table function has no name to look a rule up by -- `_check_from_sources` already
             # refuses these; this is the same guard on the rewrite path itself.
             raise RlsError(f'RLS: unsupported table reference: {node.sql()}')
-        if _is_cte_reference(node, cte_names):
+        if _is_cte_reference(node, cte_names, dialect=dialect):
             return node  # reference to a CTE in scope here, not a real table
         # The wrapper below rebuilds the table from name/db/catalog only, so any other modifier the
         # node carries would vanish and change the query's meaning. Refuse rather than drop it.

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -55,6 +55,26 @@ _RULE_KEY_HINT = 'keys must be non-empty strings of letters, digits, underscore,
 # function call, a CASE expression -- is not a filter a rules author can reason about.
 _BOOLEAN_ROOTS = (exp.Predicate, exp.And, exp.Or, exp.Not, exp.Boolean)
 
+# What a query with no real table may still call. Everything here either reads the clock or is a
+# pure scalar expression over its own arguments -- nothing that reaches the catalog, the query
+# history or a model. `exp.Localtime`/`exp.Localtimestamp` are what Snowflake's `CURRENT_TIME` and
+# BigQuery's `CURRENT_DATETIME` parse into; `exp.If` is a `CASE` branch.
+_FROMLESS_ALLOWED_FUNC_TYPES = (
+    exp.CurrentDate,
+    exp.CurrentTime,
+    exp.CurrentTimestamp,
+    exp.Localtime,
+    exp.Localtimestamp,
+    exp.Cast,
+    exp.TryCast,
+    exp.Concat,
+    exp.Coalesce,
+    exp.Case,
+    exp.If,
+)
+# `NOW()` has no dedicated node -- it parses as an `exp.Anonymous`, so it is allowed by name.
+_FROMLESS_ALLOWED_FUNC_NAMES = frozenset({'NOW', 'CURRENT_DATE', 'CURRENT_TIME', 'CURRENT_TIMESTAMP'})
+
 
 class RlsError(ValueError):
     """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means "no data"."""
@@ -328,6 +348,59 @@ def _is_cte_reference(node: exp.Table, cte_names: set[str]) -> bool:
     raise RlsError(f'RLS: table reference shadowed by a CTE declared in another scope: {node.name}')
 
 
+def _function_name(node: exp.Expression) -> str:
+    """The name a function call goes by, including any `db.schema.` prefix it was written with.
+
+    sqlglot parses `SNOWFLAKE.CORTEX.COMPLETE(...)` as a `Dot` chain whose rightmost element is an
+    `exp.Anonymous` named only `COMPLETE`, so the qualification -- the part that says which function
+    family this is -- lives in the ancestors and has to be walked back in.
+    """
+    if isinstance(node, exp.Anonymous):
+        name = node.name
+        current: exp.Expression = node
+        parent = current.parent
+        while isinstance(parent, exp.Dot) and parent.expression is current:
+            # The left side of such a `Dot` is identifiers only, so rendering it is safe.
+            name = f'{parent.this.sql()}.{name}'
+            current, parent = parent, parent.parent
+        return name
+    return node.sql_name() if isinstance(node, exp.Func) else type(node).__name__
+
+
+def _check_functions(tree: exp.Expression, cte_names: set[str]) -> None:
+    """Refuse function calls that RLS cannot reason about; raise `RlsError` if any is present.
+
+    Two bans, both allowlist-shaped where it matters:
+
+    * `SYSTEM$...` and anything under `CORTEX` are refused wherever they appear. They read metadata,
+      cancel queries or hand text to an LLM -- none of which the row filter constrains, however
+      thoroughly the FROM clause is rewritten.
+    * A query with no real table to filter (`SELECT GET_DDL(...)`, or the same thing dressed up with
+      a dummy CTE) is not a data query at all: whatever it returns, no predicate shaped it. Only a
+      small set of clock functions and pure scalar expressions is allowed there.
+    """
+    for node in tree.find_all(exp.Anonymous):
+        name = _function_name(node)
+        if any(part.upper().startswith('SYSTEM$') for part in name.split('.')) or 'CORTEX' in name.upper():
+            raise RlsError(f'RLS: function call is not allowed: {name}')
+
+    # An `exp.Table` naming a CTE in scope is not a real table. Resolution goes through
+    # `_is_cte_reference` rather than the cheap name set so that a name which only *looks* like a
+    # CTE is refused with the reason it deserves ("declared in another scope") instead of being
+    # counted as a non-table here and reported as a stray function call.
+    for table in tree.find_all(exp.Table):
+        if not isinstance(table.this, exp.Identifier) or not _is_cte_reference(table, cte_names):
+            return  # there is a real table here; the rewrite will filter it
+
+    for node in tree.find_all(exp.Func):
+        if isinstance(node, _FROMLESS_ALLOWED_FUNC_TYPES):
+            continue
+        name = _function_name(node)
+        if name.upper() in _FROMLESS_ALLOWED_FUNC_NAMES:
+            continue
+        raise RlsError(f'RLS: function calls are not allowed in a query without FROM: {name}')
+
+
 def _check_output(sql: str, *, dialect: str) -> None:
     """Assert the generated SQL is still a plain SELECT over wrapped tables; raise `RlsError` if not.
 
@@ -414,6 +487,7 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
         raise RlsError(f'RLS: CTE name(s) collide with protected table(s): {", ".join(collisions)}')
 
     _check_from_sources(tree)
+    _check_functions(tree, cte_names)
 
     applied: list[str] = []
 

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -75,9 +75,59 @@ _FROMLESS_ALLOWED_FUNC_TYPES = (
 # `NOW()` has no dedicated node -- it parses as an `exp.Anonymous`, so it is allowed by name.
 _FROMLESS_ALLOWED_FUNC_NAMES = frozenset({'NOW', 'CURRENT_DATE', 'CURRENT_TIME', 'CURRENT_TIMESTAMP'})
 
+# sqlglot underlines the offending token in a parse error with ANSI escapes.
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')
+
+# An unquoted Keboola bucket path (`in.c-crm.orders`), i.e. the single most common reason a query
+# fails to parse here. Matched on the SQL, not on the error text, because the parser gives up at a
+# different token -- and with a different message -- depending on where the dots and hyphens fall.
+_BUCKET_PATH_RE = re.compile(r'(?<![\w."`])(?:in|out)\.[A-Za-z0-9_-]+\.', re.IGNORECASE)
+
 
 class RlsError(ValueError):
     """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means "no data"."""
+
+
+def _clean_error(error: Exception) -> str:
+    """A sqlglot error message fit to put in front of a user (or a model).
+
+    sqlglot underlines the offending token with ANSI escapes. They render as mojibake in a JSON tool
+    result, an MCP client transcript or a log file, so they come out here.
+    """
+    return _ANSI_RE.sub('', str(error))
+
+
+def _parse_error_hint(sql: str) -> str:
+    """An extra sentence for a parse failure, when the SQL shows a known, fixable mistake.
+
+    Keboola bucket names contain dots, so `in.c-crm.orders` written bare is four name parts to the
+    parser and it gives up somewhere in the middle. The fix is quoting, and saying so turns an
+    opaque token error into something actionable.
+    """
+    if _BUCKET_PATH_RE.search(sql):
+        return ' -- quote the bucket, e.g. "in.c-crm"."orders"'
+    return ''
+
+
+def _unwrap_parenthesised(tree: exp.Expression) -> exp.Expression:
+    """Strip parentheses that merely wrap a whole statement, so `(SELECT ...)` is checked as SELECT.
+
+    A top-level `(SELECT ...)` is legal SQL and means exactly the SELECT inside it, but it parses as
+    an `exp.Subquery` and would be refused as "not a SELECT" -- a false refusal, and one that invites
+    the caller to go looking for a formulation that slips through. Only a bare wrapper is unwrapped:
+    anything hanging off it (an alias, an ORDER BY, a LIMIT) means the node is more than parentheses
+    and is left alone for the gate below to judge.
+    """
+    while isinstance(tree, (exp.Paren, exp.Subquery)):
+        if any(key != 'this' and value is not None and value != [] for key, value in tree.args.items()):
+            break
+        inner = tree.this
+        if not isinstance(inner, (exp.Select, exp.SetOperation, exp.Paren, exp.Subquery)):
+            break
+        tree = inner
+    # The scope-chain walks below climb `parent` pointers; the discarded wrapper must not be on them.
+    tree.parent = None
+    return tree
 
 
 def _is_boolean_condition(node: exp.Expression) -> bool:
@@ -170,7 +220,8 @@ class RlsRules:
                     parsed = sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition)
                 except sqlglot.errors.ParseError as e:
                     raise RlsError(
-                        f"RLS predicate for table '{table_key}', user '{user}' is not valid {dialect} SQL: {e}"
+                        f"RLS predicate for table '{table_key}', user '{user}' "
+                        f'is not valid {dialect} SQL: {_clean_error(e)}'
                     ) from e
                 if not _is_boolean_condition(parsed):
                     raise RlsError(
@@ -428,7 +479,7 @@ def _check_output(sql: str, *, dialect: str, predicates: Mapping[str, str]) -> N
     try:
         statements = sqlglot.parse(sql, dialect=dialect)
     except sqlglot.errors.SqlglotError as e:
-        raise RlsError(f'RLS: rewrite produced SQL that cannot be re-parsed: {e}') from e
+        raise RlsError(f'RLS: rewrite produced SQL that cannot be re-parsed: {_clean_error(e)}') from e
     if len(statements) != 1 or not isinstance(statements[0], (exp.Select, exp.SetOperation)):
         raise RlsError('RLS: rewrite produced a non-SELECT statement')
     tree = statements[0]
@@ -461,7 +512,9 @@ def _check_output(sql: str, *, dialect: str, predicates: Mapping[str, str]) -> N
         try:
             expected = sqlglot.parse_one(predicates[key], dialect=dialect, into=exp.Condition)
         except sqlglot.errors.SqlglotError as e:
-            raise RlsError(f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {e}") from e
+            raise RlsError(
+                f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {_clean_error(e)}"
+            ) from e
         # Compared as generated text in the same dialect, so the two sides are normalised the same
         # way and only a real difference in the condition can fail this.
         if where.this.sql(dialect=dialect) != expected.sql(dialect=dialect):
@@ -489,10 +542,10 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     try:
         statements = sqlglot.parse(sql, dialect=dialect)
     except sqlglot.errors.SqlglotError as e:
-        raise RlsError(f'RLS: cannot parse SQL: {e}') from e
+        raise RlsError(f'RLS: cannot parse SQL: {_clean_error(e)}{_parse_error_hint(sql)}') from e
     if len(statements) != 1 or statements[0] is None:
         raise RlsError('RLS: exactly one statement is allowed')
-    tree = statements[0]
+    tree = _unwrap_parenthesised(statements[0])
     # `exp.SetOperation` covers UNION, EXCEPT and INTERSECT alike.
     if not isinstance(tree, (exp.Select, exp.SetOperation)):
         raise RlsError(f'RLS: only SELECT statements are allowed, got {type(tree).__name__}')
@@ -557,7 +610,9 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
         try:
             predicate_expr = sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition)
         except sqlglot.errors.SqlglotError as e:
-            raise RlsError(f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {e}") from e
+            raise RlsError(
+                f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {_clean_error(e)}"
+            ) from e
         filtered = exp.select('*').from_(inner).where(predicate_expr)
         # Returning a new node stops `transform` from descending into it, so the inner table is
         # not wrapped a second time.

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -145,19 +145,34 @@ def _check_from_sources(tree: exp.Expression) -> None:
 def _cte_names(tree: exp.Expression) -> set[str]:
     """Every CTE alias in `tree`, as raw identifier text lower-cased (quoting ignored).
 
-    Quoting is deliberately ignored on both sides of every comparison in this module: a
-    `WITH "orders"` declaration and an unquoted `ORDERS` reference are the same name for the
-    purpose of deciding whether something is dangerous.
+    Case and quoting are deliberately ignored here because this set only ever *widens* a check: it
+    is the cheap "could this name mean a CTE at all?" pre-filter for `_is_cte_reference` (which then
+    resolves the name precisely) and the collision guard against rule keys, which must fire on the
+    merest resemblance to a protected table's name.
     """
     return {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
 
 
+def _identifier_key(text: str, quoted: bool) -> tuple[str, bool]:
+    """Reduce an identifier to a comparison key that matches engine name resolution.
+
+    Snowflake and BigQuery fold unquoted identifiers to a canonical case but treat quoted ones as
+    literal, so `"secret"` and `"SECRET"` are two different names while `secret` and `SECRET` are
+    one. Comparing everything lower-cased would bind a quoted reference to a differently-cased
+    quoted CTE that the engine resolves to the *base table* -- and pass that table through
+    unfiltered. Quoted and unquoted forms of the same text stay distinct too (Ruling 14): the
+    caller decides whether that mismatch is a refusal or merely a non-match.
+    """
+    return text if quoted else text.lower(), quoted
+
+
 def _cte_key(cte: exp.CTE) -> tuple[str, bool]:
-    """A CTE declaration as `(lower-cased alias, quoted)` -- the same shape a table reference is
-    reduced to in `_is_cte_reference`."""
+    """A CTE declaration as an `_identifier_key` -- the same shape a table reference is reduced to
+    in `_is_cte_reference`."""
     alias = cte.args.get('alias')
     identifier = alias.this if isinstance(alias, exp.TableAlias) else None
-    return cte.alias_or_name.lower(), isinstance(identifier, exp.Identifier) and identifier.quoted
+    quoted = isinstance(identifier, exp.Identifier) and identifier.quoted
+    return _identifier_key(cte.alias_or_name, quoted)
 
 
 def _with_clause(node: exp.Expression) -> exp.With | None:
@@ -174,12 +189,14 @@ def _with_clause(node: exp.Expression) -> exp.With | None:
 
 
 def _cte_names_in_scope(node: exp.Expression) -> set[tuple[str, bool]]:
-    """CTE aliases visible from `node`, as `(lower-cased name, quoted)` pairs.
+    """CTE aliases visible from `node`, as `_identifier_key` pairs.
 
     Walks `node`'s own ancestor chain outwards: a statement's WITH clause is visible to that
-    statement's body, and inside a CTE body only that CTE and its earlier siblings are visible (the
-    CTE itself so `WITH RECURSIVE` works). A CTE declared in a nested or sibling scope is therefore
-    not reachable -- which is the whole point, see `_is_cte_reference`.
+    statement's body, and inside a CTE body only that CTE's earlier siblings are visible -- plus the
+    CTE itself, but *only* under `WITH RECURSIVE`, which is what makes a recursive CTE work. Without
+    `RECURSIVE` the engine resolves a CTE's own name inside its body to the base table, so counting
+    it as visible here would wave a real, unfiltered table through. A CTE declared in a nested or
+    sibling scope is not reachable either -- which is the whole point, see `_is_cte_reference`.
 
     This is a scope *chain* walk, not full SQL name resolution; it never has to be more precise
     than that because every name it fails to resolve is refused, not passed through.
@@ -190,6 +207,8 @@ def _cte_names_in_scope(node: exp.Expression) -> set[tuple[str, bool]]:
         if isinstance(parent, exp.With):
             # `child` is the CTE whose body we are in: stop at it, later siblings are not visible.
             for cte in parent.expressions:
+                if cte is child and not parent.args.get('recursive'):
+                    break
                 names.add(_cte_key(cte))
                 if cte is child:
                     break
@@ -197,6 +216,25 @@ def _cte_names_in_scope(node: exp.Expression) -> set[tuple[str, bool]]:
             names.update(_cte_key(cte) for cte in with_clause.expressions)
         child, parent = parent, parent.parent
     return names
+
+
+def _is_non_recursive_self_reference(node: exp.Table, key: tuple[str, bool]) -> bool:
+    """Whether `node` sits inside the body of a CTE named `key` whose WITH lacks `RECURSIVE`.
+
+    Only used to explain a refusal: `_cte_names_in_scope` has already decided such a name is not a
+    CTE reference. It exists so the caller gets "this needs RECURSIVE" rather than the misleading
+    "declared in another scope" -- the declaration is right here, it is just not in scope yet.
+    """
+    child, parent = node, node.parent
+    while parent is not None:
+        if (
+            isinstance(parent, exp.With)
+            and not parent.args.get('recursive')
+            and any(cte is child and _cte_key(cte) == key for cte in parent.expressions)
+        ):
+            return True
+        child, parent = parent, parent.parent
+    return False
 
 
 def _is_cte_reference(node: exp.Table, cte_names: set[str]) -> bool:
@@ -212,14 +250,16 @@ def _is_cte_reference(node: exp.Table, cte_names: set[str]) -> bool:
     """
     if node.db or node.catalog or not isinstance(node.this, exp.Identifier):
         return False  # a qualified or non-identifier source is never a CTE reference
-    name = node.name.lower()
-    if name not in cte_names:
+    if node.name.lower() not in cte_names:
         return False
+    key = _identifier_key(node.name, node.this.quoted)
     in_scope = _cte_names_in_scope(node)
-    if (name, node.this.quoted) in in_scope:
+    if key in in_scope:
         return True
-    if any(scoped_name == name for scoped_name, _ in in_scope):
+    if any(scoped_name == key[0] for scoped_name, _ in in_scope):
         raise RlsError(f'RLS: ambiguous CTE reference, quoting differs from the declaration: {node.name}')
+    if _is_non_recursive_self_reference(node, key):
+        raise RlsError(f'RLS: a CTE cannot reference itself without RECURSIVE: {node.name}')
     raise RlsError(f'RLS: table reference shadowed by a CTE declared in another scope: {node.name}')
 
 
@@ -245,6 +285,12 @@ def _check_output(sql: str, *, dialect: str) -> None:
 
     cte_names = _cte_names(tree)
     for table in tree.find_all(exp.Table):
+        if not isinstance(table.this, exp.Identifier):
+            # A table function (`FROM my_udtf(1)`) parses as an `exp.Table` with no identifier to
+            # name it. The same guard `_check_from_sources` and `_transform` apply on the way in --
+            # here it also stops such a node reaching the "is it wrapped?" test, which would report
+            # it under an empty name.
+            raise RlsError('RLS: rewrite left an unsupported table reference')
         if _is_cte_reference(table, cte_names):
             continue  # reference to a CTE in scope here, not a real table
         select = table.parent.parent if isinstance(table.parent, exp.From) else None
@@ -290,6 +336,9 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     # the reference through unfiltered. Refuse instead of trying to be clever (fail-closed).
     # A CTE alias is always bare, so it is a rule key's bare table name it shadows: `in.c-crm.orders`
     # is guarded by `orders`. The full keys are compared too, for a bare key like `invoices`.
+    # Unlike `_identifier_key`, this comparison stays case- and quoting-insensitive on purpose: rule
+    # keys are stored lower-cased and have no quoting of their own, so anything that merely *looks*
+    # like a protected table's name has to collide here rather than be resolved later.
     rule_keys = {key.lower() for key in rules.tables}
     if collisions := sorted(cte_names & (rule_keys | {key.rsplit('.', 1)[-1] for key in rule_keys})):
         raise RlsError(f'RLS: CTE name(s) collide with protected table(s): {", ".join(collisions)}')

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -130,6 +130,17 @@ def _unwrap_parenthesised(tree: exp.Expression) -> exp.Expression:
     return tree
 
 
+def _normalize_schema(schema: str, dialect: str) -> str:
+    """The bucket part of a rules key, as the workspace actually spells it.
+
+    Snowflake keeps a Keboola bucket name verbatim as the schema (`"in.c-crm"`). BigQuery cannot:
+    dataset names allow neither dots nor hyphens, so the server maps bucket `in.c-crm` to dataset
+    `in_c_crm`. Normalising the key at load time means the rules file is written the same way for
+    both backends -- in Keboola's own bucket names -- and still matches what the query says.
+    """
+    return schema.replace('.', '_').replace('-', '_') if dialect == 'bigquery' else schema
+
+
 def _is_boolean_condition(node: exp.Expression) -> bool:
     """Whether `node` is a boolean-valued condition, looking through any wrapping parentheses."""
     while isinstance(node, exp.Paren):
@@ -148,12 +159,21 @@ class RewrittenQuery:
 class RlsRules:
     """RLS rules keyed by lower-cased table key, then lower-cased user name.
 
-    A table key is either a bare table name (`invoices`) or `<schema>.<name>` (`in.c-crm.invoices`);
-    the qualified form takes precedence during lookup. A bare key such as `invoices` matches a table
-    of that name in every schema/bucket; use the `<bucket>.<table>` form to scope a rule.
+    A table key is always `<bucket>.<table>` (`in.c-crm.invoices`) -- the table part is the text
+    after the LAST dot, because a Keboola bucket name contains dots of its own. There is no bare-name
+    form: a rule must say which bucket it protects, and a query must say which bucket it reads, or
+    neither side can be sure they mean the same table.
+
+    Only the bucket and table parts are matched. A reference may also carry a database/project name
+    (`OTHER_DB."in.c-crm"."orders"`, `` `proj`.`in_c_crm`.`invoices` ``) and that part is ignored: the
+    workspace credentials reach exactly one project database, so a rule keyed by bucket and table
+    cannot be side-stepped by naming a different database in front of it.
 
     `dialect` is the workspace backend the predicates were written for; it is not a default but a
-    pin, and `rewrite_query()` refuses to run these rules against any other backend.
+    pin, and `rewrite_query()` refuses to run these rules against any other backend. It also decides
+    how the bucket part of a key is normalised: BigQuery datasets cannot contain dots or hyphens, so
+    the server names the dataset for bucket `in.c-crm` `in_c_crm`, and a key written the Keboola way
+    is normalised to match at load time.
     """
 
     tables: Mapping[str, Mapping[str, str]]
@@ -197,7 +217,12 @@ class RlsRules:
         for table_key, users_raw in tables_raw.items():
             if not isinstance(table_key, str) or not _RULE_KEY_RE.match(table_key):
                 raise RlsError(f'RLS rules file {path} has an invalid table key {table_key!r}: {_RULE_KEY_HINT}')
-            key = table_key.lower()
+            bucket, _, table = table_key.rpartition('.')
+            if not bucket or not table:
+                raise RlsError(
+                    f"RLS rules file {path} has an unqualified table key '{table_key}': keys must be <bucket>.<table>"
+                )
+            key = f'{_normalize_schema(bucket, dialect)}.{table}'.lower()
             if key in tables:
                 # Only reachable when two YAML keys differ solely in case: the second would silently
                 # replace the first, so the admin would be reading a rule that is not in force.
@@ -243,22 +268,20 @@ class RlsRules:
     def predicate_for(self, *, table_name: str, schema: str | None, user: str) -> tuple[str, str]:
         """Return `(matched_key, predicate)` for the table/user, or raise `RlsError`.
 
-        The `<schema>.<name>` key is tried first, then the bare name. When a key matches but has
-        no entry for `user`, that is a denial -- we do not fall through to a less specific key.
+        `schema` is the bucket/dataset the reference names; without it there is no key to look up and
+        the reference is refused. There is deliberately no fall-back to a bare table name: a rule
+        that matched `invoices` in every bucket would silently cover tables its author never saw.
         """
-        candidates: list[str] = []
-        if schema:
-            candidates.append(f'{schema}.{table_name}'.lower())
-        candidates.append(table_name.lower())
-        for key in candidates:
-            users = self.tables.get(key)
-            if users is None:
-                continue
-            predicate = users.get(user.lower())
-            if predicate is None:
-                raise RlsError(f"RLS: no rule for user '{user.lower()}' on table '{key}'")
-            return key, predicate
-        raise RlsError(f"RLS: no rule for table '{table_name}'")
+        if not schema:
+            raise RlsError(f"RLS: table reference must be qualified as <bucket>.<table>: '{table_name}'")
+        key = f'{schema}.{table_name}'.lower()
+        users = self.tables.get(key)
+        if users is None:
+            raise RlsError(f"RLS: no rule for table '{key}'")
+        predicate = users.get(user.lower())
+        if predicate is None:
+            raise RlsError(f"RLS: no rule for user '{user.lower()}' on table '{key}'")
+        return key, predicate
 
 
 def _check_from_sources(tree: exp.Expression) -> None:
@@ -453,10 +476,11 @@ def _check_functions(tree: exp.Expression, cte_names: set[str]) -> None:
 
 
 def _matching_key(table: exp.Table, keys: Mapping[str, str]) -> str | None:
-    """The rules key `table` was wrapped under, in the same order `predicate_for` tries them."""
-    candidates = [f'{table.db}.{table.name}'.lower()] if table.db else []
-    candidates.append(table.name.lower())
-    return next((key for key in candidates if key in keys), None)
+    """The rules key `table` was wrapped under -- built exactly as `predicate_for` builds it."""
+    if not table.db:
+        return None
+    key = f'{table.db}.{table.name}'.lower()
+    return key if key in keys else None
 
 
 def _check_output(sql: str, *, dialect: str, predicates: Mapping[str, str]) -> None:

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -9,8 +9,9 @@ and no SQL is executed. See `feature_spec/rls_query_tool/RFC.md`.
 Predicates are authored in the workspace's own SQL dialect and are never transpiled: a rules file
 written for Snowflake is not portable to a BigQuery workspace (e.g. a double-quoted identifier is
 a column reference on Snowflake but a string literal on BigQuery). One rules file serves one
-workspace backend. `RlsRules.load()` only performs a dialect-agnostic syntax check; the real,
-dialect-specific parse happens in `rewrite_query()` at rewrite time and is fail-closed too.
+workspace backend, and says so: a required top-level `dialect:` key pins it. Every predicate is
+parsed in that dialect at load time, and `rewrite_query()` refuses outright when the workspace it
+is asked to rewrite for is not the dialect the rules were written for.
 """
 
 import dataclasses
@@ -36,6 +37,9 @@ _ALLOWED_FROM_SOURCES = (exp.Table, exp.Subquery, exp.Unnest, exp.Values, exp.La
 # silently dropped when the table is rebuilt inside the wrapper, changing what the query means.
 _ALLOWED_TABLE_ARGS = frozenset({'this', 'db', 'catalog', 'alias'})
 
+# The workspace backends the RLS pilot supports. A rules file must pin exactly one of them.
+_SUPPORTED_DIALECTS = ('bigquery', 'snowflake')
+
 
 class RlsError(ValueError):
     """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means "no data"."""
@@ -55,20 +59,23 @@ class RlsRules:
     A table key is either a bare table name (`invoices`) or `<schema>.<name>` (`in.c-crm.invoices`);
     the qualified form takes precedence during lookup. A bare key such as `invoices` matches a table
     of that name in every schema/bucket; use the `<bucket>.<table>` form to scope a rule.
+
+    `dialect` is the workspace backend the predicates were written for; it is not a default but a
+    pin, and `rewrite_query()` refuses to run these rules against any other backend.
     """
 
     tables: Mapping[str, Mapping[str, str]]
+    dialect: str
 
     @classmethod
     def load(cls, path: str) -> 'RlsRules':
         """Read and validate the YAML rules file. Raises `RlsError` on any problem.
 
-        This only checks that each predicate is well-formed, dialect-agnostic SQL -- it does not
-        know which workspace dialect the predicate will eventually run under. A double-quoted
-        identifier, for instance, is a column reference on Snowflake but a string literal on
-        BigQuery; that mismatch is not, and cannot be, caught here. Predicates must be written for
-        the dialect of the workspace they are used against; `rewrite_query()` does the real,
-        dialect-specific parse (and fails closed if that parse fails too).
+        The file's required top-level `dialect:` key says which workspace backend the predicates are
+        written for, and every predicate is parsed in exactly that dialect -- so the load-time check
+        is the real one, not an approximation. (A double-quoted identifier, for instance, is a column
+        reference on Snowflake but a string literal on BigQuery; without the pin that mismatch could
+        not be caught here at all.)
         """
         file = Path(path)
         if not file.is_file():
@@ -81,6 +88,15 @@ class RlsRules:
             raise RlsError(f'RLS rules file {path} is empty')
         if not isinstance(raw, Mapping) or 'tables' not in raw:
             raise RlsError(f"RLS rules file {path} must have a top-level 'tables' mapping")
+        dialect_raw = raw.get('dialect')
+        # `isinstance(..., str)` also rejects the YAML scalars that are not strings at all -- a bare
+        # `dialect:` (None), a number, or `on`/`yes` (booleans).
+        if not isinstance(dialect_raw, str) or dialect_raw.strip().lower() not in _SUPPORTED_DIALECTS:
+            raise RlsError(
+                f"RLS rules file {path} must have a top-level 'dialect' of "
+                f'{" or ".join(_SUPPORTED_DIALECTS)}, got {dialect_raw!r}'
+            )
+        dialect = dialect_raw.strip().lower()
         tables_raw = raw['tables']
         if not isinstance(tables_raw, Mapping) or not tables_raw:
             raise RlsError(f'RLS rules file {path} has no tables defined')
@@ -94,15 +110,17 @@ class RlsRules:
                 if not isinstance(predicate, str) or not predicate.strip():
                     raise RlsError(f"RLS predicate for table '{table_key}', user '{user}' must be a non-empty string")
                 try:
-                    # Dialect-agnostic parse: we only check the predicate is a well-formed condition.
-                    sqlglot.parse_one(predicate, into=exp.Condition)
+                    # Parsed in the file's own pinned dialect, so this check is the real one.
+                    sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition)
                 except sqlglot.errors.ParseError as e:
-                    raise RlsError(f"RLS predicate for table '{table_key}', user '{user}' is not valid SQL: {e}") from e
+                    raise RlsError(
+                        f"RLS predicate for table '{table_key}', user '{user}' is not valid {dialect} SQL: {e}"
+                    ) from e
                 users[str(user).lower()] = predicate
             tables[str(table_key).lower()] = users
 
-        LOG.info(f'Loaded RLS rules for {len(tables)} table(s) from {path}')
-        return cls(tables=tables)
+        LOG.info(f'Loaded RLS rules for {len(tables)} table(s) from {path} (dialect {dialect})')
+        return cls(tables=tables, dialect=dialect)
 
     def predicate_for(self, *, table_name: str, schema: str | None, user: str) -> tuple[str, str]:
         """Return `(matched_key, predicate)` for the table/user, or raise `RlsError`.
@@ -316,6 +334,11 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
         sqlglot.Dialect.get_or_raise(dialect)
     except Exception as e:
         raise RlsError(f'RLS: unsupported SQL dialect {dialect!r}') from e
+    # Predicates are never transpiled, so rules written for one backend must not be applied to
+    # another: the same text can mean different things (or silently nothing) under a different
+    # dialect. Fail closed rather than rewrite with a filter whose meaning we cannot vouch for.
+    if rules.dialect != dialect.lower():
+        raise RlsError(f'RLS: rules are for dialect {rules.dialect} but the workspace is {dialect.lower()}')
     try:
         statements = sqlglot.parse(sql, dialect=dialect)
     except sqlglot.errors.SqlglotError as e:

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -84,6 +84,11 @@ _ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')
 _BUCKET_PATH_RE = re.compile(r'(?<![\w."`])(?:in|out)\.[A-Za-z0-9_-]+\.', re.IGNORECASE)
 
 
+# What the caller is told when a rule exists but could not be applied. Deliberately says nothing
+# about the predicate: the caller is a model relaying to a user, and the predicate is the policy.
+_RULE_NOT_APPLIED = 'RLS: rule for table {key} could not be applied'
+
+
 class RlsError(ValueError):
     """Any RLS failure: bad rules file, unsupported SQL, missing rule. Always means "no data"."""
 
@@ -152,7 +157,13 @@ def _is_boolean_condition(node: exp.Expression) -> bool:
 class RewrittenQuery:
     sql: str
     applied_rules: list[str]
-    """Human-readable disclosure, one entry per rewritten table: `"<table key>: <predicate>"`."""
+    """Disclosure for the caller: the rules key of every table that was filtered, de-duplicated.
+
+    Keys only, never the predicate. The point of the disclosure is "this result is a slice, and here
+    is which tables were sliced" -- the predicate text is the admin's policy, and handing it to a
+    model (which relays it to the user, and which may be trying to work out what it is not allowed
+    to see) discloses the shape of the data that was withheld. The server log has the detail.
+    """
 
 
 @dataclasses.dataclass(frozen=True)
@@ -525,24 +536,33 @@ def _check_output(sql: str, *, dialect: str, predicates: Mapping[str, str]) -> N
             and isinstance(select.parent, exp.Subquery)
         )
         if not wrapped:
-            raise RlsError(f'RLS: rewrite left an unwrapped table reference: {table.name}')
+            # No name in the message: an unwrapped table can come from a predicate that reached for
+            # one, and naming it would disclose a table the caller never mentioned.
+            LOG.warning(f'RLS: rewrite left an unwrapped table reference: {table.sql(dialect=dialect)}')
+            raise RlsError('RLS: rewrite left an unwrapped table reference')
         assert isinstance(select, exp.Select)  # narrowed by `wrapped`
         key = _matching_key(table, predicates)
         if key is None:
-            raise RlsError(f'RLS: rewrite wrapped a table no rule was looked up for: {table.name}')
+            LOG.warning(f'RLS: rewrite wrapped a table no rule was looked up for: {table.sql(dialect=dialect)}')
+            raise RlsError('RLS: rewrite wrapped a table no rule was looked up for')
         where = select.args.get('where')
         if where is None:
-            raise RlsError(f'RLS: rewrite left a wrapper without a WHERE clause: {table.name}')
+            LOG.warning(f'RLS: rewrite left the wrapper around {key!r} without a WHERE clause')
+            raise RlsError(_RULE_NOT_APPLIED.format(key=key))
         try:
             expected = sqlglot.parse_one(predicates[key], dialect=dialect, into=exp.Condition)
         except sqlglot.errors.SqlglotError as e:
-            raise RlsError(
-                f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {_clean_error(e)}"
-            ) from e
+            LOG.warning(f'RLS: predicate for table {key!r} is not valid SQL for dialect {dialect!r}: {_clean_error(e)}')
+            raise RlsError(_RULE_NOT_APPLIED.format(key=key)) from e
         # Compared as generated text in the same dialect, so the two sides are normalised the same
-        # way and only a real difference in the condition can fail this.
+        # way and only a real difference in the condition can fail this. Neither side is quoted back
+        # to the caller: the difference between them IS the predicate.
         if where.this.sql(dialect=dialect) != expected.sql(dialect=dialect):
-            raise RlsError(f"RLS: rewrite produced a WHERE that is not the rule for table '{key}'")
+            LOG.warning(
+                f'RLS: rewrite produced a WHERE that is not the rule for table {key!r}: '
+                f'{where.this.sql(dialect=dialect)!r} != {expected.sql(dialect=dialect)!r}'
+            )
+            raise RlsError(_RULE_NOT_APPLIED.format(key=key))
 
 
 def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> RewrittenQuery:
@@ -617,7 +637,7 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
         if extra_args:
             raise RlsError(f'RLS: table modifiers are not supported on {node.name!r}: {sorted(extra_args)}')
         key, predicate = rules.predicate_for(table_name=node.name, schema=node.db or None, user=user)
-        applied.append(f'{key}: {predicate}')
+        applied.append(key)
         inserted[key] = predicate
         # Reuse the original alias identifier as-is (preserving its own quoting) so references to
         # it elsewhere in the query (e.g. an unquoted `o.id` in an ON clause) still resolve. Only
@@ -632,9 +652,10 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
         try:
             predicate_expr = sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition)
         except sqlglot.errors.SqlglotError as e:
-            raise RlsError(
-                f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {_clean_error(e)}"
-            ) from e
+            # The caller is told only that the rule could not be applied. Which predicate, and why it
+            # failed, is the admin's business and goes to the log -- the message reaches a model.
+            LOG.warning(f'RLS: predicate for table {key!r} is not valid SQL for dialect {dialect!r}: {_clean_error(e)}')
+            raise RlsError(_RULE_NOT_APPLIED.format(key=key)) from e
         filtered = exp.select('*').from_(inner).where(predicate_expr)
         # Returning a new node stops `transform` from descending into it, so the inner table is
         # not wrapped a second time.

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -401,13 +401,25 @@ def _check_functions(tree: exp.Expression, cte_names: set[str]) -> None:
         raise RlsError(f'RLS: function calls are not allowed in a query without FROM: {name}')
 
 
-def _check_output(sql: str, *, dialect: str) -> None:
+def _matching_key(table: exp.Table, keys: Mapping[str, str]) -> str | None:
+    """The rules key `table` was wrapped under, in the same order `predicate_for` tries them."""
+    candidates = [f'{table.db}.{table.name}'.lower()] if table.db else []
+    candidates.append(table.name.lower())
+    return next((key for key in candidates if key in keys), None)
+
+
+def _check_output(sql: str, *, dialect: str, predicates: Mapping[str, str]) -> None:
     """Assert the generated SQL is still a plain SELECT over wrapped tables; raise `RlsError` if not.
 
     This is the safety net: it re-parses the rewriter's own output and checks it from scratch, so a
     bug or an unforeseen node type upstream cannot smuggle DDL, a second statement or an unfiltered
     table past it. The only table shape the rewrite ever produces is
     `(SELECT * FROM <table> WHERE <predicate>) AS <alias>`; anything else is a defect, not data.
+
+    `predicates` maps each rules key the rewrite matched to the predicate text it inserted for it.
+    A wrapper is only accepted when its WHERE is present AND generates back to exactly that
+    predicate: "wrapped in something" is not the invariant, "wrapped in the filter the admin wrote"
+    is. Without the comparison a wrapper carrying a weakened or empty condition would pass.
 
     Consequence worth knowing when authoring rules: a predicate that itself references another table
     (`id IN (SELECT id FROM other)`) leaves a table outside a wrapper and is refused. Predicates must
@@ -439,6 +451,21 @@ def _check_output(sql: str, *, dialect: str) -> None:
         )
         if not wrapped:
             raise RlsError(f'RLS: rewrite left an unwrapped table reference: {table.name}')
+        assert isinstance(select, exp.Select)  # narrowed by `wrapped`
+        key = _matching_key(table, predicates)
+        if key is None:
+            raise RlsError(f'RLS: rewrite wrapped a table no rule was looked up for: {table.name}')
+        where = select.args.get('where')
+        if where is None:
+            raise RlsError(f'RLS: rewrite left a wrapper without a WHERE clause: {table.name}')
+        try:
+            expected = sqlglot.parse_one(predicates[key], dialect=dialect, into=exp.Condition)
+        except sqlglot.errors.SqlglotError as e:
+            raise RlsError(f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {e}") from e
+        # Compared as generated text in the same dialect, so the two sides are normalised the same
+        # way and only a real difference in the condition can fail this.
+        if where.this.sql(dialect=dialect) != expected.sql(dialect=dialect):
+            raise RlsError(f"RLS: rewrite produced a WHERE that is not the rule for table '{key}'")
 
 
 def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> RewrittenQuery:
@@ -490,6 +517,9 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     _check_functions(tree, cte_names)
 
     applied: list[str] = []
+    # The predicate the rewrite actually inserted for each matched key, handed to `_check_output` so
+    # the safety net can verify the WHERE it finds is the rule, not merely some WHERE.
+    inserted: dict[str, str] = {}
 
     def _transform(node: exp.Expression) -> exp.Expression:
         if not isinstance(node, exp.Table):
@@ -513,6 +543,7 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
             raise RlsError(f'RLS: table modifiers are not supported on {node.name!r}: {sorted(extra_args)}')
         key, predicate = rules.predicate_for(table_name=node.name, schema=node.db or None, user=user)
         applied.append(f'{key}: {predicate}')
+        inserted[key] = predicate
         # Reuse the original alias identifier as-is (preserving its own quoting) so references to
         # it elsewhere in the query (e.g. an unquoted `o.id` in an ON clause) still resolve. Only
         # fall back to the table's own name/quoting when the table was not aliased at all -- using
@@ -533,7 +564,7 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
         return exp.Subquery(this=filtered, alias=exp.TableAlias(this=alias_identifier))
 
     rewritten_sql = tree.transform(_transform, copy=True).sql(dialect=dialect)
-    _check_output(rewritten_sql, dialect=dialect)
+    _check_output(rewritten_sql, dialect=dialect, predicates=inserted)
     # `dict.fromkeys` deduplicates while preserving first-seen order: a table joined or unioned with
     # itself is disclosed once.
     return RewrittenQuery(sql=rewritten_sql, applied_rules=list(dict.fromkeys(applied)))

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -578,17 +578,15 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     if any(select.args.get('into') is not None for select in tree.find_all(exp.Select)):
         raise RlsError('RLS: SELECT INTO is not allowed')
 
+    # A CTE may be named after a protected table -- `WITH orders AS (SELECT * FROM "in.c-crm"."orders"
+    # WHERE amount > 0)` is the natural way to write such a query, and refusing it taught callers to
+    # go looking for a formulation that slips through instead. It is safe because a rules key names a
+    # bucket (see `RlsRules`) and a CTE alias never can: a protected table is always referenced with
+    # its bucket, and `_is_cte_reference` never treats a qualified reference as a CTE. What remains
+    # is the shadowing that is real -- a bare name resolved against the wrong scope, a quoting
+    # mismatch between declaration and reference, a CTE reading its own name without RECURSIVE -- and
+    # every one of those is still refused, where it happens, by `_is_cte_reference`.
     cte_names = _cte_names(tree)
-    # A CTE named like a protected table would shadow the real table inside its own body and let
-    # the reference through unfiltered. Refuse instead of trying to be clever (fail-closed).
-    # A CTE alias is always bare, so it is a rule key's bare table name it shadows: `in.c-crm.orders`
-    # is guarded by `orders`. The full keys are compared too, for a bare key like `invoices`.
-    # Unlike `_identifier_key`, this comparison stays case- and quoting-insensitive on purpose: rule
-    # keys are stored lower-cased and have no quoting of their own, so anything that merely *looks*
-    # like a protected table's name has to collide here rather than be resolved later.
-    rule_keys = {key.lower() for key in rules.tables}
-    if collisions := sorted(cte_names & (rule_keys | {key.rsplit('.', 1)[-1] for key in rule_keys})):
-        raise RlsError(f'RLS: CTE name(s) collide with protected table(s): {", ".join(collisions)}')
 
     _check_from_sources(tree)
     _check_functions(tree, cte_names)

--- a/src/keboola_mcp_server/rls.py
+++ b/src/keboola_mcp_server/rls.py
@@ -5,6 +5,12 @@ replaces every table referenced by a SELECT with `(SELECT * FROM <table> WHERE <
 the caller can only ever see the slice the admin wrote down for them. Everything here is
 fail-closed: a missing rule, an unsupported statement or an unparseable query raises `RlsError`
 and no SQL is executed. See `feature_spec/rls_query_tool/RFC.md`.
+
+Predicates are authored in the workspace's own SQL dialect and are never transpiled: a rules file
+written for Snowflake is not portable to a BigQuery workspace (e.g. a double-quoted identifier is
+a column reference on Snowflake but a string literal on BigQuery). One rules file serves one
+workspace backend. `RlsRules.load()` only performs a dialect-agnostic syntax check; the real,
+dialect-specific parse happens in `rewrite_query()` at rewrite time and is fail-closed too.
 """
 
 import dataclasses
@@ -42,7 +48,15 @@ class RlsRules:
 
     @classmethod
     def load(cls, path: str) -> 'RlsRules':
-        """Read and validate the YAML rules file. Raises `RlsError` on any problem."""
+        """Read and validate the YAML rules file. Raises `RlsError` on any problem.
+
+        This only checks that each predicate is well-formed, dialect-agnostic SQL -- it does not
+        know which workspace dialect the predicate will eventually run under. A double-quoted
+        identifier, for instance, is a column reference on Snowflake but a string literal on
+        BigQuery; that mismatch is not, and cannot be, caught here. Predicates must be written for
+        the dialect of the workspace they are used against; `rewrite_query()` does the real,
+        dialect-specific parse (and fails closed if that parse fails too).
+        """
         file = Path(path)
         if not file.is_file():
             raise RlsError(f'RLS rules file not found: {path}')
@@ -108,8 +122,12 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
     :raises RlsError: on anything other than one SELECT statement whose every table has a rule
     """
     try:
+        sqlglot.Dialect.get_or_raise(dialect)
+    except Exception as e:
+        raise RlsError(f'RLS: unsupported SQL dialect {dialect!r}') from e
+    try:
         statements = sqlglot.parse(sql, dialect=dialect)
-    except sqlglot.errors.ParseError as e:
+    except sqlglot.errors.SqlglotError as e:
         raise RlsError(f'RLS: cannot parse SQL: {e}') from e
     if len(statements) != 1 or statements[0] is None:
         raise RlsError('RLS: exactly one statement is allowed')
@@ -132,12 +150,24 @@ def rewrite_query(sql: str, *, user: str, dialect: str, rules: RlsRules) -> Rewr
             return node  # reference to a CTE defined in this statement, not a real table
         key, predicate = rules.predicate_for(table_name=node.name, schema=node.db or None, user=user)
         applied.append(f'{key}: {predicate}')
-        alias = node.alias or node.name
+        # Reuse the original alias identifier as-is (preserving its own quoting) so references to
+        # it elsewhere in the query (e.g. an unquoted `o.id` in an ON clause) still resolve. Only
+        # fall back to the table's own name/quoting when the table was not aliased at all -- using
+        # the table identifier's quoting for an *existing* alias would silently change whether the
+        # alias is case-sensitive, breaking those other references.
+        alias_node = node.args.get('alias')
+        alias_identifier = (
+            alias_node.this.copy() if alias_node is not None else exp.to_identifier(node.name, quoted=node.this.quoted)
+        )
         inner = exp.Table(this=node.this, db=node.args.get('db'), catalog=node.args.get('catalog'))
-        filtered = exp.select('*').from_(inner).where(sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition))
+        try:
+            predicate_expr = sqlglot.parse_one(predicate, dialect=dialect, into=exp.Condition)
+        except sqlglot.errors.SqlglotError as e:
+            raise RlsError(f"RLS: predicate for table '{key}' is not valid SQL for dialect {dialect!r}: {e}") from e
+        filtered = exp.select('*').from_(inner).where(predicate_expr)
         # Returning a new node stops `transform` from descending into it, so the inner table is
         # not wrapped a second time.
-        return exp.Subquery(this=filtered, alias=exp.TableAlias(this=exp.to_identifier(alias, quoted=node.this.quoted)))
+        return exp.Subquery(this=filtered, alias=exp.TableAlias(this=alias_identifier))
 
     rewritten = tree.transform(_transform, copy=True)
     return RewrittenQuery(sql=rewritten.sql(dialect=dialect), applied_rules=applied)

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -258,6 +258,19 @@ def create_server(
     # startup, so a broken file refuses to start the server instead of failing the first query.
     rls_rules = RlsRules.load(config.rls_rules_path) if config.rls_rules_path else None
 
+    # Where the principal comes from is a security decision, not a convenience: 'header' means an
+    # authenticating wrapper asserts the identity per request, 'argument' means the model names it.
+    # Neither is a safe default for the other's deployment, so RLS mode refuses to start until the
+    # operator has said which one this is.
+    if rls_rules is not None and not config.rls_principal_source:
+        raise RuntimeError(
+            'RLS is enabled (rls_rules_path) but no principal source is configured. Set '
+            'KBC_RLS_PRINCIPAL_SOURCE (or --rls-principal-source) to "header" -- the principal is '
+            'taken from the X-RLS-Principal header asserted by the calling application, which must '
+            'be the only client able to reach this server -- or to "argument", where the MCP client '
+            'or model supplies it as the `principal` tool argument (pilot/demo only, unverified).'
+        )
+
     # Initialize FastMCP server with system lifespan
     LOG.info(f'Creating server with config: {config}')
     server_state = ServerState(

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -23,6 +23,7 @@ from keboola_mcp_server.multiproject import MultiProjectMiddleware
 from keboola_mcp_server.oauth import SimpleOAuthProvider
 from keboola_mcp_server.preview import preview_config_diff
 from keboola_mcp_server.prompts.add_prompts import add_keboola_prompts
+from keboola_mcp_server.rls import RlsRules
 from keboola_mcp_server.session_store.crypto import resolve_encryption_key
 from keboola_mcp_server.session_store.kai_scope import PostgresKaiScopeStore
 from keboola_mcp_server.session_store.repository import PostgresSessionStore
@@ -253,10 +254,18 @@ def create_server(
     # oauth_client_id/secret is required. Independent of whether OAuth is configured above.
     kai_scope_store = PostgresKaiScopeStore(config.postgres_dsn) if config.postgres_dsn else None
 
+    # Row-level security (feature_spec/rls_query_tool/RFC.md): load and validate the rules once, at
+    # startup, so a broken file refuses to start the server instead of failing the first query.
+    rls_rules = RlsRules.load(config.rls_rules_path) if config.rls_rules_path else None
+
     # Initialize FastMCP server with system lifespan
     LOG.info(f'Creating server with config: {config}')
     server_state = ServerState(
-        config=config, runtime_info=runtime_info, session_store=session_store, kai_scope_store=kai_scope_store
+        config=config,
+        runtime_info=runtime_info,
+        session_store=session_store,
+        kai_scope_store=kai_scope_store,
+        rls_rules=rls_rules,
     )
     mcp = KeboolaMcpServer(
         name='Keboola MCP Server',
@@ -311,7 +320,7 @@ def create_server(
     add_project_tools(mcp)
     add_search_tools(mcp)
     add_semantic_tools(mcp)
-    add_sql_tools(mcp)
+    add_sql_tools(mcp, rls_rules=rls_rules)
     add_storage_tools(mcp)
     add_keboola_prompts(mcp)
 

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -19,7 +19,8 @@ from pydantic import BaseModel, Field
 from starlette.requests import Request
 
 from keboola_mcp_server.errors import tool_errors
-from keboola_mcp_server.mcp import get_http_request_or_none
+from keboola_mcp_server.mcp import ServerState, get_http_request_or_none
+from keboola_mcp_server.rls import RlsRules, rewrite_query
 from keboola_mcp_server.workspace import JobSubmittedInfo, QueryResult, SqlSelectData, WorkspaceManager
 
 LOG = logging.getLogger(__name__)
@@ -220,16 +221,88 @@ class QueryDataOutput(BaseModel):
     message: str | None = Field(default=None, description='A message from the query execution')
 
 
-def add_sql_tools(mcp: FastMCP) -> None:
-    """Add tools to the MCP server."""
+class RlsQueryDataOutput(QueryDataOutput):
+    """Output of `query_data_rls`: the data plus a disclosure of which RLS rules shaped it."""
+
+    applied_rules: list[str] = Field(
+        description='RLS rules applied to the query, one per table, as "<table>: <predicate>". '
+        'The result is a filtered slice of the data, never the whole table.'
+    )
+
+
+def add_sql_tools(mcp: FastMCP, *, rls_rules: RlsRules | None = None) -> None:
+    """Add SQL tools to the MCP server.
+
+    With `rls_rules` the server exposes only `query_data_rls`; the unrestricted `query_data` is not
+    registered at all, so no per-request header (`X-Allowed-Tools`, ...) can bring it back.
+    """
+    if rls_rules is None:
+        tool = query_data
+    else:
+        tool = query_data_rls
     mcp.add_tool(
         FunctionTool.from_function(
-            query_data,
+            tool,
             annotations=ToolAnnotations(readOnlyHint=True),
             tags={SQL_TOOLS_TAG},
         )
     )
-    LOG.info('SQL tools added to the MCP server.')
+    LOG.info(f'SQL tools added to the MCP server: {tool.__name__}.')
+
+
+async def _execute_and_serialize(sql_query: str, query_name: str, ctx: Context) -> tuple[SqlSelectData, str | None]:
+    """Run `sql_query` in the workspace and return `(data, message)`; raises `ValueError` on failure.
+
+    Shared by `query_data` and `query_data_rls` so progress notifications, disconnect watching and
+    error mapping live in exactly one place.
+    """
+    workspace_manager = WorkspaceManager.from_state(ctx.session.state)
+
+    progress_token = _client_progress_token(ctx)
+
+    async def _on_job_submitted(info: JobSubmittedInfo) -> None:
+        await _emit_job_submitted_progress(ctx, progress_token, info)
+
+    query_coro = workspace_manager.execute_query(
+        sql_query,
+        max_rows=MAX_ROWS,
+        max_chars=MAX_CHARS,
+        on_job_submitted=_on_job_submitted if progress_token is not None else None,
+    )
+    # The disconnect race only buys us anything on the HTTP path, where the client can actually
+    # drop the socket (Kai kills the sandbox SDK process on STOP). With no HTTP request bound
+    # (stdio / background workers) nothing can disconnect, so run the query directly.
+    request = get_http_request_or_none()
+    if request is None:
+        result = await query_coro
+    else:
+        result = await _execute_watching_disconnect(query_coro, request, query_name)
+    if result.is_ok:
+        LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
+        if result.data:
+            data = result.data
+        else:
+            # non-SELECT query, this should not really happen, because this tool is for running SELECT queries
+            data = SqlSelectData(columns=['message'], rows=[{'message': result.message}])
+        return data, result.message
+
+    # Surface cancellation cleanly: the workspace already produced a precise message
+    # ("Query was cancelled") for the cancel-by-client case, so don't wrap it in a
+    # generic "Failed to run SQL query, error: ..." prefix that hides what happened.
+    # A client-initiated cancel is expected, so log it at INFO; genuine failures at WARNING.
+    if result.message == 'Query was cancelled':
+        LOG.info(f'Query "{query_name}" was cancelled.')
+        raise ValueError('Query was cancelled')
+    LOG.warning(' '.join(filter(None, [f'Query "{query_name}" failed.', result.message])))
+    raise ValueError(f'Failed to run SQL query, error: {result.message}')
+
+
+def _to_csv(data: SqlSelectData) -> str:
+    output = StringIO()
+    writer = csv.DictWriter(output, fieldnames=data.columns)
+    writer.writeheader()
+    writer.writerows(data.rows)
+    return output.getvalue()
 
 
 @tool_errors()
@@ -307,50 +380,67 @@ async def query_data(
     * When querying columns with categorical values, use query_data tool to inspect distinct values beforehand
     * Ensure valid filtering by checking actual data values first
     """
+    data, message = await _execute_and_serialize(sql_query, query_name, ctx)
+    return QueryDataOutput(query_name=query_name, csv_data=_to_csv(data), message=message)
+
+
+@tool_errors()
+async def query_data_rls(
+    sql_query: Annotated[str, Field(description='SQL SELECT query to run.')],
+    query_name: Annotated[
+        str,
+        Field(
+            description=(
+                'A concise, human-readable name for this query based on its purpose and what data it retrieves. '
+                'Use normal words with spaces (e.g., "Customer Orders Last Month", "Top Selling Products", '
+                '"User Activity Summary").'
+            )
+        ),
+    ],
+    user: Annotated[
+        str,
+        Field(
+            description=(
+                'Name of the user on whose behalf the query runs. Row-level-security rules are selected by this '
+                'name; every table in the query must have a rule for it, otherwise the query is refused.'
+            )
+        ),
+    ],
+    ctx: Context,
+) -> RlsQueryDataOutput:
+    """
+    Executes an SQL SELECT query with row-level security applied for the given user.
+
+    Every table referenced by the query is replaced by a filtered view defined by the server-side RLS
+    rules for `user`. The result is therefore a SLICE of the data, never the whole table; the
+    `applied_rules` field of the output says exactly which filters were applied — always tell the user.
+    Tables that have no rule for `user`, non-SELECT statements and multi-statement input are refused.
+
+    The SQL requirements below are identical to the `query_data` tool.
+
+    BEFORE QUERYING:
+    * Always verify the table has a non-null fullyQualifiedName from get_tables tool.
+      If it does not, the table is not SQL-accessible from this workspace — do not attempt the query and inform user.
+
+    CRITICAL SQL REQUIREMENTS:
+
+    * ALWAYS check the SQL dialect before constructing queries.
+    * Do not include any comments in the SQL code
+    * Use delimited identifiers and FQN format for the current SQL dialect.
+    * Always use the LIMIT clause in your SELECT statements when fetching data; the tool truncates
+      results beyond its row/character limits and a truncated result is a contiguous prefix, not a sample.
+    * Compute aggregates (COUNT, GROUP BY, SUM, AVG, etc.) in SQL rather than pulling raw rows.
+    """
+    rules = ServerState.from_context(ctx).rls_rules
+    if rules is None:
+        raise ValueError('RLS rules are not configured on this server.')
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
+    dialect = (await workspace_manager.get_sql_dialect()).lower()
+    # Raises RlsError (a ValueError) before anything is sent to the workspace -- fail-closed.
+    rewritten = rewrite_query(sql_query, user=user, dialect=dialect, rules=rules)
+    LOG.info(f'RLS applied for user "{user}" in query "{query_name}": {rewritten.applied_rules}')
 
-    progress_token = _client_progress_token(ctx)
-
-    async def _on_job_submitted(info: JobSubmittedInfo) -> None:
-        await _emit_job_submitted_progress(ctx, progress_token, info)
-
-    query_coro = workspace_manager.execute_query(
-        sql_query,
-        max_rows=MAX_ROWS,
-        max_chars=MAX_CHARS,
-        on_job_submitted=_on_job_submitted if progress_token is not None else None,
+    data, message = await _execute_and_serialize(rewritten.sql, query_name, ctx)
+    return RlsQueryDataOutput(
+        query_name=query_name, csv_data=_to_csv(data), message=message, applied_rules=rewritten.applied_rules
     )
-    # The disconnect race only buys us anything on the HTTP path, where the client can actually
-    # drop the socket (Kai kills the sandbox SDK process on STOP). With no HTTP request bound
-    # (stdio / background workers) nothing can disconnect, so run the query directly.
-    request = get_http_request_or_none()
-    if request is None:
-        result = await query_coro
-    else:
-        result = await _execute_watching_disconnect(query_coro, request, query_name)
-    if result.is_ok:
-        LOG.info(' '.join(filter(None, [f'Query "{query_name}" executed successfully.', result.message])))
-        if result.data:
-            data = result.data
-        else:
-            # non-SELECT query, this should not really happen, because this tool is for running SELECT queries
-            data = SqlSelectData(columns=['message'], rows=[{'message': result.message}])
-
-        # Convert to CSV
-        output = StringIO()
-        writer = csv.DictWriter(output, fieldnames=data.columns)
-        writer.writeheader()
-        writer.writerows(data.rows)
-
-        return QueryDataOutput(query_name=query_name, csv_data=output.getvalue(), message=result.message)
-
-    else:
-        # Surface cancellation cleanly: the workspace already produced a precise message
-        # ("Query was cancelled") for the cancel-by-client case, so don't wrap it in a
-        # generic "Failed to run SQL query, error: ..." prefix that hides what happened.
-        # A client-initiated cancel is expected, so log it at INFO; genuine failures at WARNING.
-        if result.message == 'Query was cancelled':
-            LOG.info(f'Query "{query_name}" was cancelled.')
-            raise ValueError('Query was cancelled')
-        LOG.warning(' '.join(filter(None, [f'Query "{query_name}" failed.', result.message])))
-        raise ValueError(f'Failed to run SQL query, error: {result.message}')

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -225,8 +225,9 @@ class RlsQueryDataOutput(QueryDataOutput):
     """Output of `query_data_rls`: the data plus a disclosure of which RLS rules shaped it."""
 
     applied_rules: list[str] = Field(
-        description='RLS rules applied to the query, one per table, as "<table>: <predicate>". '
-        'The result is a filtered slice of the data, never the whole table.'
+        description='Tables that an RLS rule was applied to, as "<bucket>.<table>" keys. '
+        'The result is a filtered slice of those tables, never the whole table. '
+        'The filters themselves are server-side policy and are not disclosed.'
     )
 
 
@@ -414,7 +415,7 @@ async def query_data_rls(
 
     Every table referenced by the query is replaced by a filtered view defined by the server-side RLS
     rules for `user`. The result is therefore a SLICE of the data, never the whole table; the
-    `applied_rules` field of the output says exactly which filters were applied — always tell the user.
+    `applied_rules` field of the output names the tables that were filtered — always tell the user.
     Tables that have no rule for `user`, non-SELECT statements and multi-statement input are refused.
     Rules are keyed `<bucket>.<table>`, so every table in the query must be written with its bucket
     (`"in.c-crm"."orders"` on Snowflake, `` `in_c_crm`.`orders` `` on BigQuery); a bare table name is refused.

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 from starlette.requests import Request
 
 from keboola_mcp_server.errors import tool_errors
-from keboola_mcp_server.mcp import ServerState, get_http_request_or_none
+from keboola_mcp_server.mcp import RLS_PRINCIPAL, ServerState, get_http_request_or_none
 from keboola_mcp_server.rls import RlsRules, rewrite_query
 from keboola_mcp_server.workspace import JobSubmittedInfo, QueryResult, SqlSelectData, WorkspaceManager
 
@@ -316,7 +316,8 @@ def _rule_table_keys(applied_rules: list[str]) -> list[str]:
 def _log_rls_outcome(
     outcome: str,
     *,
-    user: str,
+    principal: str | None,
+    source: str | None,
     query_name: str,
     tables: list[str] | None = None,
     rows: int | None = None,
@@ -324,12 +325,15 @@ def _log_rls_outcome(
 ) -> None:
     """Emit the one audit line per `query_data_rls` call: `outcome=ok` or `outcome=refused`.
 
-    One shape for both outcomes so the log is evaluable — an operator can count refusals per user, or
-    find which tables a user actually read, without parsing free-form messages. `user`, `query_name`
-    and `reason` are all model-supplied, so they are quoted with `!r`: a newline or a fake `outcome=`
-    inside them cannot forge a second log line.
+    One shape for both outcomes so the log is evaluable — an operator can count refusals per
+    principal, or find which tables a principal actually read, without parsing free-form messages.
+    `source` records which of the two modes answered "who is this?" for this very call, so a
+    deployment that is supposed to be header-bound can be audited for `source=argument` lines.
+    `principal` (in argument mode), `query_name` and `reason` are model-supplied, so they are quoted
+    with `!r`: a newline or a fake `outcome=` inside them cannot forge a second log line. Both
+    `principal` and `source` are None when the call was refused before the identity was resolved.
     """
-    fields = [f'outcome={outcome}', f'user={user!r}', f'query={query_name!r}']
+    fields = [f'outcome={outcome}', f'principal={principal!r}', f'source={source}', f'query={query_name!r}']
     if tables is not None:
         fields.append(f'tables={tables}')
     if rows is not None:
@@ -341,6 +345,48 @@ def _log_rls_outcome(
         LOG.info(line)
     else:
         LOG.warning(line)
+
+
+def _resolve_rls_principal(ctx: Context, argument: str | None) -> tuple[str, str]:
+    """Answer "on whose behalf does this query run?" and return `(principal, source)`.
+
+    The answer comes from exactly one place, chosen at deployment time by
+    `Config.rls_principal_source` — never from whichever of the two happens to be present:
+
+    * `header`: the `X-RLS-Principal` value the calling application asserted for this request
+      (`Config.rls_principal`, carried into the session state per request). A missing header is a
+      refusal, and so is a `principal` tool argument — falling back to a model-supplied name, or
+      quietly dropping it, would both defeat the point of binding the identity to the transport.
+    * `argument`: the `principal` tool argument (the pilot mode; the model names the user). A stray
+      header is ignored with a warning rather than honoured, so a proxy that adds one cannot switch
+      identities behind the operator's back.
+
+    :raises ValueError: when the configured source cannot produce exactly one principal.
+    """
+    source = ServerState.from_context(ctx).config.rls_principal_source
+    header_value = (ctx.session.state.get(RLS_PRINCIPAL) or '').strip()
+    # The model may send whitespace or an empty string; both mean "not supplied".
+    argument_value = (argument or '').strip()
+
+    if source == 'header':
+        if argument is not None:
+            raise ValueError('RLS: principal must not be passed as an argument in header mode')
+        if not header_value:
+            raise ValueError('RLS: X-RLS-Principal header is required')
+        return header_value, 'header'
+
+    if source == 'argument':
+        if header_value:
+            LOG.warning(
+                'RLS: ignoring the X-RLS-Principal header -- this server is configured with '
+                'rls_principal_source=argument, so the principal comes from the tool argument.'
+            )
+        if not argument_value:
+            raise ValueError('RLS: principal argument is required')
+        return argument_value, 'argument'
+
+    # Unreachable on a server built by `create_server()`, which refuses to start without a source.
+    raise ValueError('RLS: no principal source is configured on this server.')
 
 
 def _to_csv(data: SqlSelectData) -> str:
@@ -443,27 +489,37 @@ async def query_data_rls(
             )
         ),
     ],
-    user: Annotated[
-        str,
+    ctx: Context,
+    principal: Annotated[
+        str | None,
         Field(
             description=(
-                'Name of the user on whose behalf the query runs. Row-level-security rules are selected by this '
-                'name; every table in the query must have a rule for it, otherwise the query is refused. '
-                'Leading/trailing whitespace is ignored; matching is case-insensitive.'
+                'Name of the user (the "principal") on whose behalf the query runs. Row-level-security rules are '
+                'selected by this name; every table in the query must have a rule for it, otherwise the query is '
+                'refused. Leading/trailing whitespace is ignored; matching is case-insensitive. '
+                'OMIT this argument when the server takes the principal from the X-RLS-Principal request header '
+                '(the calling application asserts it) -- passing it there is refused, not ignored.'
             )
         ),
-    ],
-    ctx: Context,
+    ] = None,
 ) -> RlsQueryDataOutput:
     """
-    Executes an SQL SELECT query with row-level security applied for the given user.
+    Executes an SQL SELECT query with row-level security applied for one principal (user).
 
     Every table referenced by the query is replaced by a filtered view defined by the server-side RLS
-    rules for `user`. The result is therefore a SLICE of the data, never the whole table; the
+    rules for that principal. The result is therefore a SLICE of the data, never the whole table; the
     `applied_rules` field of the output names the tables that were filtered — always tell the user.
-    Tables that have no rule for `user`, non-SELECT statements and multi-statement input are refused.
-    Rules are keyed `<bucket>.<table>`, so every table in the query must be written with its bucket
+    Tables that have no rule for the principal, non-SELECT statements and multi-statement input are
+    refused. Rules are keyed `<bucket>.<table>`, so every table in the query must be written with its bucket
     (`"in.c-crm"."orders"` on Snowflake, `` `in_c_crm`.`orders` `` on BigQuery); a bare table name is refused.
+
+    WHO THE PRINCIPAL IS — one of two server-configured modes:
+    * `header` mode: the principal is the `X-RLS-Principal` header that the calling application sets
+      after authenticating its own user. OMIT the `principal` argument; passing it is refused.
+    * `argument` mode: pass the principal as the `principal` argument.
+    The server does not verify the principal in either mode: in header mode it trusts the calling
+    application (which must be the only client that can reach the server), and in argument mode it
+    trusts the MCP client.
 
     The SQL requirements below are identical to the `query_data` tool.
 
@@ -480,13 +536,16 @@ async def query_data_rls(
       results beyond its row/character limits and a truncated result is a contiguous prefix, not a sample.
     * Compute aggregates (COUNT, GROUP BY, SUM, AVG, etc.) in SQL rather than pulling raw rows.
     """
-    # The user name comes from the model, so it may carry stray whitespace; rule lookup itself is
-    # case-insensitive. Stripped up front so every log line below names the user we actually matched.
-    user = user.strip()
+    # Set as soon as the identity is known, so a refusal before that point still logs one line --
+    # with `principal=None source=None` rather than a name it never actually resolved.
+    resolved: str | None = None
+    source: str | None = None
     try:
         rules = ServerState.from_context(ctx).rls_rules
         if rules is None:
             raise ValueError('RLS rules are not configured on this server.')
+        # Whitespace is stripped inside; rule lookup itself is case-insensitive.
+        resolved, source = _resolve_rls_principal(ctx, principal)
         # Refuse oversized input before touching the workspace or the parser: the size cap is the
         # cheapest check we have, and it must not be paid for with a round-trip.
         if len(sql_query) > RLS_MAX_QUERY_CHARS:
@@ -498,7 +557,7 @@ async def query_data_rls(
         # the rewrite runs in a worker thread: a pathological (but under-cap) query then slows down
         # this one session instead of stalling the event loop for every other in-flight request.
         try:
-            rewritten = await asyncio.to_thread(rewrite_query, sql_query, user=user, dialect=dialect, rules=rules)
+            rewritten = await asyncio.to_thread(rewrite_query, sql_query, user=resolved, dialect=dialect, rules=rules)
         except RecursionError as e:
             # sqlglot's parser recurses per nesting level, so deeply nested input hits Python's
             # recursion limit. Turn it into an ordinary refusal -- the caller gets a refusal, not a
@@ -506,13 +565,18 @@ async def query_data_rls(
             raise ValueError('RLS: query too deeply nested') from e
     except ValueError as e:
         # Every fail-closed path lands here: no data has left the workspace, so this is a refusal.
-        _log_rls_outcome('refused', user=user, query_name=query_name, reason=str(e))
+        _log_rls_outcome('refused', principal=resolved, source=source, query_name=query_name, reason=str(e))
         raise
 
-    LOG.debug(f'RLS applied for user {user!r} in query {query_name!r}: {rewritten.applied_rules}')
+    LOG.debug(f'RLS applied for principal {resolved!r} in query {query_name!r}: {rewritten.applied_rules}')
     data, message = await _execute_and_serialize(rewritten.sql, query_name, ctx)
     _log_rls_outcome(
-        'ok', user=user, query_name=query_name, tables=_rule_table_keys(rewritten.applied_rules), rows=len(data.rows)
+        'ok',
+        principal=resolved,
+        source=source,
+        query_name=query_name,
+        tables=_rule_table_keys(rewritten.applied_rules),
+        rows=len(data.rows),
     )
     return RlsQueryDataOutput(
         query_name=query_name, csv_data=_to_csv(data), message=message, applied_rules=rewritten.applied_rules

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -304,6 +304,45 @@ async def _execute_and_serialize(sql_query: str, query_name: str, ctx: Context) 
     raise ValueError(f'Failed to run SQL query, error: {result.message}')
 
 
+def _rule_table_keys(applied_rules: list[str]) -> list[str]:
+    """The table keys out of `applied_rules` entries, which are formatted as `'<table>: <predicate>'`.
+
+    Only the keys go into the audit line: the predicates can carry the values the rules filter on
+    (customer ids, e-mail addresses), which do not belong in an operational log.
+    """
+    return [rule.split(':', 1)[0].strip() for rule in applied_rules]
+
+
+def _log_rls_outcome(
+    outcome: str,
+    *,
+    user: str,
+    query_name: str,
+    tables: list[str] | None = None,
+    rows: int | None = None,
+    reason: str | None = None,
+) -> None:
+    """Emit the one audit line per `query_data_rls` call: `outcome=ok` or `outcome=refused`.
+
+    One shape for both outcomes so the log is evaluable — an operator can count refusals per user, or
+    find which tables a user actually read, without parsing free-form messages. `user`, `query_name`
+    and `reason` are all model-supplied, so they are quoted with `!r`: a newline or a fake `outcome=`
+    inside them cannot forge a second log line.
+    """
+    fields = [f'outcome={outcome}', f'user={user!r}', f'query={query_name!r}']
+    if tables is not None:
+        fields.append(f'tables={tables}')
+    if rows is not None:
+        fields.append(f'rows={rows}')
+    if reason is not None:
+        fields.append(f'reason={reason!r}')
+    line = 'RLS query ' + ' '.join(fields)
+    if outcome == 'ok':
+        LOG.info(line)
+    else:
+        LOG.warning(line)
+
+
 def _to_csv(data: SqlSelectData) -> str:
     output = StringIO()
     writer = csv.DictWriter(output, fieldnames=data.columns)
@@ -441,32 +480,40 @@ async def query_data_rls(
       results beyond its row/character limits and a truncated result is a contiguous prefix, not a sample.
     * Compute aggregates (COUNT, GROUP BY, SUM, AVG, etc.) in SQL rather than pulling raw rows.
     """
-    rules = ServerState.from_context(ctx).rls_rules
-    if rules is None:
-        raise ValueError('RLS rules are not configured on this server.')
-    # Refuse oversized input before touching the workspace or the parser: the size cap is the cheapest
-    # check we have, and it must not be paid for with a round-trip.
-    if len(sql_query) > RLS_MAX_QUERY_CHARS:
-        raise ValueError(f'RLS: query too long ({len(sql_query)} chars, limit {RLS_MAX_QUERY_CHARS})')
-    workspace_manager = WorkspaceManager.from_state(ctx.session.state)
-    dialect = (await workspace_manager.get_sql_dialect()).lower()
     # The user name comes from the model, so it may carry stray whitespace; rule lookup itself is
-    # case-insensitive.
+    # case-insensitive. Stripped up front so every log line below names the user we actually matched.
     user = user.strip()
-    # Raises RlsError (a ValueError) before anything is sent to the workspace -- fail-closed.
-    # sqlglot parsing and transformation are CPU-bound and hold the GIL only in short bursts, so the
-    # rewrite runs in a worker thread: a pathological (but under-cap) query then slows down this one
-    # session instead of stalling the event loop for every other in-flight request.
     try:
-        rewritten = await asyncio.to_thread(rewrite_query, sql_query, user=user, dialect=dialect, rules=rules)
-    except RecursionError as e:
-        # sqlglot's parser recurses per nesting level, so deeply nested input hits Python's recursion
-        # limit. Turn it into an ordinary refusal -- the caller gets a refusal, not a stack overflow.
-        raise ValueError('RLS: query too deeply nested') from e
-    # Both names are model-supplied: quote them with !r so odd characters cannot forge a log line.
-    LOG.info(f'RLS applied for user {user!r} in query {query_name!r}: {rewritten.applied_rules}')
+        rules = ServerState.from_context(ctx).rls_rules
+        if rules is None:
+            raise ValueError('RLS rules are not configured on this server.')
+        # Refuse oversized input before touching the workspace or the parser: the size cap is the
+        # cheapest check we have, and it must not be paid for with a round-trip.
+        if len(sql_query) > RLS_MAX_QUERY_CHARS:
+            raise ValueError(f'RLS: query too long ({len(sql_query)} chars, limit {RLS_MAX_QUERY_CHARS})')
+        workspace_manager = WorkspaceManager.from_state(ctx.session.state)
+        dialect = (await workspace_manager.get_sql_dialect()).lower()
+        # Raises RlsError (a ValueError) before anything is sent to the workspace -- fail-closed.
+        # sqlglot parsing and transformation are CPU-bound and hold the GIL only in short bursts, so
+        # the rewrite runs in a worker thread: a pathological (but under-cap) query then slows down
+        # this one session instead of stalling the event loop for every other in-flight request.
+        try:
+            rewritten = await asyncio.to_thread(rewrite_query, sql_query, user=user, dialect=dialect, rules=rules)
+        except RecursionError as e:
+            # sqlglot's parser recurses per nesting level, so deeply nested input hits Python's
+            # recursion limit. Turn it into an ordinary refusal -- the caller gets a refusal, not a
+            # stack overflow.
+            raise ValueError('RLS: query too deeply nested') from e
+    except ValueError as e:
+        # Every fail-closed path lands here: no data has left the workspace, so this is a refusal.
+        _log_rls_outcome('refused', user=user, query_name=query_name, reason=str(e))
+        raise
 
+    LOG.debug(f'RLS applied for user {user!r} in query {query_name!r}: {rewritten.applied_rules}')
     data, message = await _execute_and_serialize(rewritten.sql, query_name, ctx)
+    _log_rls_outcome(
+        'ok', user=user, query_name=query_name, tables=_rule_table_keys(rewritten.applied_rules), rows=len(data.rows)
+    )
     return RlsQueryDataOutput(
         query_name=query_name, csv_data=_to_csv(data), message=message, applied_rules=rewritten.applied_rules
     )

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -416,7 +416,8 @@ async def query_data_rls(
     rules for `user`. The result is therefore a SLICE of the data, never the whole table; the
     `applied_rules` field of the output says exactly which filters were applied — always tell the user.
     Tables that have no rule for `user`, non-SELECT statements and multi-statement input are refused.
-    A rule written for a bare table name applies to that table name in every schema/bucket.
+    Rules are keyed `<bucket>.<table>`, so every table in the query must be written with its bucket
+    (`"in.c-crm"."orders"` on Snowflake, `` `in_c_crm`.`orders` `` on BigQuery); a bare table name is refused.
 
     The SQL requirements below are identical to the `query_data` tool.
 

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -31,6 +31,12 @@ MAX_CHARS = 50_000
 # How often to check whether the HTTP client has disconnected during a long query.
 # Mirrors the 1 s job-poll cadence in `_Workspace.execute_query`.
 _DISCONNECT_POLL_INTERVAL = 1.0
+# Upper bound on the SQL text that `query_data_rls` will rewrite. The rewrite runs sqlglot's full
+# recursive-descent parser over model-supplied SQL, which is CPU-bound and superlinear in nesting
+# depth, so an oversized query is a cheap way to burn a worker (and, before the rewrite moved off
+# the event loop, to stall every other session). 20k characters is far more than any query a model
+# writes by hand, so the cap only ever hits pathological input.
+RLS_MAX_QUERY_CHARS = 20_000
 
 
 async def _watch_for_http_disconnect(request: Request, poll_interval: float | None = None) -> None:
@@ -438,13 +444,25 @@ async def query_data_rls(
     rules = ServerState.from_context(ctx).rls_rules
     if rules is None:
         raise ValueError('RLS rules are not configured on this server.')
+    # Refuse oversized input before touching the workspace or the parser: the size cap is the cheapest
+    # check we have, and it must not be paid for with a round-trip.
+    if len(sql_query) > RLS_MAX_QUERY_CHARS:
+        raise ValueError(f'RLS: query too long ({len(sql_query)} chars, limit {RLS_MAX_QUERY_CHARS})')
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
     dialect = (await workspace_manager.get_sql_dialect()).lower()
     # The user name comes from the model, so it may carry stray whitespace; rule lookup itself is
     # case-insensitive.
     user = user.strip()
     # Raises RlsError (a ValueError) before anything is sent to the workspace -- fail-closed.
-    rewritten = rewrite_query(sql_query, user=user, dialect=dialect, rules=rules)
+    # sqlglot parsing and transformation are CPU-bound and hold the GIL only in short bursts, so the
+    # rewrite runs in a worker thread: a pathological (but under-cap) query then slows down this one
+    # session instead of stalling the event loop for every other in-flight request.
+    try:
+        rewritten = await asyncio.to_thread(rewrite_query, sql_query, user=user, dialect=dialect, rules=rules)
+    except RecursionError as e:
+        # sqlglot's parser recurses per nesting level, so deeply nested input hits Python's recursion
+        # limit. Turn it into an ordinary refusal -- the caller gets a refusal, not a stack overflow.
+        raise ValueError('RLS: query too deeply nested') from e
     # Both names are model-supplied: quote them with !r so odd characters cannot forge a log line.
     LOG.info(f'RLS applied for user {user!r} in query {query_name!r}: {rewritten.applied_rules}')
 

--- a/src/keboola_mcp_server/tools/sql.py
+++ b/src/keboola_mcp_server/tools/sql.py
@@ -402,7 +402,8 @@ async def query_data_rls(
         Field(
             description=(
                 'Name of the user on whose behalf the query runs. Row-level-security rules are selected by this '
-                'name; every table in the query must have a rule for it, otherwise the query is refused.'
+                'name; every table in the query must have a rule for it, otherwise the query is refused. '
+                'Leading/trailing whitespace is ignored; matching is case-insensitive.'
             )
         ),
     ],
@@ -415,6 +416,7 @@ async def query_data_rls(
     rules for `user`. The result is therefore a SLICE of the data, never the whole table; the
     `applied_rules` field of the output says exactly which filters were applied — always tell the user.
     Tables that have no rule for `user`, non-SELECT statements and multi-statement input are refused.
+    A rule written for a bare table name applies to that table name in every schema/bucket.
 
     The SQL requirements below are identical to the `query_data` tool.
 
@@ -436,9 +438,13 @@ async def query_data_rls(
         raise ValueError('RLS rules are not configured on this server.')
     workspace_manager = WorkspaceManager.from_state(ctx.session.state)
     dialect = (await workspace_manager.get_sql_dialect()).lower()
+    # The user name comes from the model, so it may carry stray whitespace; rule lookup itself is
+    # case-insensitive.
+    user = user.strip()
     # Raises RlsError (a ValueError) before anything is sent to the workspace -- fail-closed.
     rewritten = rewrite_query(sql_query, user=user, dialect=dialect, rules=rules)
-    LOG.info(f'RLS applied for user "{user}" in query "{query_name}": {rewritten.applied_rules}')
+    # Both names are model-supplied: quote them with !r so odd characters cannot forge a log line.
+    LOG.info(f'RLS applied for user {user!r} in query {query_name!r}: {rewritten.applied_rules}')
 
     data, message = await _execute_and_serialize(rewritten.sql, query_name, ctx)
     return RlsQueryDataOutput(

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -13,6 +13,9 @@ from fastmcp.tools import Tool
 from mcp.types import ToolAnnotations
 
 from keboola_mcp_server.authorization import ToolAuthorizationMiddleware
+from keboola_mcp_server.config import Config, ServerRuntimeInfo
+from keboola_mcp_server.mcp import ServerState
+from keboola_mcp_server.rls import RlsRules
 
 # Sample tools: 3 read-only (get_configs, get_buckets, query_data), 2 write (create_config, update_descriptions)
 ALL_TOOLS = {'get_configs', 'create_config', 'get_buckets', 'update_descriptions', 'query_data'}
@@ -39,6 +42,22 @@ def mock_middleware_context():
     middleware_ctx = MagicMock(spec=MiddlewareContext)
     middleware_ctx.fastmcp_context = ctx
     return middleware_ctx
+
+
+def server_state(*, rls: bool) -> ServerState:
+    """A lifespan state with or without RLS rules loaded."""
+    return ServerState(
+        config=Config(),
+        runtime_info=ServerRuntimeInfo(transport='stdio'),
+        rls_rules=RlsRules(tables={'invoices': {'petr': 'TRUE'}}) if rls else None,
+    )
+
+
+@pytest.fixture
+def rls_middleware_context(mock_middleware_context):
+    """A middleware context whose lifespan state carries RLS rules (i.e. the server runs in RLS mode)."""
+    mock_middleware_context.fastmcp_context.request_context.lifespan_context = server_state(rls=True)
+    return mock_middleware_context
 
 
 @pytest.fixture
@@ -222,3 +241,84 @@ async def test_on_call_tool(middleware, mock_middleware_context, tool_name, tool
             assert tool_name in str(exc_info.value)
             assert 'not authorized' in str(exc_info.value)
             call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'headers',
+    [None, {}, {'X-Read-Only-Mode': 'false'}, {'X-Allowed-Tools': 'get_configs, create_config'}],
+    ids=['no_http_request', 'no_headers', 'read_only_mode_off', 'allowed_tools_include_a_write_tool'],
+)
+async def test_rls_mode_lists_read_only_tools_regardless_of_headers(
+    middleware, rls_middleware_context, sample_tools, headers
+):
+    """RLS mode is not a header: no combination of caller-supplied headers (including none at all,
+    as on stdio) can put a write tool back on the list."""
+    call_next = AsyncMock(return_value=sample_tools)
+    mock_request = MagicMock()
+    mock_request.headers = headers if headers else {}
+    http_request = mock_request if headers is not None else None
+
+    with patch('keboola_mcp_server.authorization.get_http_request_or_none', return_value=http_request):
+        result = await middleware.on_list_tools(rls_middleware_context, call_next)
+
+    assert {t.name for t in result} <= READ_ONLY_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_rls_mode_blocks_calls_to_write_tools(middleware, rls_middleware_context):
+    """Hiding a tool from tools/list is not enough -- a client that knows the name must be refused
+    too, with a message that names RLS as the reason rather than blaming the client's headers."""
+    rls_middleware_context.message = MagicMock()
+    rls_middleware_context.message.name = 'create_config'
+    rls_middleware_context.fastmcp_context.fastmcp.get_tool = AsyncMock(
+        return_value=create_mock_tool('create_config', read_only=False)
+    )
+    call_next = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch('keboola_mcp_server.authorization.get_http_request_or_none', return_value=None),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await middleware.on_call_tool(rls_middleware_context, call_next)
+
+    assert 'read-only' in str(exc_info.value)
+    assert 'RLS' in str(exc_info.value)
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rls_mode_allows_calls_to_read_only_tools(middleware, rls_middleware_context):
+    rls_middleware_context.message = MagicMock()
+    rls_middleware_context.message.name = 'query_data_rls'
+    rls_middleware_context.fastmcp_context.fastmcp.get_tool = AsyncMock(
+        return_value=create_mock_tool('query_data_rls', read_only=True)
+    )
+    call_next = AsyncMock(return_value=MagicMock())
+
+    with patch('keboola_mcp_server.authorization.get_http_request_or_none', return_value=None):
+        await middleware.on_call_tool(rls_middleware_context, call_next)
+
+    call_next.assert_called_once_with(rls_middleware_context)
+
+
+@pytest.mark.parametrize(('rls', 'expected_read_only'), [(True, True), (False, False)])
+def test_authorization_config_reports_rls_as_read_only(rls, expected_read_only):
+    """The raw `/preview/configuration` route reuses `_get_authorization_config` with the state it
+    reads from the Starlette app, so this is also what keeps that route from becoming a back door
+    around RLS mode."""
+    mock_request = MagicMock()
+    mock_request.headers = {}
+
+    allowed, disallowed, read_only_mode = ToolAuthorizationMiddleware._get_authorization_config(
+        mock_request, server_state=server_state(rls=rls)
+    )
+
+    assert (allowed, disallowed) == (None, None)
+    assert read_only_mode is expected_read_only
+
+
+def test_authorization_config_without_server_state_is_unrestricted():
+    """Call sites that cannot reach the lifespan state must keep behaving exactly as before."""
+    with patch('keboola_mcp_server.authorization.get_http_request_or_none', return_value=None):
+        assert ToolAuthorizationMiddleware._get_authorization_config() == (None, None, False)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -49,7 +49,7 @@ def server_state(*, rls: bool) -> ServerState:
     return ServerState(
         config=Config(),
         runtime_info=ServerRuntimeInfo(transport='stdio'),
-        rls_rules=RlsRules(tables={'invoices': {'petr': 'TRUE'}}) if rls else None,
+        rls_rules=RlsRules(tables={'in.c-crm.invoices': {'petr': 'TRUE'}}, dialect='snowflake') if rls else None,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -462,3 +462,18 @@ class TestRunLogout:
 def test_parse_args_workspace_id(args: list[str], expected: str | None) -> None:
     parsed = parse_args(args)
     assert parsed.workspace_id == expected
+
+
+@pytest.mark.parametrize(
+    ('args', 'expected'),
+    [
+        (['--rls-rules-path', '/etc/kbc/rls.yaml'], '/etc/kbc/rls.yaml'),
+        ([], None),
+    ],
+    ids=['rls_rules_path_set', 'rls_rules_path_defaults_to_none'],
+)
+def test_parse_args_rls_rules_path(args: list[str], expected: str | None) -> None:
+    # Without a default of None the server would silently start unrestricted (or crash) -- the flag
+    # is what swaps query_data for query_data_rls.
+    parsed = parse_args(args)
+    assert parsed.rls_rules_path == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -173,7 +173,7 @@ class TestConfig:
             'oauth_client_id=None, oauth_client_secret=None, '
             'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
             "jwt_secret=None, postgres_dsn='****', session_encryption_key='****', "
-            'bearer_token=None, conversation_id=None, project_id=None)'
+            'bearer_token=None, conversation_id=None, project_id=None, rls_rules_path=None)'
         )
 
     def test_workspace_id_must_be_numeric(self) -> None:
@@ -222,6 +222,7 @@ class TestReplaceByHeaders:
             {'X-Oauth-Client-Secret': 'evil'},
             {'X-Oauth-Server-Url': 'https://evil.example'},
             {'X-Mcp-Server-Url': 'https://evil.example'},
+            {'X-Rls-Rules-Path': '/tmp/evil.yaml'},
         ],
         ids=[
             'jwt_secret_bare',
@@ -233,12 +234,18 @@ class TestReplaceByHeaders:
             'oauth_client_secret',
             'oauth_server_url',
             'mcp_server_url',
+            'rls_rules_path',
         ],
     )
     def test_deployment_level_fields_are_unreachable(self, headers: Mapping[str, str]) -> None:
         config = Config(jwt_secret='real-secret', postgres_dsn='postgresql://real')
         out = config.replace_by_headers(headers)
         assert out == config  # nothing changed -- every one of these headers was ignored
+
+    def test_rls_rules_path_from_env_and_cli(self) -> None:
+        # Deployment-level: reachable from env / CLI (trusted), never from a header (Task 2 above).
+        assert Config().replace_by({'KBC_RLS_RULES_PATH': '/etc/rls.yaml'}).rls_rules_path == '/etc/rls.yaml'
+        assert Config(rls_rules_path='/opt/rls.yaml').rls_rules_path == '/opt/rls.yaml'
 
     def test_allowlisted_fields_still_work(self) -> None:
         config = Config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -173,7 +173,8 @@ class TestConfig:
             'oauth_client_id=None, oauth_client_secret=None, '
             'oauth_server_url=None, oauth_scope=None, mcp_server_url=None, '
             "jwt_secret=None, postgres_dsn='****', session_encryption_key='****', "
-            'bearer_token=None, conversation_id=None, project_id=None, rls_rules_path=None)'
+            'bearer_token=None, conversation_id=None, project_id=None, rls_rules_path=None, '
+            'rls_principal=None, rls_principal_source=None)'
         )
 
     def test_workspace_id_must_be_numeric(self) -> None:
@@ -223,6 +224,7 @@ class TestReplaceByHeaders:
             {'X-Oauth-Server-Url': 'https://evil.example'},
             {'X-Mcp-Server-Url': 'https://evil.example'},
             {'X-Rls-Rules-Path': '/tmp/evil.yaml'},
+            {'X-Rls-Principal-Source': 'argument'},
         ],
         ids=[
             'jwt_secret_bare',
@@ -235,6 +237,7 @@ class TestReplaceByHeaders:
             'oauth_server_url',
             'mcp_server_url',
             'rls_rules_path',
+            'rls_principal_source',
         ],
     )
     def test_deployment_level_fields_are_unreachable(self, headers: Mapping[str, str]) -> None:
@@ -246,6 +249,41 @@ class TestReplaceByHeaders:
         # Deployment-level: reachable from env / CLI (trusted), never from a header (Task 2 above).
         assert Config().replace_by({'KBC_RLS_RULES_PATH': '/etc/rls.yaml'}).rls_rules_path == '/etc/rls.yaml'
         assert Config(rls_rules_path='/opt/rls.yaml').rls_rules_path == '/opt/rls.yaml'
+
+    @pytest.mark.parametrize(
+        'header_name', ['X-RLS-Principal', 'X-Rls-Principal', 'x-rls-principal', 'KBC-RLS-Principal']
+    )
+    def test_rls_principal_is_header_eligible(self, header_name: str) -> None:
+        """The principal is per-request by nature: it is the one RLS field a caller-supplied header
+        must be able to set, under every spelling `_read_options` normalises."""
+        assert Config().replace_by_headers({header_name: 'michal'}).rls_principal == 'michal'
+
+    def test_empty_rls_principal_header_is_absent_not_empty(self) -> None:
+        # An unset header template (`X-RLS-Principal:`) must read as "no principal", not as the
+        # empty-string principal -- the tool refuses on absence, and '' would match no rule anyway.
+        assert Config().replace_by_headers({'X-RLS-Principal': ''}).rls_principal is None
+
+    def test_rls_principal_is_never_read_from_env_or_cli(self) -> None:
+        """A server-wide `KBC_RLS_PRINCIPAL` would silently answer every request that carries no
+        header with one operator-chosen identity -- exactly the fail-open the header mode exists to
+        prevent. The field is settable from a header only."""
+        assert Config().replace_by({'KBC_RLS_PRINCIPAL': 'michal'}).rls_principal is None
+        assert Config().replace_by({'rls_principal': 'michal'}).rls_principal is None
+        assert Config(rls_principal='michal').replace_by({'KBC_STORAGE_TOKEN': 't'}).rls_principal == 'michal'
+
+    @pytest.mark.parametrize(('value', 'expected'), [('header', 'header'), ('ARGUMENT', 'argument'), (None, None)])
+    def test_rls_principal_source_is_normalised(self, value: str | None, expected: str | None) -> None:
+        assert Config(rls_principal_source=value).rls_principal_source == expected
+
+    @pytest.mark.parametrize('value', ['', 'both', 'headers', 'tool-argument'])
+    def test_rls_principal_source_rejects_anything_else(self, value: str) -> None:
+        with pytest.raises(ValueError, match='rls_principal_source'):
+            Config(rls_principal_source=value)
+
+    def test_rls_principal_source_from_env_and_cli(self) -> None:
+        # Deployment-level, like rls_rules_path: env / CLI only, never a header (Task 2 above).
+        assert Config().replace_by({'KBC_RLS_PRINCIPAL_SOURCE': 'header'}).rls_principal_source == 'header'
+        assert Config(rls_principal_source='argument').rls_principal_source == 'argument'
 
     def test_allowlisted_fields_still_work(self) -> None:
         config = Config()

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -1,0 +1,161 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from keboola_mcp_server.rls import RewrittenQuery, RlsError, RlsRules, rewrite_query
+
+VALID_YAML = textwrap.dedent(
+    """
+    tables:
+      invoices:
+        petr: "country = 'CZ'"
+        Monika: "country = 'DE'"
+        admin: "TRUE"
+      in.c-crm.orders:
+        petr: "country = 'CZ' AND status <> 'draft'"
+      orders:
+        petr: "FALSE"
+    """
+)
+
+
+@pytest.fixture
+def rules(tmp_path: Path) -> RlsRules:
+    path = tmp_path / 'rls.yaml'
+    path.write_text(VALID_YAML)
+    return RlsRules.load(str(path))
+
+
+class TestLoad:
+    def test_load_normalizes_keys(self, rules: RlsRules) -> None:
+        assert rules.tables['invoices']['monika'] == "country = 'DE'"
+        assert rules.tables['in.c-crm.orders']['petr'] == "country = 'CZ' AND status <> 'draft'"
+
+    @pytest.mark.parametrize(
+        ('content', 'match'),
+        [
+            ('', 'empty'),
+            ('tables: {}', 'no tables'),
+            ('foo: bar', "'tables'"),
+            ('tables:\n  invoices: "not a mapping"', "'invoices'"),
+            ('tables:\n  invoices:\n    petr: 42', "'petr'"),
+            ('tables:\n  invoices:\n    petr: "country = = 1"', 'petr'),
+            ('tables:\n  invoices:\n    petr: ""', 'petr'),
+            ('tables: [\n', 'YAML'),
+        ],
+    )
+    def test_load_rejects_invalid_file(self, tmp_path: Path, content: str, match: str) -> None:
+        path = tmp_path / 'rls.yaml'
+        path.write_text(content)
+        with pytest.raises(RlsError, match=match):
+            RlsRules.load(str(path))
+
+    def test_load_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(RlsError, match='not found'):
+            RlsRules.load(str(tmp_path / 'nope.yaml'))
+
+
+class TestPredicateFor:
+    @pytest.mark.parametrize(
+        ('table_name', 'schema', 'user', 'expected'),
+        [
+            ('invoices', None, 'petr', ('invoices', "country = 'CZ'")),
+            ('INVOICES', None, 'PETR', ('invoices', "country = 'CZ'")),
+            ('invoices', 'in.c-main', 'monika', ('invoices', "country = 'DE'")),  # falls back to bare name
+            ('orders', 'in.c-crm', 'petr', ('in.c-crm.orders', "country = 'CZ' AND status <> 'draft'")),
+            ('orders', None, 'petr', ('orders', 'FALSE')),
+        ],
+    )
+    def test_lookup(self, rules: RlsRules, table_name, schema, user, expected) -> None:
+        assert rules.predicate_for(table_name=table_name, schema=schema, user=user) == expected
+
+    @pytest.mark.parametrize(
+        ('table_name', 'schema', 'user', 'match'),
+        [
+            ('customers', None, 'petr', "table 'customers'"),
+            ('invoices', None, 'nobody', "user 'nobody'"),
+            ('orders', 'in.c-crm', 'monika', "user 'monika'"),  # qualified key wins even if bare key has no user
+        ],
+    )
+    def test_lookup_denied(self, rules: RlsRules, table_name, schema, user, match) -> None:
+        with pytest.raises(RlsError, match=match):
+            rules.predicate_for(table_name=table_name, schema=schema, user=user)
+
+
+class TestRewriteQuery:
+    @pytest.mark.parametrize(
+        ('sql', 'dialect', 'expected_sql', 'expected_rules'),
+        [
+            (
+                'SELECT COUNT(*) FROM invoices',
+                'snowflake',
+                "SELECT COUNT(*) FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT i.id FROM invoices i JOIN "in.c-crm"."orders" AS o ON o.id = i.id',
+                'snowflake',
+                (
+                    "SELECT i.id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS i "
+                    "JOIN (SELECT * FROM \"in.c-crm\".\"orders\" WHERE country = 'CZ' AND status <> 'draft') AS \"o\" "
+                    'ON o.id = i.id'
+                ),
+                ["invoices: country = 'CZ'", "in.c-crm.orders: country = 'CZ' AND status <> 'draft'"],
+            ),
+            (
+                'WITH x AS (SELECT * FROM invoices) SELECT * FROM x',
+                'snowflake',
+                "WITH x AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) SELECT * FROM x",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT * FROM (SELECT id FROM invoices) sub',
+                'snowflake',
+                "SELECT * FROM (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) AS sub",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT id FROM invoices UNION ALL SELECT id FROM orders',
+                'snowflake',
+                (
+                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                ),
+                ["invoices: country = 'CZ'", 'orders: FALSE'],
+            ),
+            (
+                'SELECT COUNT(*) FROM `proj.ds.invoices`',
+                'bigquery',
+                "SELECT COUNT(*) FROM (SELECT * FROM `proj`.`ds`.`invoices` WHERE country = 'CZ') AS `invoices`",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'SELECT COUNT(*) FROM `ds`.`invoices` LIMIT 10',
+                'bigquery',
+                "SELECT COUNT(*) FROM (SELECT * FROM `ds`.`invoices` WHERE country = 'CZ') AS `invoices` LIMIT 10",
+                ["invoices: country = 'CZ'"],
+            ),
+        ],
+    )
+    def test_rewrite(self, rules: RlsRules, sql, dialect, expected_sql, expected_rules) -> None:
+        out = rewrite_query(sql, user='petr', dialect=dialect, rules=rules)
+        assert out == RewrittenQuery(sql=expected_sql, applied_rules=expected_rules)
+
+    @pytest.mark.parametrize(
+        ('sql', 'user', 'match'),
+        [
+            ('DELETE FROM invoices', 'petr', 'SELECT'),
+            ('INSERT INTO invoices SELECT * FROM orders', 'petr', 'SELECT'),
+            ('SELECT 1; SELECT 2', 'petr', 'one statement'),
+            ('SELCT nonsense', 'petr', 'SELECT'),
+            ('SELECT * FROM customers', 'petr', "table 'customers'"),
+            ('SELECT * FROM invoices', 'nobody', "user 'nobody'"),
+            # A CTE named like a protected table would shadow it inside its own body -- refuse.
+            ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'CTE'),
+            ('', 'petr', 'one statement'),
+        ],
+    )
+    def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, match) -> None:
+        with pytest.raises(RlsError, match=match):
+            rewrite_query(sql, user=user, dialect='snowflake', rules=rules)

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -118,6 +118,36 @@ class TestRewriteQuery:
                 ["invoices: country = 'CZ'"],
             ),
             (
+                # A CTE may reference an earlier sibling CTE.
+                'WITH a AS (SELECT * FROM invoices), b AS (SELECT * FROM a) SELECT * FROM b',
+                'snowflake',
+                (
+                    "WITH a AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices), "
+                    'b AS (SELECT * FROM a) SELECT * FROM b'
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                # A recursive CTE references itself from inside its own body.
+                'WITH RECURSIVE r AS (SELECT id FROM invoices UNION ALL SELECT id FROM r) SELECT * FROM r',
+                'snowflake',
+                (
+                    "WITH RECURSIVE r AS (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    'UNION ALL SELECT id FROM r) SELECT * FROM r'
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                # A subquery may declare its own CTE as long as the name shadows nothing outside it.
+                'SELECT * FROM invoices WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)',
+                'snowflake',
+                (
+                    "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    'WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)'
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
                 'SELECT * FROM (SELECT id FROM invoices) sub',
                 'snowflake',
                 "SELECT * FROM (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) AS sub",
@@ -204,7 +234,45 @@ class TestRewriteQuery:
             ('SELECT * FROM customers', 'petr', 'snowflake', "table 'customers'"),
             ('SELECT * FROM invoices', 'nobody', 'snowflake', "user 'nobody'"),
             # A CTE named like a protected table would shadow it inside its own body -- refuse.
-            ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'snowflake', 'CTE'),
+            ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'snowflake', 'collide'),
+            # ... whatever the quoting of either side: a quoted `"orders"` CTE and the rule key
+            # `orders` are the same name.
+            ('WITH "orders" AS (SELECT 1) SELECT * FROM ORDERS', 'petr', 'snowflake', 'collide'),
+            # A CTE declared in a nested scope must not make a top-level real table look like a CTE
+            # reference. Each of these used to pass through verbatim, unfiltered.
+            (
+                'SELECT * FROM secret WHERE 1 IN (WITH secret AS (SELECT 1) SELECT 1)',
+                'petr',
+                'snowflake',
+                'another scope',
+            ),
+            (
+                'SELECT * FROM secret WHERE 1 IN (WITH secret AS (SELECT 1) SELECT 1)',
+                'petr',
+                'bigquery',
+                'another scope',
+            ),
+            ('SELECT * FROM secret, (WITH secret AS (SELECT 1) SELECT 1) q', 'petr', 'snowflake', 'another scope'),
+            (
+                'SELECT id FROM secret UNION ALL SELECT 1 FROM (WITH secret AS (SELECT 1) SELECT 1) q',
+                'petr',
+                'snowflake',
+                'another scope',
+            ),
+            # Same trick aimed at a table that does have a rule: caught by the collision guard.
+            (
+                'SELECT * FROM invoices WHERE 1 IN (WITH invoices AS (SELECT 1) SELECT 1)',
+                'petr',
+                'snowflake',
+                'collide',
+            ),
+            # A CTE reference whose quoting differs from the declaration is ambiguous -- the engine
+            # and the rewriter can disagree about whether it resolves to the CTE or a real table.
+            ('WITH "secret" AS (SELECT 1) SELECT * FROM SECRET', 'petr', 'snowflake', 'ambiguous'),
+            # Table functions parse as an `exp.Table` whose `this` is not an identifier: there is no
+            # table name to look a rule up by, so they must be refused, not silently passed through.
+            ('SELECT * FROM my_udtf(1)', 'petr', 'snowflake', 'unsupported table reference'),
+            ('SELECT * FROM invoices(1)', 'petr', 'snowflake', 'unsupported table reference'),
             ('', 'petr', 'snowflake', 'one statement'),
             # An unknown/unsupported dialect must not let a raw sqlglot exception escape.
             ('SELECT * FROM invoices', 'petr', 'not-a-real-dialect', 'dialect'),
@@ -238,6 +306,21 @@ class TestRewriteQuery:
     def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, dialect, match) -> None:
         with pytest.raises(RlsError, match=match):
             rewrite_query(sql, user=user, dialect=dialect, rules=rules)
+
+    def test_cte_colliding_with_qualified_rule_key_fails_closed(self) -> None:
+        """A CTE alias is always bare, so it can never equal a `<schema>.<table>` rule key
+        literally -- it is the key's bare table name it shadows. The collision guard must compare
+        against that, otherwise `WITH invoices AS (...)` slips past rules keyed
+        `in.c-crm.invoices`.
+        """
+        scoped_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': "country = 'CZ'"}})
+        with pytest.raises(RlsError, match='collide'):
+            rewrite_query(
+                'SELECT * FROM invoices WHERE 1 IN (WITH invoices AS (SELECT 1) SELECT 1)',
+                user='petr',
+                dialect='snowflake',
+                rules=scoped_rules,
+            )
 
     def test_rewrite_predicate_invalid_for_dialect_fails_closed(self) -> None:
         """A predicate can pass `RlsRules.load()`'s dialect-agnostic check yet still fail to parse
@@ -283,6 +366,10 @@ class TestOutputInvariant:
             ("SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS i JOIN orders o ON TRUE", 'unwrapped'),
             # A wrapper that is not `SELECT *` would silently drop the RLS predicate's columns.
             ('SELECT * FROM (SELECT id FROM invoices) AS invoices', 'unwrapped table reference'),
+            # The CTE that would excuse `secret` is declared in a nested scope, so it excuses
+            # nothing: `secret` is a real, unwrapped table here.
+            ('SELECT * FROM secret WHERE 1 IN (WITH secret AS (SELECT 1) SELECT 1)', 'another scope'),
+            ('WITH "secret" AS (SELECT 1) SELECT * FROM SECRET', 'ambiguous'),
         ],
     )
     def test_rejects(self, sql: str, match: str) -> None:
@@ -298,6 +385,19 @@ class TestOutputInvariant:
             (
                 "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
                 'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+            ),
+            # A CTE reference from a scope that really does declare it, at every nesting shape.
+            (
+                "WITH a AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices), "
+                'b AS (SELECT * FROM a) SELECT * FROM b'
+            ),
+            (
+                "WITH RECURSIVE r AS (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                'UNION ALL SELECT id FROM r) SELECT * FROM r'
+            ),
+            (
+                "SELECT 1 FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                'WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)'
             ),
         ],
     )

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -210,7 +210,7 @@ class TestRewriteQuery:
                 'SELECT COUNT(*) FROM "in.c-crm"."invoices"',
                 'snowflake',
                 "SELECT COUNT(*) FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 'SELECT i.id FROM "in.c-crm"."invoices" i JOIN "in.c-crm"."orders" AS o ON o.id = i.id',
@@ -220,7 +220,7 @@ class TestRewriteQuery:
                     "JOIN (SELECT * FROM \"in.c-crm\".\"orders\" WHERE country = 'CZ' AND status <> 'draft') AS o "
                     'ON o.id = i.id'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'", "in.c-crm.orders: country = 'CZ' AND status <> 'draft'"],
+                ['in.c-crm.invoices', 'in.c-crm.orders'],
             ),
             (
                 # The original alias is quoted -- the rewrite must keep it quoted, not borrow the
@@ -228,13 +228,13 @@ class TestRewriteQuery:
                 'SELECT "I".id FROM "in.c-crm"."invoices" AS "I"',
                 'snowflake',
                 'SELECT "I".id FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "I"',
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 'WITH x AS (SELECT * FROM "in.c-crm"."invoices") SELECT * FROM x',
                 'snowflake',
                 "WITH x AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\") SELECT * FROM x",
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 # A CTE may reference an earlier sibling CTE.
@@ -244,7 +244,7 @@ class TestRewriteQuery:
                     "WITH a AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"), "
                     'b AS (SELECT * FROM a) SELECT * FROM b'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 # A recursive CTE references itself from inside its own body.
@@ -254,7 +254,7 @@ class TestRewriteQuery:
                     "WITH RECURSIVE r AS (SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'UNION ALL SELECT id FROM r) SELECT * FROM r'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 # Quoted CTE alias, quoted reference, same case: the same name on both engines.
@@ -264,7 +264,7 @@ class TestRewriteQuery:
                     'WITH "X" AS (SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices") '
                     'SELECT * FROM "X"'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 # Unquoted identifiers fold case on both Snowflake and BigQuery, so `x` and `X` are
@@ -272,7 +272,7 @@ class TestRewriteQuery:
                 'WITH x AS (SELECT * FROM "in.c-crm"."invoices") SELECT * FROM X',
                 'snowflake',
                 "WITH x AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\") SELECT * FROM X",
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 'WITH `X` AS (SELECT * FROM `in_c_crm`.`invoices`) SELECT * FROM `X`',
@@ -281,7 +281,7 @@ class TestRewriteQuery:
                     'WITH `X` AS (SELECT * FROM (SELECT * FROM `in_c_crm`.`invoices` '
                     "WHERE country = 'CZ') AS `invoices`) SELECT * FROM `X`"
                 ),
-                ["in_c_crm.invoices: country = 'CZ'"],
+                ['in_c_crm.invoices'],
             ),
             (
                 # A subquery may declare its own CTE as long as the name shadows nothing outside it.
@@ -291,13 +291,13 @@ class TestRewriteQuery:
                     "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 'SELECT * FROM (SELECT id FROM "in.c-crm"."invoices") sub',
                 'snowflake',
                 "SELECT * FROM (SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\") AS sub",
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 'SELECT id FROM "in.c-crm"."invoices" UNION ALL SELECT id FROM "in.c-sales"."orders"',
@@ -306,7 +306,7 @@ class TestRewriteQuery:
                     "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'UNION ALL SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
+                ['in.c-crm.invoices', 'in.c-sales.orders'],
             ),
             (
                 'SELECT id FROM "in.c-crm"."invoices" EXCEPT SELECT id FROM "in.c-sales"."orders"',
@@ -315,7 +315,7 @@ class TestRewriteQuery:
                     "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'EXCEPT SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
+                ['in.c-crm.invoices', 'in.c-sales.orders'],
             ),
             (
                 'SELECT id FROM "in.c-crm"."invoices" INTERSECT SELECT id FROM "in.c-sales"."orders"',
@@ -324,7 +324,7 @@ class TestRewriteQuery:
                     "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'INTERSECT SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
+                ['in.c-crm.invoices', 'in.c-sales.orders'],
             ),
             (
                 # The same table twice: both references are rewritten, but the disclosure lists the
@@ -335,7 +335,7 @@ class TestRewriteQuery:
                     "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     "UNION ALL SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\""
                 ),
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 # No FROM at all: nothing to filter, nothing to disclose -- must still pass.
@@ -373,7 +373,7 @@ class TestRewriteQuery:
                     'SELECT COUNT(*) FROM (SELECT * FROM `proj`.`in_c_crm`.`invoices` '
                     "WHERE country = 'CZ') AS `invoices`"
                 ),
-                ["in_c_crm.invoices: country = 'CZ'"],
+                ['in_c_crm.invoices'],
             ),
             (
                 'SELECT COUNT(*) FROM `in_c_crm`.`invoices` LIMIT 10',
@@ -382,20 +382,20 @@ class TestRewriteQuery:
                     'SELECT COUNT(*) FROM (SELECT * FROM `in_c_crm`.`invoices` '
                     "WHERE country = 'CZ') AS `invoices` LIMIT 10"
                 ),
-                ["in_c_crm.invoices: country = 'CZ'"],
+                ['in_c_crm.invoices'],
             ),
             (
                 # A whole statement in parentheses means the statement inside them.
                 '(SELECT * FROM "in.c-crm"."invoices")',
                 'snowflake',
                 "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 '((SELECT * FROM "in.c-crm"."invoices"))',
                 'snowflake',
                 "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 '(SELECT id FROM "in.c-crm"."invoices" UNION ALL SELECT id FROM "in.c-sales"."orders")',
@@ -404,14 +404,14 @@ class TestRewriteQuery:
                     "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'UNION ALL SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
                 ),
-                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
+                ['in.c-crm.invoices', 'in.c-sales.orders'],
             ),
             (
                 # A trailing semicolon is still exactly one statement.
                 'SELECT * FROM "in.c-crm"."invoices";',
                 'snowflake',
                 "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 # `UNNET(...) WITH OFFSET` is an allowed FROM source and the correlated `t.items`
@@ -422,7 +422,7 @@ class TestRewriteQuery:
                     "SELECT * FROM (SELECT * FROM `in_c_crm`.`invoices` WHERE country = 'CZ') AS t "
                     'CROSS JOIN UNNEST(t.items) AS item WITH OFFSET AS off'
                 ),
-                ["in_c_crm.invoices: country = 'CZ'"],
+                ['in_c_crm.invoices'],
             ),
             (
                 # Window function + QUALIFY over a protected table.
@@ -432,7 +432,7 @@ class TestRewriteQuery:
                     'SELECT id, ROW_NUMBER() OVER (PARTITION BY country ORDER BY id) AS rn '
                     "FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" QUALIFY rn = 1"
                 ),
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
             (
                 # A CTE named after a protected table shadows nothing: the protected reference always
@@ -471,7 +471,7 @@ class TestRewriteQuery:
                     'WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 3) '
                     "SELECT * FROM r, (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\""
                 ),
-                ["in.c-crm.invoices: country = 'CZ'"],
+                ['in.c-crm.invoices'],
             ),
         ],
     )
@@ -792,7 +792,7 @@ class TestRewriteQuery:
             'WITH invoices AS (SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" '
             'WHERE country = \'CZ\') AS "invoices" WHERE amount > 0) SELECT COUNT(*) FROM invoices'
         )
-        assert out.applied_rules == ["in.c-crm.invoices: country = 'CZ'"]
+        assert out.applied_rules == ['in.c-crm.invoices']
 
     def test_rewrite_predicate_invalid_for_dialect_fails_closed(self) -> None:
         """A predicate can pass `RlsRules.load()`'s dialect-agnostic check yet still fail to parse
@@ -808,8 +808,9 @@ class TestRewriteQuery:
     @pytest.mark.parametrize(
         ('predicate', 'match'),
         [
-            # Injection attempt: the predicate must parse as a bare condition, nothing more.
-            ('TRUE) AS x, (SELECT * FROM secret WHERE (TRUE', 'not valid SQL'),
+            # Injection attempt: the predicate must parse as a bare condition, nothing more. The
+            # refusal names the rule's key and nothing else -- not the predicate that failed.
+            ('TRUE) AS x, (SELECT * FROM secret WHERE (TRUE', 'rule for table in.c-crm.invoices could not be'),
             # A predicate referencing another table leaves that table outside a wrapper -- the
             # output invariant refuses it rather than letting an unfiltered reference through.
             ('id IN (SELECT id FROM secret)', 'unwrapped table reference'),
@@ -819,6 +820,44 @@ class TestRewriteQuery:
         bad_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': predicate}}, dialect='snowflake')
         with pytest.raises(RlsError, match=match):
             rewrite_query('SELECT * FROM "in.c-crm"."invoices"', user='petr', dialect='snowflake', rules=bad_rules)
+
+
+class TestDisclosure:
+    """What reaches the caller is the fact that a table was filtered -- never the filter itself."""
+
+    def test_applied_rules_are_keys_only_and_deduplicated(self, rules: RlsRules) -> None:
+        out = rewrite_query(
+            'SELECT id FROM "in.c-crm"."invoices" '
+            'UNION ALL SELECT id FROM "in.c-crm"."invoices" '
+            'UNION ALL SELECT id FROM "in.c-sales"."orders"',
+            user='petr',
+            dialect='snowflake',
+            rules=rules,
+        )
+
+        assert out.applied_rules == ['in.c-crm.invoices', 'in.c-sales.orders']
+        assert all("country = 'CZ'" not in entry and 'FALSE' not in entry for entry in out.applied_rules)
+
+    @pytest.mark.parametrize(
+        'predicate',
+        [
+            'country = = 1',  # fails to parse at rewrite time
+            'id IN (SELECT id FROM undisclosed_table)',  # leaves a table outside the wrapper
+        ],
+    )
+    def test_predicate_failures_do_not_echo_the_predicate(self, predicate: str, caplog) -> None:
+        """A rules object built directly, bypassing `load()`, so the rewrite-time guards are the
+        ones under test. The message the caller sees must not carry the predicate, nor a table name
+        that appears only inside it -- the detail belongs in the server log."""
+        bad_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': predicate}}, dialect='snowflake')
+
+        with caplog.at_level('WARNING', logger='keboola_mcp_server.rls'), pytest.raises(RlsError) as excinfo:
+            rewrite_query('SELECT * FROM "in.c-crm"."invoices"', user='petr', dialect='snowflake', rules=bad_rules)
+
+        message = str(excinfo.value)
+        assert 'undisclosed_table' not in message
+        assert 'country' not in message
+        assert caplog.text  # the detail is logged for the operator
 
 
 class TestOutputInvariant:
@@ -855,16 +894,22 @@ class TestOutputInvariant:
             ('SELECT * FROM my_udtf(1)', 'rewrite left an unsupported table reference'),
             # A wrapper with no WHERE at all is the whole table: the shape looks right and the data
             # is unfiltered, which is exactly what this net exists to catch.
-            ('SELECT * FROM (SELECT * FROM "in.c-crm"."invoices") AS "invoices"', 'wrapper without a WHERE clause'),
+            (
+                'SELECT * FROM (SELECT * FROM "in.c-crm"."invoices") AS "invoices"',
+                'rule for table in.c-crm.invoices could not be applied',
+            ),
             # A WHERE that is not the rule -- weakened, negated or simply a different condition.
             (
                 "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'DE') AS \"invoices\"",
-                'not the rule for table',
+                'rule for table in.c-crm.invoices could not be applied',
             ),
-            ('SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" WHERE TRUE) AS "invoices"', 'not the rule for table'),
+            (
+                'SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" WHERE TRUE) AS "invoices"',
+                'rule for table in.c-crm.invoices could not be applied',
+            ),
             (
                 "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ' OR TRUE) AS \"invoices\"",
-                'not the rule for table',
+                'rule for table in.c-crm.invoices could not be applied',
             ),
             # A table that was wrapped although no rule was ever looked up for it.
             ('SELECT * FROM (SELECT * FROM customers WHERE TRUE) AS customers', 'no rule was looked up for'),

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -7,6 +7,7 @@ from keboola_mcp_server.rls import RewrittenQuery, RlsError, RlsRules, _check_ou
 
 VALID_YAML = textwrap.dedent(
     """
+    dialect: snowflake
     tables:
       invoices:
         petr: "country = 'CZ'"
@@ -19,11 +20,21 @@ VALID_YAML = textwrap.dedent(
     """
 )
 
+BIGQUERY_YAML = VALID_YAML.replace('dialect: snowflake', 'dialect: bigquery')
+
 
 @pytest.fixture
 def rules(tmp_path: Path) -> RlsRules:
     path = tmp_path / 'rls.yaml'
     path.write_text(VALID_YAML)
+    return RlsRules.load(str(path))
+
+
+@pytest.fixture
+def bq_rules(tmp_path: Path) -> RlsRules:
+    """The same rules pinned to BigQuery -- `rewrite_query` refuses a dialect the rules are not for."""
+    path = tmp_path / 'rls-bigquery.yaml'
+    path.write_text(BIGQUERY_YAML)
     return RlsRules.load(str(path))
 
 
@@ -33,16 +44,42 @@ class TestLoad:
         assert rules.tables['in.c-crm.orders']['petr'] == "country = 'CZ' AND status <> 'draft'"
 
     @pytest.mark.parametrize(
+        ('value', 'expected'),
+        [('snowflake', 'snowflake'), ('bigquery', 'bigquery'), ('SnowFlake', 'snowflake'), (' bigquery ', 'bigquery')],
+    )
+    def test_load_reads_dialect(self, tmp_path: Path, value: str, expected: str) -> None:
+        path = tmp_path / 'rls.yaml'
+        path.write_text(f'dialect: "{value}"\ntables:\n  invoices:\n    petr: "TRUE"\n')
+        assert RlsRules.load(str(path)).dialect == expected
+
+    def test_load_parses_predicates_in_the_pinned_dialect(self, tmp_path: Path) -> None:
+        """The load-time check must be real: Snowflake's `data:name` path syntax is not BigQuery SQL,
+        so the same file is accepted under one pin and refused under the other."""
+        predicate = "payload:country = 'CZ'"
+        path = tmp_path / 'rls.yaml'
+        path.write_text(f'dialect: snowflake\ntables:\n  invoices:\n    petr: "{predicate}"\n')
+        assert RlsRules.load(str(path)).tables['invoices']['petr'] == predicate
+
+        path.write_text(f'dialect: bigquery\ntables:\n  invoices:\n    petr: "{predicate}"\n')
+        with pytest.raises(RlsError, match='not valid bigquery SQL'):
+            RlsRules.load(str(path))
+
+    @pytest.mark.parametrize(
         ('content', 'match'),
         [
             ('', 'empty'),
-            ('tables: {}', 'no tables'),
-            ('foo: bar', "'tables'"),
-            ('tables:\n  invoices: "not a mapping"', "'invoices'"),
-            ('tables:\n  invoices:\n    petr: 42', "'petr'"),
-            ('tables:\n  invoices:\n    petr: "country = = 1"', 'petr'),
-            ('tables:\n  invoices:\n    petr: ""', 'petr'),
+            ('dialect: snowflake\ntables: {}', 'no tables'),
+            ('dialect: snowflake\nfoo: bar', "'tables'"),
+            ('dialect: snowflake\ntables:\n  invoices: "not a mapping"', "'invoices'"),
+            ('dialect: snowflake\ntables:\n  invoices:\n    petr: 42', "'petr'"),
+            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "country = = 1"', 'petr'),
+            ('dialect: snowflake\ntables:\n  invoices:\n    petr: ""', 'petr'),
             ('tables: [\n', 'YAML'),
+            # The dialect pin is required and must name one of the two supported backends.
+            ('tables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
+            ('dialect: postgres\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
+            ('dialect: 42\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
+            ('dialect:\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
         ],
     )
     def test_load_rejects_invalid_file(self, tmp_path: Path, content: str, match: str) -> None:
@@ -288,8 +325,9 @@ class TestRewriteQuery:
             ),
         ],
     )
-    def test_rewrite(self, rules: RlsRules, sql, dialect, expected_sql, expected_rules) -> None:
-        out = rewrite_query(sql, user='petr', dialect=dialect, rules=rules)
+    def test_rewrite(self, rules: RlsRules, bq_rules: RlsRules, sql, dialect, expected_sql, expected_rules) -> None:
+        # The rules file pins its own dialect, so a BigQuery query needs the BigQuery rules object.
+        out = rewrite_query(sql, user='petr', dialect=dialect, rules=bq_rules if dialect == 'bigquery' else rules)
         assert out == RewrittenQuery(sql=expected_sql, applied_rules=expected_rules)
 
     @pytest.mark.parametrize(
@@ -475,9 +513,19 @@ class TestRewriteQuery:
             ('WITH secret AS (SELECT 1) SELECT * FROM public.secret', 'petr', 'snowflake', "table 'secret'"),
         ],
     )
-    def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, dialect, match) -> None:
+    def test_rewrite_fails_closed(self, rules: RlsRules, bq_rules: RlsRules, sql, user, dialect, match) -> None:
         with pytest.raises(RlsError, match=match):
-            rewrite_query(sql, user=user, dialect=dialect, rules=rules)
+            rewrite_query(sql, user=user, dialect=dialect, rules=bq_rules if dialect == 'bigquery' else rules)
+
+    @pytest.mark.parametrize('dialect', ['snowflake', 'bigquery'])
+    def test_rewrite_refuses_a_dialect_the_rules_are_not_for(
+        self, rules: RlsRules, bq_rules: RlsRules, dialect
+    ) -> None:
+        """A predicate is never transpiled, so running Snowflake rules against a BigQuery workspace
+        (or the other way round) would silently change what the filter means. Refuse instead."""
+        wrong = bq_rules if dialect == 'snowflake' else rules
+        with pytest.raises(RlsError, match=f'rules are for dialect .* but the workspace is {dialect}'):
+            rewrite_query('SELECT * FROM invoices', user='petr', dialect=dialect, rules=wrong)
 
     def test_cte_colliding_with_qualified_rule_key_fails_closed(self) -> None:
         """A CTE alias is always bare, so it can never equal a `<schema>.<table>` rule key
@@ -485,7 +533,7 @@ class TestRewriteQuery:
         against that, otherwise `WITH invoices AS (...)` slips past rules keyed
         `in.c-crm.invoices`.
         """
-        scoped_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': "country = 'CZ'"}})
+        scoped_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': "country = 'CZ'"}}, dialect='snowflake')
         with pytest.raises(RlsError, match='collide'):
             rewrite_query(
                 'SELECT * FROM invoices WHERE 1 IN (WITH invoices AS (SELECT 1) SELECT 1)',
@@ -501,7 +549,7 @@ class TestRewriteQuery:
         own; the underlying `sqlglot.parse_one(..., dialect=dialect)` call must not raise a raw
         `sqlglot` exception.
         """
-        bad_rules = RlsRules(tables={'invoices': {'petr': 'country = = 1'}})
+        bad_rules = RlsRules(tables={'invoices': {'petr': 'country = = 1'}}, dialect='snowflake')
         with pytest.raises(RlsError):
             rewrite_query('SELECT * FROM invoices', user='petr', dialect='snowflake', rules=bad_rules)
 
@@ -516,7 +564,7 @@ class TestRewriteQuery:
         ],
     )
     def test_rewrite_rejects_predicates_that_are_not_plain_conditions(self, predicate: str, match: str) -> None:
-        bad_rules = RlsRules(tables={'invoices': {'petr': predicate}})
+        bad_rules = RlsRules(tables={'invoices': {'petr': predicate}}, dialect='snowflake')
         with pytest.raises(RlsError, match=match):
             rewrite_query('SELECT * FROM invoices', user='petr', dialect='snowflake', rules=bad_rules)
 

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from keboola_mcp_server.rls import RewrittenQuery, RlsError, RlsRules, rewrite_query
+from keboola_mcp_server.rls import RewrittenQuery, RlsError, RlsRules, _check_output, rewrite_query
 
 VALID_YAML = textwrap.dedent(
     """
@@ -133,6 +133,50 @@ class TestRewriteQuery:
                 ["invoices: country = 'CZ'", 'orders: FALSE'],
             ),
             (
+                'SELECT id FROM invoices EXCEPT SELECT id FROM orders',
+                'snowflake',
+                (
+                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    'EXCEPT SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                ),
+                ["invoices: country = 'CZ'", 'orders: FALSE'],
+            ),
+            (
+                'SELECT id FROM invoices INTERSECT SELECT id FROM orders',
+                'snowflake',
+                (
+                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    'INTERSECT SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                ),
+                ["invoices: country = 'CZ'", 'orders: FALSE'],
+            ),
+            (
+                # The same table twice: both references are rewritten, but the disclosure lists the
+                # rule once (deduplicated, in first-seen order).
+                'SELECT id FROM invoices UNION ALL SELECT id FROM invoices',
+                'snowflake',
+                (
+                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    "UNION ALL SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                # No FROM at all: nothing to filter, nothing to disclose -- must still pass.
+                'SELECT 1',
+                'snowflake',
+                'SELECT 1',
+                [],
+            ),
+            (
+                # Metadata functions are out of scope for RLS: they take no table source, so there is
+                # nothing to rewrite. They are allowed through unchanged, like any other FROM-less SELECT.
+                "SELECT GET_DDL('table', 'invoices')",
+                'snowflake',
+                "SELECT GET_DDL('table', 'invoices')",
+                [],
+            ),
+            (
                 'SELECT COUNT(*) FROM `proj.ds.invoices`',
                 'bigquery',
                 "SELECT COUNT(*) FROM (SELECT * FROM `proj`.`ds`.`invoices` WHERE country = 'CZ') AS `invoices`",
@@ -164,6 +208,31 @@ class TestRewriteQuery:
             ('', 'petr', 'snowflake', 'one statement'),
             # An unknown/unsupported dialect must not let a raw sqlglot exception escape.
             ('SELECT * FROM invoices', 'petr', 'not-a-real-dialect', 'dialect'),
+            # FROM sources that are not tables/subqueries: sqlglot parses `TABLE(...)` as a
+            # TableFromRows wrapping a function call, so there is no exp.Table to rewrite and the
+            # query would otherwise reach the workspace unfiltered.
+            ('SELECT * FROM TABLE(invoices)', 'petr', 'snowflake', 'unsupported FROM source'),
+            ('SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))', 'petr', 'snowflake', 'unsupported FROM source'),
+            ('SELECT * FROM invoices JOIN TABLE(orders) ON TRUE', 'petr', 'snowflake', 'unsupported FROM source'),
+            # SELECT ... INTO generates CREATE TABLE DDL out of a read-only tool.
+            ('SELECT * INTO t FROM invoices', 'petr', 'snowflake', 'SELECT INTO'),
+            ('WITH t AS (SELECT 1) SELECT * INTO t FROM invoices', 'petr', 'snowflake', 'SELECT INTO'),
+            # Table modifiers cannot survive the rewrite, so they are refused rather than dropped.
+            ('SELECT * FROM invoices SAMPLE (10)', 'petr', 'snowflake', 'table modifiers'),
+            ('SELECT * FROM invoices AT(OFFSET => -60)', 'petr', 'snowflake', 'table modifiers'),
+            (
+                "SELECT * FROM invoices PIVOT(SUM(amount) FOR country IN ('CZ', 'DE'))",
+                'petr',
+                'snowflake',
+                'table modifiers',
+            ),
+            ('SELECT * FROM invoices AS x(a, b)', 'petr', 'snowflake', 'table modifiers'),
+            (
+                "SELECT * FROM invoices FOR SYSTEM_TIME AS OF TIMESTAMP('2024-01-01')",
+                'petr',
+                'bigquery',
+                'table modifiers',
+            ),
         ],
     )
     def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, dialect, match) -> None:
@@ -180,3 +249,57 @@ class TestRewriteQuery:
         bad_rules = RlsRules(tables={'invoices': {'petr': 'country = = 1'}})
         with pytest.raises(RlsError):
             rewrite_query('SELECT * FROM invoices', user='petr', dialect='snowflake', rules=bad_rules)
+
+    @pytest.mark.parametrize(
+        ('predicate', 'match'),
+        [
+            # Injection attempt: the predicate must parse as a bare condition, nothing more.
+            ('TRUE) AS x, (SELECT * FROM secret WHERE (TRUE', 'not valid SQL'),
+            # A predicate referencing another table leaves that table outside a wrapper -- the
+            # output invariant refuses it rather than letting an unfiltered reference through.
+            ('id IN (SELECT id FROM secret)', 'unwrapped table reference'),
+        ],
+    )
+    def test_rewrite_rejects_predicates_that_are_not_plain_conditions(self, predicate: str, match: str) -> None:
+        bad_rules = RlsRules(tables={'invoices': {'petr': predicate}})
+        with pytest.raises(RlsError, match=match):
+            rewrite_query('SELECT * FROM invoices', user='petr', dialect='snowflake', rules=bad_rules)
+
+
+class TestOutputInvariant:
+    """`_check_output` is the last-resort safety net: whatever the rewrite produced, it must be one
+    SELECT (or set operation) in which every real table sits inside a `(SELECT * FROM t WHERE ...)`
+    wrapper we generated. It is checked on the re-parsed output, so it does not trust the rewrite.
+    """
+
+    @pytest.mark.parametrize(
+        ('sql', 'match'),
+        [
+            ('CREATE TABLE t AS SELECT 1', 'non-SELECT statement'),
+            ('DROP TABLE invoices', 'non-SELECT statement'),
+            ('SELECT 1; SELECT 2', 'non-SELECT statement'),
+            ('SELCT nonsense', 'non-SELECT statement'),
+            ('SELECT * FROM invoices', 'unwrapped table reference'),
+            ("SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS i JOIN orders o ON TRUE", 'unwrapped'),
+            # A wrapper that is not `SELECT *` would silently drop the RLS predicate's columns.
+            ('SELECT * FROM (SELECT id FROM invoices) AS invoices', 'unwrapped table reference'),
+        ],
+    )
+    def test_rejects(self, sql: str, match: str) -> None:
+        with pytest.raises(RlsError, match=match):
+            _check_output(sql, dialect='snowflake')
+
+    @pytest.mark.parametrize(
+        'sql',
+        [
+            'SELECT 1',
+            "SELECT COUNT(*) FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
+            "WITH x AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) SELECT * FROM x",
+            (
+                "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+            ),
+        ],
+    )
+    def test_accepts(self, sql: str) -> None:
+        _check_output(sql, dialect='snowflake')

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -98,10 +98,18 @@ class TestRewriteQuery:
                 'snowflake',
                 (
                     "SELECT i.id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS i "
-                    "JOIN (SELECT * FROM \"in.c-crm\".\"orders\" WHERE country = 'CZ' AND status <> 'draft') AS \"o\" "
+                    "JOIN (SELECT * FROM \"in.c-crm\".\"orders\" WHERE country = 'CZ' AND status <> 'draft') AS o "
                     'ON o.id = i.id'
                 ),
                 ["invoices: country = 'CZ'", "in.c-crm.orders: country = 'CZ' AND status <> 'draft'"],
+            ),
+            (
+                # The original alias is quoted -- the rewrite must keep it quoted, not borrow the
+                # table identifier's own (unquoted) quoting.
+                'SELECT "I".id FROM invoices AS "I"',
+                'snowflake',
+                'SELECT "I".id FROM (SELECT * FROM invoices WHERE country = \'CZ\') AS "I"',
+                ["invoices: country = 'CZ'"],
             ),
             (
                 'WITH x AS (SELECT * FROM invoices) SELECT * FROM x',
@@ -143,19 +151,32 @@ class TestRewriteQuery:
         assert out == RewrittenQuery(sql=expected_sql, applied_rules=expected_rules)
 
     @pytest.mark.parametrize(
-        ('sql', 'user', 'match'),
+        ('sql', 'user', 'dialect', 'match'),
         [
-            ('DELETE FROM invoices', 'petr', 'SELECT'),
-            ('INSERT INTO invoices SELECT * FROM orders', 'petr', 'SELECT'),
-            ('SELECT 1; SELECT 2', 'petr', 'one statement'),
-            ('SELCT nonsense', 'petr', 'SELECT'),
-            ('SELECT * FROM customers', 'petr', "table 'customers'"),
-            ('SELECT * FROM invoices', 'nobody', "user 'nobody'"),
+            ('DELETE FROM invoices', 'petr', 'snowflake', 'SELECT'),
+            ('INSERT INTO invoices SELECT * FROM orders', 'petr', 'snowflake', 'SELECT'),
+            ('SELECT 1; SELECT 2', 'petr', 'snowflake', 'one statement'),
+            ('SELCT nonsense', 'petr', 'snowflake', 'SELECT'),
+            ('SELECT * FROM customers', 'petr', 'snowflake', "table 'customers'"),
+            ('SELECT * FROM invoices', 'nobody', 'snowflake', "user 'nobody'"),
             # A CTE named like a protected table would shadow it inside its own body -- refuse.
-            ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'CTE'),
-            ('', 'petr', 'one statement'),
+            ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'snowflake', 'CTE'),
+            ('', 'petr', 'snowflake', 'one statement'),
+            # An unknown/unsupported dialect must not let a raw sqlglot exception escape.
+            ('SELECT * FROM invoices', 'petr', 'not-a-real-dialect', 'dialect'),
         ],
     )
-    def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, match) -> None:
+    def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, dialect, match) -> None:
         with pytest.raises(RlsError, match=match):
-            rewrite_query(sql, user=user, dialect='snowflake', rules=rules)
+            rewrite_query(sql, user=user, dialect=dialect, rules=rules)
+
+    def test_rewrite_predicate_invalid_for_dialect_fails_closed(self) -> None:
+        """A predicate can pass `RlsRules.load()`'s dialect-agnostic check yet still fail to parse
+        under the workspace dialect used at rewrite time (see the module docstring). Build the
+        rules object directly, bypassing `load()`, so the rewrite-time guard is exercised on its
+        own; the underlying `sqlglot.parse_one(..., dialect=dialect)` call must not raise a raw
+        `sqlglot` exception.
+        """
+        bad_rules = RlsRules(tables={'invoices': {'petr': 'country = = 1'}})
+        with pytest.raises(RlsError):
+            rewrite_query('SELECT * FROM invoices', user='petr', dialect='snowflake', rules=bad_rules)

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -358,6 +358,28 @@ class TestRewriteQuery:
                 ["invoices: country = 'CZ'"],
             ),
             (
+                # A whole statement in parentheses means the statement inside them.
+                '(SELECT * FROM invoices)',
+                'snowflake',
+                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                '((SELECT * FROM invoices))',
+                'snowflake',
+                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                '(SELECT id FROM invoices UNION ALL SELECT id FROM orders)',
+                'snowflake',
+                (
+                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                ),
+                ["invoices: country = 'CZ'", 'orders: FALSE'],
+            ),
+            (
                 # A trailing semicolon is still exactly one statement.
                 'SELECT * FROM invoices;',
                 'snowflake',
@@ -619,6 +641,30 @@ class TestRewriteQuery:
         wrong = bq_rules if dialect == 'snowflake' else rules
         with pytest.raises(RlsError, match=f'rules are for dialect .* but the workspace is {dialect}'):
             rewrite_query('SELECT * FROM invoices', user='petr', dialect=dialect, rules=wrong)
+
+    @pytest.mark.parametrize(
+        'sql',
+        [
+            'SELECT * FROM in.c-crm.orders',
+            'SELECT * FROM out.c-main.tbl',
+            'SELECT a, FROM in.c-crm.orders WHERE',
+        ],
+    )
+    def test_parse_errors_are_clean_text_with_a_bucket_hint(self, rules: RlsRules, sql: str) -> None:
+        """A parse error is shown to a user and a model, so it must not carry sqlglot's ANSI
+        underline escapes -- and when the cause is an unquoted bucket path, it should say so."""
+        with pytest.raises(RlsError) as excinfo:
+            rewrite_query(sql, user='petr', dialect='snowflake', rules=rules)
+
+        message = str(excinfo.value)
+        assert '\x1b' not in message
+        assert 'quote the bucket, e.g. "in.c-crm"."orders"' in message
+
+    def test_parse_error_without_a_bucket_path_gets_no_hint(self, rules: RlsRules) -> None:
+        with pytest.raises(RlsError) as excinfo:
+            rewrite_query('SELECT * FROM t WHERE', user='petr', dialect='snowflake', rules=rules)
+
+        assert 'quote the bucket' not in str(excinfo.value)
 
     def test_cte_colliding_with_qualified_rule_key_fails_closed(self) -> None:
         """A CTE alias is always bare, so it can never equal a `<schema>.<table>` rule key

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -245,6 +245,47 @@ class TestRewriteQuery:
                 "SELECT COUNT(*) FROM (SELECT * FROM `ds`.`invoices` WHERE country = 'CZ') AS `invoices` LIMIT 10",
                 ["invoices: country = 'CZ'"],
             ),
+            (
+                # A trailing semicolon is still exactly one statement.
+                'SELECT * FROM invoices;',
+                'snowflake',
+                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                # `UNNET(...) WITH OFFSET` is an allowed FROM source and the correlated `t.items`
+                # still resolves because the wrapper keeps the original alias.
+                'SELECT * FROM invoices AS t, UNNEST(t.items) AS item WITH OFFSET AS off',
+                'bigquery',
+                (
+                    "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS t "
+                    'CROSS JOIN UNNEST(t.items) AS item WITH OFFSET AS off'
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                # Window function + QUALIFY over a protected table.
+                'SELECT id, ROW_NUMBER() OVER (PARTITION BY country ORDER BY id) rn FROM invoices QUALIFY rn = 1',
+                'snowflake',
+                (
+                    'SELECT id, ROW_NUMBER() OVER (PARTITION BY country ORDER BY id) AS rn '
+                    "FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices QUALIFY rn = 1"
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                # A recursive CTE named after nothing protected, joined with a protected table.
+                (
+                    'WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 3) '
+                    'SELECT * FROM r, invoices'
+                ),
+                'snowflake',
+                (
+                    'WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 3) '
+                    "SELECT * FROM r, (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
         ],
     )
     def test_rewrite(self, rules: RlsRules, sql, dialect, expected_sql, expected_rules) -> None:
@@ -348,6 +389,90 @@ class TestRewriteQuery:
                 'bigquery',
                 'table modifiers',
             ),
+            # --- FROM sources with no plain identifier ---
+            ('SELECT * FROM IDENTIFIER($tbl)', 'petr', 'snowflake', 'unsupported table reference'),
+            ("SELECT * FROM IDENTIFIER('invoices')", 'petr', 'snowflake', 'unsupported table reference'),
+            ('SELECT $1 FROM @my_stage/invoices.csv', 'petr', 'snowflake', 'unsupported table reference'),
+            ('SELECT * FROM DIRECTORY(@stg)', 'petr', 'snowflake', 'unsupported table reference'),
+            (
+                'SELECT * FROM SEMANTIC_VIEW(sv METRICS invoices.total)',
+                'petr',
+                'snowflake',
+                'unsupported table reference',
+            ),
+            ('SELECT * FROM a.b.c.d', 'petr', 'snowflake', 'unsupported table reference'),
+            ('SELECT * FROM :tbl', 'petr', 'snowflake', 'unsupported table reference'),
+            (
+                "SELECT * FROM EXTERNAL_QUERY('conn', 'SELECT * FROM invoices')",
+                'petr',
+                'bigquery',
+                'unsupported table reference',
+            ),
+            ('SELECT * FROM ML.PREDICT(MODEL `m`, TABLE invoices)', 'petr', 'bigquery', 'unsupported table reference'),
+            ("EXECUTE IMMEDIATE 'SELECT * FROM invoices'", 'petr', 'bigquery', 'SELECT'),
+            (
+                'SELECT * FROM invoices, LATERAL FLATTEN(input => invoices.items) f',
+                'petr',
+                'snowflake',
+                'unsupported FROM source',
+            ),
+            # --- a table without a rule, in every position a subquery can appear ---
+            ('SELECT (SELECT MAX(x) FROM secret) FROM invoices', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM invoices WHERE EXISTS (SELECT 1 FROM secret)', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM invoices, LATERAL (SELECT * FROM secret) s', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM invoices ORDER BY (SELECT MAX(x) FROM secret)', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM invoices LIMIT (SELECT COUNT(*) FROM secret)', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM invoices QUALIFY id IN (SELECT id FROM secret)', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM (VALUES ((SELECT MAX(x) FROM secret))) v', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM UNNEST((SELECT ARRAY_AGG(x) FROM secret))', 'petr', 'bigquery', "table 'secret'"),
+            ('SELECT * FROM (secret)', 'petr', 'snowflake', "table 'secret'"),
+            # an alias equal to a protected table name must not stand in for a rule
+            ('SELECT * FROM secret AS invoices', 'petr', 'snowflake', "table 'secret'"),
+            ('SELECT * FROM (SELECT * FROM secret) AS invoices', 'petr', 'snowflake', "table 'secret'"),
+            # --- CTE shadowing, remaining shapes ---
+            (
+                (
+                    'WITH RECURSIVE invoices AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM invoices WHERE n < 3) '
+                    'SELECT * FROM invoices'
+                ),
+                'petr',
+                'snowflake',
+                'collide',
+            ),
+            ('WITH "Invoices" AS (SELECT 1) SELECT * FROM "Invoices"', 'petr', 'snowflake', 'collide'),
+            ('WITH `Invoices` AS (SELECT 1) SELECT * FROM `Invoices`', 'petr', 'bigquery', 'collide'),
+            (
+                'SELECT * FROM secret JOIN (WITH secret AS (SELECT 1) SELECT * FROM secret) s ON TRUE',
+                'petr',
+                'snowflake',
+                'another scope',
+            ),
+            (
+                'SELECT * FROM secret WHERE EXISTS (WITH secret AS (SELECT 1) SELECT 1)',
+                'petr',
+                'snowflake',
+                'another scope',
+            ),
+            ('SELECT (WITH secret AS (SELECT 1) SELECT 1) FROM secret', 'petr', 'snowflake', 'another scope'),
+            (
+                'SELECT * FROM secret UNION ALL (WITH secret AS (SELECT 1) SELECT * FROM secret)',
+                'petr',
+                'snowflake',
+                'another scope',
+            ),
+            (
+                'WITH a AS (WITH secret AS (SELECT 1) SELECT * FROM secret) SELECT * FROM a, secret',
+                'petr',
+                'snowflake',
+                'another scope',
+            ),
+            (
+                'WITH a AS (SELECT * FROM secret), secret AS (SELECT 1) SELECT * FROM a',
+                'petr',
+                'snowflake',
+                'another scope',
+            ),
+            ('WITH secret AS (SELECT 1) SELECT * FROM public.secret', 'petr', 'snowflake', "table 'secret'"),
         ],
     )
     def test_rewrite_fails_closed(self, rules: RlsRules, sql, user, dialect, match) -> None:

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -9,13 +9,13 @@ VALID_YAML = textwrap.dedent(
     """
     dialect: snowflake
     tables:
-      invoices:
+      in.c-crm.invoices:
         petr: "country = 'CZ'"
         Monika: "country = 'DE'"
         admin: "TRUE"
       in.c-crm.orders:
         petr: "country = 'CZ' AND status <> 'draft'"
-      orders:
+      in.c-sales.orders:
         petr: "FALSE"
     """
 )
@@ -23,7 +23,11 @@ VALID_YAML = textwrap.dedent(
 BIGQUERY_YAML = VALID_YAML.replace('dialect: snowflake', 'dialect: bigquery')
 
 # The predicates a rewrite of the hand-built SQL in `TestOutputInvariant` would have inserted.
-OUTPUT_PREDICATES = {'invoices': "country = 'CZ'", 'orders': 'FALSE', 'secret': 'TRUE'}
+OUTPUT_PREDICATES = {
+    'in.c-crm.invoices': "country = 'CZ'",
+    'in.c-sales.orders': 'FALSE',
+    'in.c-crm.secret': 'TRUE',
+}
 
 
 @pytest.fixture
@@ -43,7 +47,7 @@ def bq_rules(tmp_path: Path) -> RlsRules:
 
 class TestLoad:
     def test_load_normalizes_keys(self, rules: RlsRules) -> None:
-        assert rules.tables['invoices']['monika'] == "country = 'DE'"
+        assert rules.tables['in.c-crm.invoices']['monika'] == "country = 'DE'"
         assert rules.tables['in.c-crm.orders']['petr'] == "country = 'CZ' AND status <> 'draft'"
 
     @pytest.mark.parametrize(
@@ -52,7 +56,7 @@ class TestLoad:
     )
     def test_load_reads_dialect(self, tmp_path: Path, value: str, expected: str) -> None:
         path = tmp_path / 'rls.yaml'
-        path.write_text(f'dialect: "{value}"\ntables:\n  invoices:\n    petr: "TRUE"\n')
+        path.write_text(f'dialect: "{value}"\ntables:\n  in.c-crm.invoices:\n    petr: "TRUE"\n')
         assert RlsRules.load(str(path)).dialect == expected
 
     def test_load_parses_predicates_in_the_pinned_dialect(self, tmp_path: Path) -> None:
@@ -60,10 +64,10 @@ class TestLoad:
         so the same file is accepted under one pin and refused under the other."""
         predicate = "payload:country = 'CZ'"
         path = tmp_path / 'rls.yaml'
-        path.write_text(f'dialect: snowflake\ntables:\n  invoices:\n    petr: "{predicate}"\n')
-        assert RlsRules.load(str(path)).tables['invoices']['petr'] == predicate
+        path.write_text(f'dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "{predicate}"\n')
+        assert RlsRules.load(str(path)).tables['in.c-crm.invoices']['petr'] == predicate
 
-        path.write_text(f'dialect: bigquery\ntables:\n  invoices:\n    petr: "{predicate}"\n')
+        path.write_text(f'dialect: bigquery\ntables:\n  in.c-crm.invoices:\n    petr: "{predicate}"\n')
         with pytest.raises(RlsError, match='not valid bigquery SQL'):
             RlsRules.load(str(path))
 
@@ -73,53 +77,53 @@ class TestLoad:
             ('', 'empty'),
             ('dialect: snowflake\ntables: {}', 'no tables'),
             ('dialect: snowflake\nfoo: bar', "'tables'"),
-            ('dialect: snowflake\ntables:\n  invoices: "not a mapping"', "'invoices'"),
-            ('dialect: snowflake\ntables:\n  invoices:\n    petr: 42', "'petr'"),
-            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "country = = 1"', 'petr'),
-            ('dialect: snowflake\ntables:\n  invoices:\n    petr: ""', 'petr'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices: "not a mapping"', "'in.c-crm.invoices'"),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: 42', "'petr'"),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "country = = 1"', 'petr'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: ""', 'petr'),
             ('tables: [\n', 'YAML'),
             # The dialect pin is required and must name one of the two supported backends.
-            ('tables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
-            ('dialect: postgres\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
-            ('dialect: 42\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
-            ('dialect:\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
+            ('tables:\n  in.c-crm.invoices:\n    petr: "TRUE"', "'dialect'"),
+            ('dialect: postgres\ntables:\n  in.c-crm.invoices:\n    petr: "TRUE"', "'dialect'"),
+            ('dialect: 42\ntables:\n  in.c-crm.invoices:\n    petr: "TRUE"', "'dialect'"),
+            ('dialect:\ntables:\n  in.c-crm.invoices:\n    petr: "TRUE"', "'dialect'"),
             # Two keys that normalize to one: the later would silently win, so refuse both.
             (
-                'dialect: snowflake\ntables:\n  Invoices:\n    petr: "TRUE"\n  invoices:\n    petr: "FALSE"',
-                "duplicate table key 'invoices'",
+                'dialect: snowflake\ntables:\n  in.c-crm.Invoices:\n    petr: "TRUE"\n  in.c-crm.invoices:\n    petr: "FALSE"',
+                "duplicate table key 'in.c-crm.invoices'",
             ),
             (
-                'dialect: snowflake\ntables:\n  invoices:\n    Petr: "TRUE"\n    petr: "FALSE"',
+                'dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    Petr: "TRUE"\n    petr: "FALSE"',
                 "duplicate user key 'petr'",
             ),
             # YAML 1.1 turns bare `yes`/`on`/`no` into booleans, so such a key is not a table name
             # at all -- and would otherwise be stringified into something the admin never wrote.
             ('dialect: snowflake\ntables:\n  yes:\n    petr: "TRUE"', 'invalid table key'),
-            ('dialect: snowflake\ntables:\n  invoices:\n    on: "TRUE"', 'invalid user key'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    on: "TRUE"', 'invalid user key'),
             ('dialect: snowflake\ntables:\n  42:\n    petr: "TRUE"', 'invalid table key'),
             ('dialect: snowflake\ntables:\n  "":\n    petr: "TRUE"', 'invalid table key'),
-            ('dialect: snowflake\ntables:\n  "*":\n    petr: "TRUE"', 'invalid table key'),
-            ('dialect: snowflake\ntables:\n  \'"invoices"\':\n    petr: "TRUE"', 'invalid table key'),
-            ('dialect: snowflake\ntables:\n  my table:\n    petr: "TRUE"', 'invalid table key'),
-            ('dialect: snowflake\ntables:\n  invoices:\n    "":\n      petr: "TRUE"', 'invalid user key'),
-            ('dialect: snowflake\ntables:\n  invoices:\n    "pe tr": "TRUE"', 'invalid user key'),
+            ('dialect: snowflake\ntables:\n  "in.c-crm.*":\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  \'in.c-crm."invoices"\':\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.my table:\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    "":\n      petr: "TRUE"', 'invalid user key'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    "pe tr": "TRUE"', 'invalid user key'),
             # A predicate must be a boolean condition, not an arbitrary expression that happens to
             # parse: `WHERE 1` or `WHERE f(x)` is not a filter the admin can reason about.
-            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "1"', 'boolean condition'),
-            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "is_active"', 'boolean condition'),
-            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "f(x)"', 'boolean condition'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "1"', 'boolean condition'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "is_active"', 'boolean condition'),
+            ('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "f(x)"', 'boolean condition'),
             (
-                'dialect: snowflake\ntables:\n  invoices:\n    petr: "CASE WHEN a THEN TRUE ELSE FALSE END"',
+                'dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "CASE WHEN a THEN TRUE ELSE FALSE END"',
                 'boolean condition',
             ),
             # A predicate that reaches for another table cannot be wrapped -- refuse it at load time
             # rather than at the first query that happens to trip the output invariant.
             (
-                'dialect: snowflake\ntables:\n  invoices:\n    petr: "id IN (SELECT id FROM secret)"',
+                'dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "id IN (SELECT id FROM secret)"',
                 'must not reference a table or subquery',
             ),
             (
-                'dialect: snowflake\ntables:\n  invoices:\n    petr: "EXISTS (SELECT 1 FROM secret)"',
+                'dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "EXISTS (SELECT 1 FROM secret)"',
                 'must not reference a table or subquery',
             ),
         ],
@@ -148,8 +152,17 @@ class TestLoad:
     )
     def test_load_accepts_boolean_predicates(self, tmp_path: Path, predicate: str) -> None:
         path = tmp_path / 'rls.yaml'
-        path.write_text(f'dialect: snowflake\ntables:\n  invoices:\n    petr: "{predicate}"\n')
-        assert RlsRules.load(str(path)).tables['invoices']['petr'] == predicate
+        path.write_text(f'dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: "{predicate}"\n')
+        assert RlsRules.load(str(path)).tables['in.c-crm.invoices']['petr'] == predicate
+
+    @pytest.mark.parametrize('key', ['invoices', '.invoices', 'invoices.', '.'])
+    def test_load_rejects_unqualified_table_keys(self, tmp_path: Path, key: str) -> None:
+        """A rule has to say which bucket it protects: a bare `invoices` would silently cover every
+        table of that name in every bucket, including ones its author never saw."""
+        path = tmp_path / 'rls.yaml'
+        path.write_text(f'dialect: snowflake\ntables:\n  "{key}":\n    petr: "TRUE"\n')
+        with pytest.raises(RlsError, match='table key|invalid table key'):
+            RlsRules.load(str(path))
 
     def test_load_missing_file(self, tmp_path: Path) -> None:
         with pytest.raises(RlsError, match='not found'):
@@ -160,11 +173,12 @@ class TestPredicateFor:
     @pytest.mark.parametrize(
         ('table_name', 'schema', 'user', 'expected'),
         [
-            ('invoices', None, 'petr', ('invoices', "country = 'CZ'")),
-            ('INVOICES', None, 'PETR', ('invoices', "country = 'CZ'")),
-            ('invoices', 'in.c-main', 'monika', ('invoices', "country = 'DE'")),  # falls back to bare name
+            ('invoices', 'in.c-crm', 'petr', ('in.c-crm.invoices', "country = 'CZ'")),
+            ('INVOICES', 'IN.C-CRM', 'PETR', ('in.c-crm.invoices', "country = 'CZ'")),
+            ('invoices', 'in.c-crm', 'monika', ('in.c-crm.invoices', "country = 'DE'")),
             ('orders', 'in.c-crm', 'petr', ('in.c-crm.orders', "country = 'CZ' AND status <> 'draft'")),
-            ('orders', None, 'petr', ('orders', 'FALSE')),
+            # The same table name in another bucket is another rule, not the same one.
+            ('orders', 'in.c-sales', 'petr', ('in.c-sales.orders', 'FALSE')),
         ],
     )
     def test_lookup(self, rules: RlsRules, table_name, schema, user, expected) -> None:
@@ -173,9 +187,14 @@ class TestPredicateFor:
     @pytest.mark.parametrize(
         ('table_name', 'schema', 'user', 'match'),
         [
-            ('customers', None, 'petr', "table 'customers'"),
-            ('invoices', None, 'nobody', "user 'nobody'"),
-            ('orders', 'in.c-crm', 'monika', "user 'monika'"),  # qualified key wins even if bare key has no user
+            ('customers', 'in.c-crm', 'petr', "table 'in.c-crm.customers'"),
+            ('invoices', 'in.c-crm', 'nobody', "user 'nobody'"),
+            ('orders', 'in.c-crm', 'monika', "user 'monika'"),
+            # A rule for the table in one bucket says nothing about the table in another.
+            ('invoices', 'in.c-sales', 'petr', "table 'in.c-sales.invoices'"),
+            # No bucket at all: there is no key to look up, so there is nothing to allow.
+            ('invoices', None, 'petr', 'must be qualified'),
+            ('invoices', '', 'petr', 'must be qualified'),
         ],
     )
     def test_lookup_denied(self, rules: RlsRules, table_name, schema, user, match) -> None:
@@ -188,135 +207,135 @@ class TestRewriteQuery:
         ('sql', 'dialect', 'expected_sql', 'expected_rules'),
         [
             (
-                'SELECT COUNT(*) FROM invoices',
+                'SELECT COUNT(*) FROM "in.c-crm"."invoices"',
                 'snowflake',
-                "SELECT COUNT(*) FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
-                ["invoices: country = 'CZ'"],
+                "SELECT COUNT(*) FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
-                'SELECT i.id FROM invoices i JOIN "in.c-crm"."orders" AS o ON o.id = i.id',
+                'SELECT i.id FROM "in.c-crm"."invoices" i JOIN "in.c-crm"."orders" AS o ON o.id = i.id',
                 'snowflake',
                 (
-                    "SELECT i.id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS i "
+                    "SELECT i.id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS i "
                     "JOIN (SELECT * FROM \"in.c-crm\".\"orders\" WHERE country = 'CZ' AND status <> 'draft') AS o "
                     'ON o.id = i.id'
                 ),
-                ["invoices: country = 'CZ'", "in.c-crm.orders: country = 'CZ' AND status <> 'draft'"],
+                ["in.c-crm.invoices: country = 'CZ'", "in.c-crm.orders: country = 'CZ' AND status <> 'draft'"],
             ),
             (
                 # The original alias is quoted -- the rewrite must keep it quoted, not borrow the
                 # table identifier's own (unquoted) quoting.
-                'SELECT "I".id FROM invoices AS "I"',
+                'SELECT "I".id FROM "in.c-crm"."invoices" AS "I"',
                 'snowflake',
-                'SELECT "I".id FROM (SELECT * FROM invoices WHERE country = \'CZ\') AS "I"',
-                ["invoices: country = 'CZ'"],
+                'SELECT "I".id FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "I"',
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
-                'WITH x AS (SELECT * FROM invoices) SELECT * FROM x',
+                'WITH x AS (SELECT * FROM "in.c-crm"."invoices") SELECT * FROM x',
                 'snowflake',
-                "WITH x AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) SELECT * FROM x",
-                ["invoices: country = 'CZ'"],
+                "WITH x AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\") SELECT * FROM x",
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
                 # A CTE may reference an earlier sibling CTE.
-                'WITH a AS (SELECT * FROM invoices), b AS (SELECT * FROM a) SELECT * FROM b',
+                'WITH a AS (SELECT * FROM "in.c-crm"."invoices"), b AS (SELECT * FROM a) SELECT * FROM b',
                 'snowflake',
                 (
-                    "WITH a AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices), "
+                    "WITH a AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"), "
                     'b AS (SELECT * FROM a) SELECT * FROM b'
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
                 # A recursive CTE references itself from inside its own body.
-                'WITH RECURSIVE r AS (SELECT id FROM invoices UNION ALL SELECT id FROM r) SELECT * FROM r',
+                'WITH RECURSIVE r AS (SELECT id FROM "in.c-crm"."invoices" UNION ALL SELECT id FROM r) SELECT * FROM r',
                 'snowflake',
                 (
-                    "WITH RECURSIVE r AS (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    "WITH RECURSIVE r AS (SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'UNION ALL SELECT id FROM r) SELECT * FROM r'
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
                 # Quoted CTE alias, quoted reference, same case: the same name on both engines.
-                'WITH "X" AS (SELECT * FROM invoices) SELECT * FROM "X"',
+                'WITH "X" AS (SELECT * FROM "in.c-crm"."invoices") SELECT * FROM "X"',
                 'snowflake',
                 (
-                    'WITH "X" AS (SELECT * FROM (SELECT * FROM invoices WHERE country = \'CZ\') AS invoices) '
+                    'WITH "X" AS (SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices") '
                     'SELECT * FROM "X"'
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
                 # Unquoted identifiers fold case on both Snowflake and BigQuery, so `x` and `X` are
                 # the same name and this is an ordinary CTE reference -- it must not be refused.
-                'WITH x AS (SELECT * FROM invoices) SELECT * FROM X',
+                'WITH x AS (SELECT * FROM "in.c-crm"."invoices") SELECT * FROM X',
                 'snowflake',
-                "WITH x AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) SELECT * FROM X",
-                ["invoices: country = 'CZ'"],
+                "WITH x AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\") SELECT * FROM X",
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
-                'WITH `X` AS (SELECT * FROM invoices) SELECT * FROM `X`',
+                'WITH `X` AS (SELECT * FROM `in_c_crm`.`invoices`) SELECT * FROM `X`',
                 'bigquery',
                 (
-                    "WITH `X` AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) "
-                    'SELECT * FROM `X`'
+                    'WITH `X` AS (SELECT * FROM (SELECT * FROM `in_c_crm`.`invoices` '
+                    "WHERE country = 'CZ') AS `invoices`) SELECT * FROM `X`"
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in_c_crm.invoices: country = 'CZ'"],
             ),
             (
                 # A subquery may declare its own CTE as long as the name shadows nothing outside it.
-                'SELECT * FROM invoices WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)',
+                'SELECT * FROM "in.c-crm"."invoices" WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)',
                 'snowflake',
                 (
-                    "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                    "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                     'WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)'
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
-                'SELECT * FROM (SELECT id FROM invoices) sub',
+                'SELECT * FROM (SELECT id FROM "in.c-crm"."invoices") sub',
                 'snowflake',
-                "SELECT * FROM (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) AS sub",
-                ["invoices: country = 'CZ'"],
+                "SELECT * FROM (SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\") AS sub",
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
-                'SELECT id FROM invoices UNION ALL SELECT id FROM orders',
-                'snowflake',
-                (
-                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
-                    'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
-                ),
-                ["invoices: country = 'CZ'", 'orders: FALSE'],
-            ),
-            (
-                'SELECT id FROM invoices EXCEPT SELECT id FROM orders',
+                'SELECT id FROM "in.c-crm"."invoices" UNION ALL SELECT id FROM "in.c-sales"."orders"',
                 'snowflake',
                 (
-                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
-                    'EXCEPT SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                    "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
+                    'UNION ALL SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
                 ),
-                ["invoices: country = 'CZ'", 'orders: FALSE'],
+                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
             ),
             (
-                'SELECT id FROM invoices INTERSECT SELECT id FROM orders',
+                'SELECT id FROM "in.c-crm"."invoices" EXCEPT SELECT id FROM "in.c-sales"."orders"',
                 'snowflake',
                 (
-                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
-                    'INTERSECT SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                    "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
+                    'EXCEPT SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
                 ),
-                ["invoices: country = 'CZ'", 'orders: FALSE'],
+                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
+            ),
+            (
+                'SELECT id FROM "in.c-crm"."invoices" INTERSECT SELECT id FROM "in.c-sales"."orders"',
+                'snowflake',
+                (
+                    "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
+                    'INTERSECT SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
+                ),
+                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
             ),
             (
                 # The same table twice: both references are rewritten, but the disclosure lists the
                 # rule once (deduplicated, in first-seen order).
-                'SELECT id FROM invoices UNION ALL SELECT id FROM invoices',
+                'SELECT id FROM "in.c-crm"."invoices" UNION ALL SELECT id FROM "in.c-crm"."invoices"',
                 'snowflake',
                 (
-                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
-                    "UNION ALL SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+                    "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
+                    "UNION ALL SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\""
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
                 # No FROM at all: nothing to filter, nothing to disclose -- must still pass.
@@ -346,79 +365,87 @@ class TestRewriteQuery:
                 [],
             ),
             (
-                'SELECT COUNT(*) FROM `proj.ds.invoices`',
+                # A project/database name in front of the dataset is ignored: the workspace can
+                # only reach its own project, so the bucket and table are what identify the rule.
+                'SELECT COUNT(*) FROM `proj.in_c_crm.invoices`',
                 'bigquery',
-                "SELECT COUNT(*) FROM (SELECT * FROM `proj`.`ds`.`invoices` WHERE country = 'CZ') AS `invoices`",
-                ["invoices: country = 'CZ'"],
+                (
+                    'SELECT COUNT(*) FROM (SELECT * FROM `proj`.`in_c_crm`.`invoices` '
+                    "WHERE country = 'CZ') AS `invoices`"
+                ),
+                ["in_c_crm.invoices: country = 'CZ'"],
             ),
             (
-                'SELECT COUNT(*) FROM `ds`.`invoices` LIMIT 10',
+                'SELECT COUNT(*) FROM `in_c_crm`.`invoices` LIMIT 10',
                 'bigquery',
-                "SELECT COUNT(*) FROM (SELECT * FROM `ds`.`invoices` WHERE country = 'CZ') AS `invoices` LIMIT 10",
-                ["invoices: country = 'CZ'"],
+                (
+                    'SELECT COUNT(*) FROM (SELECT * FROM `in_c_crm`.`invoices` '
+                    "WHERE country = 'CZ') AS `invoices` LIMIT 10"
+                ),
+                ["in_c_crm.invoices: country = 'CZ'"],
             ),
             (
                 # A whole statement in parentheses means the statement inside them.
-                '(SELECT * FROM invoices)',
+                '(SELECT * FROM "in.c-crm"."invoices")',
                 'snowflake',
-                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
-                ["invoices: country = 'CZ'"],
+                "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
-                '((SELECT * FROM invoices))',
+                '((SELECT * FROM "in.c-crm"."invoices"))',
                 'snowflake',
-                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
-                ["invoices: country = 'CZ'"],
+                "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
-                '(SELECT id FROM invoices UNION ALL SELECT id FROM orders)',
+                '(SELECT id FROM "in.c-crm"."invoices" UNION ALL SELECT id FROM "in.c-sales"."orders")',
                 'snowflake',
                 (
-                    "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
-                    'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                    "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
+                    'UNION ALL SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
                 ),
-                ["invoices: country = 'CZ'", 'orders: FALSE'],
+                ["in.c-crm.invoices: country = 'CZ'", 'in.c-sales.orders: FALSE'],
             ),
             (
                 # A trailing semicolon is still exactly one statement.
-                'SELECT * FROM invoices;',
+                'SELECT * FROM "in.c-crm"."invoices";',
                 'snowflake',
-                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
-                ["invoices: country = 'CZ'"],
+                "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
                 # `UNNET(...) WITH OFFSET` is an allowed FROM source and the correlated `t.items`
                 # still resolves because the wrapper keeps the original alias.
-                'SELECT * FROM invoices AS t, UNNEST(t.items) AS item WITH OFFSET AS off',
+                'SELECT * FROM `in_c_crm`.`invoices` AS t, UNNEST(t.items) AS item WITH OFFSET AS off',
                 'bigquery',
                 (
-                    "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS t "
+                    "SELECT * FROM (SELECT * FROM `in_c_crm`.`invoices` WHERE country = 'CZ') AS t "
                     'CROSS JOIN UNNEST(t.items) AS item WITH OFFSET AS off'
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in_c_crm.invoices: country = 'CZ'"],
             ),
             (
                 # Window function + QUALIFY over a protected table.
-                'SELECT id, ROW_NUMBER() OVER (PARTITION BY country ORDER BY id) rn FROM invoices QUALIFY rn = 1',
+                'SELECT id, ROW_NUMBER() OVER (PARTITION BY country ORDER BY id) rn FROM "in.c-crm"."invoices" QUALIFY rn = 1',
                 'snowflake',
                 (
                     'SELECT id, ROW_NUMBER() OVER (PARTITION BY country ORDER BY id) AS rn '
-                    "FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices QUALIFY rn = 1"
+                    "FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" QUALIFY rn = 1"
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
                 # A recursive CTE named after nothing protected, joined with a protected table.
                 (
                     'WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 3) '
-                    'SELECT * FROM r, invoices'
+                    'SELECT * FROM r, "in.c-crm"."invoices"'
                 ),
                 'snowflake',
                 (
                     'WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 3) '
-                    "SELECT * FROM r, (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+                    "SELECT * FROM r, (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\""
                 ),
-                ["invoices: country = 'CZ'"],
+                ["in.c-crm.invoices: country = 'CZ'"],
             ),
         ],
     )
@@ -434,8 +461,15 @@ class TestRewriteQuery:
             ('INSERT INTO invoices SELECT * FROM orders', 'petr', 'snowflake', 'SELECT'),
             ('SELECT 1; SELECT 2', 'petr', 'snowflake', 'one statement'),
             ('SELCT nonsense', 'petr', 'snowflake', 'SELECT'),
-            ('SELECT * FROM customers', 'petr', 'snowflake', "table 'customers'"),
-            ('SELECT * FROM invoices', 'nobody', 'snowflake', "user 'nobody'"),
+            ('SELECT * FROM "in.c-crm"."customers"', 'petr', 'snowflake', "table 'in.c-crm.customers'"),
+            ('SELECT * FROM "in.c-crm"."invoices"', 'nobody', 'snowflake', "user 'nobody'"),
+            # A reference with no bucket cannot be matched against a rule, so it is refused outright.
+            ('SELECT * FROM invoices', 'petr', 'snowflake', 'must be qualified'),
+            ('SELECT COUNT(*) FROM invoices', 'petr', 'snowflake', 'must be qualified'),
+            # One quoted identifier that happens to contain dots is a table name, not a bucket path.
+            ('SELECT * FROM "in.c-crm.invoices"', 'petr', 'snowflake', 'must be qualified'),
+            # The rule is keyed by bucket: the same table name in another bucket is not covered.
+            ('SELECT * FROM "in.c-sales"."invoices"', 'petr', 'snowflake', "table 'in.c-sales.invoices'"),
             # A CTE named like a protected table would shadow it inside its own body -- refuse.
             ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'snowflake', 'collide'),
             # ... whatever the quoting of either side: a quoted `"orders"` CTE and the rule key
@@ -498,7 +532,7 @@ class TestRewriteQuery:
             ('SELECT * FROM invoices(1)', 'petr', 'snowflake', 'unsupported table reference'),
             ('', 'petr', 'snowflake', 'one statement'),
             # An unknown/unsupported dialect must not let a raw sqlglot exception escape.
-            ('SELECT * FROM invoices', 'petr', 'not-a-real-dialect', 'dialect'),
+            ('SELECT * FROM "in.c-crm"."invoices"', 'petr', 'not-a-real-dialect', 'dialect'),
             # FROM sources that are not tables/subqueries: sqlglot parses `TABLE(...)` as a
             # TableFromRows wrapping a function call, so there is no exp.Table to rewrite and the
             # query would otherwise reach the workspace unfiltered.
@@ -546,24 +580,74 @@ class TestRewriteQuery:
             ('SELECT * FROM ML.PREDICT(MODEL `m`, TABLE invoices)', 'petr', 'bigquery', 'unsupported table reference'),
             ("EXECUTE IMMEDIATE 'SELECT * FROM invoices'", 'petr', 'bigquery', 'SELECT'),
             (
-                'SELECT * FROM invoices, LATERAL FLATTEN(input => invoices.items) f',
+                'SELECT * FROM "in.c-crm"."invoices", LATERAL FLATTEN(input => invoices.items) f',
                 'petr',
                 'snowflake',
                 'unsupported FROM source',
             ),
             # --- a table without a rule, in every position a subquery can appear ---
-            ('SELECT (SELECT MAX(x) FROM secret) FROM invoices', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM invoices WHERE EXISTS (SELECT 1 FROM secret)', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM invoices, LATERAL (SELECT * FROM secret) s', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM invoices ORDER BY (SELECT MAX(x) FROM secret)', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM invoices LIMIT (SELECT COUNT(*) FROM secret)', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM invoices QUALIFY id IN (SELECT id FROM secret)', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM (VALUES ((SELECT MAX(x) FROM secret))) v', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM UNNEST((SELECT ARRAY_AGG(x) FROM secret))', 'petr', 'bigquery', "table 'secret'"),
-            ('SELECT * FROM (secret)', 'petr', 'snowflake', "table 'secret'"),
+            (
+                'SELECT (SELECT MAX(x) FROM "in.c-crm"."secret") FROM "in.c-crm"."invoices"',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM "in.c-crm"."invoices" WHERE EXISTS (SELECT 1 FROM "in.c-crm"."secret")',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM "in.c-crm"."invoices", LATERAL (SELECT * FROM "in.c-crm"."secret") s',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM "in.c-crm"."invoices" ORDER BY (SELECT MAX(x) FROM "in.c-crm"."secret")',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM "in.c-crm"."invoices" LIMIT (SELECT COUNT(*) FROM "in.c-crm"."secret")',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM "in.c-crm"."invoices" QUALIFY id IN (SELECT id FROM "in.c-crm"."secret")',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM (VALUES ((SELECT MAX(x) FROM "in.c-crm"."secret"))) v',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM UNNEST((SELECT ARRAY_AGG(x) FROM `in_c_crm`.`secret`))',
+                'petr',
+                'bigquery',
+                "table 'in_c_crm.secret'",
+            ),
+            ('SELECT * FROM ("in.c-crm"."secret")', 'petr', 'snowflake', "table 'in.c-crm.secret'"),
             # an alias equal to a protected table name must not stand in for a rule
-            ('SELECT * FROM secret AS invoices', 'petr', 'snowflake', "table 'secret'"),
-            ('SELECT * FROM (SELECT * FROM secret) AS invoices', 'petr', 'snowflake', "table 'secret'"),
+            (
+                'SELECT * FROM "in.c-crm"."secret" AS invoices',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
+            (
+                'SELECT * FROM (SELECT * FROM "in.c-crm"."secret") AS invoices',
+                'petr',
+                'snowflake',
+                "table 'in.c-crm.secret'",
+            ),
             # --- CTE shadowing, remaining shapes ---
             (
                 (
@@ -607,7 +691,7 @@ class TestRewriteQuery:
                 'snowflake',
                 'another scope',
             ),
-            ('WITH secret AS (SELECT 1) SELECT * FROM public.secret', 'petr', 'snowflake', "table 'secret'"),
+            ('WITH secret AS (SELECT 1) SELECT * FROM public.secret', 'petr', 'snowflake', "table 'public.secret'"),
             # --- functions in a query with nothing to filter ---
             # `GET_DDL` reads the catalog, so RLS shapes nothing about what it returns.
             ("SELECT GET_DDL('table', 'invoices')", 'petr', 'snowflake', 'without FROM'),
@@ -618,10 +702,15 @@ class TestRewriteQuery:
             ("WITH t AS (SELECT 1) SELECT GET_DDL('table', 'invoices') FROM t", 'petr', 'snowflake', 'without FROM'),
             # --- functions banned everywhere, FROM or no FROM ---
             ('SELECT SYSTEM$CANCEL_ALL_QUERIES()', 'petr', 'snowflake', 'not allowed: SYSTEM'),
-            ("SELECT * FROM invoices WHERE SYSTEM$TYPEOF(x) = 'a'", 'petr', 'snowflake', 'not allowed: SYSTEM'),
+            (
+                'SELECT * FROM "in.c-crm"."invoices" WHERE SYSTEM$TYPEOF(x) = \'a\'',
+                'petr',
+                'snowflake',
+                'not allowed: SYSTEM',
+            ),
             ("SELECT SNOWFLAKE.CORTEX.COMPLETE('m', 'p')", 'petr', 'snowflake', 'not allowed: SNOWFLAKE.CORTEX'),
             (
-                'SELECT SNOWFLAKE.CORTEX.SENTIMENT(c) FROM invoices',
+                'SELECT SNOWFLAKE.CORTEX.SENTIMENT(c) FROM "in.c-crm"."invoices"',
                 'petr',
                 'snowflake',
                 'not allowed: SNOWFLAKE.CORTEX',
@@ -640,7 +729,7 @@ class TestRewriteQuery:
         (or the other way round) would silently change what the filter means. Refuse instead."""
         wrong = bq_rules if dialect == 'snowflake' else rules
         with pytest.raises(RlsError, match=f'rules are for dialect .* but the workspace is {dialect}'):
-            rewrite_query('SELECT * FROM invoices', user='petr', dialect=dialect, rules=wrong)
+            rewrite_query('SELECT * FROM "in.c-crm"."invoices"', user='petr', dialect=dialect, rules=wrong)
 
     @pytest.mark.parametrize(
         'sql',
@@ -688,9 +777,9 @@ class TestRewriteQuery:
         own; the underlying `sqlglot.parse_one(..., dialect=dialect)` call must not raise a raw
         `sqlglot` exception.
         """
-        bad_rules = RlsRules(tables={'invoices': {'petr': 'country = = 1'}}, dialect='snowflake')
+        bad_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': 'country = = 1'}}, dialect='snowflake')
         with pytest.raises(RlsError):
-            rewrite_query('SELECT * FROM invoices', user='petr', dialect='snowflake', rules=bad_rules)
+            rewrite_query('SELECT * FROM "in.c-crm"."invoices"', user='petr', dialect='snowflake', rules=bad_rules)
 
     @pytest.mark.parametrize(
         ('predicate', 'match'),
@@ -703,9 +792,9 @@ class TestRewriteQuery:
         ],
     )
     def test_rewrite_rejects_predicates_that_are_not_plain_conditions(self, predicate: str, match: str) -> None:
-        bad_rules = RlsRules(tables={'invoices': {'petr': predicate}}, dialect='snowflake')
+        bad_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': predicate}}, dialect='snowflake')
         with pytest.raises(RlsError, match=match):
-            rewrite_query('SELECT * FROM invoices', user='petr', dialect='snowflake', rules=bad_rules)
+            rewrite_query('SELECT * FROM "in.c-crm"."invoices"', user='petr', dialect='snowflake', rules=bad_rules)
 
 
 class TestOutputInvariant:
@@ -723,9 +812,12 @@ class TestOutputInvariant:
             ('SELECT 1; SELECT 2', 'non-SELECT statement'),
             ('SELCT nonsense', 'non-SELECT statement'),
             ('SELECT * FROM invoices', 'unwrapped table reference'),
-            ("SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS i JOIN orders o ON TRUE", 'unwrapped'),
+            (
+                "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS i JOIN orders o ON TRUE",
+                'unwrapped',
+            ),
             # A wrapper that is not `SELECT *` would silently drop the RLS predicate's columns.
-            ('SELECT * FROM (SELECT id FROM invoices) AS invoices', 'unwrapped table reference'),
+            ('SELECT * FROM (SELECT id FROM "in.c-crm"."invoices") AS "invoices"', 'unwrapped table reference'),
             # The CTE that would excuse `secret` is declared in a nested scope, so it excuses
             # nothing: `secret` is a real, unwrapped table here.
             ('SELECT * FROM secret WHERE 1 IN (WITH secret AS (SELECT 1) SELECT 1)', 'another scope'),
@@ -739,12 +831,15 @@ class TestOutputInvariant:
             ('SELECT * FROM my_udtf(1)', 'rewrite left an unsupported table reference'),
             # A wrapper with no WHERE at all is the whole table: the shape looks right and the data
             # is unfiltered, which is exactly what this net exists to catch.
-            ('SELECT * FROM (SELECT * FROM invoices) AS invoices', 'wrapper without a WHERE clause'),
+            ('SELECT * FROM (SELECT * FROM "in.c-crm"."invoices") AS "invoices"', 'wrapper without a WHERE clause'),
             # A WHERE that is not the rule -- weakened, negated or simply a different condition.
-            ("SELECT * FROM (SELECT * FROM invoices WHERE country = 'DE') AS invoices", 'not the rule for table'),
-            ('SELECT * FROM (SELECT * FROM invoices WHERE TRUE) AS invoices', 'not the rule for table'),
             (
-                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ' OR TRUE) AS invoices",
+                "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'DE') AS \"invoices\"",
+                'not the rule for table',
+            ),
+            ('SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" WHERE TRUE) AS "invoices"', 'not the rule for table'),
+            (
+                "SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ' OR TRUE) AS \"invoices\"",
                 'not the rule for table',
             ),
             # A table that was wrapped although no rule was ever looked up for it.
@@ -759,28 +854,28 @@ class TestOutputInvariant:
         'sql',
         [
             'SELECT 1',
-            "SELECT COUNT(*) FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices",
-            "WITH x AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) SELECT * FROM x",
+            "SELECT COUNT(*) FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"",
+            "WITH x AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\") SELECT * FROM x",
             (
-                "SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
-                'UNION ALL SELECT id FROM (SELECT * FROM orders WHERE FALSE) AS orders'
+                "SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
+                'UNION ALL SELECT id FROM (SELECT * FROM "in.c-sales"."orders" WHERE FALSE) AS "orders"'
             ),
             # A CTE reference from a scope that really does declare it, at every nesting shape.
             (
-                "WITH a AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices), "
+                "WITH a AS (SELECT * FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\"), "
                 'b AS (SELECT * FROM a) SELECT * FROM b'
             ),
             (
-                "WITH RECURSIVE r AS (SELECT id FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                "WITH RECURSIVE r AS (SELECT id FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                 'UNION ALL SELECT id FROM r) SELECT * FROM r'
             ),
             (
-                "SELECT 1 FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
+                "SELECT 1 FROM (SELECT * FROM \"in.c-crm\".\"invoices\" WHERE country = 'CZ') AS \"invoices\" "
                 'WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)'
             ),
             # Quoted CTE alias and quoted reference agreeing in case: an ordinary CTE reference.
             (
-                'WITH "X" AS (SELECT * FROM (SELECT * FROM invoices WHERE country = \'CZ\') AS invoices) '
+                'WITH "X" AS (SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices") '
                 'SELECT * FROM "X"'
             ),
         ],

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -80,6 +80,45 @@ class TestLoad:
             ('dialect: postgres\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
             ('dialect: 42\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
             ('dialect:\ntables:\n  invoices:\n    petr: "TRUE"', "'dialect'"),
+            # Two keys that normalize to one: the later would silently win, so refuse both.
+            (
+                'dialect: snowflake\ntables:\n  Invoices:\n    petr: "TRUE"\n  invoices:\n    petr: "FALSE"',
+                "duplicate table key 'invoices'",
+            ),
+            (
+                'dialect: snowflake\ntables:\n  invoices:\n    Petr: "TRUE"\n    petr: "FALSE"',
+                "duplicate user key 'petr'",
+            ),
+            # YAML 1.1 turns bare `yes`/`on`/`no` into booleans, so such a key is not a table name
+            # at all -- and would otherwise be stringified into something the admin never wrote.
+            ('dialect: snowflake\ntables:\n  yes:\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  invoices:\n    on: "TRUE"', 'invalid user key'),
+            ('dialect: snowflake\ntables:\n  42:\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  "":\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  "*":\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  \'"invoices"\':\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  my table:\n    petr: "TRUE"', 'invalid table key'),
+            ('dialect: snowflake\ntables:\n  invoices:\n    "":\n      petr: "TRUE"', 'invalid user key'),
+            ('dialect: snowflake\ntables:\n  invoices:\n    "pe tr": "TRUE"', 'invalid user key'),
+            # A predicate must be a boolean condition, not an arbitrary expression that happens to
+            # parse: `WHERE 1` or `WHERE f(x)` is not a filter the admin can reason about.
+            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "1"', 'boolean condition'),
+            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "is_active"', 'boolean condition'),
+            ('dialect: snowflake\ntables:\n  invoices:\n    petr: "f(x)"', 'boolean condition'),
+            (
+                'dialect: snowflake\ntables:\n  invoices:\n    petr: "CASE WHEN a THEN TRUE ELSE FALSE END"',
+                'boolean condition',
+            ),
+            # A predicate that reaches for another table cannot be wrapped -- refuse it at load time
+            # rather than at the first query that happens to trip the output invariant.
+            (
+                'dialect: snowflake\ntables:\n  invoices:\n    petr: "id IN (SELECT id FROM secret)"',
+                'must not reference a table or subquery',
+            ),
+            (
+                'dialect: snowflake\ntables:\n  invoices:\n    petr: "EXISTS (SELECT 1 FROM secret)"',
+                'must not reference a table or subquery',
+            ),
         ],
     )
     def test_load_rejects_invalid_file(self, tmp_path: Path, content: str, match: str) -> None:
@@ -87,6 +126,27 @@ class TestLoad:
         path.write_text(content)
         with pytest.raises(RlsError, match=match):
             RlsRules.load(str(path))
+
+    @pytest.mark.parametrize(
+        'predicate',
+        [
+            "country = 'CZ'",
+            'TRUE',
+            'FALSE',
+            "country = 'CZ' AND status <> 'draft'",
+            "country IN ('PL', 'SK')",
+            'NOT deleted',
+            "(country = 'CZ')",
+            "((country = 'CZ' OR country = 'SK'))",
+            'x IS NULL',
+            'amount BETWEEN 1 AND 2',
+            "name LIKE 'a%'",
+        ],
+    )
+    def test_load_accepts_boolean_predicates(self, tmp_path: Path, predicate: str) -> None:
+        path = tmp_path / 'rls.yaml'
+        path.write_text(f'dialect: snowflake\ntables:\n  invoices:\n    petr: "{predicate}"\n')
+        assert RlsRules.load(str(path)).tables['invoices']['petr'] == predicate
 
     def test_load_missing_file(self, tmp_path: Path) -> None:
         with pytest.raises(RlsError, match='not found'):

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -496,6 +496,10 @@ class TestRewriteQuery:
             ('SELECT * FROM "in.c-crm.invoices"', 'petr', 'snowflake', 'must be qualified'),
             # The rule is keyed by bucket: the same table name in another bucket is not covered.
             ('SELECT * FROM "in.c-sales"."invoices"', 'petr', 'snowflake', "table 'in.c-sales.invoices'"),
+            # BigQuery dataset and table names are case-sensitive, so a differently-cased reference
+            # names a different table -- and there is no rule for it.
+            ('SELECT * FROM `in_c_crm`.`Invoices`', 'petr', 'bigquery', "table 'in_c_crm.Invoices'"),
+            ('SELECT * FROM `IN_C_CRM`.`invoices`', 'petr', 'bigquery', "table 'IN_C_CRM.invoices'"),
             # A CTE reading its own name without RECURSIVE resolves to the base table on the
             # engine, whatever the CTE is called.
             (
@@ -543,7 +547,6 @@ class TestRewriteQuery:
             # table through unfiltered.
             ('WITH "secret" AS (SELECT 1) SELECT * FROM "SECRET"', 'petr', 'snowflake', 'another scope'),
             ('WITH "SECRET" AS (SELECT 1) SELECT * FROM "secret"', 'petr', 'snowflake', 'another scope'),
-            ('WITH `secret` AS (SELECT 1) SELECT * FROM `SECRET`', 'petr', 'bigquery', 'another scope'),
             # Without RECURSIVE a CTE is not visible inside its own body: BigQuery resolves the inner
             # `secret` to the base table. Refuse rather than pass the query through verbatim.
             (
@@ -820,6 +823,68 @@ class TestRewriteQuery:
         bad_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': predicate}}, dialect='snowflake')
         with pytest.raises(RlsError, match=match):
             rewrite_query('SELECT * FROM "in.c-crm"."invoices"', user='petr', dialect='snowflake', rules=bad_rules)
+
+
+class TestDialectIdentifierSemantics:
+    """The two backends resolve names differently, and RLS follows each rather than picking one.
+
+    Verified against a live BigQuery workspace: CTE names there are case-insensitive and backticks
+    around one are semantically null, while dataset and table names ARE case-sensitive. Snowflake is
+    the other way round for the quoting question, and its workspace FQNs come back quoted in the
+    storage case, so rule keys are matched case-insensitively there.
+    """
+
+    @pytest.mark.parametrize(
+        'sql',
+        [
+            'WITH secret AS (SELECT 1 AS x) SELECT * FROM SECRET',
+            'WITH `secret` AS (SELECT 1 AS x) SELECT * FROM secret',
+            'WITH secret AS (SELECT 1 AS x) SELECT * FROM `SECRET`',
+            'WITH Secret AS (SELECT 1 AS x) SELECT * FROM secret',
+            'WITH `Secret` AS (SELECT 1 AS x) SELECT * FROM `secret`',
+        ],
+    )
+    def test_bigquery_cte_names_ignore_case_and_backticks(self, bq_rules: RlsRules, sql: str) -> None:
+        """All five shapes return the CTE row on BigQuery, so all five are CTE references here.
+        Refusing them as "ambiguous" or "another scope" would protect nothing and reject real work.
+        """
+        out = rewrite_query(sql, user='petr', dialect='bigquery', rules=bq_rules)
+
+        assert out.applied_rules == []
+
+    @pytest.mark.parametrize(
+        ('sql', 'match'),
+        [
+            # The looser name rule does not loosen the two that matter.
+            ('WITH secret AS (SELECT * FROM `SECRET`) SELECT * FROM secret', 'without RECURSIVE'),
+            ('SELECT * FROM secret WHERE 1 IN (WITH SECRET AS (SELECT 1) SELECT 1)', 'another scope'),
+        ],
+    )
+    def test_bigquery_still_refuses_real_shadowing(self, bq_rules: RlsRules, sql: str, match: str) -> None:
+        with pytest.raises(RlsError, match=match):
+            rewrite_query(sql, user='petr', dialect='bigquery', rules=bq_rules)
+
+    @pytest.mark.parametrize(
+        'sql',
+        [
+            # Snowflake keeps the quoted/unquoted distinction: `"SECRET"` is the base table.
+            'WITH "secret" AS (SELECT 1) SELECT * FROM "SECRET"',
+            'WITH "SECRET" AS (SELECT 1) SELECT * FROM "secret"',
+        ],
+    )
+    def test_snowflake_quoting_rules_are_unchanged(self, rules: RlsRules, sql: str) -> None:
+        with pytest.raises(RlsError, match='another scope'):
+            rewrite_query(sql, user='petr', dialect='snowflake', rules=rules)
+
+    def test_snowflake_rule_keys_stay_case_insensitive(self, rules: RlsRules) -> None:
+        """A workspace FQN from `get_tables` is quoted in the storage case, and Snowflake resolves
+        `"IN.C-CRM"."INVOICES"` and `"in.c-crm"."invoices"` to the same table."""
+        out = rewrite_query('SELECT * FROM "IN.C-CRM"."INVOICES"', user='petr', dialect='snowflake', rules=rules)
+
+        assert out.applied_rules == ['in.c-crm.invoices']
+
+    def test_bigquery_rule_keys_keep_their_case(self, bq_rules: RlsRules) -> None:
+        assert sorted(bq_rules.tables) == ['in_c_crm.invoices', 'in_c_crm.orders', 'in_c_sales.orders']
 
 
 class TestDisclosure:

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -138,6 +138,33 @@ class TestRewriteQuery:
                 ["invoices: country = 'CZ'"],
             ),
             (
+                # Quoted CTE alias, quoted reference, same case: the same name on both engines.
+                'WITH "X" AS (SELECT * FROM invoices) SELECT * FROM "X"',
+                'snowflake',
+                (
+                    'WITH "X" AS (SELECT * FROM (SELECT * FROM invoices WHERE country = \'CZ\') AS invoices) '
+                    'SELECT * FROM "X"'
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                # Unquoted identifiers fold case on both Snowflake and BigQuery, so `x` and `X` are
+                # the same name and this is an ordinary CTE reference -- it must not be refused.
+                'WITH x AS (SELECT * FROM invoices) SELECT * FROM X',
+                'snowflake',
+                "WITH x AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) SELECT * FROM X",
+                ["invoices: country = 'CZ'"],
+            ),
+            (
+                'WITH `X` AS (SELECT * FROM invoices) SELECT * FROM `X`',
+                'bigquery',
+                (
+                    "WITH `X` AS (SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices) "
+                    'SELECT * FROM `X`'
+                ),
+                ["invoices: country = 'CZ'"],
+            ),
+            (
                 # A subquery may declare its own CTE as long as the name shadows nothing outside it.
                 'SELECT * FROM invoices WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)',
                 'snowflake',
@@ -269,6 +296,26 @@ class TestRewriteQuery:
             # A CTE reference whose quoting differs from the declaration is ambiguous -- the engine
             # and the rewriter can disagree about whether it resolves to the CTE or a real table.
             ('WITH "secret" AS (SELECT 1) SELECT * FROM SECRET', 'petr', 'snowflake', 'ambiguous'),
+            # Quoted identifiers are case-sensitive on Snowflake and BigQuery, so `"SECRET"` binds to
+            # the base table, not to the `"secret"` CTE. Treating them as one name would let the real
+            # table through unfiltered.
+            ('WITH "secret" AS (SELECT 1) SELECT * FROM "SECRET"', 'petr', 'snowflake', 'another scope'),
+            ('WITH "SECRET" AS (SELECT 1) SELECT * FROM "secret"', 'petr', 'snowflake', 'another scope'),
+            ('WITH `secret` AS (SELECT 1) SELECT * FROM `SECRET`', 'petr', 'bigquery', 'another scope'),
+            # Without RECURSIVE a CTE is not visible inside its own body: BigQuery resolves the inner
+            # `secret` to the base table. Refuse rather than pass the query through verbatim.
+            (
+                'WITH secret AS (SELECT * FROM secret) SELECT * FROM secret',
+                'petr',
+                'snowflake',
+                'without RECURSIVE',
+            ),
+            (
+                'WITH secret AS (SELECT * FROM secret) SELECT * FROM secret',
+                'petr',
+                'bigquery',
+                'without RECURSIVE',
+            ),
             # Table functions parse as an `exp.Table` whose `this` is not an identifier: there is no
             # table name to look a rule up by, so they must be refused, not silently passed through.
             ('SELECT * FROM my_udtf(1)', 'petr', 'snowflake', 'unsupported table reference'),
@@ -370,6 +417,13 @@ class TestOutputInvariant:
             # nothing: `secret` is a real, unwrapped table here.
             ('SELECT * FROM secret WHERE 1 IN (WITH secret AS (SELECT 1) SELECT 1)', 'another scope'),
             ('WITH "secret" AS (SELECT 1) SELECT * FROM SECRET', 'ambiguous'),
+            # Quoted identifiers are case-sensitive: `"SECRET"` is the base table, not the CTE.
+            ('WITH "secret" AS (SELECT 1) SELECT * FROM "SECRET"', 'another scope'),
+            # A non-recursive CTE does not cover a reference to its own name inside its body.
+            ('WITH secret AS (SELECT * FROM secret) SELECT * FROM secret', 'without RECURSIVE'),
+            # A table function has no name to check a wrapper against; the output check must refuse
+            # it on its own, exactly as `_check_from_sources` and `_transform` do on the way in.
+            ('SELECT * FROM my_udtf(1)', 'rewrite left an unsupported table reference'),
         ],
     )
     def test_rejects(self, sql: str, match: str) -> None:
@@ -398,6 +452,11 @@ class TestOutputInvariant:
             (
                 "SELECT 1 FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices "
                 'WHERE 1 IN (WITH t AS (SELECT 1) SELECT * FROM t)'
+            ),
+            # Quoted CTE alias and quoted reference agreeing in case: an ordinary CTE reference.
+            (
+                'WITH "X" AS (SELECT * FROM (SELECT * FROM invoices WHERE country = \'CZ\') AS invoices) '
+                'SELECT * FROM "X"'
             ),
         ],
     )

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -22,6 +22,9 @@ VALID_YAML = textwrap.dedent(
 
 BIGQUERY_YAML = VALID_YAML.replace('dialect: snowflake', 'dialect: bigquery')
 
+# The predicates a rewrite of the hand-built SQL in `TestOutputInvariant` would have inserted.
+OUTPUT_PREDICATES = {'invoices': "country = 'CZ'", 'orders': 'FALSE', 'secret': 'TRUE'}
+
 
 @pytest.fixture
 def rules(tmp_path: Path) -> RlsRules:
@@ -662,7 +665,8 @@ class TestRewriteQuery:
 class TestOutputInvariant:
     """`_check_output` is the last-resort safety net: whatever the rewrite produced, it must be one
     SELECT (or set operation) in which every real table sits inside a `(SELECT * FROM t WHERE ...)`
-    wrapper we generated. It is checked on the re-parsed output, so it does not trust the rewrite.
+    wrapper we generated, carrying exactly the predicate the rewrite inserted. It is checked on the
+    re-parsed output, so it does not trust the rewrite.
     """
 
     @pytest.mark.parametrize(
@@ -687,11 +691,23 @@ class TestOutputInvariant:
             # A table function has no name to check a wrapper against; the output check must refuse
             # it on its own, exactly as `_check_from_sources` and `_transform` do on the way in.
             ('SELECT * FROM my_udtf(1)', 'rewrite left an unsupported table reference'),
+            # A wrapper with no WHERE at all is the whole table: the shape looks right and the data
+            # is unfiltered, which is exactly what this net exists to catch.
+            ('SELECT * FROM (SELECT * FROM invoices) AS invoices', 'wrapper without a WHERE clause'),
+            # A WHERE that is not the rule -- weakened, negated or simply a different condition.
+            ("SELECT * FROM (SELECT * FROM invoices WHERE country = 'DE') AS invoices", 'not the rule for table'),
+            ('SELECT * FROM (SELECT * FROM invoices WHERE TRUE) AS invoices', 'not the rule for table'),
+            (
+                "SELECT * FROM (SELECT * FROM invoices WHERE country = 'CZ' OR TRUE) AS invoices",
+                'not the rule for table',
+            ),
+            # A table that was wrapped although no rule was ever looked up for it.
+            ('SELECT * FROM (SELECT * FROM customers WHERE TRUE) AS customers', 'no rule was looked up for'),
         ],
     )
     def test_rejects(self, sql: str, match: str) -> None:
         with pytest.raises(RlsError, match=match):
-            _check_output(sql, dialect='snowflake')
+            _check_output(sql, dialect='snowflake', predicates=OUTPUT_PREDICATES)
 
     @pytest.mark.parametrize(
         'sql',
@@ -724,4 +740,4 @@ class TestOutputInvariant:
         ],
     )
     def test_accepts(self, sql: str) -> None:
-        _check_output(sql, dialect='snowflake')
+        _check_output(sql, dialect='snowflake', predicates=OUTPUT_PREDICATES)

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -435,6 +435,32 @@ class TestRewriteQuery:
                 ["in.c-crm.invoices: country = 'CZ'"],
             ),
             (
+                # A CTE named after a protected table shadows nothing: the protected reference always
+                # carries its bucket, and a CTE alias never can.
+                (
+                    'WITH RECURSIVE invoices AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM invoices WHERE n < 3) '
+                    'SELECT * FROM invoices'
+                ),
+                'snowflake',
+                (
+                    'WITH RECURSIVE invoices AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM invoices WHERE n < 3) '
+                    'SELECT * FROM invoices'
+                ),
+                [],
+            ),
+            (
+                'WITH "Invoices" AS (SELECT 1) SELECT * FROM "Invoices"',
+                'snowflake',
+                'WITH "Invoices" AS (SELECT 1) SELECT * FROM "Invoices"',
+                [],
+            ),
+            (
+                'WITH `Invoices` AS (SELECT 1) SELECT * FROM `Invoices`',
+                'bigquery',
+                'WITH `Invoices` AS (SELECT 1) SELECT * FROM `Invoices`',
+                [],
+            ),
+            (
                 # A recursive CTE named after nothing protected, joined with a protected table.
                 (
                     'WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 3) '
@@ -470,11 +496,16 @@ class TestRewriteQuery:
             ('SELECT * FROM "in.c-crm.invoices"', 'petr', 'snowflake', 'must be qualified'),
             # The rule is keyed by bucket: the same table name in another bucket is not covered.
             ('SELECT * FROM "in.c-sales"."invoices"', 'petr', 'snowflake', "table 'in.c-sales.invoices'"),
-            # A CTE named like a protected table would shadow it inside its own body -- refuse.
-            ('WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices', 'petr', 'snowflake', 'collide'),
-            # ... whatever the quoting of either side: a quoted `"orders"` CTE and the rule key
-            # `orders` are the same name.
-            ('WITH "orders" AS (SELECT 1) SELECT * FROM ORDERS', 'petr', 'snowflake', 'collide'),
+            # A CTE reading its own name without RECURSIVE resolves to the base table on the
+            # engine, whatever the CTE is called.
+            (
+                'WITH invoices AS (SELECT * FROM invoices) SELECT * FROM invoices',
+                'petr',
+                'snowflake',
+                'without RECURSIVE',
+            ),
+            # A reference whose quoting differs from the declaration is ambiguous either way.
+            ('WITH "orders" AS (SELECT 1) SELECT * FROM ORDERS', 'petr', 'snowflake', 'ambiguous'),
             # A CTE declared in a nested scope must not make a top-level real table look like a CTE
             # reference. Each of these used to pass through verbatim, unfiltered.
             (
@@ -496,12 +527,13 @@ class TestRewriteQuery:
                 'snowflake',
                 'another scope',
             ),
-            # Same trick aimed at a table that does have a rule: caught by the collision guard.
+            # Same trick aimed at a table that does have a rule: the CTE is declared in a nested
+            # scope, so it cannot excuse the outer reference.
             (
                 'SELECT * FROM invoices WHERE 1 IN (WITH invoices AS (SELECT 1) SELECT 1)',
                 'petr',
                 'snowflake',
-                'collide',
+                'another scope',
             ),
             # A CTE reference whose quoting differs from the declaration is ambiguous -- the engine
             # and the rewriter can disagree about whether it resolves to the CTE or a real table.
@@ -650,17 +682,6 @@ class TestRewriteQuery:
             ),
             # --- CTE shadowing, remaining shapes ---
             (
-                (
-                    'WITH RECURSIVE invoices AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM invoices WHERE n < 3) '
-                    'SELECT * FROM invoices'
-                ),
-                'petr',
-                'snowflake',
-                'collide',
-            ),
-            ('WITH "Invoices" AS (SELECT 1) SELECT * FROM "Invoices"', 'petr', 'snowflake', 'collide'),
-            ('WITH `Invoices` AS (SELECT 1) SELECT * FROM `Invoices`', 'petr', 'bigquery', 'collide'),
-            (
                 'SELECT * FROM secret JOIN (WITH secret AS (SELECT 1) SELECT * FROM secret) s ON TRUE',
                 'petr',
                 'snowflake',
@@ -755,20 +776,23 @@ class TestRewriteQuery:
 
         assert 'quote the bucket' not in str(excinfo.value)
 
-    def test_cte_colliding_with_qualified_rule_key_fails_closed(self) -> None:
-        """A CTE alias is always bare, so it can never equal a `<schema>.<table>` rule key
-        literally -- it is the key's bare table name it shadows. The collision guard must compare
-        against that, otherwise `WITH invoices AS (...)` slips past rules keyed
-        `in.c-crm.invoices`.
+    def test_cte_named_after_a_protected_table_still_wraps_the_table(self, rules: RlsRules) -> None:
+        """A CTE alias is always bare and a rules key always names a bucket, so a CTE can never
+        stand in for a protected table. Naming one after a table is therefore allowed -- and it is
+        the natural way to write this query -- while the real reference inside it is still wrapped.
         """
-        scoped_rules = RlsRules(tables={'in.c-crm.invoices': {'petr': "country = 'CZ'"}}, dialect='snowflake')
-        with pytest.raises(RlsError, match='collide'):
-            rewrite_query(
-                'SELECT * FROM invoices WHERE 1 IN (WITH invoices AS (SELECT 1) SELECT 1)',
-                user='petr',
-                dialect='snowflake',
-                rules=scoped_rules,
-            )
+        out = rewrite_query(
+            'WITH invoices AS (SELECT * FROM "in.c-crm"."invoices" WHERE amount > 0) SELECT COUNT(*) FROM invoices',
+            user='petr',
+            dialect='snowflake',
+            rules=rules,
+        )
+
+        assert out.sql == (
+            'WITH invoices AS (SELECT * FROM (SELECT * FROM "in.c-crm"."invoices" '
+            'WHERE country = \'CZ\') AS "invoices" WHERE amount > 0) SELECT COUNT(*) FROM invoices'
+        )
+        assert out.applied_rules == ["in.c-crm.invoices: country = 'CZ'"]
 
     def test_rewrite_predicate_invalid_for_dialect_fails_closed(self) -> None:
         """A predicate can pass `RlsRules.load()`'s dialect-agnostic check yet still fail to parse

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -323,11 +323,23 @@ class TestRewriteQuery:
                 [],
             ),
             (
-                # Metadata functions are out of scope for RLS: they take no table source, so there is
-                # nothing to rewrite. They are allowed through unchanged, like any other FROM-less SELECT.
-                "SELECT GET_DDL('table', 'invoices')",
+                # A FROM-less SELECT may still read the clock and do scalar arithmetic: no predicate
+                # could shape such a result, but neither can it disclose anything.
+                'SELECT CURRENT_DATE',
                 'snowflake',
-                "SELECT GET_DDL('table', 'invoices')",
+                'SELECT CURRENT_DATE',
+                [],
+            ),
+            (
+                'SELECT 1 + 1 AS x',
+                'snowflake',
+                'SELECT 1 + 1 AS x',
+                [],
+            ),
+            (
+                "SELECT CAST('1' AS INT) AS x, COALESCE(NULL, 1) AS y, CONCAT('a', 'b') AS z",
+                'snowflake',
+                "SELECT CAST('1' AS INT) AS x, COALESCE(NULL, 1) AS y, CONCAT('a', 'b') AS z",
                 [],
             ),
             (
@@ -571,6 +583,24 @@ class TestRewriteQuery:
                 'another scope',
             ),
             ('WITH secret AS (SELECT 1) SELECT * FROM public.secret', 'petr', 'snowflake', "table 'secret'"),
+            # --- functions in a query with nothing to filter ---
+            # `GET_DDL` reads the catalog, so RLS shapes nothing about what it returns.
+            ("SELECT GET_DDL('table', 'invoices')", 'petr', 'snowflake', 'without FROM'),
+            ('SELECT LAST_QUERY_ID()', 'petr', 'snowflake', 'without FROM'),
+            ('SELECT COUNT(*)', 'petr', 'snowflake', 'without FROM'),
+            # A dummy CTE gives the query an `exp.Table` node but still no table to filter, so the
+            # ban must look through it rather than count the CTE reference as a real source.
+            ("WITH t AS (SELECT 1) SELECT GET_DDL('table', 'invoices') FROM t", 'petr', 'snowflake', 'without FROM'),
+            # --- functions banned everywhere, FROM or no FROM ---
+            ('SELECT SYSTEM$CANCEL_ALL_QUERIES()', 'petr', 'snowflake', 'not allowed: SYSTEM'),
+            ("SELECT * FROM invoices WHERE SYSTEM$TYPEOF(x) = 'a'", 'petr', 'snowflake', 'not allowed: SYSTEM'),
+            ("SELECT SNOWFLAKE.CORTEX.COMPLETE('m', 'p')", 'petr', 'snowflake', 'not allowed: SNOWFLAKE.CORTEX'),
+            (
+                'SELECT SNOWFLAKE.CORTEX.SENTIMENT(c) FROM invoices',
+                'petr',
+                'snowflake',
+                'not allowed: SNOWFLAKE.CORTEX',
+            ),
         ],
     )
     def test_rewrite_fails_closed(self, rules: RlsRules, bq_rules: RlsRules, sql, user, dialect, match) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 from fastmcp import Client, Context, FastMCP
 from fastmcp.client import StreamableHttpTransport
+from fastmcp.exceptions import ToolError
 from fastmcp.tools import FunctionTool
 from mcp.types import TextContent
 from pydantic import Field
@@ -699,6 +700,77 @@ async def test_rls_swaps_query_tool(tmp_path) -> None:
 
     assert 'query_data_rls' in tool_names
     assert 'query_data' not in tool_names
+
+
+def _rls_server(tmp_path, mocker, *, rls: bool):
+    """A server wired the way `Client(server)` needs it, with or without RLS rules configured."""
+    os_mock = mocker.patch('keboola_mcp_server.server.os')
+    os_mock.environ = {
+        'KBC_STORAGE_TOKEN': 'SAPI_1234',
+        'KBC_STORAGE_API_URL': 'http://connection.test.keboola.com',
+        'KBC_WORKSPACE_SCHEMA': 'WORKSPACE_1234',
+    }
+    mocker.patch(
+        'keboola_mcp_server.clients.client.AsyncStorageClient.verify_token',
+        # Deliberately the most privileged session we can build: an admin token with every feature.
+        # RLS mode must still hide the write tools, so the restriction cannot be attributed to the role.
+        return_value={'owner': {'features': ['global-search', 'conditional-flows']}, 'admin': {'role': 'admin'}},
+    )
+    config = Config()
+    if rls:
+        rules_file = tmp_path / 'rls.yaml'
+        rules_file.write_text("tables:\n  invoices:\n    petr: \"country = 'CZ'\"\n")
+        config = Config(rls_rules_path=str(rules_file))
+    return create_server(config, runtime_info=ServerRuntimeInfo(transport='stdio'))
+
+
+@pytest.mark.asyncio
+async def test_rls_mode_lists_read_only_tools_only(tmp_path, mocker) -> None:
+    """In RLS mode the whole server is read-only: the point of the mode is that a query can only ever
+    return an RLS-filtered slice, which is worth nothing if the same session can run a job or create a
+    transformation that copies the unfiltered table somewhere else. No header is involved -- the
+    caller cannot opt out."""
+    server = _rls_server(tmp_path, mocker, rls=True)
+    read_only_names = {
+        t.name
+        for t in await server.list_tools(run_middleware=False)
+        if t.annotations is not None and t.annotations.readOnlyHint is True
+    }
+
+    async with Client(server) as client:
+        tool_names = {t.name for t in await client.list_tools()}
+
+    assert 'query_data_rls' in tool_names
+    assert 'get_tables' in tool_names
+    assert not tool_names & {'create_sql_transformation', 'run_job', 'create_config', 'deploy_data_app'}
+    # Nothing outside the read-only set survives the filter, whatever the tool is called.
+    assert tool_names <= read_only_names
+
+
+@pytest.mark.asyncio
+async def test_rls_mode_refuses_calls_to_write_tools(tmp_path, mocker) -> None:
+    """Hiding the tools from tools/list is not enough: a client that knows the name can still call it."""
+    server = _rls_server(tmp_path, mocker, rls=True)
+
+    async with Client(server) as client:
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool('run_job', {'component_id': 'keboola.ex-db-mysql', 'configuration_id': '123'})
+
+    message = str(exc_info.value)
+    assert 'read-only' in message
+    assert 'RLS' in message
+
+
+@pytest.mark.asyncio
+async def test_without_rls_write_tools_stay_available(tmp_path, mocker) -> None:
+    """The restriction is tied to RLS mode alone -- a plain server keeps its write tools."""
+    server = _rls_server(tmp_path, mocker, rls=False)
+
+    async with Client(server) as client:
+        tool_names = {t.name for t in await client.list_tools()}
+
+    assert 'query_data' in tool_names
+    assert {'create_sql_transformation', 'run_job', 'create_config', 'deploy_data_app'} <= tool_names
 
 
 def test_rls_invalid_rules_file_fails_startup(tmp_path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -719,7 +719,7 @@ def _rls_server(tmp_path, mocker, *, rls: bool):
     config = Config()
     if rls:
         rules_file = tmp_path / 'rls.yaml'
-        rules_file.write_text("tables:\n  invoices:\n    petr: \"country = 'CZ'\"\n")
+        rules_file.write_text("dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: \"country = 'CZ'\"\n")
         config = Config(rls_rules_path=str(rules_file))
     return create_server(config, runtime_info=ServerRuntimeInfo(transport='stdio'))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,6 +28,7 @@ from keboola_mcp_server.mcp import (
     toon_serializer,
     toon_serializer_compact,
 )
+from keboola_mcp_server.rls import RlsError
 from keboola_mcp_server.server import CustomRoutes, create_server
 from keboola_mcp_server.tools.components.tools import COMPONENT_TOOLS_TAG
 from keboola_mcp_server.tools.constants import CONFIG_DIFF_PREVIEW_TAG
@@ -686,3 +687,30 @@ class TestCreateServerOAuthSessionStore:
         server = create_server(Config(), runtime_info=ServerRuntimeInfo(transport='stdio'))
         assert isinstance(server, FastMCP)
         assert server.auth is None
+
+
+@pytest.mark.asyncio
+async def test_rls_swaps_query_tool(tmp_path) -> None:
+    rules_file = tmp_path / 'rls.yaml'
+    rules_file.write_text("tables:\n  invoices:\n    petr: \"country = 'CZ'\"\n")
+
+    server = create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))
+    tool_names = {tool.name for tool in await server.list_tools(run_middleware=False)}
+
+    assert 'query_data_rls' in tool_names
+    assert 'query_data' not in tool_names
+
+
+def test_rls_invalid_rules_file_fails_startup(tmp_path) -> None:
+    rules_file = tmp_path / 'rls.yaml'
+    rules_file.write_text('tables:\n  invoices:\n    petr: ""\n')
+
+    with pytest.raises(RlsError, match='petr'):
+        create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))
+
+
+def test_rls_missing_rules_file_fails_startup(tmp_path) -> None:
+    with pytest.raises(RlsError, match='not found'):
+        create_server(
+            Config(rls_rules_path=str(tmp_path / 'missing.yaml')), runtime_info=ServerRuntimeInfo(transport='stdio')
+        )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -692,7 +692,7 @@ class TestCreateServerOAuthSessionStore:
 @pytest.mark.asyncio
 async def test_rls_swaps_query_tool(tmp_path) -> None:
     rules_file = tmp_path / 'rls.yaml'
-    rules_file.write_text("tables:\n  invoices:\n    petr: \"country = 'CZ'\"\n")
+    rules_file.write_text("dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: \"country = 'CZ'\"\n")
 
     server = create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))
     tool_names = {tool.name for tool in await server.list_tools(run_middleware=False)}
@@ -703,7 +703,7 @@ async def test_rls_swaps_query_tool(tmp_path) -> None:
 
 def test_rls_invalid_rules_file_fails_startup(tmp_path) -> None:
     rules_file = tmp_path / 'rls.yaml'
-    rules_file.write_text('tables:\n  invoices:\n    petr: ""\n')
+    rules_file.write_text('dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: ""\n')
 
     with pytest.raises(RlsError, match='petr'):
         create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -695,11 +695,40 @@ async def test_rls_swaps_query_tool(tmp_path) -> None:
     rules_file = tmp_path / 'rls.yaml'
     rules_file.write_text("dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: \"country = 'CZ'\"\n")
 
-    server = create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))
+    server = create_server(
+        Config(rls_rules_path=str(rules_file), rls_principal_source='argument'),
+        runtime_info=ServerRuntimeInfo(transport='stdio'),
+    )
     tool_names = {tool.name for tool in await server.list_tools(run_middleware=False)}
 
     assert 'query_data_rls' in tool_names
     assert 'query_data' not in tool_names
+
+
+@pytest.mark.parametrize('source', ['header', 'argument'])
+def test_rls_principal_source_must_be_chosen_explicitly(tmp_path, source: str) -> None:
+    """Whether the principal comes from the authenticated wrapper (`header`) or from the model
+    (`argument`) decides whether RLS is enforced against a verified identity at all. There is no
+    safe default to fall back to, so a rules file with no source stops the server."""
+    rules_file = tmp_path / 'rls.yaml'
+    rules_file.write_text("dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: \"country = 'CZ'\"\n")
+
+    with pytest.raises(RuntimeError, match='KBC_RLS_PRINCIPAL_SOURCE'):
+        create_server(Config(rls_rules_path=str(rules_file)), runtime_info=ServerRuntimeInfo(transport='stdio'))
+
+    server = create_server(
+        Config(rls_rules_path=str(rules_file), rls_principal_source=source),
+        runtime_info=ServerRuntimeInfo(transport='stdio'),
+    )
+    assert isinstance(server, FastMCP)
+
+
+@pytest.mark.asyncio
+async def test_rls_principal_source_without_rules_is_harmless() -> None:
+    """The source only means anything in RLS mode -- setting it on a plain server must not fail."""
+    server = create_server(Config(rls_principal_source='header'), runtime_info=ServerRuntimeInfo(transport='stdio'))
+    tool_names = {tool.name for tool in await server.list_tools(run_middleware=False)}
+    assert 'query_data' in tool_names
 
 
 def _rls_server(tmp_path, mocker, *, rls: bool):
@@ -720,7 +749,7 @@ def _rls_server(tmp_path, mocker, *, rls: bool):
     if rls:
         rules_file = tmp_path / 'rls.yaml'
         rules_file.write_text("dialect: snowflake\ntables:\n  in.c-crm.invoices:\n    petr: \"country = 'CZ'\"\n")
-        config = Config(rls_rules_path=str(rules_file))
+        config = Config(rls_rules_path=str(rules_file), rls_principal_source='argument')
     return create_server(config, runtime_info=ServerRuntimeInfo(transport='stdio'))
 
 

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -1,17 +1,27 @@
 import asyncio
 import contextlib
+import dataclasses
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, call
 
 import httpx
 import pytest
+from fastmcp import FastMCP
 from mcp.server.fastmcp import Context
 from mcp.types import ProgressNotification
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
-from keboola_mcp_server.tools.sql import QueryDataOutput, _watch_for_http_disconnect, query_data
+from keboola_mcp_server.rls import RlsRules
+from keboola_mcp_server.tools.sql import (
+    QueryDataOutput,
+    RlsQueryDataOutput,
+    _watch_for_http_disconnect,
+    add_sql_tools,
+    query_data,
+    query_data_rls,
+)
 from keboola_mcp_server.workspace import (
     JobSubmittedInfo,
     QueryResult,
@@ -85,6 +95,75 @@ async def test_query_data(
     assert isinstance(result, QueryDataOutput)
     assert result.query_name == query_name
     assert result.csv_data == expected_csv
+
+
+@pytest.fixture
+def rls_context(mcp_context_client: Context, mocker) -> tuple[Context, WorkspaceManager]:
+    """`mcp_context_client` with RLS rules in the server state and a Snowflake workspace mock."""
+    rules = RlsRules(tables={'invoices': {'petr': "country = 'CZ'"}})
+    state = mcp_context_client.request_context.lifespan_context
+    mcp_context_client.request_context.lifespan_context = dataclasses.replace(state, rls_rules=rules)
+    manager = mocker.AsyncMock(WorkspaceManager)
+    manager.get_sql_dialect.return_value = 'Snowflake'
+    manager.execute_query.return_value = QueryResult(
+        status='ok', data=SqlSelectData(columns=['n'], rows=[{'n': 3}]), message=None
+    )
+    mcp_context_client.session.state[WorkspaceManager.STATE_KEY] = manager
+    return mcp_context_client, manager
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_rewrites_and_discloses(rls_context) -> None:
+    ctx, manager = rls_context
+
+    result = await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', 'Petr', ctx)
+
+    assert isinstance(result, RlsQueryDataOutput)
+    assert result.csv_data == 'n\r\n3\r\n'
+    assert result.applied_rules == ["invoices: country = 'CZ'"]
+    sent_sql = manager.execute_query.call_args.args[0]
+    assert sent_sql == "SELECT COUNT(*) AS n FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('sql', 'user', 'match'),
+    [
+        ('SELECT * FROM invoices', 'nobody', "user 'nobody'"),
+        ('SELECT * FROM customers', 'petr', "table 'customers'"),
+        ('DELETE FROM invoices', 'petr', 'SELECT'),
+    ],
+)
+async def test_query_data_rls_fails_closed(rls_context, sql: str, user: str, match: str) -> None:
+    ctx, manager = rls_context
+
+    with pytest.raises(ValueError, match=match):
+        await query_data_rls(sql, 'Bad Query', user, ctx)
+
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_requires_rules_in_state(mcp_context_client: Context) -> None:
+    # Defensive: the tool is only registered when rules exist, but never run unfiltered if they are missing.
+    with pytest.raises(ValueError, match='RLS rules'):
+        await query_data_rls('SELECT 1', 'No Rules', 'petr', mcp_context_client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('rls_rules', 'expected_tools'),
+    [
+        (None, ['query_data']),
+        (RlsRules(tables={'invoices': {'petr': 'TRUE'}}), ['query_data_rls']),
+    ],
+)
+async def test_add_sql_tools_registers_exactly_one_query_tool(rls_rules, expected_tools) -> None:
+    mcp = FastMCP('test')
+    add_sql_tools(mcp, rls_rules=rls_rules)
+    tools = await mcp.list_tools(run_middleware=False)
+    assert sorted(t.name for t in tools) == expected_tools
+    assert all(t.annotations is not None and t.annotations.readOnlyHint is True for t in tools)
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -101,7 +101,7 @@ async def test_query_data(
 @pytest.fixture
 def rls_context(mcp_context_client: Context, mocker) -> tuple[Context, WorkspaceManager]:
     """`mcp_context_client` with RLS rules in the server state and a Snowflake workspace mock."""
-    rules = RlsRules(tables={'invoices': {'petr': "country = 'CZ'"}})
+    rules = RlsRules(tables={'invoices': {'petr': "country = 'CZ'"}}, dialect='snowflake')
     state = mcp_context_client.request_context.lifespan_context
     mcp_context_client.request_context.lifespan_context = dataclasses.replace(state, rls_rules=rules)
     manager = mocker.AsyncMock(WorkspaceManager)
@@ -171,7 +171,7 @@ async def test_query_data_rls_requires_rules_in_state(mcp_context_client: Contex
     ('rls_rules', 'expected_tools'),
     [
         (None, ['query_data']),
-        (RlsRules(tables={'invoices': {'petr': 'TRUE'}}), ['query_data_rls']),
+        (RlsRules(tables={'invoices': {'petr': 'TRUE'}}, dialect='snowflake'), ['query_data_rls']),
     ],
 )
 async def test_add_sql_tools_registers_exactly_one_query_tool(rls_rules, expected_tools) -> None:

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -218,7 +218,7 @@ async def test_query_data_rls_runs_the_rewrite_off_the_event_loop(rls_context, m
 
     mocker.patch.object(sql_tools, 'rewrite_query', _recording_rewrite)
 
-    await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', 'petr', ctx)
+    await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', 'petr', ctx)
 
     assert threads and threads[0] != threading.current_thread().name
 
@@ -244,12 +244,12 @@ async def test_query_data_rls_logs_success_with_tables_and_row_count(rls_context
     ctx, _manager = rls_context
 
     with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
-        await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', 'Petr', ctx)
+        await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', 'Petr', ctx)
 
     assert 'outcome=ok' in caplog.text
     assert "user='Petr'" in caplog.text
     assert "query='Invoice Count'" in caplog.text
-    assert "tables=['invoices']" in caplog.text
+    assert "tables=['in.c-crm.invoices']" in caplog.text
     assert 'rows=1' in caplog.text
 
 

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -14,6 +14,7 @@ from mcp.types import ProgressNotification
 
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
+from keboola_mcp_server.mcp import RLS_PRINCIPAL
 from keboola_mcp_server.rls import RlsRules
 from keboola_mcp_server.tools import sql as sql_tools
 from keboola_mcp_server.tools.sql import (
@@ -101,12 +102,25 @@ async def test_query_data(
     assert result.csv_data == expected_csv
 
 
+def _set_principal_source(ctx: Context, source: str | None) -> None:
+    """Switch the server's deployment-level RLS principal source (`header` or `argument`)."""
+    state = ctx.request_context.lifespan_context
+    ctx.request_context.lifespan_context = dataclasses.replace(
+        state, config=dataclasses.replace(state.config, rls_principal_source=source)
+    )
+
+
 @pytest.fixture
 def rls_context(mcp_context_client: Context, mocker) -> tuple[Context, WorkspaceManager]:
-    """`mcp_context_client` with RLS rules in the server state and a Snowflake workspace mock."""
+    """`mcp_context_client` with RLS rules in the server state and a Snowflake workspace mock.
+
+    Defaults to `argument` mode -- the header-mode tests switch it with `_set_principal_source`.
+    """
     rules = RlsRules(tables={'in.c-crm.invoices': {'petr': "country = 'CZ'"}}, dialect='snowflake')
     state = mcp_context_client.request_context.lifespan_context
-    mcp_context_client.request_context.lifespan_context = dataclasses.replace(state, rls_rules=rules)
+    mcp_context_client.request_context.lifespan_context = dataclasses.replace(
+        state, rls_rules=rules, config=dataclasses.replace(state.config, rls_principal_source='argument')
+    )
     manager = mocker.AsyncMock(WorkspaceManager)
     manager.get_sql_dialect.return_value = 'Snowflake'
     manager.execute_query.return_value = QueryResult(
@@ -120,7 +134,9 @@ def rls_context(mcp_context_client: Context, mocker) -> tuple[Context, Workspace
 async def test_query_data_rls_rewrites_and_discloses(rls_context) -> None:
     ctx, manager = rls_context
 
-    result = await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', 'Petr', ctx)
+    result = await query_data_rls(
+        'SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', ctx, principal='Petr'
+    )
 
     assert isinstance(result, RlsQueryDataOutput)
     assert result.csv_data == 'n\r\n3\r\n'
@@ -132,14 +148,14 @@ async def test_query_data_rls_rewrites_and_discloses(rls_context) -> None:
 
 
 @pytest.mark.asyncio
-async def test_query_data_rls_strips_user_and_logs_it_quoted(rls_context, caplog) -> None:
-    """The `user` value comes from the model, so it may carry stray whitespace (matching must still
-    work) and arbitrary characters (the log line must quote it rather than splice it in raw)."""
+async def test_query_data_rls_strips_principal_and_logs_it_quoted(rls_context, caplog) -> None:
+    """The principal may carry stray whitespace (matching must still work) and arbitrary characters
+    (the log line must quote it rather than splice it in raw)."""
     ctx, manager = rls_context
 
     with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
         result = await query_data_rls(
-            'SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', '  Petr\n', ctx
+            'SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', ctx, principal='  Petr\n'
         )
 
     assert result.applied_rules == ['in.c-crm.invoices']
@@ -165,7 +181,104 @@ async def test_query_data_rls_fails_closed(rls_context, sql: str, user: str, mat
     ctx, manager = rls_context
 
     with pytest.raises(ValueError, match=match):
-        await query_data_rls(sql, 'Bad Query', user, ctx)
+        await query_data_rls(sql, 'Bad Query', ctx, principal=user)
+
+    manager.execute_query.assert_not_called()
+
+
+_RLS_SQL = 'SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"'
+_RLS_REWRITTEN = 'SELECT COUNT(*) AS n FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices"'
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_header_mode_takes_the_principal_from_the_header(rls_context, caplog) -> None:
+    """In header mode the identity comes from the authenticating wrapper, not from the model: the
+    tool argument is absent and the `X-RLS-Principal` value drives the rule lookup."""
+    ctx, manager = rls_context
+    _set_principal_source(ctx, 'header')
+    ctx.session.state[RLS_PRINCIPAL] = 'Petr'
+
+    with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
+        result = await query_data_rls(_RLS_SQL, 'Invoice Count', ctx)
+
+    assert result.applied_rules == ['in.c-crm.invoices']
+    assert manager.execute_query.call_args.args[0] == _RLS_REWRITTEN
+    assert 'source=header' in caplog.text
+    assert "principal='Petr'" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('header_value', [None, '', '   '])
+async def test_query_data_rls_header_mode_refuses_without_the_header(rls_context, header_value) -> None:
+    """No header, no query: falling back to anything (a default principal, the model's own idea of
+    who it is) would hand out unfiltered or wrongly filtered rows to an unauthenticated caller."""
+    ctx, manager = rls_context
+    _set_principal_source(ctx, 'header')
+    if header_value is not None:
+        ctx.session.state[RLS_PRINCIPAL] = header_value
+
+    with pytest.raises(ValueError, match='RLS: X-RLS-Principal header is required'):
+        await query_data_rls(_RLS_SQL, 'Invoice Count', ctx)
+
+    manager.get_sql_dialect.assert_not_called()
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('header_value', [None, 'Petr'])
+async def test_query_data_rls_header_mode_refuses_a_principal_argument(rls_context, header_value) -> None:
+    """A model-supplied `principal` in header mode is refused outright -- whether or not the header
+    agrees. Silently ignoring it would let a caller believe it chose the identity, and honouring it
+    would let it actually do so."""
+    ctx, manager = rls_context
+    _set_principal_source(ctx, 'header')
+    if header_value is not None:
+        ctx.session.state[RLS_PRINCIPAL] = header_value
+
+    with pytest.raises(ValueError, match='RLS: principal must not be passed as an argument in header mode'):
+        await query_data_rls(_RLS_SQL, 'Invoice Count', ctx, principal='monika')
+
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_argument_mode_requires_the_argument(rls_context) -> None:
+    ctx, manager = rls_context
+
+    with pytest.raises(ValueError, match='RLS: principal argument is required'):
+        await query_data_rls(_RLS_SQL, 'Invoice Count', ctx)
+
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_argument_mode_ignores_a_stray_header_and_warns(rls_context, caplog) -> None:
+    """A server configured for argument mode must not silently switch identities because a proxy
+    added a header -- but the operator should see that it happened."""
+    ctx, manager = rls_context
+    ctx.session.state[RLS_PRINCIPAL] = 'monika'
+
+    with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
+        result = await query_data_rls(_RLS_SQL, 'Invoice Count', ctx, principal='Petr')
+
+    assert result.applied_rules == ['in.c-crm.invoices']
+    assert manager.execute_query.call_args.args[0] == _RLS_REWRITTEN
+    assert 'source=argument' in caplog.text
+    assert any(r.levelname == 'WARNING' and 'X-RLS-Principal' in r.message for r in caplog.records), caplog.text
+    # The header value is not the identity here, and must not be logged as if it were.
+    assert "principal='Petr'" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_refuses_when_no_principal_source_is_configured(rls_context) -> None:
+    """`create_server()` refuses to start without a source, so this is defence in depth -- but an
+    unconfigured server must never fall back to trusting the model."""
+    ctx, manager = rls_context
+    _set_principal_source(ctx, None)
+    ctx.session.state[RLS_PRINCIPAL] = 'Petr'
+
+    with pytest.raises(ValueError, match='RLS: no principal source is configured'):
+        await query_data_rls(_RLS_SQL, 'Invoice Count', ctx, principal='Petr')
 
     manager.execute_query.assert_not_called()
 
@@ -174,7 +287,7 @@ async def test_query_data_rls_fails_closed(rls_context, sql: str, user: str, mat
 async def test_query_data_rls_requires_rules_in_state(mcp_context_client: Context) -> None:
     # Defensive: the tool is only registered when rules exist, but never run unfiltered if they are missing.
     with pytest.raises(ValueError, match='RLS rules'):
-        await query_data_rls('SELECT 1', 'No Rules', 'petr', mcp_context_client)
+        await query_data_rls('SELECT 1', 'No Rules', mcp_context_client, principal='petr')
 
 
 @pytest.mark.asyncio
@@ -185,7 +298,7 @@ async def test_query_data_rls_refuses_oversized_query(rls_context) -> None:
     oversized = f"SELECT * FROM invoices WHERE note = '{'a' * (RLS_MAX_QUERY_CHARS + 1)}'"
 
     with pytest.raises(ValueError, match='RLS: query too long'):
-        await query_data_rls(oversized, 'Huge Query', 'petr', ctx)
+        await query_data_rls(oversized, 'Huge Query', ctx, principal='petr')
 
     manager.get_sql_dialect.assert_not_called()
     manager.execute_query.assert_not_called()
@@ -199,7 +312,7 @@ async def test_query_data_rls_turns_recursion_error_into_a_plain_refusal(rls_con
     nested = 'SELECT ' + '(' * 3_000 + '1' + ')' * 3_000
 
     with pytest.raises(ValueError, match='RLS: query too deeply nested'):
-        await query_data_rls(nested, 'Nested Query', 'petr', ctx)
+        await query_data_rls(nested, 'Nested Query', ctx, principal='petr')
 
     manager.execute_query.assert_not_called()
 
@@ -218,7 +331,7 @@ async def test_query_data_rls_runs_the_rewrite_off_the_event_loop(rls_context, m
 
     mocker.patch.object(sql_tools, 'rewrite_query', _recording_rewrite)
 
-    await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', 'petr', ctx)
+    await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', ctx, principal='petr')
 
     assert threads and threads[0] != threading.current_thread().name
 
@@ -230,10 +343,10 @@ async def test_query_data_rls_logs_refusal_with_user_and_outcome(rls_context, ca
     ctx, manager = rls_context
 
     with caplog.at_level('WARNING', logger='keboola_mcp_server.tools.sql'), pytest.raises(ValueError):
-        await query_data_rls('SELECT * FROM customers', 'Forbidden Table', 'Petr', ctx)
+        await query_data_rls('SELECT * FROM customers', 'Forbidden Table', ctx, principal='Petr')
 
     assert 'outcome=refused' in caplog.text
-    assert "user='Petr'" in caplog.text
+    assert "principal='Petr'" in caplog.text
     assert "query='Forbidden Table'" in caplog.text
     assert 'customers' in caplog.text
     manager.execute_query.assert_not_called()
@@ -244,10 +357,10 @@ async def test_query_data_rls_logs_success_with_tables_and_row_count(rls_context
     ctx, _manager = rls_context
 
     with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
-        await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', 'Petr', ctx)
+        await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', ctx, principal='Petr')
 
     assert 'outcome=ok' in caplog.text
-    assert "user='Petr'" in caplog.text
+    assert "principal='Petr'" in caplog.text
     assert "query='Invoice Count'" in caplog.text
     assert "tables=['in.c-crm.invoices']" in caplog.text
     assert 'rows=1' in caplog.text

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -101,7 +101,7 @@ async def test_query_data(
 @pytest.fixture
 def rls_context(mcp_context_client: Context, mocker) -> tuple[Context, WorkspaceManager]:
     """`mcp_context_client` with RLS rules in the server state and a Snowflake workspace mock."""
-    rules = RlsRules(tables={'invoices': {'petr': "country = 'CZ'"}}, dialect='snowflake')
+    rules = RlsRules(tables={'in.c-crm.invoices': {'petr': "country = 'CZ'"}}, dialect='snowflake')
     state = mcp_context_client.request_context.lifespan_context
     mcp_context_client.request_context.lifespan_context = dataclasses.replace(state, rls_rules=rules)
     manager = mocker.AsyncMock(WorkspaceManager)
@@ -117,13 +117,15 @@ def rls_context(mcp_context_client: Context, mocker) -> tuple[Context, Workspace
 async def test_query_data_rls_rewrites_and_discloses(rls_context) -> None:
     ctx, manager = rls_context
 
-    result = await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', 'Petr', ctx)
+    result = await query_data_rls('SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', 'Petr', ctx)
 
     assert isinstance(result, RlsQueryDataOutput)
     assert result.csv_data == 'n\r\n3\r\n'
-    assert result.applied_rules == ["invoices: country = 'CZ'"]
+    assert result.applied_rules == ["in.c-crm.invoices: country = 'CZ'"]
     sent_sql = manager.execute_query.call_args.args[0]
-    assert sent_sql == "SELECT COUNT(*) AS n FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+    assert sent_sql == (
+        'SELECT COUNT(*) AS n FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices"'
+    )
 
 
 @pytest.mark.asyncio
@@ -133,11 +135,15 @@ async def test_query_data_rls_strips_user_and_logs_it_quoted(rls_context, caplog
     ctx, manager = rls_context
 
     with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
-        result = await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', '  Petr\n', ctx)
+        result = await query_data_rls(
+            'SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', '  Petr\n', ctx
+        )
 
-    assert result.applied_rules == ["invoices: country = 'CZ'"]
+    assert result.applied_rules == ["in.c-crm.invoices: country = 'CZ'"]
     sent_sql = manager.execute_query.call_args.args[0]
-    assert sent_sql == "SELECT COUNT(*) AS n FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+    assert sent_sql == (
+        'SELECT COUNT(*) AS n FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices"'
+    )
     assert "'Petr'" in caplog.text
 
 
@@ -145,8 +151,10 @@ async def test_query_data_rls_strips_user_and_logs_it_quoted(rls_context, caplog
 @pytest.mark.parametrize(
     ('sql', 'user', 'match'),
     [
-        ('SELECT * FROM invoices', 'nobody', "user 'nobody'"),
-        ('SELECT * FROM customers', 'petr', "table 'customers'"),
+        ('SELECT * FROM "in.c-crm"."invoices"', 'nobody', "user 'nobody'"),
+        ('SELECT * FROM "in.c-crm"."customers"', 'petr', "table 'in.c-crm.customers'"),
+        # A reference with no bucket has no rule key to match, so it is refused too.
+        ('SELECT * FROM invoices', 'petr', 'must be qualified'),
         ('DELETE FROM invoices', 'petr', 'SELECT'),
     ],
 )
@@ -171,7 +179,7 @@ async def test_query_data_rls_requires_rules_in_state(mcp_context_client: Contex
     ('rls_rules', 'expected_tools'),
     [
         (None, ['query_data']),
-        (RlsRules(tables={'invoices': {'petr': 'TRUE'}}, dialect='snowflake'), ['query_data_rls']),
+        (RlsRules(tables={'in.c-crm.invoices': {'petr': 'TRUE'}}, dialect='snowflake'), ['query_data_rls']),
     ],
 )
 async def test_add_sql_tools_registers_exactly_one_query_tool(rls_rules, expected_tools) -> None:

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -121,7 +121,7 @@ async def test_query_data_rls_rewrites_and_discloses(rls_context) -> None:
 
     assert isinstance(result, RlsQueryDataOutput)
     assert result.csv_data == 'n\r\n3\r\n'
-    assert result.applied_rules == ["in.c-crm.invoices: country = 'CZ'"]
+    assert result.applied_rules == ['in.c-crm.invoices']
     sent_sql = manager.execute_query.call_args.args[0]
     assert sent_sql == (
         'SELECT COUNT(*) AS n FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices"'
@@ -139,7 +139,7 @@ async def test_query_data_rls_strips_user_and_logs_it_quoted(rls_context, caplog
             'SELECT COUNT(*) AS n FROM "in.c-crm"."invoices"', 'Invoice Count', '  Petr\n', ctx
         )
 
-    assert result.applied_rules == ["in.c-crm.invoices: country = 'CZ'"]
+    assert result.applied_rules == ['in.c-crm.invoices']
     sent_sql = manager.execute_query.call_args.args[0]
     assert sent_sql == (
         'SELECT COUNT(*) AS n FROM (SELECT * FROM "in.c-crm"."invoices" WHERE country = \'CZ\') AS "invoices"'

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -224,6 +224,36 @@ async def test_query_data_rls_runs_the_rewrite_off_the_event_loop(rls_context, m
 
 
 @pytest.mark.asyncio
+async def test_query_data_rls_logs_refusal_with_user_and_outcome(rls_context, caplog) -> None:
+    """Refusals must be greppable: the same one-line format as a successful query, so an operator can
+    count `outcome=refused` per user without parsing free-form messages."""
+    ctx, manager = rls_context
+
+    with caplog.at_level('WARNING', logger='keboola_mcp_server.tools.sql'), pytest.raises(ValueError):
+        await query_data_rls('SELECT * FROM customers', 'Forbidden Table', 'Petr', ctx)
+
+    assert 'outcome=refused' in caplog.text
+    assert "user='Petr'" in caplog.text
+    assert "query='Forbidden Table'" in caplog.text
+    assert 'customers' in caplog.text
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_logs_success_with_tables_and_row_count(rls_context, caplog) -> None:
+    ctx, _manager = rls_context
+
+    with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
+        await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', 'Petr', ctx)
+
+    assert 'outcome=ok' in caplog.text
+    assert "user='Petr'" in caplog.text
+    assert "query='Invoice Count'" in caplog.text
+    assert "tables=['invoices']" in caplog.text
+    assert 'rows=1' in caplog.text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ('rls_rules', 'expected_tools'),
     [

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -15,6 +15,7 @@ from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
 from keboola_mcp_server.rls import RlsRules
 from keboola_mcp_server.tools.sql import (
+    SQL_TOOLS_TAG,
     QueryDataOutput,
     RlsQueryDataOutput,
     _watch_for_http_disconnect,
@@ -126,6 +127,21 @@ async def test_query_data_rls_rewrites_and_discloses(rls_context) -> None:
 
 
 @pytest.mark.asyncio
+async def test_query_data_rls_strips_user_and_logs_it_quoted(rls_context, caplog) -> None:
+    """The `user` value comes from the model, so it may carry stray whitespace (matching must still
+    work) and arbitrary characters (the log line must quote it rather than splice it in raw)."""
+    ctx, manager = rls_context
+
+    with caplog.at_level('INFO', logger='keboola_mcp_server.tools.sql'):
+        result = await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', '  Petr\n', ctx)
+
+    assert result.applied_rules == ["invoices: country = 'CZ'"]
+    sent_sql = manager.execute_query.call_args.args[0]
+    assert sent_sql == "SELECT COUNT(*) AS n FROM (SELECT * FROM invoices WHERE country = 'CZ') AS invoices"
+    assert "'Petr'" in caplog.text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ('sql', 'user', 'match'),
     [
@@ -164,6 +180,8 @@ async def test_add_sql_tools_registers_exactly_one_query_tool(rls_rules, expecte
     tools = await mcp.list_tools(run_middleware=False)
     assert sorted(t.name for t in tools) == expected_tools
     assert all(t.annotations is not None and t.annotations.readOnlyHint is True for t in tools)
+    # The tag drives tool filtering elsewhere in the server; the RLS tool must carry it too.
+    assert all(SQL_TOOLS_TAG in t.tags for t in tools)
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_sql.py
+++ b/tests/tools/test_sql.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import dataclasses
 import json
+import threading
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, call
 
@@ -14,7 +15,9 @@ from mcp.types import ProgressNotification
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.clients.query import QueryServiceClient
 from keboola_mcp_server.rls import RlsRules
+from keboola_mcp_server.tools import sql as sql_tools
 from keboola_mcp_server.tools.sql import (
+    RLS_MAX_QUERY_CHARS,
     SQL_TOOLS_TAG,
     QueryDataOutput,
     RlsQueryDataOutput,
@@ -172,6 +175,52 @@ async def test_query_data_rls_requires_rules_in_state(mcp_context_client: Contex
     # Defensive: the tool is only registered when rules exist, but never run unfiltered if they are missing.
     with pytest.raises(ValueError, match='RLS rules'):
         await query_data_rls('SELECT 1', 'No Rules', 'petr', mcp_context_client)
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_refuses_oversized_query(rls_context) -> None:
+    """A query above the size cap is refused before anything reaches the workspace -- the rewrite
+    parses model-supplied SQL, so an oversized input must never get as far as the parser."""
+    ctx, manager = rls_context
+    oversized = f"SELECT * FROM invoices WHERE note = '{'a' * (RLS_MAX_QUERY_CHARS + 1)}'"
+
+    with pytest.raises(ValueError, match='RLS: query too long'):
+        await query_data_rls(oversized, 'Huge Query', 'petr', ctx)
+
+    manager.get_sql_dialect.assert_not_called()
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_turns_recursion_error_into_a_plain_refusal(rls_context) -> None:
+    """A deeply nested expression blows sqlglot's recursive parser; the RecursionError must surface
+    as an ordinary refusal (and never reach the workspace) instead of a stack-trace-shaped 500."""
+    ctx, manager = rls_context
+    nested = 'SELECT ' + '(' * 3_000 + '1' + ')' * 3_000
+
+    with pytest.raises(ValueError, match='RLS: query too deeply nested'):
+        await query_data_rls(nested, 'Nested Query', 'petr', ctx)
+
+    manager.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_data_rls_runs_the_rewrite_off_the_event_loop(rls_context, mocker) -> None:
+    """`rewrite_query` is CPU-bound (full sqlglot parse + transform); running it inline would block
+    the event loop for every other in-flight session, so it must run in a worker thread."""
+    ctx, _manager = rls_context
+    real_rewrite = sql_tools.rewrite_query
+    threads: list[str] = []
+
+    def _recording_rewrite(*args, **kwargs):
+        threads.append(threading.current_thread().name)
+        return real_rewrite(*args, **kwargs)
+
+    mocker.patch.object(sql_tools, 'rewrite_query', _recording_rewrite)
+
+    await query_data_rls('SELECT COUNT(*) AS n FROM invoices', 'Invoice Count', 'petr', ctx)
+
+    assert threads and threads[0] != threading.current_thread().name
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-26T11:34:53.592161Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -25,7 +25,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -44,7 +44,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -1061,7 +1061,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.79.2"
+version = "1.80.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -2331,8 +2331,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1307,7 +1307,7 @@ requires-dist = [
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "requests", marker = "extra == 'integtests'", specifier = "~=2.34" },
     { name = "ruff", marker = "extra == 'codestyle'", specifier = "~=0.16" },
-    { name = "sqlglot", specifier = "~=30.0" },
+    { name = "sqlglot", specifier = "==30.17.0" },
     { name = "toon-format", specifier = "~=0.9.0b1" },
     { name = "tox", marker = "extra == 'dev'", specifier = "~=4.35" },
 ]


### PR DESCRIPTION
## Description

**Linear**: AI-XXX (pilot, no issue yet)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Pilot of row-level security (RLS) for SQL queries. **Draft, not for merge as-is** — technical validation phase, being tested on-site with a client.

RFC: `feature_spec/rls_query_tool/RFC.md` · Plan: `feature_spec/rls_query_tool/PLAN.md` · Strategy write-up (CZ/EN): https://artifact-hub-1304628444.hub.keboola.com/a/g-R9YYqZvSaAKJenwN4C0PHi

- New tool `query_data_rls(sql_query, query_name, user)`: rewrites every table in a `SELECT` to `(SELECT * FROM <table> WHERE <predicate>) AS <alias>` using rules from a YAML file (`--rls-rules-path` / `KBC_RLS_RULES_PATH`, never settable from a header), and discloses the applied rules in `applied_rules`.
- Fail-closed: non-`SELECT`, multiple statements, unparseable SQL, unknown dialect, a table or user without a rule, CTE names colliding with protected tables, `SELECT ... INTO`, table modifiers (SAMPLE / AT / PIVOT / FOR SYSTEM_TIME / alias column lists) and any FROM source that is not a plain table, subquery, VALUES or UNNEST are refused. A re-parse of the generated SQL asserts the output is still a single `SELECT` with every table wrapped.
- When the rules path is set the server registers **only** `query_data_rls`; `query_data` is not registered at all, so it cannot be re-enabled via `X-Allowed-Tools`. Without the path nothing changes (`TOOLS.md` unchanged).
- Rules are validated at startup; a missing or invalid file refuses to start the server.
- Principal binding: `KBC_RLS_PRINCIPAL_SOURCE=header|argument` must be chosen when RLS is on. In `header` mode the identity comes only from the `X-RLS-Principal` request header asserted by the calling application (AD / Google / Okta / app session — the MCP does not validate it and must be reachable only from that application); the tool's `principal` argument is refused. `argument` mode keeps the model-supplied identity for local/stdio use.
- Review hardening (see the review thread): mandatory `dialect:` in the rules file, `<bucket>.<table>` keys only (BigQuery dataset normalisation), `applied_rules` discloses table keys only, FROM-less function allowlist, output WHERE check, query size cap + off-loop rewrite, `outcome=` logging, sqlglot pinned, and **RLS mode forces read-only tools** so no write tool can bypass the rewrite.
- `examples/rls-demo/`: a small Node manual test harness (users, editable rules grid/YAML with validate-and-reload, SQL editor with live rewritten SQL, run-as-user and run-for-all-users comparison in tabs). Env-only configuration, local use only; not part of the server package.
- `query_data`'s execution body was extracted into a shared helper (`_execute_and_serialize`, `_to_csv`) — behaviour-preserving, covered by the existing tests.

Documented pilot limitations (see README section "Row-Level Security (pilot)"): in `argument` mode the identity is model-supplied; predicates are authored in the workspace dialect (no transpilation); no groups, column masking, audit log or hot reload; other tool docstrings still mention `query_data`.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Local: `ruff` clean; `pytest tests` green except the pre-existing, environment-specific `test_json_logging`; `TOOLS.md` regeneration produces no diff. Unit coverage: `tests/test_rls.py` (rules loading, rewrite, adversarial fail-closed cases), `tests/tools/test_sql.py`, `tests/test_server.py`, `tests/test_config.py`, `tests/test_cli.py`.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable)
