### PR TITLE
DMD-1701: merge-request MCP tools (Branches 2.0, non-SOX)

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3922,6 +3922,18 @@ Walk the user through them one by one and resolve each with resolve_merge_reques
       ],
       "default": null,
       "description": "The merge request id. Omit to use the current branch's merge request."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
     }
   },
   "type": "object"
@@ -3989,6 +4001,18 @@ Usage:
       ],
       "default": null,
       "description": "List mode only: keep merge requests whose state or derived state equals this value (e.g. 'in_development', 'approved', 'rejected', 'merged'). Ignored when ids are given."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
     }
   },
   "type": "object"

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -34,6 +34,19 @@ name or description.
 - [get_jobs](#get_jobs): Retrieves job execution information from the Keboola project.
 - [run_job](#run_job): Starts a new job for a given component or transformation.
 
+### Merge Request Tools
+- [approve_merge_request](#approve_merge_request): Approves a merge request as a reviewer.
+- [create_merge_request](#create_merge_request): Creates a merge request for the CURRENT development branch into production.
+- [get_merge_request_conflicts](#get_merge_request_conflicts): Shows what blocks the current branch's merge request from merging: each conflicting configuration with its
+three-way diff and a per-path classification.
+- [get_merge_requests](#get_merge_requests): Lists the project's merge requests, or returns the full detail of the given ones.
+- [merge_merge_request](#merge_merge_request): Merges the current branch's merge request into production and waits for the merge to finish.
+- [request_merge_request_changes](#request_merge_request_changes): Sends a merge request back to its author for changes (a reviewer's "reject").
+- [request_merge_request_review](#request_merge_request_review): Sends the current branch's merge request for review (author action).
+- [resolve_merge_request_conflict](#resolve_merge_request_conflict): Resolves ONE conflicting configuration of the current branch's merge request by re-anchoring the branch
+configuration onto the current production version with the chosen content.
+- [update_merge_request](#update_merge_request): Updates a merge request's title, description, reviewers or auto-merge setting.
+
 ### OAuth Tools
 - [create_oauth_url](#create_oauth_url): Generates an OAuth authorization URL for a Keboola component configuration.
 
@@ -3729,6 +3742,642 @@ Starts a new job for a given component or transformation.
   "required": [
     "component_id",
     "configuration_id"
+  ],
+  "type": "object"
+}
+```
+
+---
+
+# Merge Request Tools
+<a name="approve_merge_request"></a>
+## approve_merge_request
+**Annotations**: 
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Approves a merge request as a reviewer.
+
+Valid only while the merge request is `in_review` (the backend rejects it otherwise) and never for its
+creator. Projects with the default of 0 required approvals never enter `in_review`, so this is needed only
+when the project requires approvals. Works from any session. Returns the merge request with its status;
+follow `next_step`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "merge_request_id": {
+      "description": "The merge request id.",
+      "type": "integer"
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
+    }
+  },
+  "required": [
+    "merge_request_id"
+  ],
+  "type": "object"
+}
+```
+
+---
+<a name="create_merge_request"></a>
+## create_merge_request
+**Annotations**: `destructive`
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Creates a merge request for the CURRENT development branch into production.
+
+Available only from a development-branch session; on production, tell the user to open a session on the
+merge request's source branch and ask again there. The source branch is the session branch and the target
+is production — there are no branch parameters. A branch can have only one merge request.
+
+On a project with the default of 0 required approvals the happy path is two calls:
+create_merge_request → merge_merge_request (no review step). Returns the merge request with its status;
+follow `next_step`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "title": {
+      "description": "A short title describing the change.",
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "An optional longer description for the reviewers."
+    },
+    "reviewer_ids": {
+      "default": [],
+      "description": "User ids of the reviewers to request. Optional.",
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "auto_merge": {
+      "default": "none",
+      "description": "'none' (default) = the user merges explicitly. 'immediately' / 'scheduled' ARM auto-merge: the backend merges on its own once approvals suffice (at auto_merge_at for scheduled). Confirm with the user before arming.",
+      "enum": [
+        "none",
+        "immediately",
+        "scheduled"
+      ],
+      "type": "string"
+    },
+    "auto_merge_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "ISO-8601 date-time; required if and only if auto_merge='scheduled'."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
+    }
+  },
+  "required": [
+    "title"
+  ],
+  "type": "object"
+}
+```
+
+---
+<a name="get_merge_request_conflicts"></a>
+## get_merge_request_conflicts
+**Annotations**: `read-only`
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Shows what blocks the current branch's merge request from merging: each conflicting configuration with its
+three-way diff and a per-path classification.
+
+Available only from a development-branch session; on production, tell the user to open a session on the
+merge request's source branch and ask again there. A configuration conflicts when it changed both on the
+branch and in production since the branch was created. For each one you get `base` / `ours` (branch) /
+`theirs` (production), `changes` (each path tagged `changed_by` ours|theirs|both), `conflicting_paths`
+(both sides changed differently — the actual conflict) and `suggested_take` when one side is a safe pick.
+Walk the user through them one by one and resolve each with resolve_merge_request_conflict. Follow `next_step`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "merge_request_id": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The merge request id. Omit to use the current branch's merge request."
+    }
+  },
+  "type": "object"
+}
+```
+
+---
+<a name="get_merge_requests"></a>
+## get_merge_requests
+**Annotations**: `read-only`
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Lists the project's merge requests, or returns the full detail of the given ones.
+
+A merge request promotes a development branch's configuration changes into production. Works from any
+session (production or branch).
+
+Without ids: summaries of all merge requests (title, state, who created it, reviewers, source branch).
+With ids: per merge request the status block (`derived_state`, `merge_blockers`, `mergeable`,
+`allowed_actions`, `viewer`, live `conflicts`, and `next_step` — the single recommended next action),
+the changed configurations and the review history. Follow `next_step` verbatim when guiding the user.
+
+Usage:
+- "Is there anything to merge?" → list (optionally with `state`), then get the candidates' detail and read
+  `merge_blockers` / `next_step`.
+- "What is in merge request 42?" → detail of [42]; narrate `changed_configurations` and `activity_log`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "merge_request_ids": {
+      "default": [],
+      "description": "Merge request ids to get the full detail of. Leave empty to list all merge requests.",
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "state": {
+      "anyOf": [
+        {
+          "enum": [
+            "development",
+            "in_review",
+            "approved",
+            "in_merge",
+            "published",
+            "canceled",
+            "rejected",
+            "closed",
+            "in_development",
+            "merged"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "List mode only: keep merge requests whose state or derived state equals this value (e.g. 'in_development', 'approved', 'rejected', 'merged'). Ignored when ids are given."
+    }
+  },
+  "type": "object"
+}
+```
+
+---
+<a name="merge_merge_request"></a>
+## merge_merge_request
+**Annotations**: `destructive`
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Merges the current branch's merge request into production and waits for the merge to finish.
+
+Available only from a development-branch session; on production, tell the user to open a session on the
+merge request's source branch and ask again there. IRREVERSIBLE: on success the changes are in production
+and the source branch (with everything else on it: buckets, tables, workspaces) is deleted by a background
+job — confirm with the user first. Works directly from `development` when the project requires no
+approvals.
+
+When the backend refuses, nothing changes and the result explains why: `refusal='conflicts'` lists the
+conflicting configurations (resolve them with get_merge_request_conflicts / resolve_merge_request_conflict,
+then merge again); `refusal='not_ready'` means missing approvals, a merge lock or a wrong state. After a
+success the session's branch is gone: follow `next_step` and tell the user to open a production session.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "merge_request_id": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The merge request id. Omit to use the current branch's merge request."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
+    }
+  },
+  "type": "object"
+}
+```
+
+---
+<a name="request_merge_request_changes"></a>
+## request_merge_request_changes
+**Annotations**: 
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Sends a merge request back to its author for changes (a reviewer's "reject").
+
+The merge request returns to `development` and loses its approvals; it is NOT closed — the author fixes the
+branch and merges (or requests a review) again. Works from any session. Returns the merge request with its
+status; follow `next_step`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "merge_request_id": {
+      "description": "The merge request id.",
+      "type": "integer"
+    },
+    "reason": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Why changes are needed; recorded in the review history for the author."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
+    }
+  },
+  "required": [
+    "merge_request_id"
+  ],
+  "type": "object"
+}
+```
+
+---
+<a name="request_merge_request_review"></a>
+## request_merge_request_review
+**Annotations**: 
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Sends the current branch's merge request for review (author action).
+
+Available only from a development-branch session; on production, tell the user to open a session on the
+merge request's source branch and ask again there. Rarely needed: merge_merge_request already skips the
+review when the project requires no approvals, so call this only when a merge was refused as "not ready"
+or when the project requires approvals. The merge request moves to `in_review` (or straight to `approved`
+when 0 approvals are required). Returns the merge request with its status; follow `next_step`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "merge_request_id": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The merge request id. Omit to use the current branch's merge request."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
+    }
+  },
+  "type": "object"
+}
+```
+
+---
+<a name="resolve_merge_request_conflict"></a>
+## resolve_merge_request_conflict
+**Annotations**: 
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Resolves ONE conflicting configuration of the current branch's merge request by re-anchoring the branch
+configuration onto the current production version with the chosen content.
+
+Available only from a development-branch session; on production, tell the user to open a session on the
+merge request's source branch and ask again there. Call get_merge_request_conflicts first, then for each
+conflict have the user choose: `take='ours'` / `'theirs'` / `'delete'`, or pass `resolved` with the
+hand-merged content. Taking one side discards the other side's changes — say so. The configuration must
+be in the merge request's live conflict set. `remaining_conflicts` tells you whether to continue the loop;
+approvals survive the resolution. Follow `next_step`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "component_id": {
+      "description": "The component id of the conflicting configuration.",
+      "type": "string"
+    },
+    "configuration_id": {
+      "description": "The configuration id.",
+      "type": "string"
+    },
+    "take": {
+      "anyOf": [
+        {
+          "enum": [
+            "ours",
+            "theirs",
+            "delete"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "'ours' keeps the branch version, 'theirs' takes the production version, 'delete' deletes the configuration. Taking one side DISCARDS the other side's changes. Pass exactly one of take / resolved."
+    },
+    "resolved": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The manually merged content when neither side alone is right, as an object with ALL of these keys: \"name\" (non-empty string), \"description\" (string or null), \"is_disabled\" (boolean), \"configuration\" (object) and \"rows\" (array of row objects, complete) \u2014 the rebase replaces the whole version, so nothing may be omitted."
+    },
+    "change_description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The new version's change description (any mode; ignored for 'delete')."
+    },
+    "merge_request_id": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The merge request id. Omit to use the current branch's merge request."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
+    }
+  },
+  "required": [
+    "component_id",
+    "configuration_id"
+  ],
+  "type": "object"
+}
+```
+
+---
+<a name="update_merge_request"></a>
+## update_merge_request
+**Annotations**: `destructive`
+
+**Tags**: `merge-request`
+
+**Description**:
+
+Updates a merge request's title, description, reviewers or auto-merge setting. Omitted fields are kept.
+
+Use it to disarm auto-merge (`auto_merge='none'`) or to change reviewers. Arming auto-merge
+(`'immediately'` / `'scheduled'`) makes the backend merge without a further confirmation — confirm with
+the user first. Not allowed once the merge request is merged or canceled. Works from any session.
+Returns the merge request with its status; follow `next_step`.
+
+
+**Input JSON Schema**:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "merge_request_id": {
+      "description": "The merge request id.",
+      "type": "integer"
+    },
+    "title": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "New title. Omit to keep the current one."
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "New description. Omit to keep the current one; an empty string clears it."
+    },
+    "reviewer_ids": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "New complete list of reviewer user ids. Omit to keep the current one."
+    },
+    "auto_merge": {
+      "anyOf": [
+        {
+          "enum": [
+            "none",
+            "immediately",
+            "scheduled"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "'none' turns auto-merge OFF (the only way to disarm it). 'immediately' and 'scheduled' ARM it: the backend merges on its own once the merge request is approved (at auto_merge_at for 'scheduled'). Omit to keep the current setting."
+    },
+    "auto_merge_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "ISO-8601 date-time of a 'scheduled' auto-merge. Required with auto_merge='scheduled'."
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Target Keboola project id for this write. Required when the session is scoped to 2+ projects; optional (defaults to the single scoped project) otherwise."
+    }
+  },
+  "required": [
+    "merge_request_id"
   ],
   "type": "object"
 }

--- a/integtests/README.md
+++ b/integtests/README.md
@@ -51,6 +51,9 @@ INTEGTEST_STORAGE_TOKENS=<token-project-A> <token-project-B>
 # Required — branch storage tests (dedicated project, not in pool)
 INTEGTEST_STORAGE_TOKEN_STORAGE_BRANCHES=<token-for-project-WITH-storage-branches>
 
+# Optional — merge-request tests (dedicated project WITH branches-merge-requests, not in pool; skipped when unset)
+INTEGTEST_STORAGE_TOKEN_MERGE_REQUESTS=<token-for-project-WITH-branches-merge-requests>
+
 # Optional — second project for multi-client tests
 INTEGTEST_STORAGE_TOKEN_PRJ2=<token>
 INTEGTEST_WORKSPACE_SCHEMA_PRJ2=<WORKSPACE_XXX>
@@ -311,6 +314,7 @@ repository's GitHub Secrets/Variables:
 | `INTEGTEST_STORAGE_TOKENS` | Secret | Space-separated master tokens for all four pool projects |
 | `INTEGTEST_POOL_STORAGE_API_URL` | Variable | `https://connection.europe-west3.gcp.keboola.com` |
 | `INTEGTEST_STORAGE_TOKEN_STORAGE_BRANCHES` | Secret | Master token for a project **with** the `storage-branches` feature (used by `test_storage_branches.py`) |
+| `INTEGTEST_STORAGE_TOKEN_MERGE_REQUESTS` | Secret | Master token for a project **with** the `branches-merge-requests` feature (used by `test_merge_requests.py`; the tests are skipped when unset) |
 
 ### Concurrency
 

--- a/integtests/test_mcp_server.py
+++ b/integtests/test_mcp_server.py
@@ -152,9 +152,18 @@ async def test_http_multiple_clients_with_different_headers(
 
 async def _assert_basic_setup(client: Client):
     tools = await client.list_tools()
-    # the create_conditional_flow, create_flow, search, and semantic tools may not be present
+    # the create_conditional_flow, create_flow, search, semantic and merge-request tools may not be present
     # based on the testing project features
     exclude = {
+        'approve_merge_request',
+        'create_merge_request',
+        'get_merge_request_conflicts',
+        'get_merge_requests',
+        'merge_merge_request',
+        'request_merge_request_changes',
+        'request_merge_request_review',
+        'resolve_merge_request_conflict',
+        'update_merge_request',
         'create_conditional_flow',
         'create_flow',
         'search',

--- a/integtests/tools/test_merge_requests.py
+++ b/integtests/tools/test_merge_requests.py
@@ -1,0 +1,281 @@
+"""Integration tests for the merge-request tools (Branches 2.0, non-SOX flow).
+
+They need a dedicated project WITH the `branches-merge-requests` feature, addressed by the
+`INTEGTEST_STORAGE_TOKEN_MERGE_REQUESTS` token (outside the pool). The whole module is skipped when the
+variable is not set, so the suite stays green until such a project exists.
+
+A merge deletes the source branch, so every test creates its own branch; production configurations
+created for the conflict scenario are deleted afterwards.
+"""
+
+import json
+import logging
+import os
+import time
+import uuid
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastmcp import Context
+from mcp.server.session import ServerSession
+from mcp.types import ClientCapabilities, InitializeRequestParams
+
+from keboola_mcp_server.clients.client import KeboolaClient
+from keboola_mcp_server.config import Config
+from keboola_mcp_server.mcp import ServerRuntimeInfo, ServerState
+from keboola_mcp_server.tools.merge_requests.models import MergeRequestsDetailOutput
+from keboola_mcp_server.tools.merge_requests.tools import (
+    create_merge_request,
+    get_merge_request_conflicts,
+    get_merge_requests,
+    merge_merge_request,
+    resolve_merge_request_conflict,
+)
+from keboola_mcp_server.workspace import WorkspaceManager
+
+LOG = logging.getLogger(__name__)
+
+MERGE_REQUESTS_TOKEN_ENV_VAR = 'INTEGTEST_STORAGE_TOKEN_MERGE_REQUESTS'
+COMPONENT_ID = 'keboola.python-transformation-v2'
+BRANCH_GONE_TIMEOUT_SEC = 120
+
+
+def _api_request(method: str, url: str, token: str, **kwargs: Any) -> Any:
+    headers = {'X-StorageApi-Token': token, 'Content-Type': 'application/json'}
+    resp = httpx.request(method, url, headers=headers, timeout=60, **kwargs)
+    resp.raise_for_status()
+    return resp.json() if resp.content else {}
+
+
+def _wait_for_storage_job(base_url: str, token: str, job_id: str, timeout: int = 120) -> dict:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = _api_request('GET', f'{base_url}/v2/storage/jobs/{job_id}', token)
+        if job.get('status') == 'success':
+            return job
+        if job.get('status') in ('error', 'cancelled'):
+            raise RuntimeError(f'Storage job {job_id} failed: {job}')
+        time.sleep(2)
+    raise TimeoutError(f'Storage job {job_id} did not complete within {timeout}s')
+
+
+def _create_branch(base_url: str, token: str, name: str) -> str:
+    job = _api_request('POST', f'{base_url}/v2/storage/dev-branches', token, json={'name': name})
+    job = _wait_for_storage_job(base_url, token, str(job['id']))
+    return str(job['results']['id'])
+
+
+def _branch_exists(base_url: str, token: str, branch_id: str) -> bool:
+    try:
+        _api_request('GET', f'{base_url}/v2/storage/dev-branches/{branch_id}', token)
+        return True
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return False
+        raise
+
+
+def _delete_branch(base_url: str, token: str, branch_id: str) -> None:
+    try:
+        if _branch_exists(base_url, token, branch_id):
+            job = _api_request('DELETE', f'{base_url}/v2/storage/dev-branches/{branch_id}', token)
+            _wait_for_storage_job(base_url, token, str(job['id']))
+    except Exception:
+        LOG.exception(f'Failed to delete branch {branch_id}')
+
+
+def _config_path(base_url: str, branch_id: str | None, config_id: str | None = None) -> str:
+    prefix = f'{base_url}/v2/storage' + (f'/branch/{branch_id}' if branch_id else '')
+    return f'{prefix}/components/{COMPONENT_ID}/configs' + (f'/{config_id}' if config_id else '')
+
+
+def _create_config(base_url: str, token: str, branch_id: str | None, name: str, parameters: dict) -> str:
+    result = _api_request(
+        'POST',
+        _config_path(base_url, branch_id),
+        token,
+        json={
+            'name': name,
+            'description': 'Integration test config',
+            'configuration': json.dumps({'parameters': parameters}),
+        },
+    )
+    return str(result['id'])
+
+
+def _update_config(
+    base_url: str, token: str, branch_id: str | None, config_id: str, parameters: dict, change: str
+) -> None:
+    _api_request(
+        'PUT',
+        _config_path(base_url, branch_id, config_id),
+        token,
+        json={'configuration': json.dumps({'parameters': parameters}), 'changeDescription': change},
+    )
+
+
+def _delete_config(base_url: str, token: str, config_id: str) -> None:
+    try:
+        _api_request('DELETE', _config_path(base_url, None, config_id), token)
+    except Exception:
+        LOG.exception(f'Failed to delete production config {config_id}')
+
+
+@dataclass
+class MergeRequestProject:
+    storage_api_url: str
+    storage_api_token: str
+
+
+@pytest.fixture(scope='session')
+def mr_project(storage_api_url: str, env_file_loaded: bool) -> MergeRequestProject:
+    """A dedicated project with the `branches-merge-requests` feature; skips the module when not configured."""
+    token = os.getenv(MERGE_REQUESTS_TOKEN_ENV_VAR, '').strip()
+    if not token:
+        pytest.skip(f'{MERGE_REQUESTS_TOKEN_ENV_VAR} not set; skipping merge-request integration tests.')
+    token_info = _api_request('GET', f'{storage_api_url}/v2/storage/tokens/verify', token)
+    features = token_info.get('owner', {}).get('features', [])
+    if 'branches-merge-requests' not in features:
+        pytest.fail(f'project {token_info["owner"]["name"]!r} must have the branches-merge-requests feature enabled')
+    return MergeRequestProject(storage_api_url=storage_api_url, storage_api_token=token)
+
+
+@pytest.fixture
+def dev_branch(mr_project: MergeRequestProject) -> Generator[str, Any, None]:
+    """A fresh development branch per test (a merge deletes it)."""
+    branch_id = _create_branch(
+        mr_project.storage_api_url, mr_project.storage_api_token, f'integtest-mr-{uuid.uuid4().hex[:8]}'
+    )
+    try:
+        yield branch_id
+    finally:
+        _delete_branch(mr_project.storage_api_url, mr_project.storage_api_token, branch_id)
+
+
+async def _build_context(mocker, project: MergeRequestProject, *, branch_id: str | None) -> Context:
+    keboola_client = KeboolaClient(
+        storage_api_url=project.storage_api_url,
+        legacy_storage_token=project.storage_api_token,
+        headers={'User-Agent': 'KeboolaMCPServer/integtest'},
+    )
+    if branch_id is not None:
+        keboola_client = await keboola_client.with_branch_id(branch_id)
+    workspace_manager = await WorkspaceManager.create(keboola_client)
+    ctx = mocker.MagicMock(Context)
+    ctx.session = mocker.MagicMock(ServerSession)
+    ctx.session.state = {KeboolaClient.STATE_KEY: keboola_client, WorkspaceManager.STATE_KEY: workspace_manager}
+    ctx.session.client_params = InitializeRequestParams(
+        protocolVersion='1', capabilities=ClientCapabilities(), clientInfo={'name': 'integtest-mr', 'version': '0.0.1'}
+    )
+    ctx.client_id = 'KeboolaMCPServer/integtest'
+    ctx.session_id = None
+    ctx.request_context = mocker.MagicMock()
+    ctx.request_context.lifespan_context = ServerState(
+        Config(storage_api_url=project.storage_api_url, storage_token=project.storage_api_token),
+        ServerRuntimeInfo(transport='stdio'),
+    )
+    return ctx
+
+
+@pytest_asyncio.fixture
+async def branch_context(mocker, mr_project: MergeRequestProject, dev_branch: str) -> Context:
+    return await _build_context(mocker, mr_project, branch_id=dev_branch)
+
+
+@pytest_asyncio.fixture
+async def production_context(mocker, mr_project: MergeRequestProject) -> Context:
+    return await _build_context(mocker, mr_project, branch_id=None)
+
+
+def _wait_until_branch_gone(project: MergeRequestProject, branch_id: str) -> None:
+    deadline = time.time() + BRANCH_GONE_TIMEOUT_SEC
+    while time.time() < deadline:
+        if not _branch_exists(project.storage_api_url, project.storage_api_token, branch_id):
+            return
+        time.sleep(3)
+    raise TimeoutError(f'Source branch {branch_id} still exists {BRANCH_GONE_TIMEOUT_SEC}s after the merge')
+
+
+@pytest.mark.asyncio
+async def test_happy_path_create_then_merge(
+    branch_context: Context, production_context: Context, mr_project: MergeRequestProject, dev_branch: str
+) -> None:
+    """Non-SOX default (0 approvals): create → merge, no review step; the MR is published and the branch is deleted."""
+    config_id = _create_config(
+        mr_project.storage_api_url,
+        mr_project.storage_api_token,
+        dev_branch,
+        f'integtest-new-{uuid.uuid4().hex[:6]}',
+        {'x': 1},
+    )
+    try:
+        created = await create_merge_request(branch_context, title='integtest happy path')
+        assert created.state == 'development'
+        assert created.status.mergeable is True
+        assert 'merge_merge_request' in created.status.next_step
+
+        merged = await merge_merge_request(branch_context)
+        assert merged.merged is True, merged
+        assert merged.state == 'published'
+        assert merged.source_branch_deleting is True
+        assert 'production' in merged.next_step
+
+        detail = await get_merge_requests(production_context, merge_request_ids=[created.id])
+        assert isinstance(detail, MergeRequestsDetailOutput)
+        published = detail.merge_requests[0]
+        assert published.derived_state == 'merged'
+        assert {c.configuration_id for c in published.changed_configurations} == {config_id}
+
+        _wait_until_branch_gone(mr_project, dev_branch)
+    finally:
+        _delete_config(mr_project.storage_api_url, mr_project.storage_api_token, config_id)
+
+
+@pytest.mark.asyncio
+async def test_conflict_is_reported_and_resolved(mocker, mr_project: MergeRequestProject) -> None:
+    """Change the same configuration on the branch and in production → conflict → take ours → merge succeeds."""
+    url, token = mr_project.storage_api_url, mr_project.storage_api_token
+    # A conflict needs the configuration on both sides, so it must exist in production BEFORE the branch is
+    # created (a development branch is a copy of production at creation time).
+    config_id = _create_config(url, token, None, f'integtest-conflict-{uuid.uuid4().hex[:6]}', {'query': 'SELECT 1'})
+    branch_id = _create_branch(url, token, f'integtest-mr-conflict-{uuid.uuid4().hex[:8]}')
+    try:
+        ctx = await _build_context(mocker, mr_project, branch_id=branch_id)
+        _update_config(url, token, branch_id, config_id, {'query': 'SELECT 2'}, 'branch change')
+        _update_config(url, token, None, config_id, {'query': 'SELECT 3'}, 'production change')
+
+        created = await create_merge_request(ctx, title='integtest conflict')
+        assert created.status.merge_blockers == ['conflicts']
+        assert created.status.mergeable is False
+
+        refused = await merge_merge_request(ctx)
+        assert refused.merged is False
+        assert refused.refusal == 'conflicts'
+        assert refused.conflicts is not None and {c.configuration_id for c in refused.conflicts} == {config_id}
+
+        conflicts = await get_merge_request_conflicts(ctx)
+        assert [c.configuration_id for c in conflicts.conflicts] == [config_id]
+        conflict = conflicts.conflicts[0]
+        assert conflict.conflicting_paths == ['/configuration/parameters/query']
+        assert {c.changed_by for c in conflict.changes} == {'both'}
+        assert conflict.suggested_take is None
+
+        resolved = await resolve_merge_request_conflict(
+            ctx, component_id=COMPONENT_ID, configuration_id=config_id, take='ours'
+        )
+        assert resolved.resolved is True and resolved.mode == 'ours'
+        assert resolved.remaining_conflicts == []
+        assert 'merge_merge_request' in resolved.next_step
+
+        merged = await merge_merge_request(ctx)
+        assert merged.merged is True, merged
+        production = _api_request('GET', _config_path(url, None, config_id), token)
+        assert production['configuration'] == {'parameters': {'query': 'SELECT 2'}}
+        _wait_until_branch_gone(mr_project, branch_id)
+    finally:
+        _delete_branch(url, token, branch_id)
+        _delete_config(url, token, config_id)

--- a/integtests/tools/test_merge_requests.py
+++ b/integtests/tools/test_merge_requests.py
@@ -59,7 +59,7 @@ def _wait_for_storage_job(base_url: str, token: str, job_id: str, timeout: int =
         job = _api_request('GET', f'{base_url}/v2/storage/jobs/{job_id}', token)
         if job.get('status') == 'success':
             return job
-        if job.get('status') in ('error', 'cancelled'):
+        if job.get('status') in ('error', 'warning', 'terminated', 'cancelled', 'canceled'):
             raise RuntimeError(f'Storage job {job_id} failed: {job}')
         time.sleep(2)
     raise TimeoutError(f'Storage job {job_id} did not complete within {timeout}s')

--- a/integtests/tools/test_merge_requests.py
+++ b/integtests/tools/test_merge_requests.py
@@ -33,7 +33,9 @@ from keboola_mcp_server.tools.merge_requests.tools import (
     get_merge_request_conflicts,
     get_merge_requests,
     merge_merge_request,
+    request_merge_request_review,
     resolve_merge_request_conflict,
+    update_merge_request,
 )
 from keboola_mcp_server.workspace import WorkspaceManager
 
@@ -218,6 +220,16 @@ async def test_happy_path_create_then_merge(
         assert created.status.mergeable is True
         assert 'merge_merge_request' in created.status.next_step
 
+        updated = await update_merge_request(
+            branch_context, merge_request_id=created.id, description='updated by integtest'
+        )
+        assert (updated.id, updated.description, updated.title) == (created.id, 'updated by integtest', created.title)
+
+        # 0 required approvals: request-review lands straight in `approved` and the changeLog gets populated
+        reviewed = await request_merge_request_review(branch_context)
+        assert reviewed.state == 'approved'
+        assert {c.configuration_id for c in reviewed.changed_configurations} == {config_id}
+
         merged = await merge_merge_request(branch_context)
         assert merged.merged is True, merged
         assert merged.state == 'published'
@@ -242,8 +254,9 @@ async def test_conflict_is_reported_and_resolved(mocker, mr_project: MergeReques
     # A conflict needs the configuration on both sides, so it must exist in production BEFORE the branch is
     # created (a development branch is a copy of production at creation time).
     config_id = _create_config(url, token, None, f'integtest-conflict-{uuid.uuid4().hex[:6]}', {'query': 'SELECT 1'})
-    branch_id = _create_branch(url, token, f'integtest-mr-conflict-{uuid.uuid4().hex[:8]}')
+    branch_id: str | None = None
     try:
+        branch_id = _create_branch(url, token, f'integtest-mr-conflict-{uuid.uuid4().hex[:8]}')
         ctx = await _build_context(mocker, mr_project, branch_id=branch_id)
         _update_config(url, token, branch_id, config_id, {'query': 'SELECT 2'}, 'branch change')
         _update_config(url, token, None, config_id, {'query': 'SELECT 3'}, 'production change')
@@ -277,5 +290,6 @@ async def test_conflict_is_reported_and_resolved(mocker, mr_project: MergeReques
         assert production['configuration'] == {'parameters': {'query': 'SELECT 2'}}
         _wait_until_branch_gone(mr_project, branch_id)
     finally:
-        _delete_branch(url, token, branch_id)
+        if branch_id is not None:
+            _delete_branch(url, token, branch_id)
         _delete_config(url, token, config_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "1.80.1"
+version = "1.81.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -154,6 +154,7 @@ pass_env = [
     "INTEGTEST_STORAGE_TOKEN_PRJ2",
     "INTEGTEST_WORKSPACE_SCHEMA_PRJ2",
     "INTEGTEST_STORAGE_TOKEN_STORAGE_BRANCHES",
+    "INTEGTEST_STORAGE_TOKEN_MERGE_REQUESTS",
     "INTEGTEST_LOCK_TTL_MINUTES",
     "INTEGTEST_LOCK_POLL_INTERVAL_SECONDS",
     "INTEGTEST_LOCK_MAX_WAIT_MINUTES",

--- a/src/keboola_mcp_server/clients/storage.py
+++ b/src/keboola_mcp_server/clients/storage.py
@@ -21,7 +21,7 @@ ComponentResource = Literal['configuration', 'rows', 'state']
 StorageEventType = Literal['info', 'success', 'warn', 'error']
 
 # Project features that can be checked with the is_enabled method
-ProjectFeature = Literal['global-search', 'storage-branches']
+ProjectFeature = Literal['global-search', 'storage-branches', 'branches-merge-requests']
 
 ItemType = Literal[
     'flow',
@@ -904,6 +904,105 @@ class AsyncStorageClient(KeboolaServiceClient):
         :return: Job details as dictionary
         """
         return cast(JsonDict, await self.get(endpoint=f'jobs/{job_id}'))  # TODO: no branch support
+
+    # ---- Merge requests -----------------------------------------------------------------------------
+    # Project-level endpoints (`isAvailableInBranch: false`): the paths are never branch-prefixed.
+
+    async def merge_requests_list(self) -> list[JsonDict]:
+        """Lists all merge requests of the project (the endpoint takes no filters)."""
+        return cast(list[JsonDict], await self.get(endpoint='merge-request'))
+
+    async def merge_request_detail(
+        self, merge_request_id: int | str, *, include_activity_log: bool = False
+    ) -> JsonDict:
+        """
+        Retrieves a merge request. The response carries `changeLog`; `activityLog` only when requested.
+
+        :param merge_request_id: The merge request id
+        :param include_activity_log: Whether to include the `activityLog` list in the response
+        """
+        params = {'include': 'activityLog'} if include_activity_log else None
+        return cast(JsonDict, await self.get(endpoint=f'merge-request/{merge_request_id}', params=params))
+
+    async def merge_request_conflicts(self, merge_request_id: int | str) -> list[JsonDict]:
+        """Returns the live list of conflicting configurations of a merge request (empty when mergeable)."""
+        return cast(list[JsonDict], await self.get(endpoint=f'merge-request/{merge_request_id}/conflicts'))
+
+    async def merge_request_create(
+        self,
+        *,
+        branch_from_id: int | str,
+        branch_into_id: int | str,
+        title: str,
+        description: str | None = None,
+        reviewer_ids: Sequence[int] = (),
+        auto_merge_strategy: str = 'none',
+        auto_merge_at: str | None = None,
+    ) -> JsonDict:
+        """Creates a merge request from a development branch into the default branch."""
+        payload: JsonDict = {
+            'branchFromId': int(branch_from_id),
+            'branchIntoId': int(branch_into_id),
+            'title': title,
+            'autoMergeStrategy': auto_merge_strategy,
+        }
+        if description is not None:
+            payload['description'] = description
+        if reviewer_ids:
+            payload['reviewerIds'] = list(reviewer_ids)
+        if auto_merge_at is not None:
+            payload['autoMergeAt'] = auto_merge_at
+        return cast(JsonDict, await self.post(endpoint='merge-request', data=payload))
+
+    async def merge_request_update(self, merge_request_id: int | str, payload: JsonDict) -> JsonDict:
+        """
+        Updates a merge request. Only the keys present in `payload` are changed
+        (`title`, `description`, `reviewerIds`, `autoMergeStrategy`, `autoMergeAt`).
+        """
+        return cast(JsonDict, await self.put(endpoint=f'merge-request/{merge_request_id}', data=payload))
+
+    async def merge_request_request_review(self, merge_request_id: int | str) -> JsonDict:
+        """Sends the merge request for review (`development` -> `in_review`, or `approved` when 0 approvals are required)."""
+        return cast(JsonDict, await self.put(endpoint=f'merge-request/{merge_request_id}/request-review'))
+
+    async def merge_request_approve(self, merge_request_id: int | str) -> JsonDict:
+        """Adds the caller's approval (valid only in `in_review`)."""
+        return cast(JsonDict, await self.put(endpoint=f'merge-request/{merge_request_id}/approve'))
+
+    async def merge_request_request_changes(self, merge_request_id: int | str, reason: str | None = None) -> JsonDict:
+        """Sends the merge request back to `development`; the optional reason lands in the activity log."""
+        payload: JsonDict | None = {'reason': reason} if reason is not None else None
+        return cast(
+            JsonDict, await self.put(endpoint=f'merge-request/{merge_request_id}/request-changes', data=payload)
+        )
+
+    async def merge_request_merge(self, merge_request_id: int | str) -> JsonDict:
+        """
+        Starts the merge; returns the Storage job (`{id, ...}`) to await. On a 409 the raised
+        `httpx.HTTPStatusError` carries the body with `code`, `error` and (for conflicts) `params.errors`.
+        """
+        return cast(JsonDict, await self.put(endpoint=f'merge-request/{merge_request_id}/merge'))
+
+    # Branch-scoped endpoints of the conflict-resolution flow (the current session branch).
+
+    async def configuration_diff(self, component_id: str, configuration_id: str) -> JsonDict:
+        """
+        Returns the three-way diff `{base, ours, theirs}` of a configuration on the current branch
+        against the default branch; each side is `{version, isDeleted, diff: {...}}` or null.
+        """
+        endpoint = f'branch/{self._branch_id}/components/{component_id}/configs/{configuration_id}/diff'
+        return cast(JsonDict, await self.get(endpoint=endpoint))
+
+    async def configuration_rebase(
+        self, component_id: str, configuration_id: str, *, version: int, diff: JsonDict
+    ) -> JsonDict:
+        """
+        Re-anchors the branch configuration onto default-branch `version` with the resolved content `diff`
+        (`{name, description, changeDescription, isDisabled, configuration, rows}`); an empty `diff` ({})
+        is the delete resolution. The wire envelope is always exactly `{version, diff}`.
+        """
+        endpoint = f'branch/{self._branch_id}/components/{component_id}/configs/{configuration_id}/rebase'
+        return cast(JsonDict, await self.post(endpoint=endpoint, data={'version': version, 'diff': diff}))
 
     async def global_search(
         self,

--- a/src/keboola_mcp_server/generate_tool_docs.py
+++ b/src/keboola_mcp_server/generate_tool_docs.py
@@ -14,7 +14,7 @@ from mcp.types import ToolAnnotations
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
 from keboola_mcp_server.server import create_server
 from keboola_mcp_server.tools.components.tools import COMPONENT_TOOLS_TAG
-from keboola_mcp_server.tools.constants import FLOW_TOOLS_TAG
+from keboola_mcp_server.tools.constants import FLOW_TOOLS_TAG, MERGE_REQUEST_TOOLS_TAG
 from keboola_mcp_server.tools.doc import DOC_TOOLS_TAG
 from keboola_mcp_server.tools.jobs import JOB_TOOLS_TAG
 from keboola_mcp_server.tools.oauth import OAUTH_TOOLS_TAG
@@ -187,6 +187,7 @@ async def generate_docs() -> None:
             ToolCategory('Component Tools', COMPONENT_TOOLS_TAG),
             ToolCategory('Flow Tools', FLOW_TOOLS_TAG),
             ToolCategory('Jobs Tools', JOB_TOOLS_TAG),
+            ToolCategory('Merge Request Tools', MERGE_REQUEST_TOOLS_TAG),
             ToolCategory('Documentation Tools', DOC_TOOLS_TAG),
             ToolCategory('Search Tools', SEARCH_TOOLS_TAG),
             ToolCategory('Semantic Tools', SEMANTIC_TOOLS_TAG),

--- a/src/keboola_mcp_server/links.py
+++ b/src/keboola_mcp_server/links.py
@@ -99,6 +99,13 @@ class ProjectLinksManager:
         return []
 
     # --- Project ---
+    def get_merge_request_link(self, branch_from_id: str | int, title: str) -> Link:
+        """The Keboola UI page of a merge request: its source branch's development overview."""
+        return Link.detail(
+            title=f'Merge request: {title}' if title else 'Merge request',
+            url=self._url(f'branch/{branch_from_id}/development-overview'),
+        )
+
     def get_project_detail_link(self) -> Link:
         return Link.detail(title='Project Dashboard', url=self._url(''))
 

--- a/src/keboola_mcp_server/links.py
+++ b/src/keboola_mcp_server/links.py
@@ -101,10 +101,11 @@ class ProjectLinksManager:
     # --- Project ---
     def get_merge_request_link(self, branch_from_id: str | int, title: str) -> Link:
         """The Keboola UI page of a merge request: its source branch's development overview."""
-        return Link.detail(
-            title=f'Merge request: {title}' if title else 'Merge request',
-            url=self._url(f'branch/{branch_from_id}/development-overview'),
+        # Built without the manager's session-branch prefix: the page lives on the MR's own source branch.
+        url = '/'.join(
+            [self._base_url, 'admin/projects', self._project_id, 'branch', str(branch_from_id), 'development-overview']
         )
+        return Link.detail(title=f'Merge request: {title}' if title else 'Merge request', url=url)
 
     def get_project_detail_link(self) -> Link:
         return Link.detail(title='Project Dashboard', url=self._url(''))

--- a/src/keboola_mcp_server/mcp.py
+++ b/src/keboola_mcp_server/mcp.py
@@ -53,6 +53,10 @@ from keboola_mcp_server.session_store.kai_scope import KaiScopeStore
 from keboola_mcp_server.session_store.repository import SessionStore
 from keboola_mcp_server.tools.constants import (
     BOOTSTRAP_TOOLS,
+    MERGE_REQUEST_BRANCH_ONLY_MESSAGE,
+    MERGE_REQUEST_BRANCH_ONLY_TOOLS,
+    MERGE_REQUEST_TOOL_NAMES,
+    MERGE_REQUESTS_FEATURE,
     MODIFY_FLOW_TOOL_NAME,
     SEMANTIC_TOOLS_TAG,
     UPDATE_FLOW_TOOL_NAME,
@@ -61,6 +65,9 @@ from keboola_mcp_server.workspace import WorkspaceManager
 
 LOG = logging.getLogger(__name__)
 CONVERSATION_ID = 'conversation_id'
+# Session-state key under which ToolsFilteringMiddleware.on_call_tool stores the `verify_token` result of the
+# current call, so tool bodies (merge requests: role, admin id, project id) can read it without a second call.
+TOKEN_INFO_STATE_KEY = 'token_info'
 
 R = TypeVar('R')
 T = TypeVar('T')
@@ -1015,6 +1022,14 @@ class ToolsFilteringMiddleware(fmw.Middleware):
             # Filter out data app tools when the client is not using the main/production branch
             tools = [t for t in tools if t.name not in DATA_APP_BRANCH_GATED_TOOLS]
 
+        # Merge-request tools: hidden when the project lacks the feature; the writes hidden for roles that cannot
+        # use them. The branch-only tools stay visible on production on purpose (call-time denial only) so the
+        # model keeps their descriptions and can hand the user off to a development-branch session.
+        if MERGE_REQUESTS_FEATURE not in features:
+            tools = [t for t in tools if t.name not in MERGE_REQUEST_TOOL_NAMES]
+        elif not (token_role in ('admin', 'share') or is_oauth):
+            tools = [t for t in tools if t.name not in MERGE_REQUEST_TOOL_NAMES or is_read_only_tool(t)]
+
         if token_role == 'readonly':
             tools = [t for t in tools if is_read_only_tool(t)]
             LOG.debug(f'Read-only access: filtered to {len(tools)} read-only tools for role={token_role}')
@@ -1094,6 +1109,22 @@ class ToolsFilteringMiddleware(fmw.Middleware):
         if tool_name in DATA_APP_BRANCH_GATED_TOOLS and not is_main_branch:
             return 'Data apps are supported only in the main production branch.'
 
+        if tool_name in MERGE_REQUEST_TOOL_NAMES:
+            # Three axes (RFC feature_spec/branches_merge_requests_mcp): feature, role (+ OAuth carve-out as for
+            # the flow tools above), and session branch. Reads are open to every role.
+            if MERGE_REQUESTS_FEATURE not in features:
+                return (
+                    f'The tool "{tool_name}" is not available in this project. Merge requests require the '
+                    f'"{MERGE_REQUESTS_FEATURE}" project feature; ask Keboola support to enable it.'
+                )
+            if not is_read_only and token_role not in ('admin', 'share') and not is_oauth:
+                return (
+                    f'The tool "{tool_name}" is not available for your role ({token_role or "unknown"}). '
+                    'Only project admins (role "admin" or "share") can modify merge requests.'
+                )
+            if is_main_branch and tool_name in MERGE_REQUEST_BRANCH_ONLY_TOOLS:
+                return MERGE_REQUEST_BRANCH_ONLY_MESSAGE
+
         return None
 
     async def on_call_tool(
@@ -1112,6 +1143,7 @@ class ToolsFilteringMiddleware(fmw.Middleware):
             return await call_next(context)
 
         token_info = await self.get_token_info(context.fastmcp_context)
+        context.fastmcp_context.session.state[TOKEN_INFO_STATE_KEY] = token_info
 
         has_semantic_models = False
         if is_semantic_tool(tool):

--- a/src/keboola_mcp_server/multiproject.py
+++ b/src/keboola_mcp_server/multiproject.py
@@ -33,7 +33,9 @@ _NO_FANOUT_TOOLS = {'get_accessible_projects', 'set_project_scope'}
 # project_id argument to say which -- same single-target resolution/swap as a write tool, just
 # without the write semantics. get_project_info resolves through the active project's
 # WorkspaceManager (workspace id / sql dialect), so it can only ever report one project at a time.
-_SINGLE_TARGET_READ_TOOLS = {'get_project_info'}
+# Merge requests are project-specific ids and the conflict tool is bound to the session branch: neither can be
+# fanned out across projects, so both target one project like a write tool does.
+_SINGLE_TARGET_READ_TOOLS = {'get_project_info', 'get_merge_requests', 'get_merge_request_conflicts'}
 
 # Optional per-call argument injected on fan-out-eligible read tools to restrict a single call to a
 # subset of the scoped projects (consumed and stripped by MultiProjectMiddleware.on_call_tool).

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -31,6 +31,7 @@ from keboola_mcp_server.tools.data_apps import add_data_app_tools
 from keboola_mcp_server.tools.doc import add_doc_tools
 from keboola_mcp_server.tools.flow.tools import add_flow_tools
 from keboola_mcp_server.tools.jobs import add_job_tools
+from keboola_mcp_server.tools.merge_requests.tools import add_merge_request_tools
 from keboola_mcp_server.tools.oauth import add_oauth_tools
 from keboola_mcp_server.tools.project import add_project_tools
 from keboola_mcp_server.tools.search import add_search_tools
@@ -307,6 +308,7 @@ def create_server(
     add_doc_tools(mcp)
     add_flow_tools(mcp)
     add_job_tools(mcp)
+    add_merge_request_tools(mcp)
     add_oauth_tools(mcp)
     add_project_tools(mcp)
     add_search_tools(mcp)

--- a/src/keboola_mcp_server/tools/constants.py
+++ b/src/keboola_mcp_server/tools/constants.py
@@ -12,3 +12,36 @@ CONFIG_DIFF_PREVIEW_TAG = 'config-diff-preview'
 
 # Tag for semantic layer tools
 SEMANTIC_TOOLS_TAG = 'semantic'
+
+# Merge-request (Branches 2.0, non-SOX) tools. The tag drives TOOLS.md categorization and list-time
+# filtering; the name sets are the call-time gating rules in mcp.py's `authorize_tool_call` (which
+# receives a tool *name*, not a Tool). Keep them in sync with `tools/merge_requests/tools.py`.
+MERGE_REQUEST_TOOLS_TAG = 'merge-request'
+MERGE_REQUESTS_FEATURE = 'branches-merge-requests'
+MERGE_REQUEST_TOOL_NAMES = {
+    'get_merge_requests',
+    'create_merge_request',
+    'update_merge_request',
+    'request_merge_request_review',
+    'approve_merge_request',
+    'request_merge_request_changes',
+    'merge_merge_request',
+    'get_merge_request_conflicts',
+    'resolve_merge_request_conflict',
+}
+# Tools that touch or promote branch content: usable only from a development-branch session. They stay
+# visible on production (their descriptions state the constraint) and are denied at call time only.
+MERGE_REQUEST_BRANCH_ONLY_TOOLS = {
+    'create_merge_request',
+    'request_merge_request_review',
+    'merge_merge_request',
+    'get_merge_request_conflicts',
+    'resolve_merge_request_conflict',
+}
+# The call-time denial for MERGE_REQUEST_BRANCH_ONLY_TOOLS on a production session. Deliberately
+# branch-agnostic: `authorize_tool_call` has no branch name in scope; the named handoff ("open a session on
+# branch 'reporting'") comes from the read tools' `next_step`, where `branch_from_name` is known.
+MERGE_REQUEST_BRANCH_ONLY_MESSAGE = (
+    'This tool runs only from a development-branch session. Tell the user to open a session on the merge '
+    "request's source branch and ask again there."
+)

--- a/src/keboola_mcp_server/tools/merge_requests/__init__.py
+++ b/src/keboola_mcp_server/tools/merge_requests/__init__.py
@@ -1,0 +1,1 @@
+"""Merge-request tools (Keboola Branches 2.0, non-SOX flow)."""

--- a/src/keboola_mcp_server/tools/merge_requests/conflicts.py
+++ b/src/keboola_mcp_server/tools/merge_requests/conflicts.py
@@ -61,6 +61,14 @@ def _content(side: Mapping[str, Any] | None) -> dict[str, Any]:
     return {key: envelope[key] for key in DIFF_CONTENT_KEYS if key in envelope}
 
 
+def _ids(items: list[Any]) -> dict[str, Any] | None:
+    """`{id: item}` when every item is a dict with a unique `id` (configuration rows), else None."""
+    if not items or not all(isinstance(item, dict) and item.get('id') is not None for item in items):
+        return None
+    by_id = {str(item['id']): item for item in items}
+    return by_id if len(by_id) == len(items) else None
+
+
 def _walk(old: Any, new: Any, path: str, out: dict[str, tuple[Any, Any]]) -> None:
     """Records changed leaf paths (JSON pointers) between two JSON values into `out` as `(old, new)`
     where a missing side is `_ABSENT`. Dicts and lists recurse; anything else compares by value."""
@@ -75,6 +83,19 @@ def _walk(old: Any, new: Any, path: str, out: dict[str, tuple[Any, Any]]) -> Non
                 out[sub] = (_ABSENT, new[key])
         return
     if isinstance(old, list) and isinstance(new, list):
+        if _ids(old) is not None and _ids(new) is not None:
+            # Rows carry ids: align by id so an insertion does not shift every following row into a "change".
+            old_by_id, new_by_id = _ids(old), _ids(new)
+            assert old_by_id is not None and new_by_id is not None
+            for key in sorted(set(old_by_id) | set(new_by_id)):
+                sub = f'{path}/{key}'
+                if key in old_by_id and key in new_by_id:
+                    _walk(old_by_id[key], new_by_id[key], sub, out)
+                elif key in old_by_id:
+                    out[sub] = (old_by_id[key], _ABSENT)
+                else:
+                    out[sub] = (_ABSENT, new_by_id[key])
+            return
         for i in range(max(len(old), len(new))):
             sub = f'{path}/{i}'
             if i < len(old) and i < len(new):
@@ -129,6 +150,21 @@ def classify_three_way(diff: Mapping[str, Any]) -> list[PathChange]:
     return changes
 
 
+def conflicting_paths(changes: list[PathChange]) -> list[str]:
+    """
+    Paths the two sides changed differently: `both` rows that are not agreed, plus one-sided rows where one side
+    changed a subtree and the other side a path inside it (an ancestor/descendant collision is a conflict too).
+    """
+    result = {c.path for c in changes if c.changed_by == 'both' and not c.agreed}
+    ours = [c.path for c in changes if c.changed_by == 'ours']
+    theirs = [c.path for c in changes if c.changed_by == 'theirs']
+    for a in ours:
+        for b in theirs:
+            if a.startswith(b + '/') or b.startswith(a + '/'):
+                result.update((a, b))
+    return sorted(result)
+
+
 def suggest_take(changes: list[PathChange]) -> TakeMode | None:
     """`ours`/`theirs` when only that side changed anything; None when paths collide or `changes` is empty."""
     if not changes:
@@ -156,6 +192,6 @@ def build_config_conflict(ref: ConflictRef, diff: Mapping[str, Any]) -> ConfigCo
         ours_deleted=bool(ours_raw.get('isDeleted', False)) if ours_raw is not None else None,
         theirs_deleted=bool(theirs_raw.get('isDeleted', False)) if theirs_raw is not None else None,
         changes=changes,
-        conflicting_paths=[c.path for c in changes if c.changed_by == 'both' and not c.agreed],
+        conflicting_paths=conflicting_paths(changes),
         suggested_take=suggest_take(changes),
     )

--- a/src/keboola_mcp_server/tools/merge_requests/conflicts.py
+++ b/src/keboola_mcp_server/tools/merge_requests/conflicts.py
@@ -1,0 +1,161 @@
+"""Per-path classification of a conflicting configuration's three-way diff.
+
+Pure functions, a port of the kbagent CLI's `_classify_three_way` / `_envelope_holes` / `_diff_warnings`
+(`merge_request_service.py`). A side that is absent, `isDeleted` or key-incomplete produces no path rows at
+all (`changes=[]`) — fabricating rows against an empty stand-in would contradict the side flags.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+from keboola_mcp_server.tools.merge_requests.models import (
+    ConfigConflict,
+    ConfigVersionSnapshot,
+    ConflictRef,
+    PathChange,
+    TakeMode,
+)
+
+# Content-bearing keys of a diff side's `diff` envelope. `changeDescription` is excluded: it is a per-version
+# commit message, not content to resolve.
+DIFF_CONTENT_KEYS: tuple[str, ...] = ('name', 'description', 'configuration', 'isDisabled', 'rows')
+# The keys the backend's rebase requires (`description` is genuinely nullable and may be absent on the wire).
+REQUIRED_CONTENT_KEYS: tuple[str, ...] = ('name', 'rows', 'configuration', 'isDisabled')
+
+_ABSENT = object()
+
+
+def envelope_holes(side: Mapping[str, Any]) -> list[str]:
+    """Required content keys absent from a (non-null, non-deleted) side's envelope."""
+    envelope = side.get('diff') or {}
+    return [key for key in REQUIRED_CONTENT_KEYS if key not in envelope]
+
+
+def diff_warnings(diff: Mapping[str, Any]) -> list[str]:
+    """Explains why a side yielded no classification: an empty or holed envelope is a backend contract violation."""
+    warnings: list[str] = []
+    for label in ('ours', 'theirs'):
+        side = diff.get(label)
+        if side is None or side.get('isDeleted'):
+            continue
+        holes = envelope_holes(side)
+        if not holes:
+            continue
+        what = (
+            'has an empty content envelope'
+            if holes == list(REQUIRED_CONTENT_KEYS)
+            else f'carries no {", ".join(holes)}'
+        )
+        warnings.append(
+            f"The diff's {label} side {what}; no per-path classification is possible (backend envelope hole)."
+        )
+    return warnings
+
+
+def _classifiable(side: Mapping[str, Any] | None) -> bool:
+    return side is not None and not side.get('isDeleted') and not envelope_holes(side)
+
+
+def _content(side: Mapping[str, Any] | None) -> dict[str, Any]:
+    envelope = (side or {}).get('diff') or {}
+    return {key: envelope[key] for key in DIFF_CONTENT_KEYS if key in envelope}
+
+
+def _walk(old: Any, new: Any, path: str, out: dict[str, tuple[Any, Any]]) -> None:
+    """Records changed leaf paths (JSON pointers) between two JSON values into `out` as `(old, new)`
+    where a missing side is `_ABSENT`. Dicts and lists recurse; anything else compares by value."""
+    if isinstance(old, dict) and isinstance(new, dict):
+        for key in sorted(set(old) | set(new)):
+            sub = f'{path}/{key}'
+            if key in old and key in new:
+                _walk(old[key], new[key], sub, out)
+            elif key in old:
+                out[sub] = (old[key], _ABSENT)
+            else:
+                out[sub] = (_ABSENT, new[key])
+        return
+    if isinstance(old, list) and isinstance(new, list):
+        for i in range(max(len(old), len(new))):
+            sub = f'{path}/{i}'
+            if i < len(old) and i < len(new):
+                _walk(old[i], new[i], sub, out)
+            elif i < len(old):
+                out[sub] = (old[i], _ABSENT)
+            else:
+                out[sub] = (_ABSENT, new[i])
+        return
+    if old != new:
+        out[path] = (old, new)
+
+
+def classify_three_way(diff: Mapping[str, Any]) -> list[PathChange]:
+    """
+    Intersects the two pairwise diffs (base→ours, base→theirs) per JSON-pointer path. Covers all replaced
+    keys: `/name`, `/description`, `/isDisabled` as top-level pseudo-paths, `/configuration/...` and
+    `/rows/...` structurally. Returns `[]` when either side is not classifiable.
+    """
+    if not _classifiable(diff.get('ours')) or not _classifiable(diff.get('theirs')):
+        return []
+
+    base = _content(diff.get('base'))
+    ours: dict[str, tuple[Any, Any]] = {}
+    theirs: dict[str, tuple[Any, Any]] = {}
+    _walk(base, _content(diff.get('ours')), '', ours)
+    _walk(base, _content(diff.get('theirs')), '', theirs)
+
+    def present(value: Any) -> Any:
+        return None if value is _ABSENT else value
+
+    changes: list[PathChange] = []
+    for path in sorted(set(ours) | set(theirs)):
+        o = ours.get(path)
+        t = theirs.get(path)
+        reference = o or t
+        assert reference is not None
+        base_value = present(reference[0])
+        ours_value = present(o[1]) if o is not None else base_value
+        theirs_value = present(t[1]) if t is not None else base_value
+        if o is not None and t is not None:
+            changed_by = 'both'
+            agreed: bool | None = (o[1] is _ABSENT) == (t[1] is _ABSENT) and ours_value == theirs_value
+        else:
+            changed_by = 'ours' if o is not None else 'theirs'
+            agreed = None
+        changes.append(
+            PathChange(
+                path=path, changed_by=changed_by, agreed=agreed, base=base_value, ours=ours_value, theirs=theirs_value
+            )
+        )
+    return changes
+
+
+def suggest_take(changes: list[PathChange]) -> TakeMode | None:
+    """`ours`/`theirs` when only that side changed anything; None when paths collide or `changes` is empty."""
+    if not changes:
+        return None
+    sides = {c.changed_by for c in changes}
+    if 'both' in sides:
+        return None
+    if sides == {'ours'}:
+        return 'ours'
+    if sides == {'theirs'}:
+        return 'theirs'
+    return None
+
+
+def build_config_conflict(ref: ConflictRef, diff: Mapping[str, Any]) -> ConfigConflict:
+    """Combines a conflict reference with its three-way diff into everything needed to resolve it."""
+    ours_raw = diff.get('ours')
+    theirs_raw = diff.get('theirs')
+    changes = classify_three_way(diff)
+    return ConfigConflict(
+        **ref.model_dump(),
+        base=ConfigVersionSnapshot.from_api(diff.get('base')),
+        ours=ConfigVersionSnapshot.from_api(ours_raw),
+        theirs=ConfigVersionSnapshot.from_api(theirs_raw),
+        ours_deleted=bool(ours_raw.get('isDeleted', False)) if ours_raw is not None else None,
+        theirs_deleted=bool(theirs_raw.get('isDeleted', False)) if theirs_raw is not None else None,
+        changes=changes,
+        conflicting_paths=[c.path for c in changes if c.changed_by == 'both' and not c.agreed],
+        suggested_take=suggest_take(changes),
+    )

--- a/src/keboola_mcp_server/tools/merge_requests/models.py
+++ b/src/keboola_mcp_server/tools/merge_requests/models.py
@@ -1,0 +1,355 @@
+"""Result models of the merge-request tools.
+
+`MergeRequest`, `Reviewer`, `ActivityEvent`, `ConflictRef` and `ConfigVersionSnapshot` map 1:1 onto the
+Connection responses (`MergeRequestResponse`, the `/conflicts` action, `ConfigurationDiffResponse`).
+`DerivedStatus`, `PathChange` and `suggested_take` have no backend counterpart today; they are computed
+by this server exactly as the kbagent CLI computes them (see `status.py` / `conflicts.py`) and will be
+read server-first once Connection serializes them (DMD-1988).
+"""
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, StrictBool, field_validator
+
+from keboola_mcp_server.links import Link
+
+MergeRequestState = Literal['development', 'in_review', 'approved', 'in_merge', 'published', 'canceled']
+DerivedState = Literal['rejected', 'closed', 'in_development', 'in_review', 'approved', 'in_merge', 'merged']
+MergeRequestStateFilter = Literal[
+    'development',
+    'in_review',
+    'approved',
+    'in_merge',
+    'published',
+    'canceled',
+    'rejected',
+    'closed',
+    'in_development',
+    'merged',
+]
+MergeBlocker = Literal['conflicts', 'approvals', 'state']
+AllowedAction = Literal['request_review', 'approve', 'request_changes', 'merge', 'update', 'resolve_conflicts']
+AutoMergeStrategy = Literal['none', 'immediately', 'scheduled']
+ReviewerStatus = Literal['approved', 'rejected', 'pending']
+TakeMode = Literal['ours', 'theirs', 'delete']
+ChangedBy = Literal['ours', 'theirs', 'both']
+MergeRefusal = Literal['conflicts', 'not_ready']
+ResolutionMode = Literal['ours', 'theirs', 'delete', 'custom']
+
+
+def _opt_str(value: Any) -> str | None:
+    """Normalizes the API's `''` to `None`."""
+    if value is None:
+        return None
+    text = str(value)
+    return text if text.strip() else None
+
+
+class Reviewer(BaseModel):
+    id: int = Field(description="The reviewer's Keboola user id.")
+    name: str = Field(description="The reviewer's name.")
+    status: ReviewerStatus = Field(
+        description="The reviewer's decision in the current review round; 'pending' when none."
+    )
+
+    @classmethod
+    def from_api(cls, raw: Mapping[str, Any]) -> 'Reviewer':
+        return cls(id=int(raw['id']), name=str(raw.get('name') or ''), status=raw.get('status') or 'pending')
+
+
+class Viewer(BaseModel):
+    """The caller's relation to the merge request."""
+
+    is_creator: bool | None = Field(
+        description='True when the caller created the MR; None when the identity is unknown.'
+    )
+    has_approved: bool | None = Field(
+        description='True when the caller already approved the MR; None when the identity is unknown.'
+    )
+
+
+class ConflictRef(BaseModel):
+    """One conflicting configuration, exactly as `GET /merge-request/{id}/conflicts` (and the merge 409) reports it."""
+
+    component_id: str = Field(description='The component id of the conflicting configuration.')
+    configuration_id: str = Field(description='The configuration id.')
+    message: str = Field(description="The backend's description of the conflict.")
+    is_deleted: bool = Field(description='True when the configuration is deleted on the development branch.')
+    dev_branch_version_identifier: str = Field(
+        description='The version identifier the development branch was created from (evidence only).'
+    )
+    default_branch_version_identifier: str = Field(
+        description="The default branch's current version identifier (evidence only)."
+    )
+
+    @classmethod
+    def from_api(cls, raw: Mapping[str, Any]) -> 'ConflictRef':
+        return cls(
+            component_id=str(raw.get('componentId') or ''),
+            configuration_id=str(raw.get('configurationId') or ''),
+            message=str(raw.get('message') or ''),
+            is_deleted=bool(raw.get('isDeleted', False)),
+            dev_branch_version_identifier=str(raw.get('devBranchVersionIdentifier') or ''),
+            default_branch_version_identifier=str(raw.get('defaultBranchVersionIdentifier') or ''),
+        )
+
+    @property
+    def label(self) -> str:
+        return f'{self.component_id}/{self.configuration_id}'
+
+
+class DerivedStatus(BaseModel):
+    """What the merge request is waiting on and what to do next. Server-first polyfill for DMD-1988."""
+
+    state: MergeRequestState = Field(description='The raw lifecycle state reported by the API.')
+    derived_state: DerivedState = Field(description='The client-facing state (what the Keboola UI badge shows).')
+    merge_blockers: list[MergeBlocker] = Field(
+        description="Everything currently blocking a merge; informational, the backend's merge check is the authority."
+    )
+    mergeable: bool | None = Field(
+        description='True when nothing blocks the merge and conflicts were checked; None when conflicts were not fetched.'
+    )
+    allowed_actions: list[AllowedAction] = Field(description='Actions the current state permits (state-only).')
+    viewer: Viewer = Field(description="The caller's relation to the merge request.")
+    approved_by: list[str] = Field(description='Names of the users who approved.')
+    pending_reviewers: list[str] = Field(description='Names of the requested reviewers who have not approved yet.')
+    conflicts: list[ConflictRef] | None = Field(
+        description='The live list of conflicting configurations when fetched; None when not fetched.'
+    )
+    next_step: str = Field(description='The single recommended next action, in one sentence.')
+
+
+class ChangedConfig(BaseModel):
+    component_id: str = Field(description='The component id.')
+    configuration_id: str = Field(description='The configuration id.')
+    is_deleted: bool = Field(description='True when the merge request deletes this configuration.')
+
+    @classmethod
+    def list_from_change_log(cls, change_log: Any) -> list['ChangedConfig']:
+        """Parses `changeLog.configurations` defensively: a missing or malformed key yields `[]`."""
+        if not isinstance(change_log, Mapping):
+            return []
+        configurations = change_log.get('configurations')
+        if not isinstance(configurations, list):
+            return []
+        result: list[ChangedConfig] = []
+        for item in configurations:
+            if not isinstance(item, Mapping):
+                continue
+            result.append(
+                cls(
+                    component_id=str(item.get('componentId') or ''),
+                    configuration_id=str(item.get('configurationId') or ''),
+                    is_deleted=bool(item.get('isDeleted', False)),
+                )
+            )
+        return result
+
+
+class ActivityEvent(BaseModel):
+    event_type: str = Field(description="The event type, e.g. 'review_requested', 'approved', 'changes_requested'.")
+    admin_name: str | None = Field(description='Who did it; None for system events (e.g. auto-merge).')
+    note: str | None = Field(description='The note attached to the event, e.g. the reason for requesting changes.')
+    created_at: str = Field(description='When the event happened.')
+
+    @classmethod
+    def from_api(cls, raw: Mapping[str, Any]) -> 'ActivityEvent':
+        admin = raw.get('admin')
+        return cls(
+            event_type=str(raw.get('eventType') or ''),
+            admin_name=str(admin['name']) if isinstance(admin, Mapping) and admin.get('name') else None,
+            note=_opt_str(raw.get('note')),
+            created_at=str(raw.get('createdAt') or ''),
+        )
+
+
+class MergeRequest(BaseModel):
+    """A merge request summary (list rows)."""
+
+    id: int = Field(description='The merge request id.')
+    title: str = Field(description='The title.')
+    description: str | None = Field(description='The description.')
+    state: MergeRequestState = Field(description='The raw lifecycle state reported by the API.')
+    derived_state: DerivedState = Field(description='The client-facing state (what the Keboola UI badge shows).')
+    branch_from_id: int | None = Field(description='The source development branch id; None once the branch is deleted.')
+    branch_from_name: str | None = Field(description='The source development branch name.')
+    branch_into_name: str = Field(description='The target branch name (the production/default branch).')
+    creator_name: str = Field(description='Who created the merge request.')
+    reviewers: list[Reviewer] = Field(description='The requested reviewers and their decisions.')
+    auto_merge: AutoMergeStrategy = Field(
+        description="Auto-merge strategy: 'none' (off), 'immediately' (merge once approved), 'scheduled' (at auto_merge_at)."
+    )
+    auto_merge_at: str | None = Field(description="When a 'scheduled' auto-merge runs.")
+    created_at: str = Field(description='When the merge request was created.')
+    merged_at: str | None = Field(description='When it was merged; None until then.')
+    merged_by: str | None = Field(description='Who merged it (the system for auto-merges); None until merged.')
+    links: list[Link] = Field(description='Keboola UI links.')
+
+    @classmethod
+    def from_api(cls, raw: Mapping[str, Any], *, branch_names: Mapping[str, str], links: list[Link]) -> 'MergeRequest':
+        from keboola_mcp_server.tools.merge_requests.status import derive_state
+
+        branches = raw.get('branches') or {}
+        branch_from_id = branches.get('branchFromId')
+        branch_into_id = branches.get('branchIntoId')
+        merge = raw.get('merge') or {}
+        creator = raw.get('creator') or {}
+        return cls(
+            id=int(raw['id']),
+            title=str(raw.get('title') or ''),
+            description=_opt_str(raw.get('description')),
+            state=raw.get('state'),
+            derived_state=derive_state(raw),
+            branch_from_id=int(branch_from_id) if branch_from_id is not None else None,
+            branch_from_name=branch_names.get(str(branch_from_id)) if branch_from_id is not None else None,
+            branch_into_name=branch_names.get(str(branch_into_id), 'production')
+            if branch_into_id is not None
+            else 'production',
+            creator_name=str(creator.get('name') or ''),
+            reviewers=[Reviewer.from_api(r) for r in raw.get('reviewers') or []],
+            auto_merge=raw.get('autoMergeStrategy') or 'none',
+            auto_merge_at=_opt_str(raw.get('autoMergeAt')),
+            created_at=str(raw.get('createdAt') or ''),
+            merged_at=_opt_str(merge.get('mergedAt')),
+            merged_by=_opt_str(merge.get('mergerName')),
+            links=links,
+        )
+
+
+class MergeRequestDetail(MergeRequest):
+    status: DerivedStatus = Field(description='What the merge request is waiting on and what to do next.')
+    changed_configurations: list[ChangedConfig] = Field(
+        description='Configurations the merge request changes; empty until a review is requested or the MR is merged.'
+    )
+    activity_log: list[ActivityEvent] | None = Field(
+        description='The review history (oldest first); None when the tool did not fetch it.'
+    )
+
+
+class MergeRequestsListOutput(BaseModel):
+    merge_requests: list[MergeRequest] = Field(description='The merge requests of the project.')
+    links: list[Link] = Field(description='Keboola UI links.')
+
+
+class MergeRequestsDetailOutput(BaseModel):
+    merge_requests: list[MergeRequestDetail] = Field(description='The requested merge requests with their status.')
+
+
+class ConfigVersionSnapshot(BaseModel):
+    """One side of a three-way configuration diff (`ConfigurationVersionResponse` with its `diff` flattened in)."""
+
+    version: int = Field(description='The configuration version on that branch.')
+    is_deleted: bool = Field(description='True when the configuration is deleted in this version.')
+    name: str | None = Field(description='The configuration name.')
+    description: str | None = Field(description='The configuration description.')
+    change_description: str | None = Field(description="This version's change description.")
+    is_disabled: bool = Field(description='Whether the configuration is disabled.')
+    configuration: dict[str, Any] = Field(description='The configuration content.')
+    rows: list[dict[str, Any]] = Field(description='The configuration rows (complete set).')
+
+    @classmethod
+    def from_api(cls, raw: Mapping[str, Any] | None) -> 'ConfigVersionSnapshot | None':
+        if raw is None:
+            return None
+        diff = raw.get('diff') or {}
+        return cls(
+            version=int(raw.get('version') or 0),
+            is_deleted=bool(raw.get('isDeleted', False)),
+            name=diff.get('name'),
+            description=diff.get('description'),
+            change_description=diff.get('changeDescription'),
+            is_disabled=bool(diff.get('isDisabled', False)),
+            configuration=diff.get('configuration') if isinstance(diff.get('configuration'), dict) else {},
+            rows=list(diff.get('rows') or []),
+        )
+
+
+class PathChange(BaseModel):
+    """A change to one path of the configuration, classified by who made it."""
+
+    path: str = Field(
+        description="The changed path: '/name', '/description', '/isDisabled', or '/configuration/...', '/rows/...'."
+    )
+    changed_by: ChangedBy = Field(
+        description="'ours' = development branch, 'theirs' = production, 'both' = both sides."
+    )
+    agreed: bool | None = Field(description="On 'both' rows: True when both sides made the same change.")
+    base: Any | None = Field(description='The value the development branch started from.')
+    ours: Any | None = Field(description='The value on the development branch.')
+    theirs: Any | None = Field(description='The value on production.')
+
+
+class ConfigConflict(ConflictRef):
+    """One conflicting configuration with everything needed to resolve it."""
+
+    base: ConfigVersionSnapshot | None = Field(description='The version the development branch started from.')
+    ours: ConfigVersionSnapshot | None = Field(description="The development branch's current version.")
+    theirs: ConfigVersionSnapshot | None = Field(
+        description="Production's current version (a rebase re-anchors onto it)."
+    )
+    ours_deleted: bool | None = Field(description='True when the development branch deleted it; None when absent.')
+    theirs_deleted: bool | None = Field(description='True when production deleted it; None when absent.')
+    changes: list[PathChange] = Field(
+        description='Per-path changes of both sides; empty when either side is deleted or absent.'
+    )
+    conflicting_paths: list[str] = Field(description='Paths both sides changed differently: the actual conflict.')
+    suggested_take: TakeMode | None = Field(
+        description="'ours'/'theirs' when only that side changed anything; None when the user has to decide."
+    )
+
+
+class MergeRequestConflictsOutput(BaseModel):
+    merge_request_id: int = Field(description='The merge request id.')
+    conflicts: list[ConfigConflict] = Field(description='The conflicting configurations; empty when nothing blocks.')
+    status: DerivedStatus = Field(description='The merge request status.')
+    next_step: str = Field(description='The single recommended next action.')
+
+
+class MergeResult(BaseModel):
+    merge_request_id: int = Field(description='The merge request id.')
+    merged: bool = Field(description='True when the merge finished successfully.')
+    state: MergeRequestState = Field(description='The merge request state after the call.')
+    job_id: str | None = Field(description='The Storage job that performed the merge.')
+    refusal: MergeRefusal | None = Field(
+        description="Why the backend refused: 'conflicts' or 'not_ready' (lock, wrong state, missing approvals)."
+    )
+    refusal_message: str | None = Field(description="The backend's message.")
+    conflicts: list[ConflictRef] | None = Field(description='The conflicting configurations on a conflict refusal.')
+    status: DerivedStatus | None = Field(description='The merge request status when the merge did not happen.')
+    source_branch_deleting: bool = Field(
+        description='True after a successful merge: the source branch is being deleted by a background job.'
+    )
+    warnings: list[str] = Field(description='Soft failures that did not prevent the merge.')
+    next_step: str = Field(description='The single recommended next action.')
+
+
+class ResolvedConfiguration(BaseModel):
+    """The manually merged configuration content. Every key is required because a rebase REPLACES the version."""
+
+    name: str = Field(description='The configuration name (non-empty).')
+    description: str | None = Field(
+        description='The configuration description (null to clear, but the key is required).'
+    )
+    is_disabled: StrictBool = Field(description='Whether the configuration is disabled (a JSON boolean).')
+    configuration: dict[str, Any] = Field(description='The complete configuration content.')
+    rows: list[dict[str, Any]] = Field(description='The complete row set; an empty list deletes all rows.')
+
+    @field_validator('name')
+    @classmethod
+    def _name_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError('name must be a non-empty string')
+        return value
+
+
+class ResolveConflictResult(BaseModel):
+    component_id: str = Field(description='The component id.')
+    configuration_id: str = Field(description='The configuration id.')
+    resolved: bool = Field(description='True when the configuration was rebased.')
+    mode: ResolutionMode = Field(description="How it was resolved: 'ours', 'theirs', 'delete' or 'custom'.")
+    rebased_onto_version: int = Field(description='The production version the configuration is now anchored onto.')
+    remaining_conflicts: list[ConflictRef] = Field(description='Conflicts still blocking the merge; empty = mergeable.')
+    status: DerivedStatus = Field(description='The merge request status.')
+    warnings: list[str] = Field(description='Soft issues, e.g. an ignored change description on delete.')
+    next_step: str = Field(description='The single recommended next action.')

--- a/src/keboola_mcp_server/tools/merge_requests/status.py
+++ b/src/keboola_mcp_server/tools/merge_requests/status.py
@@ -188,6 +188,7 @@ def build_next_step(
     branch_from_name: str | None,
     remaining_conflicts: Sequence[ConflictRef] | None = None,
     last_refusal: LastRefusal | None = None,
+    refusal_message: str | None = None,
     rejection_reason: str | None = None,
 ) -> str:
     """The 15-row decision table (RFC "next_step — the deterministic guide"); the first matching row wins."""
@@ -208,6 +209,13 @@ def build_next_step(
     if remaining_conflicts:  # 4
         first = remaining_conflicts[0]
         return f'Resolve the next conflict: {first.label} ({len(remaining_conflicts)} left).'
+    if last_refusal == 'conflicts' and 'conflicts' not in merge_blockers:  # 5/6 without a usable conflict list
+        if not session.on_mr_branch:
+            return f'Conflicts must be resolved from a session on {branch}; open one and call get_merge_request_conflicts there.'
+        return (
+            'The merge was refused because of conflicts; call get_merge_request_conflicts to see them and resolve them '
+            'one by one with resolve_merge_request_conflict.'
+        )
     if 'conflicts' in merge_blockers:
         n = len(conflicts) if conflicts is not None else 0
         noun = 'conflict' if n == 1 else 'conflicts'
@@ -226,8 +234,17 @@ def build_next_step(
         if session.can_write:  # 9
             return 'Approve it (approve_merge_request) or request changes (request_merge_request_changes).'
         return "Waiting for a reviewer's approval."  # 10
-    if last_refusal == 'not_ready' and state == 'development':  # 11
-        return 'This project requires approvals before a merge; request a review (request_merge_request_review).'
+    if last_refusal == 'not_ready':  # 11
+        backend = f' Backend: {refusal_message}' if refusal_message else ''
+        if state == 'development':
+            return (
+                'This project requires approvals before a merge; request a review (request_merge_request_review).'
+                + backend
+            )
+        return (
+            'The merge was refused as not ready (a merge lock is held or another merge request is being processed); '
+            'wait for it to clear, then merge again.' + backend
+        )
     if derived_state == 'rejected':  # 12
         reason = f' ({rejection_reason})' if rejection_reason else ''
         return f'Changes were requested{reason}; address them on the branch, then merge again.'
@@ -248,6 +265,7 @@ def build_status(
     branch_from_name: str | None,
     remaining_conflicts: Sequence[ConflictRef] | None = None,
     last_refusal: LastRefusal | None = None,
+    refusal_message: str | None = None,
 ) -> DerivedStatus:
     """Assembles the derived status of a raw MR payload plus the (optionally fetched) live conflicts."""
     state = mr.get('state') or 'development'
@@ -257,7 +275,9 @@ def build_status(
     viewer = derive_viewer(mr, admin_id)
     pending = pending_reviewers(mr)
     mergeable: bool | None
-    if conflicts is None:
+    if last_refusal is not None:
+        mergeable = False  # the backend just refused the merge; that beats any local derivation
+    elif conflicts is None:
         mergeable = None
     else:
         mergeable = not blockers
@@ -283,6 +303,7 @@ def build_status(
             branch_from_name=branch_from_name,
             remaining_conflicts=remaining_conflicts,
             last_refusal=last_refusal,
+            refusal_message=refusal_message,
             rejection_reason=request_changes_reason(mr),
         ),
     )

--- a/src/keboola_mcp_server/tools/merge_requests/status.py
+++ b/src/keboola_mcp_server/tools/merge_requests/status.py
@@ -1,0 +1,288 @@
+"""Derived merge-request status and the deterministic `next_step` guide.
+
+Pure functions, no I/O. This is a port of the kbagent CLI's Layer 2 tables (`merge_request_service.py`)
+so the two clients cannot disagree. Every derivation is *server-first*: it prefers the serialized field
+when Connection ships it (`derivedState`, `mergeBlockers`, `allowedActions`, `viewer`; DMD-1988,
+https://linear.app/keboola/issue/DMD-1988) and falls back to the local table below. Delete the fallbacks
+when the backend serializes the fields.
+"""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from keboola_mcp_server.tools.merge_requests.models import (
+    AllowedAction,
+    ConflictRef,
+    DerivedState,
+    DerivedStatus,
+    MergeBlocker,
+    Viewer,
+)
+
+_DERIVED_STATE_BY_RAW: dict[str, DerivedState] = {
+    'development': 'in_development',
+    'in_review': 'in_review',
+    'approved': 'approved',
+    'in_merge': 'in_merge',
+    'published': 'merged',
+    'canceled': 'closed',
+}
+
+_ALLOWED_ACTIONS_BY_STATE: dict[str, tuple[AllowedAction, ...]] = {
+    'development': ('request_review', 'merge', 'update', 'resolve_conflicts'),
+    'in_review': ('approve', 'request_changes', 'update', 'resolve_conflicts'),
+    'approved': ('request_changes', 'merge', 'update', 'resolve_conflicts'),
+    'in_merge': ('update',),
+    'published': (),
+    'canceled': (),
+}
+
+_ALLOWED_ACTIONS: frozenset[str] = frozenset(
+    {'request_review', 'approve', 'request_changes', 'merge', 'update', 'resolve_conflicts'}
+)
+_BLOCKERS: frozenset[str] = frozenset({'conflicts', 'approvals', 'state'})
+_DERIVED_STATES: frozenset[str] = frozenset(_DERIVED_STATE_BY_RAW.values()) | {'rejected'}
+
+
+def same_id(a: Any, b: Any) -> bool:
+    """Compares two ids that may arrive as int or str (`approverId` is a string, `creator.id` an int)."""
+    return a is not None and b is not None and str(a) == str(b)
+
+
+def _creator_id(mr: Mapping[str, Any]) -> Any:
+    return (mr.get('creator') or {}).get('id')
+
+
+def derive_state(mr: Mapping[str, Any]) -> DerivedState:
+    """
+    The client-facing state: the UI list badge's decision table, evaluated in order.
+
+    - `rejected`: `development` + a non-creator reviewer with `status=rejected`
+    - `closed`: `canceled`, or `development` + the creator's own rejection (the UI "cancel" trick)
+    - otherwise the raw state mapped through `_DERIVED_STATE_BY_RAW`
+
+    `reviewers[].status` is populated only inside a review round anchored by a real `request_review` event,
+    so with the non-SOX default of 0 approvals the first two rows never fire — the UI badge has the same
+    blind spot, and DMD-1988 asks the backend to derive from the activity log instead.
+    """
+    server = mr.get('derivedState')
+    if isinstance(server, str) and server in _DERIVED_STATES:
+        return server  # type: ignore[return-value]
+
+    state = mr.get('state') or ''
+    creator_id = _creator_id(mr)
+    non_creator_rejected = False
+    creator_self_rejected = False
+    for reviewer in mr.get('reviewers') or []:
+        if reviewer.get('status') != 'rejected':
+            continue
+        if same_id(reviewer.get('id'), creator_id):
+            creator_self_rejected = True
+        else:
+            non_creator_rejected = True
+
+    if state == 'development' and non_creator_rejected:
+        return 'rejected'
+    if state == 'canceled' or (state == 'development' and creator_self_rejected):
+        return 'closed'
+    return _DERIVED_STATE_BY_RAW.get(state, 'in_development')
+
+
+def derive_merge_blockers(mr: Mapping[str, Any], conflicts: Sequence[Any] | None) -> list[MergeBlocker]:
+    """
+    What currently blocks `merge`, as a list so concurrent blockers do not mask each other. Never `None`.
+
+    - `conflicts`: the live conflicts list is non-empty; `conflicts=None` (not fetched) skips only this check
+    - `approvals`: `state == in_review` (the state collapses the requirement; no count until DMD-1969)
+    - `state`: `in_merge` / `published` / `canceled`
+    """
+    server = mr.get('mergeBlockers')
+    if isinstance(server, list):
+        return [b for b in server if b in _BLOCKERS]  # type: ignore[misc]
+
+    state = mr.get('state') or ''
+    blockers: list[MergeBlocker] = []
+    if conflicts:
+        blockers.append('conflicts')
+    if state == 'in_review':
+        blockers.append('approvals')
+    if state in ('in_merge', 'published', 'canceled'):
+        blockers.append('state')
+    return blockers
+
+
+def derive_allowed_actions(mr: Mapping[str, Any]) -> list[AllowedAction]:
+    """Actions the state machine mechanically allows; state-only, an unknown state yields `[]`."""
+    server = mr.get('allowedActions')
+    if isinstance(server, list):
+        return [a for a in server if a in _ALLOWED_ACTIONS]  # type: ignore[misc]
+    return list(_ALLOWED_ACTIONS_BY_STATE.get(mr.get('state') or '', ()))
+
+
+def _server_viewer(mr: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """The single predicate for "DMD-1988 landed" on the viewer block."""
+    server = mr.get('viewer')
+    if isinstance(server, Mapping) and ('isCreator' in server or 'hasApproved' in server):
+        return server
+    return None
+
+
+def derive_viewer(mr: Mapping[str, Any], admin_id: Any) -> Viewer:
+    """
+    The caller's relation to the MR. `admin_id` comes from `verify_token`'s `admin.id`; when it is `None`
+    (an OAuth or scoped token) both flags are `None` — an honest "unknown", never `False`.
+    """
+    server = _server_viewer(mr)
+    if server is not None:
+        return Viewer(is_creator=server.get('isCreator'), has_approved=server.get('hasApproved'))
+    if admin_id is None:
+        return Viewer(is_creator=None, has_approved=None)
+    return Viewer(
+        is_creator=same_id(_creator_id(mr), admin_id),
+        has_approved=any(same_id(a.get('approverId'), admin_id) for a in mr.get('approvals') or []),
+    )
+
+
+def approved_by(mr: Mapping[str, Any]) -> list[str]:
+    return [str(a.get('approverName') or a.get('approverId') or '') for a in mr.get('approvals') or []]
+
+
+def pending_reviewers(mr: Mapping[str, Any]) -> list[str]:
+    return [str(r.get('name') or r.get('id') or '') for r in mr.get('reviewers') or [] if r.get('status') != 'approved']
+
+
+def request_changes_reason(mr: Mapping[str, Any]) -> str | None:
+    """The note of the latest `changes_requested` activity event, when the activity log was fetched."""
+    log = mr.get('activityLog')
+    if not isinstance(log, list):
+        return None
+    for event in reversed(log):
+        if isinstance(event, Mapping) and event.get('eventType') == 'changes_requested':
+            note = event.get('note')
+            return str(note) if note else None
+    return None
+
+
+@dataclass(frozen=True)
+class SessionContext:
+    """Session facts `next_step` needs: is this a session on the MR's source branch, and may the caller write."""
+
+    on_mr_branch: bool
+    can_write: bool
+
+
+LastRefusal = Literal['conflicts', 'not_ready']
+
+
+def build_next_step(
+    *,
+    state: str,
+    derived_state: str,
+    merge_blockers: Sequence[str],
+    conflicts: Sequence[ConflictRef] | None,
+    allowed_actions: Sequence[str],
+    viewer: Viewer,
+    pending: Sequence[str],
+    session: SessionContext,
+    branch_from_name: str | None,
+    remaining_conflicts: Sequence[ConflictRef] | None = None,
+    last_refusal: LastRefusal | None = None,
+    rejection_reason: str | None = None,
+) -> str:
+    """The 15-row decision table (RFC "next_step — the deterministic guide"); the first matching row wins."""
+    branch = f"branch '{branch_from_name}'" if branch_from_name else "the merge request's source branch"
+
+    if derived_state == 'merged':  # 1
+        return (
+            'Done: the changes are in production and the source branch is being deleted. '
+            'Open a session on the production branch to continue.'
+        )
+    if derived_state == 'closed':  # 2
+        return 'Nothing to do: the merge request is closed.'
+    if derived_state == 'in_merge':  # 3
+        return (
+            'A merge is running. Do not edit this branch until it finishes (edits made now are lost when the '
+            'branch is deleted) and do not start a second merge.'
+        )
+    if remaining_conflicts:  # 4
+        first = remaining_conflicts[0]
+        return f'Resolve the next conflict: {first.label} ({len(remaining_conflicts)} left).'
+    if 'conflicts' in merge_blockers:
+        n = len(conflicts) if conflicts is not None else 0
+        noun = 'conflict' if n == 1 else 'conflicts'
+        if not session.on_mr_branch:  # 5
+            return f'Conflicts must be resolved from a session on {branch}; open one and call get_merge_request_conflicts there.'
+        return (  # 6
+            f'{n} {noun} block the merge; call get_merge_request_conflicts and resolve them one by one '
+            'with resolve_merge_request_conflict.'
+        )
+    if 'approvals' in merge_blockers:
+        names = ', '.join(pending) if pending else 'the requested reviewers'
+        if viewer.has_approved is True:  # 7
+            return f'You already approved; wait for the other reviewers ({names}).'
+        if viewer.is_creator is True:  # 8
+            return f'Waiting for approval from {names}; you cannot approve your own merge request.'
+        if session.can_write:  # 9
+            return 'Approve it (approve_merge_request) or request changes (request_merge_request_changes).'
+        return "Waiting for a reviewer's approval."  # 10
+    if last_refusal == 'not_ready' and state == 'development':  # 11
+        return 'This project requires approvals before a merge; request a review (request_merge_request_review).'
+    if derived_state == 'rejected':  # 12
+        reason = f' ({rejection_reason})' if rejection_reason else ''
+        return f'Changes were requested{reason}; address them on the branch, then merge again.'
+    if 'merge' in allowed_actions:
+        if not session.on_mr_branch:  # 13
+            return f'Ready to merge; open a session on {branch} and call merge_merge_request there.'
+        if session.can_write:  # 14
+            return 'Ready: merge it with merge_merge_request (irreversible; the source branch is deleted afterwards).'
+    return 'Show the merge request (read-only).'  # 15
+
+
+def build_status(
+    mr: Mapping[str, Any],
+    *,
+    conflicts: Sequence[ConflictRef] | None,
+    admin_id: Any,
+    session: SessionContext,
+    branch_from_name: str | None,
+    remaining_conflicts: Sequence[ConflictRef] | None = None,
+    last_refusal: LastRefusal | None = None,
+) -> DerivedStatus:
+    """Assembles the derived status of a raw MR payload plus the (optionally fetched) live conflicts."""
+    state = mr.get('state') or 'development'
+    derived_state = derive_state(mr)
+    blockers = derive_merge_blockers(mr, conflicts)
+    allowed = derive_allowed_actions(mr)
+    viewer = derive_viewer(mr, admin_id)
+    pending = pending_reviewers(mr)
+    mergeable: bool | None
+    if conflicts is None:
+        mergeable = None
+    else:
+        mergeable = not blockers
+    return DerivedStatus(
+        state=state,
+        derived_state=derived_state,
+        merge_blockers=blockers,
+        mergeable=mergeable,
+        allowed_actions=allowed,
+        viewer=viewer,
+        approved_by=approved_by(mr),
+        pending_reviewers=pending,
+        conflicts=list(conflicts) if conflicts is not None else None,
+        next_step=build_next_step(
+            state=state,
+            derived_state=derived_state,
+            merge_blockers=blockers,
+            conflicts=conflicts,
+            allowed_actions=allowed,
+            viewer=viewer,
+            pending=pending,
+            session=session,
+            branch_from_name=branch_from_name,
+            remaining_conflicts=remaining_conflicts,
+            last_refusal=last_refusal,
+            rejection_reason=request_changes_reason(mr),
+        ),
+    )

--- a/src/keboola_mcp_server/tools/merge_requests/tools.py
+++ b/src/keboola_mcp_server/tools/merge_requests/tools.py
@@ -68,12 +68,14 @@ LOG = logging.getLogger(__name__)
 
 MERGE_CONFLICT_CODE = 'storage.mergeRequests.validation'
 MERGE_NOT_READY_CODE = 'storage.mergeRequests.notReadyToMerge'
-STORAGE_JOB_TERMINAL_STATUSES = frozenset({'success', 'error'})
+# Storage job statuses after which the job never changes again (same set as workspace.py's poller).
+STORAGE_JOB_TERMINAL_STATUSES = frozenset({'success', 'error', 'warning', 'terminated', 'cancelled', 'canceled'})
 MERGE_JOB_TIMEOUT_SEC = 600.0
 MERGE_JOB_POLL_INTERVAL_SEC = 1.0
 
 ROLE_DENIED_MESSAGE = (
-    'Your project role does not permit this merge-request action; a project admin (role "admin" or "share") must do it.'
+    'Your project role may not permit this merge-request action (a project admin with role "admin" or "share" can '
+    'do it), or the merge request is no longer open.'
 )
 BRANCH_ONLY_SENTENCE = (
     "Available only from a development-branch session; on production, tell the user to open a session on the "
@@ -126,6 +128,8 @@ class _MrContext:
     def can_write(self) -> bool:
         admin = self.token_info.get('admin')
         role = str(admin.get('role') or '').lower() if isinstance(admin, Mapping) else ''
+        if role == 'readonly' or getattr(self.client, 'readonly', False) is True:
+            return False
         return role in ('admin', 'share') or bool(self.client.bearer_token)
 
     @property
@@ -199,7 +203,10 @@ def _error_body(exc: httpx.HTTPStatusError) -> dict[str, Any]:
 def _map_write_error(exc: httpx.HTTPStatusError) -> ToolError | None:
     """Every MR write maps the backend's 403 onto one clear message; other statuses are left to the caller."""
     if exc.response.status_code == 403:
-        return ToolError(ROLE_DENIED_MESSAGE)
+        body = _error_body(exc)
+        error = body.get('error') or body.get('message')
+        detail = f'The backend refused it: {error} ' if error else ''
+        return ToolError(f'{detail}{ROLE_DENIED_MESSAGE}')
     return None
 
 
@@ -311,9 +318,11 @@ def _validate_resolved(resolved: Mapping[str, Any]) -> ResolvedConfiguration:
 
 def _job_error_message(job: Mapping[str, Any]) -> str:
     error = job.get('error')
-    if isinstance(error, Mapping):
-        return str(error.get('message') or error)
-    return str(error or 'The merge job failed.')
+    if isinstance(error, Mapping) and error.get('message'):
+        return str(error['message'])
+    if error:
+        return str(error)
+    return f"The merge job ended with status '{job.get('status')}'."
 
 
 # ---- Read / diagnosis — any session, any role ------------------------------------------------------------
@@ -335,6 +344,7 @@ async def get_merge_requests(
             )
         ),
     ] = None,
+    project_id: ProjectIdArg = None,
 ) -> MergeRequestsListOutput | MergeRequestsDetailOutput:
     """
     Lists the project's merge requests, or returns the full detail of the given ones.
@@ -482,10 +492,8 @@ async def update_merge_request(
     try:
         mr = await c.client.storage_client.merge_request_update(merge_request_id, payload)
     except httpx.HTTPStatusError as exc:
-        if _map_write_error(exc) is not None:
-            raise ToolError(
-                f'{ROLE_DENIED_MESSAGE} (If the merge request is already merged or canceled, it can no longer be updated.)'
-            ) from exc
+        if mapped := _map_write_error(exc):
+            raise mapped from exc
         raise
     return await _detail_with_conflicts(c, mr, with_activity_log=False)
 
@@ -636,6 +644,10 @@ async def merge_merge_request(
             refusal = 'conflicts'
             params = body.get('params')
             conflicts = _parse_conflicts(params.get('errors') if isinstance(params, Mapping) else None)
+            if not conflicts:
+                # A conflict 409 without a usable `params.errors` (older stack, proxy body): fetch the live list so
+                # the status never claims "mergeable" right after the backend refused the merge.
+                conflicts = _parse_conflicts(await c.client.storage_client.merge_request_conflicts(mr_id))
         else:
             raise
         status = build_status(
@@ -645,6 +657,7 @@ async def merge_merge_request(
             session=session,
             branch_from_name=branch_name,
             last_refusal=refusal,
+            refusal_message=message,
         )
         return MergeResult(
             merge_request_id=mr_id,
@@ -738,6 +751,7 @@ async def get_merge_request_conflicts(
         int | None,
         Field(description="The merge request id. Omit to use the current branch's merge request."),
     ] = None,
+    project_id: ProjectIdArg = None,
 ) -> MergeRequestConflictsOutput:
     """
     Shows what blocks the current branch's merge request from merging: each conflicting configuration with its
@@ -855,8 +869,14 @@ async def resolve_merge_request_conflict(
         body, mode = {}, 'delete'
     else:
         side = diff.get('ours') if take == 'ours' else theirs
-        if not isinstance(side, Mapping) or side.get('isDeleted'):
-            body, mode = {}, 'delete'  # taking a deleted (or never-existing) side IS the delete resolution
+        if not isinstance(side, Mapping):
+            # An absent side is not a deletion: never turn it into a tombstone behind the user's back.
+            raise ToolError(
+                f"The diff has no {take} side: the configuration does not exist on that branch. "
+                "Use take='delete' to delete it explicitly, or pass the content as `resolved`."
+            )
+        if side.get('isDeleted'):
+            body, mode = {}, 'delete'  # taking a deleted side IS the delete resolution
         else:
             holes = envelope_holes(side)
             envelope = side.get('diff') or {}

--- a/src/keboola_mcp_server/tools/merge_requests/tools.py
+++ b/src/keboola_mcp_server/tools/merge_requests/tools.py
@@ -1,0 +1,912 @@
+"""Merge-request tools: the Keboola Branches 2.0 (non-SOX) promotion flow for a development branch.
+
+Read and review-state tools work from any session. Tools that touch or promote branch content (create,
+request review, merge, conflicts, resolve) run only from a development-branch session; the middleware
+denies them on production (see `ToolsFilteringMiddleware.authorize_tool_call`), and their descriptions
+say so up front so the model can hand the user off.
+"""
+
+import asyncio
+import logging
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Annotated, Any
+
+import httpx
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import FunctionTool
+from mcp.types import ToolAnnotations
+from pydantic import Field, ValidationError
+
+from keboola_mcp_server.clients.base import JsonDict
+from keboola_mcp_server.clients.client import KeboolaClient
+from keboola_mcp_server.errors import tool_errors
+from keboola_mcp_server.links import Link, ProjectLinksManager
+from keboola_mcp_server.mcp import (
+    TOKEN_INFO_STATE_KEY,
+    KeboolaMcpServer,
+    process_concurrently,
+    toon_serializer_compact,
+    unwrap_results,
+)
+from keboola_mcp_server.scope import ProjectIdArg
+from keboola_mcp_server.tools.constants import MERGE_REQUEST_BRANCH_ONLY_MESSAGE, MERGE_REQUEST_TOOLS_TAG
+from keboola_mcp_server.tools.merge_requests.conflicts import (
+    DIFF_CONTENT_KEYS,
+    build_config_conflict,
+    diff_warnings,
+    envelope_holes,
+)
+from keboola_mcp_server.tools.merge_requests.models import (
+    ActivityEvent,
+    AutoMergeStrategy,
+    ChangedConfig,
+    ConfigConflict,
+    ConflictRef,
+    MergeRequest,
+    MergeRequestConflictsOutput,
+    MergeRequestDetail,
+    MergeRequestsDetailOutput,
+    MergeRequestsListOutput,
+    MergeRequestStateFilter,
+    MergeResult,
+    ResolveConflictResult,
+    ResolvedConfiguration,
+    TakeMode,
+)
+from keboola_mcp_server.tools.merge_requests.status import (
+    LastRefusal,
+    SessionContext,
+    build_next_step,
+    build_status,
+    same_id,
+)
+
+LOG = logging.getLogger(__name__)
+
+MERGE_CONFLICT_CODE = 'storage.mergeRequests.validation'
+MERGE_NOT_READY_CODE = 'storage.mergeRequests.notReadyToMerge'
+STORAGE_JOB_TERMINAL_STATUSES = frozenset({'success', 'error'})
+MERGE_JOB_TIMEOUT_SEC = 600.0
+MERGE_JOB_POLL_INTERVAL_SEC = 1.0
+
+ROLE_DENIED_MESSAGE = (
+    'Your project role does not permit this merge-request action; a project admin (role "admin" or "share") must do it.'
+)
+BRANCH_ONLY_SENTENCE = (
+    "Available only from a development-branch session; on production, tell the user to open a session on the "
+    "merge request's source branch and ask again there."
+)
+
+
+def add_merge_request_tools(mcp: KeboolaMcpServer) -> None:
+    """Add merge-request tools to the MCP server."""
+    read_only = ToolAnnotations(readOnlyHint=True)
+    destructive = ToolAnnotations(destructiveHint=True)
+    write = ToolAnnotations(destructiveHint=False)
+    for fn, annotations in (
+        (get_merge_requests, read_only),
+        (create_merge_request, destructive),
+        (update_merge_request, destructive),
+        (request_merge_request_review, write),
+        (approve_merge_request, write),
+        (request_merge_request_changes, write),
+        (merge_merge_request, destructive),
+        (get_merge_request_conflicts, read_only),
+        (resolve_merge_request_conflict, write),
+    ):
+        mcp.add_tool(
+            FunctionTool.from_function(
+                fn, annotations=annotations, serializer=toon_serializer_compact, tags={MERGE_REQUEST_TOOLS_TAG}
+            )
+        )
+    LOG.info('Merge-request tools added to the MCP server.')
+
+
+# ---- shared plumbing --------------------------------------------------------------------------------------
+
+
+@dataclass
+class _MrContext:
+    """Everything a merge-request tool needs besides the MR itself, loaded once per call."""
+
+    client: KeboolaClient
+    token_info: Mapping[str, Any]
+    branches: list[JsonDict]
+    links: ProjectLinksManager
+
+    @property
+    def admin_id(self) -> Any:
+        admin = self.token_info.get('admin')
+        return admin.get('id') if isinstance(admin, Mapping) else None
+
+    @property
+    def can_write(self) -> bool:
+        admin = self.token_info.get('admin')
+        role = str(admin.get('role') or '').lower() if isinstance(admin, Mapping) else ''
+        return role in ('admin', 'share') or bool(self.client.bearer_token)
+
+    @property
+    def branch_names(self) -> dict[str, str]:
+        return {str(b['id']): str(b.get('name') or b['id']) for b in self.branches if 'id' in b}
+
+    @property
+    def default_branch(self) -> JsonDict:
+        for branch in self.branches:
+            if branch.get('isDefault'):
+                return branch
+        raise ToolError('The project has no default branch; cannot resolve the merge target.')
+
+    @property
+    def session_branch(self) -> JsonDict | None:
+        """The session's development branch, or None on the production branch."""
+        if self.client.branch_id is None:
+            return None
+        for branch in self.branches:
+            if same_id(branch.get('id'), self.client.branch_id):
+                return branch
+        raise ToolError(f'Branch "{self.client.branch_id}" not found in the project; it may have been deleted.')
+
+    def session(self, mr: Mapping[str, Any]) -> SessionContext:
+        branch_from_id = (mr.get('branches') or {}).get('branchFromId')
+        on_mr_branch = self.client.branch_id is not None and same_id(branch_from_id, self.client.branch_id)
+        return SessionContext(on_mr_branch=on_mr_branch, can_write=self.can_write)
+
+    def branch_from_name(self, mr: Mapping[str, Any]) -> str | None:
+        branch_from_id = (mr.get('branches') or {}).get('branchFromId')
+        return self.branch_names.get(str(branch_from_id)) if branch_from_id is not None else None
+
+    def mr_links(self, mr: Mapping[str, Any]) -> list[Link]:
+        branch_from_id = (mr.get('branches') or {}).get('branchFromId')
+        if branch_from_id is None:
+            return []
+        return [self.links.get_merge_request_link(branch_from_id, str(mr.get('title') or ''))]
+
+
+async def resolve_branch_pair(client: KeboolaClient) -> tuple[JsonDict | None, JsonDict]:
+    """
+    One `branches_list` call resolving both the session branch (None on production) and the default branch.
+    Unlike `tools.project._resolve_branch_context`, it returns the default branch even while on a dev branch.
+    """
+    ctx = _MrContext(client=client, token_info={}, branches=await client.storage_client.branches_list(), links=None)  # type: ignore[arg-type]
+    return ctx.session_branch, ctx.default_branch
+
+
+async def _load(ctx: Context) -> _MrContext:
+    client = KeboolaClient.from_state(ctx.session.state)
+    token_info = ctx.session.state.get(TOKEN_INFO_STATE_KEY) if hasattr(ctx.session.state, 'get') else None
+    if not isinstance(token_info, Mapping):
+        # Not called through ToolsFilteringMiddleware (which caches the verification for this call).
+        token_info = await client.storage_client.verify_token()
+    branches = await client.storage_client.branches_list()
+    owner = token_info.get('owner')
+    project_id = str(owner.get('id')) if isinstance(owner, Mapping) else await client.storage_client.project_id()
+    # Project-level links (no session-branch prefix): a merge request lives on its own source branch.
+    links = ProjectLinksManager(base_url=client.storage_api_url, project_id=project_id, branch_id=None)
+    return _MrContext(client=client, token_info=token_info, branches=branches, links=links)
+
+
+def _error_body(exc: httpx.HTTPStatusError) -> dict[str, Any]:
+    try:
+        body = exc.response.json()
+    except ValueError:
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
+def _map_write_error(exc: httpx.HTTPStatusError) -> ToolError | None:
+    """Every MR write maps the backend's 403 onto one clear message; other statuses are left to the caller."""
+    if exc.response.status_code == 403:
+        return ToolError(ROLE_DENIED_MESSAGE)
+    return None
+
+
+def _parse_conflicts(raw: Any) -> list[ConflictRef]:
+    if not isinstance(raw, list):
+        return []
+    return [ConflictRef.from_api(item) for item in raw if isinstance(item, Mapping)]
+
+
+def _build_detail(
+    c: _MrContext,
+    mr: Mapping[str, Any],
+    *,
+    conflicts: Sequence[ConflictRef] | None,
+    with_activity_log: bool,
+    last_refusal: LastRefusal | None = None,
+) -> MergeRequestDetail:
+    summary = MergeRequest.from_api(mr, branch_names=c.branch_names, links=c.mr_links(mr))
+    activity_log = mr.get('activityLog')
+    return MergeRequestDetail(
+        **summary.model_dump(),
+        status=build_status(
+            mr,
+            conflicts=conflicts,
+            admin_id=c.admin_id,
+            session=c.session(mr),
+            branch_from_name=c.branch_from_name(mr),
+            last_refusal=last_refusal,
+        ),
+        changed_configurations=ChangedConfig.list_from_change_log(mr.get('changeLog')),
+        activity_log=(
+            [ActivityEvent.from_api(e) for e in activity_log if isinstance(e, Mapping)]
+            if with_activity_log and isinstance(activity_log, list)
+            else None
+        ),
+    )
+
+
+async def _detail_with_conflicts(
+    c: _MrContext, mr: Mapping[str, Any], *, with_activity_log: bool
+) -> MergeRequestDetail:
+    conflicts = _parse_conflicts(await c.client.storage_client.merge_request_conflicts(mr['id']))
+    return _build_detail(c, mr, conflicts=conflicts, with_activity_log=with_activity_log)
+
+
+async def _resolve_branch_mr(
+    c: _MrContext, merge_request_id: int | None, *, include_activity_log: bool = False
+) -> JsonDict:
+    """
+    The MR-id convention for branch-only tools: with the id omitted, the session branch's single MR; with the
+    id given, the MR is validated to belong to the session branch — never act on another branch's MR.
+    """
+    if c.client.branch_id is None:
+        raise ToolError(MERGE_REQUEST_BRANCH_ONLY_MESSAGE)
+    if merge_request_id is None:
+        rows = await c.client.storage_client.merge_requests_list()
+        matches = [r for r in rows if same_id((r.get('branches') or {}).get('branchFromId'), c.client.branch_id)]
+        if not matches:
+            raise ToolError(
+                'The current development branch has no merge request yet. Create one with create_merge_request, '
+                'or pass merge_request_id if you meant another branch (open a session on that branch first).'
+            )
+        mr = matches[0]
+        if include_activity_log:
+            mr = await c.client.storage_client.merge_request_detail(mr['id'], include_activity_log=True)
+        return mr
+    mr = await c.client.storage_client.merge_request_detail(merge_request_id, include_activity_log=include_activity_log)
+    branch_from_id = (mr.get('branches') or {}).get('branchFromId')
+    if not same_id(branch_from_id, c.client.branch_id):
+        name = c.branch_from_name(mr)
+        where = f"branch '{name}' (id {branch_from_id})" if name else f'branch id {branch_from_id}'
+        raise ToolError(
+            f'Merge request {merge_request_id} belongs to {where}, not to the current session branch. '
+            'Tell the user to open a session on that branch and ask again there.'
+        )
+    return mr
+
+
+def _validate_auto_merge(strategy: str | None, at: str | None, *, require_pairing: bool) -> None:
+    if strategy == 'scheduled' and not at:
+        raise ToolError("auto_merge='scheduled' requires auto_merge_at (ISO-8601 date-time).")
+    if require_pairing and at is not None and strategy != 'scheduled':
+        raise ToolError("auto_merge_at is only meaningful with auto_merge='scheduled'.")
+
+
+async def _await_storage_job(client: KeboolaClient, job_id: str) -> JsonDict | None:
+    """Polls a Storage job until `success`/`error`; returns None on timeout (the job keeps running)."""
+    deadline = time.monotonic() + MERGE_JOB_TIMEOUT_SEC
+    while True:
+        job = await client.storage_client.job_detail(job_id)
+        if str(job.get('status') or '') in STORAGE_JOB_TERMINAL_STATUSES:
+            return job
+        if time.monotonic() >= deadline:
+            return None
+        await asyncio.sleep(MERGE_JOB_POLL_INTERVAL_SEC)
+
+
+def _validate_resolved(resolved: Mapping[str, Any]) -> ResolvedConfiguration:
+    """Strict validation of a caller-authored body: all five keys, non-empty name, a real boolean is_disabled."""
+    try:
+        return ResolvedConfiguration.model_validate(dict(resolved))
+    except ValidationError as exc:
+        problems = '; '.join(f"{'.'.join(str(p) for p in e['loc']) or 'body'}: {e['msg']}" for e in exc.errors())
+        raise ToolError(
+            'The resolved configuration must spell out the full replaced content (a rebase REPLACES the version): '
+            f'{problems}. Required keys: name, description (may be null), is_disabled (boolean), configuration, rows.'
+        ) from exc
+
+
+def _job_error_message(job: Mapping[str, Any]) -> str:
+    error = job.get('error')
+    if isinstance(error, Mapping):
+        return str(error.get('message') or error)
+    return str(error or 'The merge job failed.')
+
+
+# ---- Read / diagnosis — any session, any role ------------------------------------------------------------
+
+
+@tool_errors()
+async def get_merge_requests(
+    ctx: Context,
+    merge_request_ids: Annotated[
+        Sequence[int],
+        Field(description='Merge request ids to get the full detail of. Leave empty to list all merge requests.'),
+    ] = (),
+    state: Annotated[
+        MergeRequestStateFilter | None,
+        Field(
+            description=(
+                'List mode only: keep merge requests whose state or derived state equals this value '
+                "(e.g. 'in_development', 'approved', 'rejected', 'merged'). Ignored when ids are given."
+            )
+        ),
+    ] = None,
+) -> MergeRequestsListOutput | MergeRequestsDetailOutput:
+    """
+    Lists the project's merge requests, or returns the full detail of the given ones.
+
+    A merge request promotes a development branch's configuration changes into production. Works from any
+    session (production or branch).
+
+    Without ids: summaries of all merge requests (title, state, who created it, reviewers, source branch).
+    With ids: per merge request the status block (`derived_state`, `merge_blockers`, `mergeable`,
+    `allowed_actions`, `viewer`, live `conflicts`, and `next_step` — the single recommended next action),
+    the changed configurations and the review history. Follow `next_step` verbatim when guiding the user.
+
+    Usage:
+    - "Is there anything to merge?" → list (optionally with `state`), then get the candidates' detail and read
+      `merge_blockers` / `next_step`.
+    - "What is in merge request 42?" → detail of [42]; narrate `changed_configurations` and `activity_log`.
+    """
+    c = await _load(ctx)
+    if merge_request_ids:
+
+        async def _one(mr_id: int) -> MergeRequestDetail:
+            mr, conflicts_raw = await asyncio.gather(
+                c.client.storage_client.merge_request_detail(mr_id, include_activity_log=True),
+                c.client.storage_client.merge_request_conflicts(mr_id),
+            )
+            return _build_detail(c, mr, conflicts=_parse_conflicts(conflicts_raw), with_activity_log=True)
+
+        results = await process_concurrently(list(dict.fromkeys(merge_request_ids)), _one)
+        return MergeRequestsDetailOutput(merge_requests=unwrap_results(results, 'Failed to get merge requests'))
+
+    rows = await c.client.storage_client.merge_requests_list()
+    merge_requests = [MergeRequest.from_api(r, branch_names=c.branch_names, links=c.mr_links(r)) for r in rows]
+    if state is not None:
+        wanted = state.lower()
+        merge_requests = [m for m in merge_requests if wanted in (m.state.lower(), m.derived_state.lower())]
+    return MergeRequestsListOutput(merge_requests=merge_requests, links=[c.links.get_project_detail_link()])
+
+
+# ---- Review-state actions — any session, admin/share/OAuth -----------------------------------------------
+
+
+@tool_errors()
+async def approve_merge_request(
+    ctx: Context,
+    merge_request_id: Annotated[int, Field(description='The merge request id.')],
+    project_id: ProjectIdArg = None,
+) -> MergeRequestDetail:
+    """
+    Approves a merge request as a reviewer.
+
+    Valid only while the merge request is `in_review` (the backend rejects it otherwise) and never for its
+    creator. Projects with the default of 0 required approvals never enter `in_review`, so this is needed only
+    when the project requires approvals. Works from any session. Returns the merge request with its status;
+    follow `next_step`.
+    """
+    c = await _load(ctx)
+    try:
+        mr = await c.client.storage_client.merge_request_approve(merge_request_id)
+    except httpx.HTTPStatusError as exc:
+        if mapped := _map_write_error(exc):
+            raise mapped from exc
+        raise
+    return await _detail_with_conflicts(c, mr, with_activity_log=False)
+
+
+@tool_errors()
+async def request_merge_request_changes(
+    ctx: Context,
+    merge_request_id: Annotated[int, Field(description='The merge request id.')],
+    reason: Annotated[
+        str | None, Field(description='Why changes are needed; recorded in the review history for the author.')
+    ] = None,
+    project_id: ProjectIdArg = None,
+) -> MergeRequestDetail:
+    """
+    Sends a merge request back to its author for changes (a reviewer's "reject").
+
+    The merge request returns to `development` and loses its approvals; it is NOT closed — the author fixes the
+    branch and merges (or requests a review) again. Works from any session. Returns the merge request with its
+    status; follow `next_step`.
+    """
+    c = await _load(ctx)
+    try:
+        mr = await c.client.storage_client.merge_request_request_changes(merge_request_id, reason=reason)
+    except httpx.HTTPStatusError as exc:
+        if mapped := _map_write_error(exc):
+            raise mapped from exc
+        raise
+    return await _detail_with_conflicts(c, mr, with_activity_log=False)
+
+
+@tool_errors()
+async def update_merge_request(
+    ctx: Context,
+    merge_request_id: Annotated[int, Field(description='The merge request id.')],
+    title: Annotated[str | None, Field(description='New title. Omit to keep the current one.')] = None,
+    description: Annotated[
+        str | None, Field(description='New description. Omit to keep the current one; an empty string clears it.')
+    ] = None,
+    reviewer_ids: Annotated[
+        Sequence[int] | None, Field(description='New complete list of reviewer user ids. Omit to keep the current one.')
+    ] = None,
+    auto_merge: Annotated[
+        AutoMergeStrategy | None,
+        Field(
+            description=(
+                "'none' turns auto-merge OFF (the only way to disarm it). 'immediately' and 'scheduled' ARM it: "
+                'the backend merges on its own once the merge request is approved (at auto_merge_at for '
+                "'scheduled'). Omit to keep the current setting."
+            )
+        ),
+    ] = None,
+    auto_merge_at: Annotated[
+        str | None,
+        Field(description="ISO-8601 date-time of a 'scheduled' auto-merge. Required with auto_merge='scheduled'."),
+    ] = None,
+    project_id: ProjectIdArg = None,
+) -> MergeRequestDetail:
+    """
+    Updates a merge request's title, description, reviewers or auto-merge setting. Omitted fields are kept.
+
+    Use it to disarm auto-merge (`auto_merge='none'`) or to change reviewers. Arming auto-merge
+    (`'immediately'` / `'scheduled'`) makes the backend merge without a further confirmation — confirm with
+    the user first. Not allowed once the merge request is merged or canceled. Works from any session.
+    Returns the merge request with its status; follow `next_step`.
+    """
+    _validate_auto_merge(auto_merge, auto_merge_at, require_pairing=False)
+    payload: JsonDict = {}
+    if title is not None:
+        payload['title'] = title
+    if description is not None:
+        payload['description'] = description
+    if reviewer_ids is not None:
+        payload['reviewerIds'] = list(reviewer_ids)
+    if auto_merge is not None:
+        payload['autoMergeStrategy'] = auto_merge
+    if auto_merge_at is not None:
+        payload['autoMergeAt'] = auto_merge_at
+    if not payload:
+        raise ToolError(
+            'Nothing to update: pass at least one of title, description, reviewer_ids, auto_merge, auto_merge_at.'
+        )
+
+    c = await _load(ctx)
+    try:
+        mr = await c.client.storage_client.merge_request_update(merge_request_id, payload)
+    except httpx.HTTPStatusError as exc:
+        if _map_write_error(exc) is not None:
+            raise ToolError(
+                f'{ROLE_DENIED_MESSAGE} (If the merge request is already merged or canceled, it can no longer be updated.)'
+            ) from exc
+        raise
+    return await _detail_with_conflicts(c, mr, with_activity_log=False)
+
+
+# ---- Author / promotion — development-branch session only ------------------------------------------------
+
+
+@tool_errors()
+async def create_merge_request(
+    ctx: Context,
+    title: Annotated[str, Field(description='A short title describing the change.')],
+    description: Annotated[str | None, Field(description='An optional longer description for the reviewers.')] = None,
+    reviewer_ids: Annotated[Sequence[int], Field(description='User ids of the reviewers to request. Optional.')] = (),
+    auto_merge: Annotated[
+        AutoMergeStrategy,
+        Field(
+            description=(
+                "'none' (default) = the user merges explicitly. 'immediately' / 'scheduled' ARM auto-merge: the "
+                'backend merges on its own once approvals suffice (at auto_merge_at for scheduled). Confirm with the '
+                'user before arming.'
+            )
+        ),
+    ] = 'none',
+    auto_merge_at: Annotated[
+        str | None, Field(description="ISO-8601 date-time; required if and only if auto_merge='scheduled'.")
+    ] = None,
+    project_id: ProjectIdArg = None,
+) -> MergeRequestDetail:
+    """
+    Creates a merge request for the CURRENT development branch into production.
+
+    Available only from a development-branch session; on production, tell the user to open a session on the
+    merge request's source branch and ask again there. The source branch is the session branch and the target
+    is production — there are no branch parameters. A branch can have only one merge request.
+
+    On a project with the default of 0 required approvals the happy path is two calls:
+    create_merge_request → merge_merge_request (no review step). Returns the merge request with its status;
+    follow `next_step`.
+    """
+    _validate_auto_merge(auto_merge, auto_merge_at, require_pairing=True)
+    c = await _load(ctx)
+    session_branch = c.session_branch
+    if session_branch is None:
+        raise ToolError(MERGE_REQUEST_BRANCH_ONLY_MESSAGE)
+    default_branch = c.default_branch
+    if same_id(session_branch.get('id'), default_branch.get('id')):
+        raise ToolError(MERGE_REQUEST_BRANCH_ONLY_MESSAGE)
+    try:
+        mr = await c.client.storage_client.merge_request_create(
+            branch_from_id=session_branch['id'],
+            branch_into_id=default_branch['id'],
+            title=title,
+            description=description,
+            reviewer_ids=reviewer_ids,
+            auto_merge_strategy=auto_merge,
+            auto_merge_at=auto_merge_at,
+        )
+    except httpx.HTTPStatusError as exc:
+        if mapped := _map_write_error(exc):
+            raise mapped from exc
+        if 400 <= exc.response.status_code < 500:
+            rows = await c.client.storage_client.merge_requests_list()
+            existing = [r for r in rows if same_id((r.get('branches') or {}).get('branchFromId'), session_branch['id'])]
+            if existing:
+                detail = await _detail_with_conflicts(c, existing[0], with_activity_log=False)
+                raise ToolError(
+                    f"Branch '{session_branch.get('name')}' already has merge request {detail.id} "
+                    f"('{detail.title}', state {detail.derived_state}); a branch can have only one. "
+                    f'Next step: {detail.status.next_step}'
+                ) from exc
+        raise
+    return await _detail_with_conflicts(c, mr, with_activity_log=False)
+
+
+@tool_errors()
+async def request_merge_request_review(
+    ctx: Context,
+    merge_request_id: Annotated[
+        int | None,
+        Field(description="The merge request id. Omit to use the current branch's merge request."),
+    ] = None,
+    project_id: ProjectIdArg = None,
+) -> MergeRequestDetail:
+    """
+    Sends the current branch's merge request for review (author action).
+
+    Available only from a development-branch session; on production, tell the user to open a session on the
+    merge request's source branch and ask again there. Rarely needed: merge_merge_request already skips the
+    review when the project requires no approvals, so call this only when a merge was refused as "not ready"
+    or when the project requires approvals. The merge request moves to `in_review` (or straight to `approved`
+    when 0 approvals are required). Returns the merge request with its status; follow `next_step`.
+    """
+    c = await _load(ctx)
+    mr = await _resolve_branch_mr(c, merge_request_id)
+    try:
+        updated = await c.client.storage_client.merge_request_request_review(mr['id'])
+    except httpx.HTTPStatusError as exc:
+        if mapped := _map_write_error(exc):
+            raise mapped from exc
+        raise
+    return await _detail_with_conflicts(c, updated, with_activity_log=False)
+
+
+@tool_errors()
+async def merge_merge_request(
+    ctx: Context,
+    merge_request_id: Annotated[
+        int | None,
+        Field(description="The merge request id. Omit to use the current branch's merge request."),
+    ] = None,
+    project_id: ProjectIdArg = None,
+) -> MergeResult:
+    """
+    Merges the current branch's merge request into production and waits for the merge to finish.
+
+    Available only from a development-branch session; on production, tell the user to open a session on the
+    merge request's source branch and ask again there. IRREVERSIBLE: on success the changes are in production
+    and the source branch (with everything else on it: buckets, tables, workspaces) is deleted by a background
+    job — confirm with the user first. Works directly from `development` when the project requires no
+    approvals.
+
+    When the backend refuses, nothing changes and the result explains why: `refusal='conflicts'` lists the
+    conflicting configurations (resolve them with get_merge_request_conflicts / resolve_merge_request_conflict,
+    then merge again); `refusal='not_ready'` means missing approvals, a merge lock or a wrong state. After a
+    success the session's branch is gone: follow `next_step` and tell the user to open a production session.
+    """
+    c = await _load(ctx)
+    mr = await _resolve_branch_mr(c, merge_request_id)  # `branchFromId` captured before the merge (nulled later)
+    mr_id = int(mr['id'])
+    session = c.session(mr)
+    branch_name = c.branch_from_name(mr)
+
+    try:
+        job = await c.client.storage_client.merge_request_merge(mr_id)
+    except httpx.HTTPStatusError as exc:
+        if mapped := _map_write_error(exc):
+            raise mapped from exc
+        if exc.response.status_code != 409:
+            raise
+        body = _error_body(exc)
+        code = body.get('code')
+        message = str(body.get('error') or body.get('message') or exc)
+        conflicts: list[ConflictRef] | None
+        refusal: LastRefusal
+        if code == MERGE_NOT_READY_CODE:
+            refusal, conflicts = 'not_ready', None
+        elif code == MERGE_CONFLICT_CODE or code is None:
+            refusal = 'conflicts'
+            params = body.get('params')
+            conflicts = _parse_conflicts(params.get('errors') if isinstance(params, Mapping) else None)
+        else:
+            raise
+        status = build_status(
+            mr,
+            conflicts=conflicts,
+            admin_id=c.admin_id,
+            session=session,
+            branch_from_name=branch_name,
+            last_refusal=refusal,
+        )
+        return MergeResult(
+            merge_request_id=mr_id,
+            merged=False,
+            state=status.state,
+            job_id=None,
+            refusal=refusal,
+            refusal_message=message,
+            conflicts=conflicts,
+            status=status,
+            source_branch_deleting=False,
+            warnings=[],
+            next_step=status.next_step,
+        )
+
+    job_id = str(job['id'])
+    final = await _await_storage_job(c.client, job_id)
+    if final is None:
+        in_merge = {**mr, 'state': 'in_merge'}
+        status = build_status(
+            in_merge, conflicts=None, admin_id=c.admin_id, session=session, branch_from_name=branch_name
+        )
+        return MergeResult(
+            merge_request_id=mr_id,
+            merged=False,
+            state='in_merge',
+            job_id=job_id,
+            refusal=None,
+            refusal_message=None,
+            conflicts=None,
+            status=status,
+            source_branch_deleting=False,
+            warnings=[f'The merge job {job_id} is still running after {int(MERGE_JOB_TIMEOUT_SEC)} s.'],
+            next_step=(
+                f'The merge is still running (Storage job {job_id}); check again with get_merge_requests in a moment '
+                'and do not edit the branch meanwhile.'
+            ),
+        )
+    if str(final.get('status')) == 'success':
+        return MergeResult(
+            merge_request_id=mr_id,
+            merged=True,
+            state='published',
+            job_id=job_id,
+            refusal=None,
+            refusal_message=None,
+            conflicts=None,
+            status=None,
+            source_branch_deleting=True,
+            warnings=[],
+            next_step=build_next_step(
+                state='published',
+                derived_state='merged',
+                merge_blockers=['state'],
+                conflicts=None,
+                allowed_actions=[],
+                viewer=build_status(
+                    mr, conflicts=None, admin_id=c.admin_id, session=session, branch_from_name=branch_name
+                ).viewer,
+                pending=[],
+                session=session,
+                branch_from_name=branch_name,
+            ),
+        )
+    rolled_back = {**mr, 'state': 'approved'}  # the backend rolls a failed merge back to `approved`
+    status = build_status(
+        rolled_back, conflicts=None, admin_id=c.admin_id, session=session, branch_from_name=branch_name
+    )
+    return MergeResult(
+        merge_request_id=mr_id,
+        merged=False,
+        state='approved',
+        job_id=job_id,
+        refusal=None,
+        refusal_message=_job_error_message(final),
+        conflicts=None,
+        status=status,
+        source_branch_deleting=False,
+        warnings=[],
+        next_step=f'The merge job failed ({_job_error_message(final)}); the merge request is back in `approved`. {status.next_step}',
+    )
+
+
+# ---- Conflict resolution — development-branch session only -----------------------------------------------
+
+
+@tool_errors()
+async def get_merge_request_conflicts(
+    ctx: Context,
+    merge_request_id: Annotated[
+        int | None,
+        Field(description="The merge request id. Omit to use the current branch's merge request."),
+    ] = None,
+) -> MergeRequestConflictsOutput:
+    """
+    Shows what blocks the current branch's merge request from merging: each conflicting configuration with its
+    three-way diff and a per-path classification.
+
+    Available only from a development-branch session; on production, tell the user to open a session on the
+    merge request's source branch and ask again there. A configuration conflicts when it changed both on the
+    branch and in production since the branch was created. For each one you get `base` / `ours` (branch) /
+    `theirs` (production), `changes` (each path tagged `changed_by` ours|theirs|both), `conflicting_paths`
+    (both sides changed differently — the actual conflict) and `suggested_take` when one side is a safe pick.
+    Walk the user through them one by one and resolve each with resolve_merge_request_conflict. Follow `next_step`.
+    """
+    c = await _load(ctx)
+    mr = await _resolve_branch_mr(c, merge_request_id)
+    mr_id = int(mr['id'])
+    refs = _parse_conflicts(await c.client.storage_client.merge_request_conflicts(mr_id))
+
+    async def _one(ref: ConflictRef) -> ConfigConflict:
+        diff = await c.client.storage_client.configuration_diff(ref.component_id, ref.configuration_id)
+        return build_config_conflict(ref, diff)
+
+    conflicts = unwrap_results(await process_concurrently(refs, _one), 'Failed to load configuration diffs')
+    status = build_status(
+        mr, conflicts=refs, admin_id=c.admin_id, session=c.session(mr), branch_from_name=c.branch_from_name(mr)
+    )
+    return MergeRequestConflictsOutput(
+        merge_request_id=mr_id, conflicts=conflicts, status=status, next_step=status.next_step
+    )
+
+
+@tool_errors()
+async def resolve_merge_request_conflict(
+    ctx: Context,
+    component_id: Annotated[str, Field(description='The component id of the conflicting configuration.')],
+    configuration_id: Annotated[str, Field(description='The configuration id.')],
+    take: Annotated[
+        TakeMode | None,
+        Field(
+            description=(
+                "'ours' keeps the branch version, 'theirs' takes the production version, 'delete' deletes the "
+                "configuration. Taking one side DISCARDS the other side's changes. Pass exactly one of take / resolved."
+            )
+        ),
+    ] = None,
+    resolved: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description=(
+                'The manually merged content when neither side alone is right, as an object with ALL of these keys: '
+                '"name" (non-empty string), "description" (string or null), "is_disabled" (boolean), '
+                '"configuration" (object) and "rows" (array of row objects, complete) — the rebase replaces the whole '
+                'version, so nothing may be omitted.'
+            )
+        ),
+    ] = None,
+    change_description: Annotated[
+        str | None, Field(description="The new version's change description (any mode; ignored for 'delete').")
+    ] = None,
+    merge_request_id: Annotated[
+        int | None,
+        Field(description="The merge request id. Omit to use the current branch's merge request."),
+    ] = None,
+    project_id: ProjectIdArg = None,
+) -> ResolveConflictResult:
+    """
+    Resolves ONE conflicting configuration of the current branch's merge request by re-anchoring the branch
+    configuration onto the current production version with the chosen content.
+
+    Available only from a development-branch session; on production, tell the user to open a session on the
+    merge request's source branch and ask again there. Call get_merge_request_conflicts first, then for each
+    conflict have the user choose: `take='ours'` / `'theirs'` / `'delete'`, or pass `resolved` with the
+    hand-merged content. Taking one side discards the other side's changes — say so. The configuration must
+    be in the merge request's live conflict set. `remaining_conflicts` tells you whether to continue the loop;
+    approvals survive the resolution. Follow `next_step`.
+    """
+    if (take is None) == (resolved is None):
+        raise ToolError("Pass exactly one of take='ours'|'theirs'|'delete' or a resolved configuration.")
+    if resolved is not None:
+        _validate_resolved(resolved)  # strict, before any network call
+
+    c = await _load(ctx)
+    mr = await _resolve_branch_mr(c, merge_request_id)
+    mr_id = int(mr['id'])
+
+    live = _parse_conflicts(await c.client.storage_client.merge_request_conflicts(mr_id))
+    if not any(r.component_id == component_id and r.configuration_id == str(configuration_id) for r in live):
+        raise ToolError(
+            f'{component_id}/{configuration_id} is not in merge request {mr_id}\'s conflict set; nothing to resolve. '
+            'Call get_merge_request_conflicts for the current set.'
+        )
+
+    diff = await c.client.storage_client.configuration_diff(component_id, configuration_id)
+    theirs = diff.get('theirs')
+    onto_version = theirs.get('version') if isinstance(theirs, Mapping) else None
+    if onto_version is None:
+        raise ToolError(
+            f'The diff of {component_id}/{configuration_id} has no production (theirs) side; cannot determine the '
+            'version to rebase onto.'
+        )
+
+    warnings = list(diff_warnings(diff))
+    body: dict[str, Any]
+    mode: str
+    if resolved is not None:
+        custom = _validate_resolved(resolved)
+        body = {
+            'name': custom.name,
+            'description': custom.description,
+            'isDisabled': custom.is_disabled,
+            'configuration': custom.configuration,
+            'rows': custom.rows,
+        }
+        mode = 'custom'
+    elif take == 'delete':
+        body, mode = {}, 'delete'
+    else:
+        side = diff.get('ours') if take == 'ours' else theirs
+        if not isinstance(side, Mapping) or side.get('isDeleted'):
+            body, mode = {}, 'delete'  # taking a deleted (or never-existing) side IS the delete resolution
+        else:
+            holes = envelope_holes(side)
+            envelope = side.get('diff') or {}
+            if holes or not str(envelope.get('name') or '').strip():
+                raise ToolError(
+                    f"The diff's {take} side carries no {', '.join(holes) or 'name'}; cannot compose the content from it "
+                    '(backend envelope hole). Pass the resolution as `resolved` instead.'
+                )
+            if not isinstance(envelope.get('isDisabled'), bool):
+                raise ToolError(
+                    f"The diff's {take} side carries a non-boolean isDisabled ({envelope.get('isDisabled')!r}). "
+                    'Pass the resolution as `resolved` instead.'
+                )
+            body = {key: envelope[key] for key in DIFF_CONTENT_KEYS if key in envelope}
+            mode = take  # type: ignore[assignment]
+
+    if body:
+        if change_description is not None:
+            body['changeDescription'] = change_description
+    elif change_description is not None:
+        warnings.append(
+            'change_description ignored: the delete resolution cannot carry one; the backend records its default message.'
+        )
+
+    try:
+        await c.client.storage_client.configuration_rebase(
+            component_id, configuration_id, version=int(onto_version), diff=body
+        )
+    except httpx.HTTPStatusError as exc:
+        if mapped := _map_write_error(exc):
+            raise mapped from exc
+        raise
+
+    remaining = _parse_conflicts(await c.client.storage_client.merge_request_conflicts(mr_id))
+    status = build_status(
+        mr,
+        conflicts=remaining,
+        admin_id=c.admin_id,
+        session=c.session(mr),
+        branch_from_name=c.branch_from_name(mr),
+        remaining_conflicts=remaining,
+    )
+    return ResolveConflictResult(
+        component_id=component_id,
+        configuration_id=str(configuration_id),
+        resolved=True,
+        mode=mode,  # type: ignore[arg-type]
+        rebased_onto_version=int(onto_version),
+        remaining_conflicts=remaining,
+        status=status,
+        warnings=warnings,
+        next_step=status.next_step,
+    )

--- a/src/keboola_mcp_server/tools/merge_requests/tools.py
+++ b/src/keboola_mcp_server/tools/merge_requests/tools.py
@@ -829,8 +829,7 @@ async def resolve_merge_request_conflict(
     """
     if (take is None) == (resolved is None):
         raise ToolError("Pass exactly one of take='ours'|'theirs'|'delete' or a resolved configuration.")
-    if resolved is not None:
-        _validate_resolved(resolved)  # strict, before any network call
+    custom = _validate_resolved(resolved) if resolved is not None else None  # strict, before any network call
 
     c = await _load(ctx)
     mr = await _resolve_branch_mr(c, merge_request_id)
@@ -855,8 +854,7 @@ async def resolve_merge_request_conflict(
     warnings = list(diff_warnings(diff))
     body: dict[str, Any]
     mode: str
-    if resolved is not None:
-        custom = _validate_resolved(resolved)
+    if custom is not None:
         body = {
             'name': custom.name,
             'description': custom.description,

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -1113,3 +1113,161 @@ class TestStepUpStorageClient:
         stepped = client.step_up_storage_client(str(token_file))
 
         assert stepped.raw_client.readonly is None
+
+
+class TestAsyncStorageClientMergeRequests:
+    @pytest.fixture
+    def storage_client(self, mocker: MockerFixture) -> AsyncStorageClient:
+        raw = mocker.AsyncMock(RawKeboolaClient)
+        return AsyncStorageClient(raw_client=raw, branch_id='123')
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('method', 'kwargs', 'verb', 'expected_call'),
+        [
+            pytest.param('merge_requests_list', {}, 'get', {'endpoint': 'merge-request'}, id='list'),
+            pytest.param(
+                'merge_request_detail',
+                {'merge_request_id': 7},
+                'get',
+                {'endpoint': 'merge-request/7', 'params': None},
+                id='detail',
+            ),
+            pytest.param(
+                'merge_request_detail',
+                {'merge_request_id': 7, 'include_activity_log': True},
+                'get',
+                {'endpoint': 'merge-request/7', 'params': {'include': 'activityLog'}},
+                id='detail_with_activity_log',
+            ),
+            pytest.param(
+                'merge_request_conflicts',
+                {'merge_request_id': 7},
+                'get',
+                {'endpoint': 'merge-request/7/conflicts'},
+                id='conflicts',
+            ),
+            pytest.param(
+                'merge_request_create',
+                {'branch_from_id': '123', 'branch_into_id': 1, 'title': 'T'},
+                'post',
+                {
+                    'endpoint': 'merge-request',
+                    'data': {'branchFromId': 123, 'branchIntoId': 1, 'title': 'T', 'autoMergeStrategy': 'none'},
+                },
+                id='create_minimal',
+            ),
+            pytest.param(
+                'merge_request_create',
+                {
+                    'branch_from_id': 123,
+                    'branch_into_id': 1,
+                    'title': 'T',
+                    'description': 'D',
+                    'reviewer_ids': [5, 6],
+                    'auto_merge_strategy': 'scheduled',
+                    'auto_merge_at': '2026-09-08T10:00:00+00:00',
+                },
+                'post',
+                {
+                    'endpoint': 'merge-request',
+                    'data': {
+                        'branchFromId': 123,
+                        'branchIntoId': 1,
+                        'title': 'T',
+                        'autoMergeStrategy': 'scheduled',
+                        'description': 'D',
+                        'reviewerIds': [5, 6],
+                        'autoMergeAt': '2026-09-08T10:00:00+00:00',
+                    },
+                },
+                id='create_full',
+            ),
+            pytest.param(
+                'merge_request_update',
+                {'merge_request_id': 7, 'payload': {'title': 'New', 'autoMergeStrategy': 'none'}},
+                'put',
+                {'endpoint': 'merge-request/7', 'data': {'title': 'New', 'autoMergeStrategy': 'none'}},
+                id='update',
+            ),
+            pytest.param(
+                'merge_request_request_review',
+                {'merge_request_id': 7},
+                'put',
+                {'endpoint': 'merge-request/7/request-review'},
+                id='request_review',
+            ),
+            pytest.param(
+                'merge_request_approve',
+                {'merge_request_id': 7},
+                'put',
+                {'endpoint': 'merge-request/7/approve'},
+                id='approve',
+            ),
+            pytest.param(
+                'merge_request_request_changes',
+                {'merge_request_id': 7},
+                'put',
+                {'endpoint': 'merge-request/7/request-changes', 'data': None},
+                id='request_changes_no_reason',
+            ),
+            pytest.param(
+                'merge_request_request_changes',
+                {'merge_request_id': 7, 'reason': 'fix it'},
+                'put',
+                {'endpoint': 'merge-request/7/request-changes', 'data': {'reason': 'fix it'}},
+                id='request_changes_with_reason',
+            ),
+            pytest.param(
+                'merge_request_merge', {'merge_request_id': 7}, 'put', {'endpoint': 'merge-request/7/merge'}, id='merge'
+            ),
+            pytest.param(
+                'configuration_diff',
+                {'component_id': 'keboola.ex-db', 'configuration_id': '42'},
+                'get',
+                {'endpoint': 'branch/123/components/keboola.ex-db/configs/42/diff'},
+                id='diff_is_branch_scoped',
+            ),
+            pytest.param(
+                'configuration_rebase',
+                {'component_id': 'keboola.ex-db', 'configuration_id': '42', 'version': 9, 'diff': {'name': 'n'}},
+                'post',
+                {
+                    'endpoint': 'branch/123/components/keboola.ex-db/configs/42/rebase',
+                    'data': {'version': 9, 'diff': {'name': 'n'}},
+                },
+                id='rebase_envelope_is_version_and_diff',
+            ),
+            pytest.param(
+                'configuration_rebase',
+                {'component_id': 'keboola.ex-db', 'configuration_id': '42', 'version': 9, 'diff': {}},
+                'post',
+                {
+                    'endpoint': 'branch/123/components/keboola.ex-db/configs/42/rebase',
+                    'data': {'version': 9, 'diff': {}},
+                },
+                id='rebase_delete_tombstone',
+            ),
+        ],
+    )
+    async def test_merge_request_methods(
+        self,
+        storage_client: AsyncStorageClient,
+        method: str,
+        kwargs: dict[str, Any],
+        verb: str,
+        expected_call: dict[str, Any],
+    ):
+        """Every MR method hits the project-level (never branch-prefixed) endpoint with the exact payload;
+        the two conflict-resolution methods are branch-scoped."""
+        raw_verb = getattr(storage_client.raw_client, verb)
+        raw_verb.return_value = {'id': 7}
+
+        result = await getattr(storage_client, method)(**kwargs)
+
+        assert result == {'id': 7}
+        raw_verb.assert_called_once()
+        _, called_kwargs = raw_verb.call_args
+        for key, value in expected_call.items():
+            assert called_kwargs.get(key) == value, f'{key}: {called_kwargs.get(key)!r} != {value!r}'
+        assert not called_kwargs['endpoint'].startswith('branch/') or method.startswith('configuration_')

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -17,6 +17,7 @@ from keboola_mcp_server.clients.auth_bridge import StorageTokenResolver
 from keboola_mcp_server.clients.client import KeboolaClient
 from keboola_mcp_server.config import Config, ServerRuntimeInfo
 from keboola_mcp_server.mcp import (
+    TOKEN_INFO_STATE_KEY,
     AggregateError,
     ServerState,
     SessionStateMiddleware,
@@ -730,6 +731,211 @@ class TestToolsFilteringMiddleware:
         else:
             result = await middleware.on_call_tool(context, call_next)
             assert result is expected
+
+    @pytest.mark.parametrize(
+        ('tool_name', 'is_read_only', 'token_role', 'features', 'is_oauth', 'is_main_branch', 'expected_fragment'),
+        [
+            # feature axis: every MR tool needs the project feature, reads included
+            ('get_merge_requests', True, 'admin', set(), False, True, 'branches-merge-requests'),
+            ('merge_merge_request', False, 'admin', set(), False, False, 'branches-merge-requests'),
+            # role axis: reads open to everyone, writes need admin/share or OAuth
+            ('get_merge_requests', True, 'guest', {'branches-merge-requests'}, False, True, None),
+            ('get_merge_requests', True, 'developer', {'branches-merge-requests'}, False, True, None),
+            ('approve_merge_request', False, 'admin', {'branches-merge-requests'}, False, True, None),
+            ('approve_merge_request', False, 'share', {'branches-merge-requests'}, False, True, None),
+            ('approve_merge_request', False, 'developer', {'branches-merge-requests'}, False, True, 'admin" or "share'),
+            ('approve_merge_request', False, 'reviewer', {'branches-merge-requests'}, False, True, 'admin" or "share'),
+            ('approve_merge_request', False, 'guest', {'branches-merge-requests'}, False, True, 'admin" or "share'),
+            ('approve_merge_request', False, '', {'branches-merge-requests'}, True, True, None),  # OAuth carve-out
+            (
+                'update_merge_request',
+                False,
+                'readOnly',
+                {'branches-merge-requests'},
+                False,
+                True,
+                'read-only operations',
+            ),
+            # branch axis: branch-only tools deny on main with the branch-agnostic message, any-session tools pass
+            (
+                'create_merge_request',
+                False,
+                'admin',
+                {'branches-merge-requests'},
+                False,
+                True,
+                'development-branch session',
+            ),
+            (
+                'request_merge_request_review',
+                False,
+                'admin',
+                {'branches-merge-requests'},
+                False,
+                True,
+                'development-branch session',
+            ),
+            (
+                'merge_merge_request',
+                False,
+                'admin',
+                {'branches-merge-requests'},
+                False,
+                True,
+                'development-branch session',
+            ),
+            (
+                'get_merge_request_conflicts',
+                True,
+                'guest',
+                {'branches-merge-requests'},
+                False,
+                True,
+                'development-branch session',
+            ),
+            (
+                'resolve_merge_request_conflict',
+                False,
+                'admin',
+                {'branches-merge-requests'},
+                False,
+                True,
+                'development-branch session',
+            ),
+            ('create_merge_request', False, 'admin', {'branches-merge-requests'}, False, False, None),
+            ('get_merge_request_conflicts', True, 'guest', {'branches-merge-requests'}, False, False, None),
+            ('request_merge_request_changes', False, 'share', {'branches-merge-requests'}, False, True, None),
+            ('get_merge_requests', True, 'guest', {'branches-merge-requests'}, False, False, None),
+        ],
+    )
+    def test_authorize_merge_request_tools(
+        self,
+        tool_name: str,
+        is_read_only: bool,
+        token_role: str,
+        features: set[str],
+        is_oauth: bool,
+        is_main_branch: bool,
+        expected_fragment: str | None,
+    ) -> None:
+        """The three gating axes of the merge-request tools (feature, role + OAuth carve-out, session branch)."""
+        denial = ToolsFilteringMiddleware.authorize_tool_call(
+            tool_name=tool_name,
+            is_read_only=is_read_only,
+            is_semantic=False,
+            has_semantic_models=False,
+            token_role=token_role,
+            features=features,
+            is_oauth=is_oauth,
+            is_main_branch=is_main_branch,
+        )
+        if expected_fragment is None:
+            assert denial is None
+        else:
+            assert denial is not None and expected_fragment in denial
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('token_role', 'bearer_token', 'features', 'branch_id', 'hidden_tools', 'visible_tools'),
+        [
+            pytest.param(
+                'admin',
+                None,
+                [],
+                None,
+                {'get_merge_requests', 'create_merge_request', 'approve_merge_request'},
+                set(),
+                id='no_feature_hides_all',
+            ),
+            pytest.param(
+                'developer',
+                None,
+                ['branches-merge-requests'],
+                None,
+                {'create_merge_request', 'approve_merge_request'},
+                {'get_merge_requests', 'get_merge_request_conflicts'},
+                id='developer_sees_reads_only',
+            ),
+            pytest.param(
+                '',
+                'oauth_token',
+                ['branches-merge-requests'],
+                None,
+                set(),
+                {'get_merge_requests', 'create_merge_request', 'approve_merge_request'},
+                id='oauth_sees_writes',
+            ),
+            pytest.param(
+                'admin',
+                None,
+                ['branches-merge-requests'],
+                None,
+                set(),
+                {'create_merge_request', 'merge_merge_request', 'get_merge_request_conflicts'},
+                id='branch_only_tools_stay_visible_on_main',
+            ),
+            pytest.param(
+                'admin',
+                None,
+                ['branches-merge-requests'],
+                'dev-55',
+                set(),
+                {'create_merge_request', 'merge_merge_request', 'approve_merge_request'},
+                id='dev_branch_sees_everything',
+            ),
+        ],
+    )
+    async def test_list_tools_filters_merge_request_tools(
+        self,
+        mcp_context_client,
+        keboola_client,
+        token_role: str,
+        bearer_token: str | None,
+        features: list[str],
+        branch_id: str | None,
+        hidden_tools: set[str],
+        visible_tools: set[str],
+    ) -> None:
+        keboola_client.bearer_token = bearer_token
+        keboola_client.branch_id = branch_id
+        keboola_client.storage_client.verify_token = AsyncMock(
+            return_value={'owner': {'features': features}, 'admin': {'role': token_role}}
+        )
+        tools = [
+            _tool('get_merge_requests', read_only=True),
+            _tool('get_merge_request_conflicts', read_only=True),
+            _tool('create_merge_request'),
+            _tool('approve_merge_request'),
+            _tool('merge_merge_request'),
+            _tool('other_tool'),
+        ]
+
+        async def call_next(_):
+            return tools
+
+        middleware = ToolsFilteringMiddleware()
+        context = SimpleNamespace(fastmcp_context=mcp_context_client)
+        result_names = {t.name for t in await middleware.on_list_tools(context, call_next)}
+
+        assert 'other_tool' in result_names
+        assert hidden_tools.isdisjoint(result_names)
+        assert visible_tools <= result_names
+
+    @pytest.mark.asyncio
+    async def test_call_tool_caches_token_info_in_session_state(self, mcp_context_client, keboola_client) -> None:
+        """The tool body reads the verification the middleware already paid for (no second verify_token)."""
+        token_info = {'owner': {'id': 1, 'features': ['branches-merge-requests']}, 'admin': {'id': 10, 'role': 'admin'}}
+        keboola_client.storage_client.verify_token = AsyncMock(return_value=token_info)
+        tool = _tool('get_merge_requests', read_only=True)
+        mcp_context_client.fastmcp = SimpleNamespace(get_tool=AsyncMock(return_value=tool))
+        context = SimpleNamespace(fastmcp_context=mcp_context_client, message=SimpleNamespace(name=tool.name))
+
+        async def call_next(_):
+            return MagicMock()
+
+        await ToolsFilteringMiddleware().on_call_tool(context, call_next)
+
+        assert mcp_context_client.session.state[TOKEN_INFO_STATE_KEY] is token_info
 
 
 class TestServerStateStorageTokenResolver:

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -130,6 +130,8 @@ class TestPreviewConfigDiff:
             ('modify_streamlit_data_app', 'admin', 'dev-123', 'main production branch'),
             # update_flow is not available to admin/OAuth tokens (they use modify_flow).
             ('update_flow', 'admin', None, 'admin/OAuth'),
+            # Merge-request tools need the branches-merge-requests project feature (the preview mock has none).
+            ('create_merge_request', 'admin', None, 'branches-merge-requests'),
         ],
     )
     def test_preview_project_role_branch_authorization(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,7 +30,7 @@ from keboola_mcp_server.mcp import (
 )
 from keboola_mcp_server.server import CustomRoutes, create_server
 from keboola_mcp_server.tools.components.tools import COMPONENT_TOOLS_TAG
-from keboola_mcp_server.tools.constants import CONFIG_DIFF_PREVIEW_TAG
+from keboola_mcp_server.tools.constants import CONFIG_DIFF_PREVIEW_TAG, MERGE_REQUEST_TOOLS_TAG
 from keboola_mcp_server.tools.data_apps import DATA_APP_TOOLS_TAG
 from keboola_mcp_server.tools.doc import DOC_TOOLS_TAG
 from keboola_mcp_server.tools.flow.tools import FLOW_TOOLS_TAG
@@ -61,9 +61,11 @@ class TestServer:
         tools = await server.list_tools(run_middleware=False)
         assert sorted(tool.name for tool in tools) == [
             'add_config_row',
+            'approve_merge_request',
             'create_conditional_flow',
             'create_config',
             'create_flow',
+            'create_merge_request',
             'create_oauth_url',
             'create_python_js_data_app_git_credential',
             'create_sql_transformation',
@@ -81,16 +83,22 @@ class TestServer:
             'get_flow_schema',
             'get_flows',
             'get_jobs',
+            'get_merge_request_conflicts',
+            'get_merge_requests',
             'get_project_info',
             'get_semantic_context',
             'get_semantic_schema',
             'get_shared_buckets',
             'get_tables',
             'link_shared_bucket',
+            'merge_merge_request',
             'modify_flow',
             'modify_python_js_data_app',
             'modify_streamlit_data_app',
             'query_data',
+            'request_merge_request_changes',
+            'request_merge_request_review',
+            'resolve_merge_request_conflict',
             'run_job',
             'run_sync_action',
             'search',
@@ -100,6 +108,7 @@ class TestServer:
             'update_config_row',
             'update_descriptions',
             'update_flow',
+            'update_merge_request',
             'update_project_description',
             'update_sql_transformation',
             'validate_semantic_query',
@@ -290,8 +299,9 @@ async def test_with_session_state(config: Config, envs: dict[str, Any], mocker):
     async with Client(mcp) as client:
         tools = await client.list_tools()
         # plus the one we've added in this test minus two filtered tools
-        # create_flow() and update_flow(), and four semantic tools (feature not enabled in mock)
-        assert len(tools) == tools_count + 1 - 2 - 4
+        # create_flow() and update_flow(), four semantic tools (feature not enabled in mock)
+        # and nine merge-request tools (the 'branches-merge-requests' feature is not enabled in mock)
+        assert len(tools) == tools_count + 1 - 2 - 4 - 9
         assert tools[-1].name == 'assessed-function'
         assert tools[-1].description == 'custom text'
         # check if the inputSchema contains the expected param description
@@ -453,6 +463,16 @@ async def test_tool_annotations_and_tags():
         # jobs
         ('get_jobs', True, None, None, {JOB_TOOLS_TAG}),
         ('run_job', None, True, None, {JOB_TOOLS_TAG}),
+        # merge requests
+        ('get_merge_requests', True, None, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('create_merge_request', None, True, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('update_merge_request', None, True, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('request_merge_request_review', None, False, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('approve_merge_request', None, False, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('request_merge_request_changes', None, False, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('merge_merge_request', None, True, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('get_merge_request_conflicts', True, None, None, {MERGE_REQUEST_TOOLS_TAG}),
+        ('resolve_merge_request_conflict', None, False, None, {MERGE_REQUEST_TOOLS_TAG}),
         # project/doc/search
         ('get_project_info', True, None, None, {PROJECT_TOOLS_TAG}),
         ('update_project_description', None, True, None, {PROJECT_TOOLS_TAG}),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,7 +30,12 @@ from keboola_mcp_server.mcp import (
 )
 from keboola_mcp_server.server import CustomRoutes, create_server
 from keboola_mcp_server.tools.components.tools import COMPONENT_TOOLS_TAG
-from keboola_mcp_server.tools.constants import CONFIG_DIFF_PREVIEW_TAG, MERGE_REQUEST_TOOLS_TAG
+from keboola_mcp_server.tools.constants import (
+    CONFIG_DIFF_PREVIEW_TAG,
+    MERGE_REQUEST_BRANCH_ONLY_TOOLS,
+    MERGE_REQUEST_TOOL_NAMES,
+    MERGE_REQUEST_TOOLS_TAG,
+)
 from keboola_mcp_server.tools.data_apps import DATA_APP_TOOLS_TAG
 from keboola_mcp_server.tools.doc import DOC_TOOLS_TAG
 from keboola_mcp_server.tools.flow.tools import FLOW_TOOLS_TAG
@@ -113,6 +118,19 @@ class TestServer:
             'update_sql_transformation',
             'validate_semantic_query',
         ]
+
+    @pytest.mark.asyncio
+    async def test_merge_request_name_sets_match_the_tagged_tools(self):
+        """The gating in authorize_tool_call keys on name sets; they must equal the tools tagged merge-request."""
+        server = create_server(Config(), runtime_info=ServerRuntimeInfo(transport='stdio'))
+        tools = await server.list_tools(run_middleware=False)
+        tagged = {t.name for t in tools if MERGE_REQUEST_TOOLS_TAG in (t.tags or set())}
+
+        assert tagged == MERGE_REQUEST_TOOL_NAMES
+        assert MERGE_REQUEST_BRANCH_ONLY_TOOLS < MERGE_REQUEST_TOOL_NAMES
+        for tool in tools:
+            if tool.name in MERGE_REQUEST_BRANCH_ONLY_TOOLS:
+                assert 'development-branch session' in (tool.description or ''), tool.name
 
     @pytest.mark.asyncio
     async def test_tools_have_descriptions(self):

--- a/tests/tools/merge_requests/test_conflicts.py
+++ b/tests/tools/merge_requests/test_conflicts.py
@@ -1,0 +1,235 @@
+from typing import Any
+
+import pytest
+
+from keboola_mcp_server.tools.merge_requests.conflicts import (
+    build_config_conflict,
+    classify_three_way,
+    diff_warnings,
+    envelope_holes,
+    suggest_take,
+)
+from keboola_mcp_server.tools.merge_requests.models import ConflictRef, PathChange
+
+
+def _side(version: int = 1, is_deleted: bool = False, **content: Any) -> dict[str, Any]:
+    envelope: dict[str, Any] = {
+        'name': 'My config',
+        'description': None,
+        'changeDescription': 'v',
+        'isDisabled': False,
+        'configuration': {'parameters': {'query': 'SELECT 1', 'limit': 10}},
+        'rows': [],
+    }
+    envelope.update(content)
+    return {'version': version, 'isDeleted': is_deleted, 'diff': envelope}
+
+
+def _ref() -> ConflictRef:
+    return ConflictRef(
+        component_id='keboola.ex-db',
+        configuration_id='42',
+        message='changed on both sides',
+        is_deleted=False,
+        dev_branch_version_identifier='a',
+        default_branch_version_identifier='b',
+    )
+
+
+def _by_path(changes: list[PathChange]) -> dict[str, PathChange]:
+    return {c.path: c for c in changes}
+
+
+@pytest.mark.parametrize(
+    ('diff', 'expected'),
+    [
+        pytest.param(
+            {
+                'base': _side(1),
+                'ours': _side(3, configuration={'parameters': {'query': 'SELECT 2', 'limit': 10}}),
+                'theirs': _side(5, configuration={'parameters': {'query': 'SELECT 1', 'limit': 20}}),
+            },
+            {
+                '/configuration/parameters/query': ('ours', None, 'SELECT 1', 'SELECT 2', 'SELECT 1'),
+                '/configuration/parameters/limit': ('theirs', None, 10, 10, 20),
+            },
+            id='disjoint_paths',
+        ),
+        pytest.param(
+            {
+                'base': _side(1),
+                'ours': _side(3, configuration={'parameters': {'query': 'SELECT 2', 'limit': 10}}),
+                'theirs': _side(5, configuration={'parameters': {'query': 'SELECT 3', 'limit': 10}}),
+            },
+            {'/configuration/parameters/query': ('both', False, 'SELECT 1', 'SELECT 2', 'SELECT 3')},
+            id='both_disagree',
+        ),
+        pytest.param(
+            {
+                'base': _side(1),
+                'ours': _side(3, configuration={'parameters': {'query': 'SELECT 2', 'limit': 10}}),
+                'theirs': _side(5, configuration={'parameters': {'query': 'SELECT 2', 'limit': 10}}),
+            },
+            {'/configuration/parameters/query': ('both', True, 'SELECT 1', 'SELECT 2', 'SELECT 2')},
+            id='both_agree',
+        ),
+        pytest.param(
+            {
+                'base': _side(1),
+                'ours': _side(3, name='Renamed', isDisabled=True),
+                'theirs': _side(5, description='Documented'),
+            },
+            {
+                '/name': ('ours', None, 'My config', 'Renamed', 'My config'),
+                '/isDisabled': ('ours', None, False, True, False),
+                '/description': ('theirs', None, None, None, 'Documented'),
+            },
+            id='pseudo_paths_name_description_isDisabled',
+        ),
+        pytest.param(
+            {
+                'base': _side(1),
+                'ours': _side(3, configuration={'parameters': {'query': 'SELECT 1'}}),
+                'theirs': _side(5, configuration={'parameters': {'query': 'SELECT 1', 'limit': 10, 'extra': 1}}),
+            },
+            {
+                '/configuration/parameters/limit': ('ours', None, 10, None, 10),
+                '/configuration/parameters/extra': ('theirs', None, None, None, 1),
+            },
+            id='removed_and_added_keys',
+        ),
+        pytest.param(
+            {
+                'base': _side(1, rows=[{'id': 'r1', 'configuration': {'x': 1}}]),
+                'ours': _side(3, rows=[{'id': 'r1', 'configuration': {'x': 2}}]),
+                'theirs': _side(5, rows=[{'id': 'r1', 'configuration': {'x': 1}}, {'id': 'r2', 'configuration': {}}]),
+            },
+            {
+                '/rows/0/configuration/x': ('ours', None, 1, 2, 1),
+                '/rows/1': ('theirs', None, None, None, {'id': 'r2', 'configuration': {}}),
+            },
+            id='rows_by_index',
+        ),
+        pytest.param(
+            {'base': None, 'ours': _side(1, name='A'), 'theirs': _side(2, name='A')},
+            {
+                '/name': ('both', True, None, 'A', 'A'),
+                '/isDisabled': ('both', True, None, False, False),
+                '/configuration': (
+                    'both',
+                    True,
+                    None,
+                    {'parameters': {'query': 'SELECT 1', 'limit': 10}},
+                    {'parameters': {'query': 'SELECT 1', 'limit': 10}},
+                ),
+                '/rows': ('both', True, None, [], []),
+                '/description': ('both', True, None, None, None),
+            },
+            id='null_base_created_on_both_sides',
+        ),
+    ],
+)
+def test_classify_three_way(diff: dict[str, Any], expected: dict[str, tuple[Any, ...]]) -> None:
+    changes = _by_path(classify_three_way(diff))
+
+    assert set(changes) == set(expected)
+    for path, (changed_by, agreed, base, ours, theirs) in expected.items():
+        change = changes[path]
+        assert (change.changed_by, change.agreed, change.base, change.ours, change.theirs) == (
+            changed_by,
+            agreed,
+            base,
+            ours,
+            theirs,
+        ), path
+
+
+@pytest.mark.parametrize(
+    ('diff', 'expected_ours_deleted', 'expected_theirs_deleted', 'expected_warnings'),
+    [
+        pytest.param(
+            {'base': _side(1), 'ours': _side(2, is_deleted=True), 'theirs': _side(3)}, True, False, 0, id='ours_deleted'
+        ),
+        pytest.param(
+            {'base': _side(1), 'ours': _side(2), 'theirs': _side(3, is_deleted=True)},
+            False,
+            True,
+            0,
+            id='theirs_deleted',
+        ),
+        pytest.param({'base': _side(1), 'ours': None, 'theirs': _side(3)}, None, False, 0, id='ours_absent'),
+        pytest.param(
+            {'base': _side(1), 'ours': {'version': 2, 'isDeleted': False, 'diff': {}}, 'theirs': _side(3)},
+            False,
+            False,
+            1,
+            id='ours_empty_envelope_is_a_hole',
+        ),
+        pytest.param(
+            {'base': _side(1), 'ours': _side(2), 'theirs': {'version': 3, 'isDeleted': False, 'diff': {'name': 'x'}}},
+            False,
+            False,
+            1,
+            id='theirs_holed_envelope',
+        ),
+    ],
+)
+def test_unclassifiable_sides_yield_no_changes(
+    diff: dict[str, Any],
+    expected_ours_deleted: bool | None,
+    expected_theirs_deleted: bool | None,
+    expected_warnings: int,
+) -> None:
+    conflict = build_config_conflict(_ref(), diff)
+
+    assert conflict.changes == []
+    assert conflict.conflicting_paths == []
+    assert conflict.suggested_take is None
+    assert conflict.ours_deleted is expected_ours_deleted
+    assert conflict.theirs_deleted is expected_theirs_deleted
+    assert len(diff_warnings(diff)) == expected_warnings
+
+
+@pytest.mark.parametrize(
+    ('changed_by_list', 'expected'),
+    [
+        pytest.param([], None, id='empty_is_none'),
+        pytest.param(['ours', 'ours'], 'ours', id='only_ours'),
+        pytest.param(['theirs'], 'theirs', id='only_theirs'),
+        pytest.param(['ours', 'theirs'], None, id='disjoint_but_both_sides_changed'),
+        pytest.param(['ours', 'both'], None, id='collision'),
+    ],
+)
+def test_suggest_take(changed_by_list: list[str], expected: str | None) -> None:
+    changes = [
+        PathChange(path=f'/p{i}', changed_by=cb, agreed=False if cb == 'both' else None, base=1, ours=2, theirs=3)
+        for i, cb in enumerate(changed_by_list)
+    ]
+    assert suggest_take(changes) == expected
+
+
+def test_build_config_conflict_full() -> None:
+    diff = {
+        'base': _side(1),
+        'ours': _side(3, configuration={'parameters': {'query': 'SELECT 2', 'limit': 10}}),
+        'theirs': _side(5, configuration={'parameters': {'query': 'SELECT 3', 'limit': 20}}),
+    }
+
+    conflict = build_config_conflict(_ref(), diff)
+
+    assert conflict.component_id == 'keboola.ex-db'
+    assert conflict.theirs is not None and conflict.theirs.version == 5
+    assert conflict.ours is not None and conflict.ours.configuration == {
+        'parameters': {'query': 'SELECT 2', 'limit': 10}
+    }
+    assert conflict.base is not None and conflict.base.rows == []
+    assert conflict.conflicting_paths == ['/configuration/parameters/query']
+    assert conflict.suggested_take is None
+    assert [c.changed_by for c in conflict.changes] == ['theirs', 'both']
+
+
+def test_envelope_holes() -> None:
+    assert envelope_holes(_side()) == []
+    assert envelope_holes({'diff': {}}) == ['name', 'rows', 'configuration', 'isDisabled']
+    assert envelope_holes({'diff': {'name': 'n', 'rows': [], 'configuration': {}, 'isDisabled': False}}) == []
+    assert envelope_holes({'diff': {'name': 'n'}}) == ['rows', 'configuration', 'isDisabled']

--- a/tests/tools/merge_requests/test_conflicts.py
+++ b/tests/tools/merge_requests/test_conflicts.py
@@ -105,10 +105,10 @@ def _by_path(changes: list[PathChange]) -> dict[str, PathChange]:
                 'theirs': _side(5, rows=[{'id': 'r1', 'configuration': {'x': 1}}, {'id': 'r2', 'configuration': {}}]),
             },
             {
-                '/rows/0/configuration/x': ('ours', None, 1, 2, 1),
-                '/rows/1': ('theirs', None, None, None, {'id': 'r2', 'configuration': {}}),
+                '/rows/r1/configuration/x': ('ours', None, 1, 2, 1),
+                '/rows/r2': ('theirs', None, None, None, {'id': 'r2', 'configuration': {}}),
             },
-            id='rows_by_index',
+            id='rows_with_ids_align_by_id',
         ),
         pytest.param(
             {'base': None, 'ours': _side(1, name='A'), 'theirs': _side(2, name='A')},
@@ -226,6 +226,42 @@ def test_build_config_conflict_full() -> None:
     assert conflict.conflicting_paths == ['/configuration/parameters/query']
     assert conflict.suggested_take is None
     assert [c.changed_by for c in conflict.changes] == ['theirs', 'both']
+
+
+def test_rows_with_ids_align_by_id_not_index() -> None:
+    base = _side(1, rows=[{'id': 'r1', 'configuration': {'x': 1}}, {'id': 'r2', 'configuration': {'x': 2}}])
+    ours = _side(
+        3,
+        rows=[
+            {'id': 'r0', 'configuration': {}},
+            {'id': 'r1', 'configuration': {'x': 1}},
+            {'id': 'r2', 'configuration': {'x': 2}},
+        ],
+    )
+    theirs = _side(5, rows=[{'id': 'r1', 'configuration': {'x': 1}}, {'id': 'r2', 'configuration': {'x': 99}}])
+
+    conflict = build_config_conflict(_ref(), {'base': base, 'ours': ours, 'theirs': theirs})
+
+    changes = _by_path(conflict.changes)
+    assert set(changes) == {'/rows/r0', '/rows/r2/configuration/x'}
+    assert changes['/rows/r0'].changed_by == 'ours'
+    assert changes['/rows/r2/configuration/x'].changed_by == 'theirs'
+    assert conflict.conflicting_paths == []  # an insertion is not a conflict with an edit of another row
+
+
+def test_subtree_vs_leaf_edit_is_a_conflict() -> None:
+    base = _side(1, configuration={'parameters': {'a': 1}})
+    ours = _side(3, configuration={})  # removed the whole subtree
+    theirs = _side(5, configuration={'parameters': {'a': 2}})  # edited inside it
+
+    conflict = build_config_conflict(_ref(), {'base': base, 'ours': ours, 'theirs': theirs})
+
+    assert {c.path: c.changed_by for c in conflict.changes} == {
+        '/configuration/parameters': 'ours',
+        '/configuration/parameters/a': 'theirs',
+    }
+    assert conflict.conflicting_paths == ['/configuration/parameters', '/configuration/parameters/a']
+    assert conflict.suggested_take is None
 
 
 def test_envelope_holes() -> None:

--- a/tests/tools/merge_requests/test_status.py
+++ b/tests/tools/merge_requests/test_status.py
@@ -1,0 +1,390 @@
+from typing import Any
+
+import pytest
+
+from keboola_mcp_server.tools.merge_requests.models import ConflictRef, Viewer
+from keboola_mcp_server.tools.merge_requests.status import (
+    SessionContext,
+    build_next_step,
+    build_status,
+    derive_allowed_actions,
+    derive_merge_blockers,
+    derive_state,
+    derive_viewer,
+    request_changes_reason,
+)
+
+
+def _mr(state: str = 'development', **extra: Any) -> dict[str, Any]:
+    return {'id': 1, 'state': state, 'creator': {'id': 10, 'name': 'Alice'}, 'reviewers': [], 'approvals': [], **extra}
+
+
+def _conflict(cid: str = 'cfg-1') -> ConflictRef:
+    return ConflictRef(
+        component_id='keboola.ex-db',
+        configuration_id=cid,
+        message='changed on both sides',
+        is_deleted=False,
+        dev_branch_version_identifier='a',
+        default_branch_version_identifier='b',
+    )
+
+
+ON_BRANCH_WRITER = SessionContext(on_mr_branch=True, can_write=True)
+ON_BRANCH_READER = SessionContext(on_mr_branch=True, can_write=False)
+PRODUCTION_WRITER = SessionContext(on_mr_branch=False, can_write=True)
+UNKNOWN_VIEWER = Viewer(is_creator=None, has_approved=None)
+
+
+@pytest.mark.parametrize(
+    ('mr', 'expected'),
+    [
+        pytest.param(_mr('development'), 'in_development', id='development'),
+        pytest.param(_mr('in_review'), 'in_review', id='in_review'),
+        pytest.param(_mr('approved'), 'approved', id='approved'),
+        pytest.param(_mr('in_merge'), 'in_merge', id='in_merge'),
+        pytest.param(_mr('published'), 'merged', id='published_is_merged'),
+        pytest.param(_mr('canceled'), 'closed', id='canceled_is_closed'),
+        pytest.param(
+            _mr('development', reviewers=[{'id': 20, 'name': 'Bob', 'status': 'rejected'}]),
+            'rejected',
+            id='non_creator_rejection',
+        ),
+        pytest.param(
+            _mr('development', reviewers=[{'id': 10, 'name': 'Alice', 'status': 'rejected'}]),
+            'closed',
+            id='creator_self_rejection_is_closed',
+        ),
+        pytest.param(
+            _mr('in_review', reviewers=[{'id': 20, 'name': 'Bob', 'status': 'rejected'}]),
+            'in_review',
+            id='rejection_only_counts_in_development',
+        ),
+        pytest.param(_mr('development', derivedState='rejected'), 'rejected', id='server_first_override'),
+        pytest.param(_mr('development', derivedState='nonsense'), 'in_development', id='unknown_server_value_ignored'),
+    ],
+)
+def test_derive_state(mr: dict[str, Any], expected: str) -> None:
+    assert derive_state(mr) == expected
+
+
+@pytest.mark.parametrize(
+    ('mr', 'conflicts', 'expected'),
+    [
+        pytest.param(_mr('development'), None, [], id='development_nothing_fetched'),
+        pytest.param(_mr('development'), [], [], id='development_no_conflicts'),
+        pytest.param(_mr('development'), [_conflict()], ['conflicts'], id='conflicts'),
+        pytest.param(_mr('in_review'), None, ['approvals'], id='approvals_kept_without_conflict_fetch'),
+        pytest.param(_mr('in_review'), [_conflict()], ['conflicts', 'approvals'], id='concurrent_blockers'),
+        pytest.param(_mr('in_merge'), None, ['state'], id='in_merge'),
+        pytest.param(_mr('published'), None, ['state'], id='published'),
+        pytest.param(_mr('canceled'), None, ['state'], id='canceled'),
+        pytest.param(_mr('approved'), [], [], id='approved_mergeable'),
+        pytest.param(_mr('in_review', mergeBlockers=['state']), [_conflict()], ['state'], id='server_first_override'),
+    ],
+)
+def test_derive_merge_blockers(mr: dict[str, Any], conflicts: list[ConflictRef] | None, expected: list[str]) -> None:
+    assert derive_merge_blockers(mr, conflicts) == expected
+
+
+@pytest.mark.parametrize(
+    ('mr', 'expected'),
+    [
+        pytest.param(_mr('development'), ['request_review', 'merge', 'update', 'resolve_conflicts'], id='development'),
+        pytest.param(_mr('in_review'), ['approve', 'request_changes', 'update', 'resolve_conflicts'], id='in_review'),
+        pytest.param(_mr('approved'), ['request_changes', 'merge', 'update', 'resolve_conflicts'], id='approved'),
+        pytest.param(_mr('in_merge'), ['update'], id='in_merge'),
+        pytest.param(_mr('published'), [], id='published'),
+        pytest.param(_mr('canceled'), [], id='canceled'),
+        pytest.param(_mr('weird'), [], id='unknown_state'),
+        pytest.param(_mr('published', allowedActions=['update']), ['update'], id='server_first_override'),
+    ],
+)
+def test_derive_allowed_actions(mr: dict[str, Any], expected: list[str]) -> None:
+    assert derive_allowed_actions(mr) == expected
+
+
+@pytest.mark.parametrize(
+    ('mr', 'admin_id', 'expected'),
+    [
+        pytest.param(_mr(), None, Viewer(is_creator=None, has_approved=None), id='no_admin_block_is_unknown'),
+        pytest.param(_mr(), 10, Viewer(is_creator=True, has_approved=False), id='creator'),
+        pytest.param(_mr(), '10', Viewer(is_creator=True, has_approved=False), id='creator_str_vs_int'),
+        pytest.param(
+            _mr(approvals=[{'approverId': '20', 'approverName': 'Bob'}]),
+            20,
+            Viewer(is_creator=False, has_approved=True),
+            id='approver_id_string_on_the_wire',
+        ),
+        pytest.param(_mr(), 99, Viewer(is_creator=False, has_approved=False), id='bystander'),
+        pytest.param(
+            _mr(viewer={'isCreator': False, 'hasApproved': True}),
+            10,
+            Viewer(is_creator=False, has_approved=True),
+            id='server_first_override',
+        ),
+        pytest.param(_mr(viewer={}), 10, Viewer(is_creator=True, has_approved=False), id='empty_server_viewer_ignored'),
+    ],
+)
+def test_derive_viewer(mr: dict[str, Any], admin_id: Any, expected: Viewer) -> None:
+    assert derive_viewer(mr, admin_id) == expected
+
+
+@pytest.mark.parametrize(
+    ('row', 'kwargs', 'expected_fragment'),
+    [
+        pytest.param(
+            1,
+            {'state': 'published', 'derived_state': 'merged', 'allowed_actions': [], 'merge_blockers': ['state']},
+            'source branch is being deleted',
+            id='1_merged',
+        ),
+        pytest.param(
+            2, {'state': 'canceled', 'derived_state': 'closed', 'merge_blockers': ['state']}, 'closed', id='2_closed'
+        ),
+        pytest.param(
+            3,
+            {
+                'state': 'in_merge',
+                'derived_state': 'in_merge',
+                'merge_blockers': ['state'],
+                'allowed_actions': ['update'],
+            },
+            'Do not edit this branch',
+            id='3_in_merge_is_a_warning',
+        ),
+        pytest.param(
+            4,
+            {
+                'merge_blockers': ['conflicts'],
+                'conflicts': [_conflict('a'), _conflict('b')],
+                'remaining_conflicts': [_conflict('b')],
+            },
+            'Resolve the next conflict: keboola.ex-db/b (1 left)',
+            id='4_remaining_conflicts',
+        ),
+        pytest.param(
+            5,
+            {'merge_blockers': ['conflicts'], 'conflicts': [_conflict()], 'session': PRODUCTION_WRITER},
+            "session on branch 'reporting'",
+            id='5_conflicts_handoff_from_production',
+        ),
+        pytest.param(
+            6,
+            {'merge_blockers': ['conflicts'], 'conflicts': [_conflict('a'), _conflict('b')]},
+            '2 conflicts block the merge',
+            id='6_conflicts_on_branch',
+        ),
+        pytest.param(
+            7,
+            {
+                'state': 'in_review',
+                'derived_state': 'in_review',
+                'merge_blockers': ['approvals'],
+                'viewer': Viewer(is_creator=False, has_approved=True),
+                'pending': ['Bob'],
+            },
+            'You already approved; wait for the other reviewers (Bob)',
+            id='7_already_approved',
+        ),
+        pytest.param(
+            8,
+            {
+                'state': 'in_review',
+                'derived_state': 'in_review',
+                'merge_blockers': ['approvals'],
+                'viewer': Viewer(is_creator=True, has_approved=False),
+                'pending': ['Bob'],
+            },
+            'cannot approve your own',
+            id='8_creator_waits',
+        ),
+        pytest.param(
+            9,
+            {'state': 'in_review', 'derived_state': 'in_review', 'merge_blockers': ['approvals']},
+            'Approve it (approve_merge_request) or request changes',
+            id='9_reviewer_can_write',
+        ),
+        pytest.param(
+            10,
+            {
+                'state': 'in_review',
+                'derived_state': 'in_review',
+                'merge_blockers': ['approvals'],
+                'session': ON_BRANCH_READER,
+            },
+            "Waiting for a reviewer's approval",
+            id='10_reader_waits',
+        ),
+        pytest.param(
+            11,
+            {'last_refusal': 'not_ready'},
+            'request a review (request_merge_request_review)',
+            id='11_not_ready_in_development_means_request_review',
+        ),
+        pytest.param(
+            12,
+            {'derived_state': 'rejected', 'rejection_reason': 'typo in query'},
+            'Changes were requested (typo in query); address them',
+            id='12_rejected_before_merge',
+        ),
+        pytest.param(
+            13,
+            {'session': PRODUCTION_WRITER},
+            "open a session on branch 'reporting' and call merge_merge_request",
+            id='13_merge_handoff_from_production',
+        ),
+        pytest.param(14, {}, 'merge it with merge_merge_request (irreversible', id='14_merge_from_development'),
+        pytest.param(15, {'session': ON_BRANCH_READER}, 'read-only', id='15_reader_fallback'),
+    ],
+)
+def test_next_step_rows(row: int, kwargs: dict[str, Any], expected_fragment: str) -> None:
+    defaults: dict[str, Any] = {
+        'state': 'development',
+        'derived_state': 'in_development',
+        'merge_blockers': [],
+        'conflicts': None,
+        'allowed_actions': ['request_review', 'merge', 'update', 'resolve_conflicts'],
+        'viewer': UNKNOWN_VIEWER,
+        'pending': [],
+        'session': ON_BRANCH_WRITER,
+        'branch_from_name': 'reporting',
+    }
+    assert expected_fragment in build_next_step(**{**defaults, **kwargs})
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'expected_fragment', 'reason'),
+    [
+        pytest.param(
+            {
+                'state': 'in_review',
+                'derived_state': 'in_merge',
+                'merge_blockers': ['state', 'conflicts', 'approvals'],
+                'conflicts': [_conflict()],
+            },
+            'A merge is running',
+            'state beats conflicts beats approvals',
+            id='precedence_state_first',
+        ),
+        pytest.param(
+            {
+                'state': 'in_review',
+                'derived_state': 'in_review',
+                'merge_blockers': ['conflicts', 'approvals'],
+                'conflicts': [_conflict()],
+            },
+            'block the merge',
+            'conflicts beat approvals',
+            id='precedence_conflicts_before_approvals',
+        ),
+        pytest.param(
+            {},
+            'merge it',
+            'from development the recommendation is merge, not request review',
+            id='development_recommends_merge_not_review',
+        ),
+        pytest.param(
+            {'last_refusal': None},
+            'merge it',
+            'without last_refusal the table would loop back to merge',
+            id='without_refusal_merge_again',
+        ),
+        pytest.param(
+            {
+                'state': 'in_review',
+                'derived_state': 'in_review',
+                'merge_blockers': ['approvals'],
+                'viewer': Viewer(is_creator=None, has_approved=None),
+            },
+            'Approve it',
+            'rows 7/8 fire only on True, not on None',
+            id='none_viewer_falls_through_to_row_9',
+        ),
+        pytest.param(
+            {'derived_state': 'rejected', 'session': PRODUCTION_WRITER},
+            'Changes were requested',
+            'rejected is told before the merge handoff',
+            id='rejected_before_merge_rows',
+        ),
+        pytest.param(
+            {'session': SessionContext(on_mr_branch=True, can_write=False)},
+            'read-only',
+            'no write recommended to a session that cannot perform it',
+            id='no_write_for_reader',
+        ),
+        pytest.param(
+            {
+                'merge_blockers': ['conflicts'],
+                'conflicts': [_conflict()],
+                'session': PRODUCTION_WRITER,
+                'branch_from_name': None,
+            },
+            "the merge request's source branch",
+            'unknown branch name degrades gracefully',
+            id='handoff_without_branch_name',
+        ),
+    ],
+)
+def test_next_step_rules(kwargs: dict[str, Any], expected_fragment: str, reason: str) -> None:
+    defaults: dict[str, Any] = {
+        'state': 'development',
+        'derived_state': 'in_development',
+        'merge_blockers': [],
+        'conflicts': None,
+        'allowed_actions': ['request_review', 'merge', 'update', 'resolve_conflicts'],
+        'viewer': UNKNOWN_VIEWER,
+        'pending': [],
+        'session': ON_BRANCH_WRITER,
+        'branch_from_name': 'reporting',
+    }
+    assert expected_fragment in build_next_step(**{**defaults, **kwargs}), reason
+
+
+@pytest.mark.parametrize(
+    ('mr', 'conflicts', 'expected_mergeable', 'expected_blockers'),
+    [
+        pytest.param(_mr('approved'), None, None, [], id='not_fetched_is_none'),
+        pytest.param(_mr('approved'), [], True, [], id='fetched_empty_is_true'),
+        pytest.param(_mr('approved'), [_conflict()], False, ['conflicts'], id='conflicts_is_false'),
+        pytest.param(_mr('in_review'), [], False, ['approvals'], id='approvals_blocker_even_without_conflicts'),
+    ],
+)
+def test_build_status_mergeable_fail_closed(
+    mr: dict[str, Any],
+    conflicts: list[ConflictRef] | None,
+    expected_mergeable: bool | None,
+    expected_blockers: list[str],
+) -> None:
+    status = build_status(mr, conflicts=conflicts, admin_id=10, session=ON_BRANCH_WRITER, branch_from_name='reporting')
+
+    assert status.mergeable is expected_mergeable
+    assert status.merge_blockers == expected_blockers
+    assert status.conflicts == conflicts
+    assert status.state == mr['state']
+
+
+def test_build_status_names_and_reason() -> None:
+    mr = _mr(
+        'development',
+        reviewers=[{'id': 20, 'name': 'Bob', 'status': 'rejected'}, {'id': 30, 'name': 'Cid', 'status': 'approved'}],
+        approvals=[{'approverId': '30', 'approverName': 'Cid'}],
+        activityLog=[
+            {'eventType': 'review_requested', 'admin': {'id': 10, 'name': 'Alice'}, 'note': '', 'createdAt': 't1'},
+            {
+                'eventType': 'changes_requested',
+                'admin': {'id': 20, 'name': 'Bob'},
+                'note': 'fix the join',
+                'createdAt': 't2',
+            },
+        ],
+    )
+
+    status = build_status(mr, conflicts=[], admin_id=10, session=ON_BRANCH_WRITER, branch_from_name='reporting')
+
+    assert status.derived_state == 'rejected'
+    assert status.approved_by == ['Cid']
+    assert status.pending_reviewers == ['Bob']
+    assert status.viewer == Viewer(is_creator=True, has_approved=False)
+    assert 'fix the join' in status.next_step
+    assert request_changes_reason(_mr()) is None

--- a/tests/tools/merge_requests/test_status.py
+++ b/tests/tools/merge_requests/test_status.py
@@ -218,9 +218,32 @@ def test_derive_viewer(mr: dict[str, Any], admin_id: Any, expected: Viewer) -> N
         ),
         pytest.param(
             11,
-            {'last_refusal': 'not_ready'},
-            'request a review (request_merge_request_review)',
+            {'last_refusal': 'not_ready', 'refusal_message': 'Cannot merge, branch is in "development" state.'},
+            'request a review (request_merge_request_review). Backend: Cannot merge',
             id='11_not_ready_in_development_means_request_review',
+        ),
+        pytest.param(
+            11,
+            {
+                'state': 'approved',
+                'derived_state': 'approved',
+                'last_refusal': 'not_ready',
+                'refusal_message': 'Locked.',
+            },
+            'wait for it to clear, then merge again. Backend: Locked.',
+            id='11b_not_ready_elsewhere_means_wait',
+        ),
+        pytest.param(
+            6,
+            {'last_refusal': 'conflicts'},
+            'refused because of conflicts; call get_merge_request_conflicts',
+            id='6b_conflict_refusal_without_a_list',
+        ),
+        pytest.param(
+            5,
+            {'last_refusal': 'conflicts', 'session': PRODUCTION_WRITER},
+            "session on branch 'reporting'",
+            id='5b_conflict_refusal_without_a_list_hands_off',
         ),
         pytest.param(
             12,
@@ -362,6 +385,21 @@ def test_build_status_mergeable_fail_closed(
     assert status.merge_blockers == expected_blockers
     assert status.conflicts == conflicts
     assert status.state == mr['state']
+
+
+@pytest.mark.parametrize('last_refusal', ['conflicts', 'not_ready'])
+def test_build_status_refusal_beats_local_derivation(last_refusal: str) -> None:
+    status = build_status(
+        _mr('approved'),
+        conflicts=[],
+        admin_id=10,
+        session=ON_BRANCH_WRITER,
+        branch_from_name='reporting',
+        last_refusal=last_refusal,  # type: ignore[arg-type]
+    )
+
+    assert status.mergeable is False
+    assert 'Ready: merge it' not in status.next_step
 
 
 def test_build_status_names_and_reason() -> None:

--- a/tests/tools/merge_requests/test_tools.py
+++ b/tests/tools/merge_requests/test_tools.py
@@ -1,0 +1,824 @@
+from typing import Any
+from unittest.mock import AsyncMock, call
+
+import httpx
+import pytest
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+
+from keboola_mcp_server.clients.client import KeboolaClient
+from keboola_mcp_server.mcp import TOKEN_INFO_STATE_KEY
+from keboola_mcp_server.tools.merge_requests import tools as mr_tools
+from keboola_mcp_server.tools.merge_requests.models import (
+    MergeRequestsDetailOutput,
+    MergeRequestsListOutput,
+)
+from keboola_mcp_server.tools.merge_requests.tools import (
+    approve_merge_request,
+    create_merge_request,
+    get_merge_request_conflicts,
+    get_merge_requests,
+    merge_merge_request,
+    request_merge_request_changes,
+    request_merge_request_review,
+    resolve_branch_pair,
+    resolve_merge_request_conflict,
+    update_merge_request,
+)
+
+DEV_BRANCH_ID = 55
+DEFAULT_BRANCH_ID = 1
+TOKEN_INFO = {
+    'owner': {'id': 123, 'features': ['branches-merge-requests']},
+    'admin': {'id': 10, 'name': 'Alice', 'role': 'admin'},
+}
+BRANCHES = [
+    {'id': DEFAULT_BRANCH_ID, 'name': 'Main', 'isDefault': True},
+    {'id': DEV_BRANCH_ID, 'name': 'reporting', 'isDefault': False},
+    {'id': 77, 'name': 'other', 'isDefault': False},
+]
+MR_UI_URL = f'https://connection.test.keboola.com/admin/projects/123/branch/{DEV_BRANCH_ID}/development-overview'
+
+
+def _mr_raw(
+    state: str = 'development', *, mr_id: int = 42, branch_from: int | None = DEV_BRANCH_ID, **extra: Any
+) -> dict:
+    return {
+        'id': mr_id,
+        'creator': {'id': 10, 'name': 'Alice'},
+        'title': 'Add reporting',
+        'description': '',
+        'state': state,
+        'branches': {'branchFromId': branch_from, 'branchIntoId': DEFAULT_BRANCH_ID},
+        'merge': {'mergedAt': None, 'mergerId': None, 'mergerName': None},
+        'createdAt': '2026-09-07T10:00:00+0200',
+        'externalId': None,
+        'autoMergeStrategy': 'none',
+        'autoMergeAt': None,
+        'approvals': [],
+        'reviewers': [],
+        'changeLog': {'configurations': []},
+        **extra,
+    }
+
+
+def _conflict_raw(cid: str = 'cfg-1', component: str = 'keboola.ex-db') -> dict:
+    return {
+        'componentId': component,
+        'configurationId': cid,
+        'message': 'Configuration changed in the default branch',
+        'isDeleted': False,
+        'devBranchVersionIdentifier': 'v-dev',
+        'defaultBranchVersionIdentifier': 'v-prod',
+    }
+
+
+def _side(version: int, is_deleted: bool = False, **content: Any) -> dict:
+    envelope: dict[str, Any] = {
+        'name': 'My config',
+        'description': None,
+        'changeDescription': 'x',
+        'isDisabled': False,
+        'configuration': {'parameters': {'query': 'SELECT 1'}},
+        'rows': [],
+    }
+    envelope.update(content)
+    return {'version': version, 'isDeleted': is_deleted, 'diff': envelope}
+
+
+def _diff(**overrides: Any) -> dict:
+    diff = {
+        'base': _side(1),
+        'ours': _side(3, configuration={'parameters': {'query': 'SELECT 2'}}),
+        'theirs': _side(9, configuration={'parameters': {'query': 'SELECT 3'}}),
+    }
+    diff.update(overrides)
+    return diff
+
+
+def _http_error(status: int, body: Any = None) -> httpx.HTTPStatusError:
+    request = httpx.Request('PUT', 'https://connection.test.keboola.com/v2/storage/merge-request/42/merge')
+    response = (
+        httpx.Response(status, json=body, request=request)
+        if body is not None
+        else httpx.Response(status, request=request)
+    )
+    return httpx.HTTPStatusError(f'HTTP {status}', request=request, response=response)
+
+
+@pytest.fixture
+def storage(mcp_context_client: Context, keboola_client: KeboolaClient) -> AsyncMock:
+    """The mocked storage client of a dev-branch session with the MR feature; tests override what they need."""
+    keboola_client.branch_id = str(DEV_BRANCH_ID)
+    sc = keboola_client.storage_client
+    sc.verify_token.return_value = TOKEN_INFO
+    sc.branches_list.return_value = BRANCHES
+    sc.merge_requests_list.return_value = [_mr_raw()]
+    sc.merge_request_detail.return_value = _mr_raw()
+    sc.merge_request_conflicts.return_value = []
+    return sc
+
+
+def _n_calls(storage: AsyncMock) -> int:
+    return sum(
+        getattr(storage, name).await_count
+        for name in (
+            'verify_token',
+            'branches_list',
+            'merge_requests_list',
+            'merge_request_detail',
+            'merge_request_conflicts',
+            'merge_request_create',
+            'merge_request_update',
+            'merge_request_request_review',
+            'merge_request_approve',
+            'merge_request_request_changes',
+            'merge_request_merge',
+            'configuration_diff',
+            'configuration_rebase',
+            'job_detail',
+        )
+    )
+
+
+# ---- get_merge_requests -----------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('state', 'expected_ids'),
+    [
+        pytest.param(None, [42, 43, 44], id='no_filter'),
+        pytest.param('development', [42, 44], id='raw_state'),
+        pytest.param('in_development', [42], id='derived_state'),
+        pytest.param('rejected', [44], id='derived_rejected_matches_development_mr'),
+        pytest.param('merged', [43], id='derived_merged'),
+        pytest.param('published', [43], id='raw_published'),
+    ],
+)
+async def test_get_merge_requests_list(
+    mcp_context_client: Context, storage: AsyncMock, state: str | None, expected_ids: list[int]
+) -> None:
+    storage.merge_requests_list.return_value = [
+        _mr_raw('development'),
+        _mr_raw(
+            'published', mr_id=43, branch_from=None, merge={'mergedAt': 't', 'mergerId': 10, 'mergerName': 'Alice'}
+        ),
+        _mr_raw('development', mr_id=44, reviewers=[{'id': 20, 'name': 'Bob', 'email': 'b@x', 'status': 'rejected'}]),
+    ]
+
+    result = await get_merge_requests(mcp_context_client, state=state)
+
+    assert isinstance(result, MergeRequestsListOutput)
+    assert [m.id for m in result.merge_requests] == expected_ids
+    first = result.merge_requests[0]
+    if first.id == 42:
+        assert (first.branch_from_name, first.branch_into_name, first.creator_name) == ('reporting', 'Main', 'Alice')
+        assert first.description is None  # '' normalized
+        assert [link.url for link in first.links] == [MR_UI_URL]
+    if 43 in expected_ids:
+        merged = next(m for m in result.merge_requests if m.id == 43)
+        assert (merged.derived_state, merged.merged_by, merged.branch_from_id, merged.links) == (
+            'merged',
+            'Alice',
+            None,
+            [],
+        )
+    # list = 3 requests: GET /merge-request + branches_list + verify_token; no detail/conflicts fetched
+    assert _n_calls(storage) == 3
+    storage.merge_request_detail.assert_not_called()
+    storage.merge_request_conflicts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_merge_requests_detail(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_detail.side_effect = [
+        _mr_raw(
+            'in_review',
+            reviewers=[{'id': 20, 'name': 'Bob', 'email': 'b@x', 'status': None}],
+            changeLog={
+                'configurations': [{'componentId': 'keboola.ex-db', 'configurationId': 'cfg-1', 'isDeleted': False}]
+            },
+            activityLog=[
+                {
+                    'id': 1,
+                    'eventType': 'review_requested',
+                    'admin': {'id': 10, 'name': 'Alice'},
+                    'note': '',
+                    'createdAt': 't1',
+                },
+                {'id': 2, 'eventType': 'auto_merge', 'admin': None, 'note': None, 'createdAt': 't2'},
+            ],
+        ),
+        _mr_raw('approved', mr_id=43),
+    ]
+    storage.merge_request_conflicts.side_effect = [[_conflict_raw()], []]
+
+    result = await get_merge_requests(mcp_context_client, merge_request_ids=[42, 43])
+
+    assert isinstance(result, MergeRequestsDetailOutput)
+    first, second = result.merge_requests
+    assert first.reviewers[0].status == 'pending'  # null -> pending
+    assert [c.configuration_id for c in first.changed_configurations] == ['cfg-1']
+    assert first.activity_log is not None and [e.admin_name for e in first.activity_log] == ['Alice', None]
+    assert first.activity_log[0].note is None  # '' -> None
+    assert first.status.merge_blockers == ['conflicts', 'approvals']
+    assert first.status.mergeable is False
+    assert first.status.conflicts is not None and first.status.conflicts[0].configuration_id == 'cfg-1'
+    assert second.status.mergeable is True
+    assert 'merge it' in second.status.next_step
+    # detail = 2 + 2N requests, activity log requested
+    assert _n_calls(storage) == 2 + 2 * 2
+    storage.merge_request_detail.assert_has_awaits(
+        [call(42, include_activity_log=True), call(43, include_activity_log=True)], any_order=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_info_cached_by_middleware_is_reused(mcp_context_client: Context, storage: AsyncMock) -> None:
+    mcp_context_client.session.state[TOKEN_INFO_STATE_KEY] = TOKEN_INFO
+
+    await get_merge_requests(mcp_context_client)
+
+    storage.verify_token.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_detail_on_production_session_hands_off_by_branch_name(
+    mcp_context_client: Context, storage: AsyncMock, keboola_client: KeboolaClient
+) -> None:
+    keboola_client.branch_id = None
+    storage.merge_request_detail.return_value = _mr_raw('approved')
+
+    result = await get_merge_requests(mcp_context_client, merge_request_ids=[42])
+
+    assert isinstance(result, MergeRequestsDetailOutput)
+    assert "open a session on branch 'reporting'" in result.merge_requests[0].status.next_step
+
+
+# ---- resolve_branch_pair / create --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('branch_id', 'expected_session_id'),
+    [pytest.param(str(DEV_BRANCH_ID), DEV_BRANCH_ID, id='dev_branch'), pytest.param(None, None, id='production')],
+)
+async def test_resolve_branch_pair(
+    keboola_client: KeboolaClient, storage: AsyncMock, branch_id: str | None, expected_session_id: int | None
+) -> None:
+    keboola_client.branch_id = branch_id
+
+    session_branch, default_branch = await resolve_branch_pair(keboola_client)
+
+    assert (session_branch or {}).get('id') == expected_session_id
+    assert default_branch['id'] == DEFAULT_BRANCH_ID
+    storage.branches_list.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_merge_request_from_session_branch(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_create.return_value = _mr_raw()
+
+    result = await create_merge_request(mcp_context_client, title='Add reporting', reviewer_ids=[20])
+
+    storage.merge_request_create.assert_awaited_once_with(
+        branch_from_id=DEV_BRANCH_ID,
+        branch_into_id=DEFAULT_BRANCH_ID,
+        title='Add reporting',
+        description=None,
+        reviewer_ids=[20],
+        auto_merge_strategy='none',
+        auto_merge_at=None,
+    )
+    assert result.branch_from_name == 'reporting'
+    assert result.activity_log is None
+    assert result.status.mergeable is True
+    assert 'merge it' in result.status.next_step
+    assert _n_calls(storage) == 4  # POST + /conflicts + branches_list + verify_token
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('branch_id', 'kwargs', 'expected_fragment'),
+    [
+        pytest.param(None, {}, 'development-branch session', id='production_session'),
+        pytest.param(str(DEFAULT_BRANCH_ID), {}, 'development-branch session', id='session_on_default_branch'),
+        pytest.param(
+            str(DEV_BRANCH_ID), {'auto_merge': 'scheduled'}, 'requires auto_merge_at', id='scheduled_without_time'
+        ),
+        pytest.param(
+            str(DEV_BRANCH_ID),
+            {'auto_merge_at': '2026-09-08T10:00:00Z'},
+            'only meaningful',
+            id='time_without_scheduled',
+        ),
+    ],
+)
+async def test_create_merge_request_refuses_without_calling(
+    mcp_context_client: Context,
+    storage: AsyncMock,
+    keboola_client: KeboolaClient,
+    branch_id: str | None,
+    kwargs: dict[str, Any],
+    expected_fragment: str,
+) -> None:
+    keboola_client.branch_id = branch_id
+
+    with pytest.raises(ToolError, match=expected_fragment):
+        await create_merge_request(mcp_context_client, title='T', **kwargs)
+
+    storage.merge_request_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_merge_request_names_the_existing_one(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_create.side_effect = _http_error(400, {'error': 'Merge request already exists', 'code': 'x'})
+    storage.merge_requests_list.return_value = [_mr_raw('approved')]
+
+    with pytest.raises(ToolError, match="already has merge request 42 .*Next step: .*merge it"):
+        await create_merge_request(mcp_context_client, title='T')
+
+
+# ---- review-state actions ---------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_merge_request_sends_only_supplied_keys(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_update.return_value = _mr_raw()
+
+    result = await update_merge_request(mcp_context_client, merge_request_id=42, title='New', auto_merge='none')
+
+    storage.merge_request_update.assert_awaited_once_with(42, {'title': 'New', 'autoMergeStrategy': 'none'})
+    assert result.id == 42 and result.activity_log is None
+    assert (
+        _n_calls(storage) == 4
+    )  # PUT + /conflicts + verify_token + branches_list (names/links); 3 with the token cache
+
+
+@pytest.mark.asyncio
+async def test_update_merge_request_requires_a_change(mcp_context_client: Context, storage: AsyncMock) -> None:
+    with pytest.raises(ToolError, match='Nothing to update'):
+        await update_merge_request(mcp_context_client, merge_request_id=42)
+    storage.merge_request_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('tool', 'kwargs', 'method'),
+    [
+        pytest.param(approve_merge_request, {'merge_request_id': 42}, 'merge_request_approve', id='approve'),
+        pytest.param(
+            request_merge_request_changes,
+            {'merge_request_id': 42, 'reason': 'no'},
+            'merge_request_request_changes',
+            id='request_changes',
+        ),
+        pytest.param(update_merge_request, {'merge_request_id': 42, 'title': 'x'}, 'merge_request_update', id='update'),
+        pytest.param(
+            request_merge_request_review, {'merge_request_id': 42}, 'merge_request_request_review', id='request_review'
+        ),
+        pytest.param(merge_merge_request, {'merge_request_id': 42}, 'merge_request_merge', id='merge'),
+    ],
+)
+async def test_backend_403_maps_to_role_message(
+    mcp_context_client: Context, storage: AsyncMock, tool: Any, kwargs: dict[str, Any], method: str
+) -> None:
+    getattr(storage, method).side_effect = _http_error(403, {'error': 'Forbidden'})
+
+    with pytest.raises(ToolError, match='project role does not permit'):
+        await tool(mcp_context_client, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_approve_and_request_changes_pass_through(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_approve.return_value = _mr_raw(
+        'approved', approvals=[{'approverId': '10', 'approverName': 'Alice'}]
+    )
+    storage.merge_request_request_changes.return_value = _mr_raw('development')
+
+    approved = await approve_merge_request(mcp_context_client, merge_request_id=42)
+    sent_back = await request_merge_request_changes(mcp_context_client, merge_request_id=42, reason='fix the join')
+
+    storage.merge_request_approve.assert_awaited_once_with(42)
+    storage.merge_request_request_changes.assert_awaited_once_with(42, reason='fix the join')
+    assert approved.status.approved_by == ['Alice'] and approved.status.viewer.has_approved is True
+    assert sent_back.state == 'development'
+
+
+# ---- MR-id convention (branch-only tools) ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('merge_request_id', 'listed', 'detail', 'expected_error', 'expected_acted_on'),
+    [
+        pytest.param(None, [_mr_raw(mr_id=42)], None, None, 42, id='omitted_resolves_branch_mr'),
+        pytest.param(42, None, _mr_raw(mr_id=42), None, 42, id='given_and_matching'),
+        pytest.param(
+            9, None, _mr_raw(mr_id=9, branch_from=77), "belongs to branch 'other'", None, id='given_other_branch'
+        ),
+        pytest.param(
+            None,
+            [_mr_raw(mr_id=9, branch_from=77)],
+            None,
+            'has no merge request yet',
+            None,
+            id='omitted_none_on_branch',
+        ),
+    ],
+)
+async def test_mr_id_convention(
+    mcp_context_client: Context,
+    storage: AsyncMock,
+    merge_request_id: int | None,
+    listed: list[dict] | None,
+    detail: dict | None,
+    expected_error: str | None,
+    expected_acted_on: int | None,
+) -> None:
+    if listed is not None:
+        storage.merge_requests_list.return_value = listed
+    if detail is not None:
+        storage.merge_request_detail.return_value = detail
+    storage.merge_request_request_review.return_value = _mr_raw('approved', mr_id=expected_acted_on or 0)
+
+    if expected_error:
+        with pytest.raises(ToolError, match=expected_error):
+            await request_merge_request_review(mcp_context_client, merge_request_id=merge_request_id)
+        storage.merge_request_request_review.assert_not_called()
+    else:
+        result = await request_merge_request_review(mcp_context_client, merge_request_id=merge_request_id)
+        storage.merge_request_request_review.assert_awaited_once_with(expected_acted_on)
+        assert result.state == 'approved'
+        if merge_request_id is None:
+            storage.merge_requests_list.assert_awaited_once()  # the +1 of the omitted id
+        else:
+            storage.merge_requests_list.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_branch_only_tool_on_production_is_refused(
+    mcp_context_client: Context, storage: AsyncMock, keboola_client: KeboolaClient
+) -> None:
+    keboola_client.branch_id = None
+
+    with pytest.raises(ToolError, match='development-branch session'):
+        await merge_merge_request(mcp_context_client)
+
+    storage.merge_request_merge.assert_not_called()
+
+
+# ---- merge ------------------------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('body', 'expected_refusal', 'expected_conflict_ids', 'expected_fragment'),
+    [
+        pytest.param(
+            {
+                'code': 'storage.mergeRequests.validation',
+                'error': 'Merge request has conflicts',
+                'params': {'errors': [_conflict_raw('cfg-1'), _conflict_raw('cfg-2')]},
+            },
+            'conflicts',
+            ['cfg-1', 'cfg-2'],
+            '2 conflicts block the merge',
+            id='conflict_409_carries_the_conflicts',
+        ),
+        pytest.param(
+            {
+                'code': 'storage.mergeRequests.notReadyToMerge',
+                'error': 'Cannot merge, branch is in "development" state.',
+            },
+            'not_ready',
+            None,
+            'request a review',
+            id='not_ready_in_development_means_request_review',
+        ),
+        pytest.param(
+            {'error': 'Conflicts', 'params': {'errors': [_conflict_raw('cfg-1')]}},
+            'conflicts',
+            ['cfg-1'],
+            '1 conflict block',
+            id='code_less_409_is_a_conflict',
+        ),
+    ],
+)
+async def test_merge_refusals(
+    mcp_context_client: Context,
+    storage: AsyncMock,
+    body: dict,
+    expected_refusal: str,
+    expected_conflict_ids: list[str] | None,
+    expected_fragment: str,
+) -> None:
+    storage.merge_request_merge.side_effect = _http_error(409, body)
+
+    result = await merge_merge_request(mcp_context_client, merge_request_id=42)
+
+    assert result.merged is False
+    assert result.refusal == expected_refusal
+    assert result.refusal_message == body['error']
+    assert result.state == 'development'
+    assert result.source_branch_deleting is False
+    assert (
+        None if result.conflicts is None else [c.configuration_id for c in result.conflicts]
+    ) == expected_conflict_ids
+    assert result.status is not None and expected_fragment in result.next_step
+    storage.merge_request_conflicts.assert_not_called()  # the 409 already carries them
+    storage.job_detail.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_merge_reraises_unknown_409(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_merge.side_effect = _http_error(409, {'code': 'storage.something.else', 'error': 'nope'})
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await merge_merge_request(mcp_context_client, merge_request_id=42)
+
+
+@pytest.mark.asyncio
+async def test_merge_success_awaits_job_and_hands_off(
+    mcp_context_client: Context, storage: AsyncMock, monkeypatch
+) -> None:
+    monkeypatch.setattr(mr_tools, 'MERGE_JOB_POLL_INTERVAL_SEC', 0)
+    storage.merge_request_merge.return_value = {'id': 987, 'status': 'waiting'}  # int on the wire
+    storage.job_detail.side_effect = [{'id': 987, 'status': 'processing'}, {'id': 987, 'status': 'success'}]
+
+    result = await merge_merge_request(mcp_context_client, merge_request_id=42)
+
+    assert result.merged is True
+    assert result.state == 'published'
+    assert result.job_id == '987'
+    assert result.source_branch_deleting is True
+    assert result.refusal is None and result.status is None
+    assert 'source branch is being deleted' in result.next_step and 'production' in result.next_step
+    assert storage.job_detail.await_count == 2
+    # branchFromId is read from the MR BEFORE the merge is issued
+    assert storage.method_calls.index(
+        call.merge_request_detail(42, include_activity_log=False)
+    ) < storage.method_calls.index(call.merge_request_merge(42))
+
+
+@pytest.mark.asyncio
+async def test_merge_job_error_rolls_back_to_approved(
+    mcp_context_client: Context, storage: AsyncMock, monkeypatch
+) -> None:
+    monkeypatch.setattr(mr_tools, 'MERGE_JOB_POLL_INTERVAL_SEC', 0)
+    storage.merge_request_detail.return_value = _mr_raw('approved')
+    storage.merge_request_merge.return_value = {'id': '988'}
+    storage.job_detail.return_value = {'id': 988, 'status': 'error', 'error': {'message': 'boom'}}
+
+    result = await merge_merge_request(mcp_context_client, merge_request_id=42)
+
+    assert result.merged is False
+    assert result.state == 'approved'
+    assert result.refusal is None
+    assert result.refusal_message == 'boom'
+    assert 'boom' in result.next_step
+
+
+@pytest.mark.asyncio
+async def test_merge_timeout_is_not_a_failure(mcp_context_client: Context, storage: AsyncMock, monkeypatch) -> None:
+    monkeypatch.setattr(mr_tools, 'MERGE_JOB_POLL_INTERVAL_SEC', 0)
+    monkeypatch.setattr(mr_tools, 'MERGE_JOB_TIMEOUT_SEC', 0)
+    storage.merge_request_merge.return_value = {'id': 989}
+    storage.job_detail.return_value = {'id': 989, 'status': 'processing'}
+
+    result = await merge_merge_request(mcp_context_client, merge_request_id=42)
+
+    assert result.merged is False
+    assert result.state == 'in_merge'
+    assert result.job_id == '989'
+    assert 'still running' in result.next_step
+    assert result.warnings
+
+
+# ---- conflicts ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_merge_request_conflicts_fans_out(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_conflicts.return_value = [_conflict_raw('cfg-1'), _conflict_raw('cfg-2')]
+    storage.configuration_diff.side_effect = [
+        _diff(),
+        _diff(ours=_side(3, name='Renamed'), theirs=_side(9)),
+    ]
+
+    result = await get_merge_request_conflicts(mcp_context_client, merge_request_id=42)
+
+    assert result.merge_request_id == 42
+    assert [c.configuration_id for c in result.conflicts] == ['cfg-1', 'cfg-2']
+    first, second = result.conflicts
+    assert first.conflicting_paths == ['/configuration/parameters/query'] and first.suggested_take is None
+    assert first.theirs is not None and first.theirs.version == 9
+    assert second.changes[0].path == '/name' and second.suggested_take == 'ours'
+    assert result.status.merge_blockers == ['conflicts']
+    assert '2 conflicts block the merge' in result.next_step
+    storage.configuration_diff.assert_has_awaits(
+        [call('keboola.ex-db', 'cfg-1'), call('keboola.ex-db', 'cfg-2')], any_order=True
+    )
+    assert _n_calls(storage) == 2 + 2 + 2  # detail + /conflicts + N diffs (+ branches_list + verify_token overhead)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('kwargs', 'diff', 'expected_mode', 'expected_diff', 'expected_warning'),
+    [
+        pytest.param(
+            {'take': 'ours', 'change_description': 'keep dev'},
+            _diff(),
+            'ours',
+            {
+                'name': 'My config',
+                'description': None,
+                'configuration': {'parameters': {'query': 'SELECT 2'}},
+                'isDisabled': False,
+                'rows': [],
+                'changeDescription': 'keep dev',
+            },
+            None,
+            id='take_ours',
+        ),
+        pytest.param(
+            {'take': 'theirs'},
+            _diff(),
+            'theirs',
+            {
+                'name': 'My config',
+                'description': None,
+                'configuration': {'parameters': {'query': 'SELECT 3'}},
+                'isDisabled': False,
+                'rows': [],
+            },
+            None,
+            id='take_theirs',
+        ),
+        pytest.param(
+            {'take': 'delete', 'change_description': 'bye'}, _diff(), 'delete', {}, 'ignored', id='take_delete_warns'
+        ),
+        pytest.param(
+            {'take': 'ours'}, _diff(ours=_side(3, is_deleted=True)), 'delete', {}, None, id='ours_deleted_is_delete'
+        ),
+        pytest.param(
+            {'take': 'theirs'},
+            _diff(theirs=_side(9, is_deleted=True)),
+            'delete',
+            {},
+            None,
+            id='theirs_deleted_is_delete',
+        ),
+        pytest.param(
+            {
+                'resolved': {
+                    'name': 'Merged',
+                    'description': None,
+                    'is_disabled': True,
+                    'configuration': {'parameters': {'query': 'SELECT 2 UNION SELECT 3'}},
+                    'rows': [{'id': 'r1'}],
+                },
+                'change_description': 'manual',
+            },
+            _diff(),
+            'custom',
+            {
+                'name': 'Merged',
+                'description': None,
+                'isDisabled': True,
+                'configuration': {'parameters': {'query': 'SELECT 2 UNION SELECT 3'}},
+                'rows': [{'id': 'r1'}],
+                'changeDescription': 'manual',
+            },
+            None,
+            id='custom_body',
+        ),
+    ],
+)
+async def test_resolve_conflict_modes(
+    mcp_context_client: Context,
+    storage: AsyncMock,
+    kwargs: dict[str, Any],
+    diff: dict,
+    expected_mode: str,
+    expected_diff: dict,
+    expected_warning: str | None,
+) -> None:
+    storage.merge_request_conflicts.side_effect = [
+        [_conflict_raw('cfg-1'), _conflict_raw('cfg-2')],
+        [_conflict_raw('cfg-2')],
+    ]
+    storage.configuration_diff.return_value = diff
+    storage.configuration_rebase.return_value = {'id': 'cfg-1', 'version': 4}
+
+    result = await resolve_merge_request_conflict(
+        mcp_context_client, component_id='keboola.ex-db', configuration_id='cfg-1', merge_request_id=42, **kwargs
+    )
+
+    storage.configuration_rebase.assert_awaited_once_with('keboola.ex-db', 'cfg-1', version=9, diff=expected_diff)
+    assert result.resolved is True
+    assert result.mode == expected_mode
+    assert result.rebased_onto_version == 9
+    assert [c.configuration_id for c in result.remaining_conflicts] == ['cfg-2']
+    assert 'Resolve the next conflict: keboola.ex-db/cfg-2 (1 left)' in result.next_step
+    assert (expected_warning is None) == (not result.warnings)
+    if expected_warning:
+        assert expected_warning in result.warnings[0]
+    assert _n_calls(storage) == 5 + 2  # detail + /conflicts guard + /diff + rebase + /conflicts re-check (+ overhead)
+
+
+@pytest.mark.asyncio
+async def test_resolve_last_conflict_recommends_merge(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_conflicts.side_effect = [[_conflict_raw('cfg-1')], []]
+    storage.configuration_diff.return_value = _diff()
+
+    result = await resolve_merge_request_conflict(
+        mcp_context_client, component_id='keboola.ex-db', configuration_id='cfg-1', take='ours'
+    )
+
+    assert result.remaining_conflicts == []
+    assert result.status.mergeable is True
+    assert 'merge it' in result.next_step
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('kwargs', 'diff', 'expected_fragment', 'expect_network'),
+    [
+        pytest.param({}, _diff(), 'exactly one of', False, id='neither'),
+        pytest.param({'take': 'ours', 'resolved': {'name': 'x'}}, _diff(), 'exactly one of', False, id='both'),
+        pytest.param(
+            {'resolved': {'name': 'x', 'is_disabled': False, 'configuration': {}, 'rows': []}},
+            _diff(),
+            'description',
+            False,
+            id='custom_missing_description_key',
+        ),
+        pytest.param(
+            {'resolved': {'name': '  ', 'description': None, 'is_disabled': False, 'configuration': {}, 'rows': []}},
+            _diff(),
+            'non-empty',
+            False,
+            id='custom_blank_name',
+        ),
+        pytest.param(
+            {'resolved': {'name': 'x', 'description': None, 'is_disabled': 'false', 'configuration': {}, 'rows': []}},
+            _diff(),
+            'is_disabled',
+            False,
+            id='custom_string_boolean',
+        ),
+        pytest.param(
+            {'take': 'ours'},
+            _diff(ours={'version': 3, 'isDeleted': False, 'diff': {}}),
+            'envelope hole',
+            True,
+            id='take_empty_side_is_not_a_delete',
+        ),
+        pytest.param(
+            {'take': 'ours'},
+            _diff(ours={'version': 3, 'isDeleted': False, 'diff': {'name': 'n', 'rows': [], 'configuration': {}}}),
+            'carries no isDisabled',
+            True,
+            id='take_holed_side',
+        ),
+        pytest.param({'take': 'ours'}, _diff(theirs=None), 'no production', True, id='theirs_missing'),
+    ],
+)
+async def test_resolve_conflict_refuses_without_rebasing(
+    mcp_context_client: Context,
+    storage: AsyncMock,
+    kwargs: dict[str, Any],
+    diff: dict,
+    expected_fragment: str,
+    expect_network: bool,
+) -> None:
+    storage.merge_request_conflicts.return_value = [_conflict_raw('cfg-1')]
+    storage.configuration_diff.return_value = diff
+
+    with pytest.raises(ToolError, match=expected_fragment):
+        await resolve_merge_request_conflict(
+            mcp_context_client, component_id='keboola.ex-db', configuration_id='cfg-1', merge_request_id=42, **kwargs
+        )
+
+    storage.configuration_rebase.assert_not_called()
+    if not expect_network:
+        assert _n_calls(storage) == 0  # validated before any request
+
+
+@pytest.mark.asyncio
+async def test_resolve_conflict_guards_the_conflict_set(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_conflicts.return_value = [_conflict_raw('cfg-1')]
+
+    with pytest.raises(ToolError, match='not in merge request 42'):
+        await resolve_merge_request_conflict(
+            mcp_context_client,
+            component_id='keboola.ex-db',
+            configuration_id='cfg-other',
+            take='ours',
+            merge_request_id=42,
+        )
+
+    storage.configuration_diff.assert_not_called()
+    storage.configuration_rebase.assert_not_called()

--- a/tests/tools/merge_requests/test_tools.py
+++ b/tests/tools/merge_requests/test_tools.py
@@ -244,6 +244,38 @@ async def test_token_info_cached_by_middleware_is_reused(mcp_context_client: Con
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('role', 'bearer_token', 'client_readonly', 'expect_write_recommended'),
+    [
+        pytest.param('admin', None, False, True, id='admin'),
+        pytest.param('readOnly', 'oauth', False, False, id='oauth_readonly_role'),
+        pytest.param('', 'oauth', False, True, id='oauth_regular'),
+        pytest.param('admin', None, True, False, id='readonly_client'),
+        pytest.param('developer', None, False, False, id='developer'),
+    ],
+)
+async def test_next_step_never_recommends_a_write_the_session_cannot_do(
+    mcp_context_client: Context,
+    storage: AsyncMock,
+    keboola_client: KeboolaClient,
+    role: str,
+    bearer_token: str | None,
+    client_readonly: bool,
+    expect_write_recommended: bool,
+) -> None:
+    keboola_client.bearer_token = bearer_token
+    keboola_client.readonly = client_readonly
+    storage.verify_token.return_value = {'owner': {'id': 123}, 'admin': {'id': 10, 'role': role}}
+    storage.merge_request_detail.return_value = _mr_raw('approved')
+
+    result = await get_merge_requests(mcp_context_client, merge_request_ids=[42])
+
+    assert isinstance(result, MergeRequestsDetailOutput)
+    next_step = result.merge_requests[0].status.next_step
+    assert ('merge it with merge_merge_request' in next_step) is expect_write_recommended
+
+
+@pytest.mark.asyncio
 async def test_detail_on_production_session_hands_off_by_branch_name(
     mcp_context_client: Context, storage: AsyncMock, keboola_client: KeboolaClient
 ) -> None:
@@ -379,6 +411,7 @@ async def test_update_merge_request_requires_a_change(mcp_context_client: Contex
             request_merge_request_review, {'merge_request_id': 42}, 'merge_request_request_review', id='request_review'
         ),
         pytest.param(merge_merge_request, {'merge_request_id': 42}, 'merge_request_merge', id='merge'),
+        pytest.param(create_merge_request, {'title': 'T'}, 'merge_request_create', id='create'),
     ],
 )
 async def test_backend_403_maps_to_role_message(
@@ -386,7 +419,7 @@ async def test_backend_403_maps_to_role_message(
 ) -> None:
     getattr(storage, method).side_effect = _http_error(403, {'error': 'Forbidden'})
 
-    with pytest.raises(ToolError, match='project role does not permit'):
+    with pytest.raises(ToolError, match='The backend refused it: Forbidden.*project role'):
         await tool(mcp_context_client, **kwargs)
 
 
@@ -532,6 +565,38 @@ async def test_merge_refusals(
 
 
 @pytest.mark.asyncio
+async def test_merge_conflict_409_without_errors_fetches_the_live_list(
+    mcp_context_client: Context, storage: AsyncMock
+) -> None:
+    """A conflict 409 with no usable params must never yield mergeable=True / "merge it"."""
+    storage.merge_request_merge.side_effect = _http_error(409, {'error': 'Conflicts'})
+    storage.merge_request_conflicts.return_value = []  # even the live list is empty (race / proxy)
+
+    result = await merge_merge_request(mcp_context_client, merge_request_id=42)
+
+    assert result.refusal == 'conflicts'
+    assert result.status is not None and result.status.mergeable is False
+    assert 'refused because of conflicts' in result.next_step and 'merge it' not in result.next_step
+    storage.merge_request_conflicts.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_merge_not_ready_on_approved_says_wait(mcp_context_client: Context, storage: AsyncMock) -> None:
+    storage.merge_request_detail.return_value = _mr_raw('approved')
+    storage.merge_request_merge.side_effect = _http_error(
+        409, {'code': 'storage.mergeRequests.notReadyToMerge', 'error': 'Another merge request is being processed.'}
+    )
+
+    result = await merge_merge_request(mcp_context_client, merge_request_id=42)
+
+    assert result.refusal == 'not_ready'
+    assert result.status is not None and result.status.mergeable is False
+    assert 'wait for it to clear' in result.next_step
+    assert 'Another merge request is being processed.' in result.next_step
+    assert 'Ready: merge it' not in result.next_step
+
+
+@pytest.mark.asyncio
 async def test_merge_reraises_unknown_409(mcp_context_client: Context, storage: AsyncMock) -> None:
     storage.merge_request_merge.side_effect = _http_error(409, {'code': 'storage.something.else', 'error': 'nope'})
 
@@ -563,21 +628,30 @@ async def test_merge_success_awaits_job_and_hands_off(
 
 
 @pytest.mark.asyncio
-async def test_merge_job_error_rolls_back_to_approved(
-    mcp_context_client: Context, storage: AsyncMock, monkeypatch
+@pytest.mark.parametrize(
+    ('job', 'expected_message'),
+    [
+        pytest.param({'id': 988, 'status': 'error', 'error': {'message': 'boom'}}, 'boom', id='error_with_message'),
+        pytest.param({'id': 988, 'status': 'cancelled'}, "ended with status 'cancelled'", id='cancelled_is_terminal'),
+        pytest.param({'id': 988, 'status': 'terminated', 'error': 'killed'}, 'killed', id='terminated_string_error'),
+    ],
+)
+async def test_merge_job_failure_rolls_back_to_approved(
+    mcp_context_client: Context, storage: AsyncMock, monkeypatch, job: dict, expected_message: str
 ) -> None:
     monkeypatch.setattr(mr_tools, 'MERGE_JOB_POLL_INTERVAL_SEC', 0)
     storage.merge_request_detail.return_value = _mr_raw('approved')
     storage.merge_request_merge.return_value = {'id': '988'}
-    storage.job_detail.return_value = {'id': 988, 'status': 'error', 'error': {'message': 'boom'}}
+    storage.job_detail.return_value = job
 
     result = await merge_merge_request(mcp_context_client, merge_request_id=42)
 
     assert result.merged is False
     assert result.state == 'approved'
     assert result.refusal is None
-    assert result.refusal_message == 'boom'
-    assert 'boom' in result.next_step
+    assert result.refusal_message is not None and expected_message in result.refusal_message
+    assert expected_message in result.next_step
+    assert storage.job_detail.await_count == 1  # terminal on the first poll, no spinning
 
 
 @pytest.mark.asyncio
@@ -784,6 +858,7 @@ async def test_resolve_last_conflict_recommends_merge(mcp_context_client: Contex
             id='take_holed_side',
         ),
         pytest.param({'take': 'ours'}, _diff(theirs=None), 'no production', True, id='theirs_missing'),
+        pytest.param({'take': 'ours'}, _diff(ours=None), 'no ours side', True, id='absent_side_is_not_a_delete'),
     ],
 )
 async def test_resolve_conflict_refuses_without_rebasing(

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "keboola-mcp-server"
-version = "1.80.1"
+version = "1.81.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Description

**Linear**: [DMD-1701](https://linear.app/keboola/issue/DMD-1701)
**RFC**: [`feature_spec/branches_merge_requests_mcp/RFC.md`](https://github.com/keboola/mcp-server/pull/612) (PR #612, reviewed separately; this PR implements it)

### Change Type

- [ ] Major (breaking changes, significant new features)
- [x] Minor (new features, enhancements, backward compatible)
- [ ] Patch (bug fixes, small improvements, no new features)

### Summary

Implements the Branches 2.0 (non-SOX) merge-request flow as **9 MCP tools** in a new package `tools/merge_requests/`, so a user on a development branch can ship changes to production from the chat:

| Tool | Session | Role | Notes |
|---|---|---|---|
| `get_merge_requests` | any | any | list (optional `state` filter, raw or derived) or batched detail with the derived status |
| `create_merge_request` | dev branch | admin/share/OAuth | source = session branch, target = production; no branch params |
| `update_merge_request` | any | admin/share/OAuth | the only way to disarm auto-merge |
| `request_merge_request_review` | dev branch | admin/share/OAuth | rarely needed: merge skips review itself when approvals suffice |
| `approve_merge_request` | any | admin/share/OAuth | valid only in `in_review` |
| `request_merge_request_changes` | any | admin/share/OAuth | reviewer's "reject"; not terminal |
| `merge_merge_request` | dev branch | admin/share/OAuth | awaits the Storage job; 409 mapped by `code` (`conflicts` / `not_ready`) |
| `get_merge_request_conflicts` | dev branch | any | conflicts + three-way diff + per-path `changed_by` classification |
| `resolve_merge_request_conflict` | dev branch | admin/share/OAuth | `take=ours|theirs|delete` or a strict custom body, via rebase `{version, diff}` |

Every MR-returning tool carries the same **derived status** (`derived_state`, `merge_blockers`, `mergeable`, `allowed_actions`, `viewer`, live `conflicts`) and a deterministic **`next_step`** sentence (15-row decision table, `status.py`) so the agent branches on data, not prose. The derivations are a port of the kbagent CLI's Layer 2 and read server-first (DMD-1988) with the local tables as fallback.

Other changes:

- `clients/storage.py`: `merge_requests_list`, `merge_request_detail(include_activity_log)`, `merge_request_conflicts`, `merge_request_create/update/request_review/approve/request_changes/merge`, `configuration_diff`, `configuration_rebase(version, diff)`; `'branches-merge-requests'` added to `ProjectFeature`.
- `mcp.py`: three-axis gating in `authorize_tool_call` by name set (`MERGE_REQUEST_TOOL_NAMES`, `MERGE_REQUEST_BRANCH_ONLY_TOOLS` in `tools/constants.py`): feature (hide + deny), role with the existing OAuth carve-out (hide writes + deny), session branch (**deny only**, the branch-only tools stay visible on production so the model keeps their descriptions and can hand the user off). `on_call_tool` now stores `token_info` in session state (`TOKEN_INFO_STATE_KEY`) so tool bodies do not verify the token a second time.
- `links.py`: `get_merge_request_link` (the source branch's development overview, as Connection's MR emails link it).
- `TOOLS.md` regenerated; version `1.80.1 → 1.81.0`; `uv.lock` refreshed.

Deviations from the RFC worth knowing: `resolved` is typed `dict` in the tool schema (validated by `ResolvedConfiguration` with `StrictBool` before any network call) because the tool-schema test requires a `type` on every parameter; the write tools cost one more request than the RFC's count (the `branches_list` needed for branch names / links), i.e. 4 uncached / 3 with the token cache. `get_merge_requests` and `get_merge_request_conflicts` additionally take `project_id` and are dispatched single-target by `MultiProjectMiddleware` (merge-request ids are project-specific; the conflict tool is bound to the session branch), so they are not fanned out across a multi-project scope. `update_merge_request` also ships (RFC decision C2). A self-review pass (`/code-review`, 10 findings) is folded in as the last commit.

## Testing

- [ ] Tested with Cursor AI desktop (`Streamable-HTTP` transports)

### Optional testing
- [ ] Tested with Cursor AI desktop (all transports)
- [ ] Tested with claude.ai web and `canary-orion` MCP (`Streamable-HTTP`)
- [ ] Tested with In Platform Agent on `canary-orion`
- [ ] Tested with RO chat on `canary-orion`

Unit tests (`tests/tools/merge_requests/`, `tests/test_mcp.py`, `tests/test_preview.py`, `tests/clients/test_client.py`, `tests/test_server.py`): derivation tables row by row incl. server-first overrides, all 15 `next_step` rows and their precedence rules, per-path classification (pseudo-paths, `agreed`, deleted/holed sides), the MR-id convention, merge 409 shapes / job success / job error / timeout, every resolve mode and refusal (no request sent on a validation failure), request counts, the gating table for `authorize_tool_call` and list-time filtering, the `token_info` cache.

Integration tests (`integtests/tools/test_merge_requests.py`): happy path `create → merge → published` and the conflict loop. **Not run yet** — they need a project with the `branches-merge-requests` feature (`INTEGTEST_STORAGE_TOKEN_MERGE_REQUESTS`, registered in `tox` `pass_env` and the integtests README) and are skipped when the variable is unset. Manual E2E on such a project is pending for the same reason.

## Checklist

- [x] Self-review completed
- [x] Unit tests added/updated (if applicable)
- [x] Integration tests added/updated (if applicable) — written, run pending a `branches-merge-requests` project
- [x] Project version bumped according to the change type
- [x] Documentation updated (if applicable) — `TOOLS.md`, `integtests/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
