### PR TITLE
AI-3830: allow keboola-testing.com hosts in Storage API URL allowlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.80.0"
+version = "1.80.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/clients/base.py
+++ b/src/keboola_mcp_server/clients/base.py
@@ -20,12 +20,15 @@ JsonStruct = Union[JsonDict, JsonList]  # noqa: UP007
 LOG = logging.getLogger(__name__)
 
 # A genuine Keboola stack host: a `connection.` label, any number of region/cloud-provider
-# subdomain labels, ending in `.keboola.com`/`.keboola.dev` (multi-tenant stacks) or `.keboola.cloud`
-# (single-tenant stacks). `hostname.startswith('connection.')` alone is not a domain allowlist --
-# `connection.attacker.tld` would satisfy it -- see the "Security hardening" RFC increment. Mirrors
-# the domain-allowlist pattern `oauth.py`'s `_ALLOWED_DOMAINS` already uses for redirect URIs,
-# scoped to this server's own kind of host.
-_STORAGE_API_HOST_RE = re.compile(r'^connection\.(?:[a-z0-9-]+\.)*keboola\.(?:com|dev|cloud)$', re.IGNORECASE)
+# subdomain labels, ending in `.keboola.com`/`.keboola.dev` (multi-tenant stacks), `.keboola.cloud`
+# (single-tenant stacks), or `.keboola-testing.com` (test stacks, e.g. kbc-testing-azure-east-us-2).
+# `hostname.startswith('connection.')` alone is not a domain allowlist -- `connection.attacker.tld`
+# would satisfy it -- see the "Security hardening" RFC increment. Mirrors the domain-allowlist
+# pattern `oauth.py`'s `_ALLOWED_DOMAINS` already uses for redirect URIs, scoped to this server's
+# own kind of host.
+_STORAGE_API_HOST_RE = re.compile(
+    r'^connection\.(?:[a-z0-9-]+\.)*(?:keboola\.(?:com|dev|cloud)|keboola-testing\.com)$', re.IGNORECASE
+)
 
 
 def normalize_storage_api_url(storage_api_url: str) -> str:

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -26,6 +26,11 @@ class TestNormalizeStorageApiUrl:
             ('https://connection.keboola.com/v2/storage', 'https://connection.keboola.com'),
             ('https://connection.acme.keboola.cloud', 'https://connection.acme.keboola.cloud'),
             ('https://connection.example-tenant.keboola.cloud', 'https://connection.example-tenant.keboola.cloud'),
+            (
+                'https://connection.east-us-2.azure.keboola-testing.com',
+                'https://connection.east-us-2.azure.keboola-testing.com',
+            ),
+            ('https://connection.keboola-testing.com', 'https://connection.keboola-testing.com'),
         ],
     )
     def test_accepts_genuine_keboola_stack_hosts(self, url: str, expected: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.80.0"
+version = "1.80.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: AI-3830

### Change Type

- [ ] Major (breaking changes, significant new features)
- [ ] Minor (new features, enhancements, backward compatible)
- [x] Patch (bug fixes, small improvements, no new features)

### Summary

`normalize_storage_api_url()` in `src/keboola_mcp_server/clients/base.py` only accepted Storage API hosts ending in `.keboola.com`, `.keboola.dev`, or `.keboola.cloud`. kbc-testing-azure-east-us-2's Storage API host is `connection.east-us-2.azure.keboola-testing.com` — a legitimate but different Keboola-owned domain, missing from the allowlist. Every `tools/list` call from kai-assistant on that stack was failing with:

```
event=request_error method=tools/list source=client duration_ms=2.15
error=Invalid Keboola Storage API URL: https://connection.east-us-2.azure.keboola-testing.com
```

Extends `_STORAGE_API_HOST_RE` to also accept `keboola-testing.com` hosts, using the same anchored subdomain structure as the existing suffixes (no widening of the lookalike-domain protection this regex exists for — see the "Security hardening" RFC increment referenced in the comment). Same class of gap as AI-3773 (`agnes.keboola.systems` missing from the OAuth redirect allowlist) and the precedent fix `0bc239fb` (adding `keboola.cloud`).

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Added two regression cases to `TestNormalizeStorageApiUrl::test_accepts_genuine_keboola_stack_hosts` (`tests/clients/test_base.py`) covering the exact failing host plus a bare `connection.keboola-testing.com`. Full `tests/clients/test_base.py`, `tests/test_auth_login.py`, `tests/clients/test_client.py`, `tests/clients/test_auth_bridge.py` (163 tests total) pass. `ruff format --check` and `ruff check` clean.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [ ] Integration tests added/updated (if applicable)
- [x] Project version bumped according to the change type (1.80.0 -> 1.80.1)
- [ ] Documentation updated (if applicable)